### PR TITLE
Add Claude Code plugin marketplace + OpenClaw skill for distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,57 @@
+{
+  "name": "fhir-r6-guardrails",
+  "version": "0.9.0",
+  "owner": {
+    "name": "FHIR IQ / Eugene Vestel",
+    "email": "contact@fhiriq.com",
+    "url": "https://www.fhiriq.com"
+  },
+  "description": "FHIR R6 MCP guardrail patterns for AI agent access to clinical data. Runtime security layer with PHI redaction, step-up authorization, immutable audit trails, tenant isolation, and upstream FHIR server proxy. Complements the Anthropic healthcare marketplace's fhir-developer knowledge skill with a live MCP server and guardrail enforcement.",
+  "plugins": [
+    {
+      "name": "fhir-r6-guardrails",
+      "description": "FHIR R6 MCP server with 10 tools for agent-safe clinical data access. Enforces PHI redaction, step-up auth for writes, immutable audit trails, and tenant isolation on every request.",
+      "source": "./",
+      "category": "healthcare",
+      "tags": [
+        "fhir",
+        "fhir-r6",
+        "hl7",
+        "mcp",
+        "phi-redaction",
+        "hipaa",
+        "guardrails",
+        "clinical-ai",
+        "audit-trail",
+        "step-up-auth"
+      ]
+    },
+    {
+      "name": "fhir-upstream-proxy",
+      "description": "Connect to real FHIR servers (HAPI, SMART Health IT, Epic) while enforcing the full MCP guardrail stack. Redaction, audit, and URL rewriting applied to upstream responses.",
+      "source": "./",
+      "category": "healthcare",
+      "tags": [
+        "fhir",
+        "proxy",
+        "hapi",
+        "epic",
+        "smart-on-fhir",
+        "interoperability"
+      ]
+    },
+    {
+      "name": "phi-redaction",
+      "description": "PHI redaction patterns for FHIR resources. Names truncated to initials, identifiers masked, addresses stripped, birth dates truncated to year, photos removed. Applied automatically on all read paths.",
+      "source": "./",
+      "category": "healthcare",
+      "tags": [
+        "phi",
+        "redaction",
+        "hipaa",
+        "privacy",
+        "de-identification"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,82 @@
+{
+  "name": "fhir-r6-guardrails",
+  "version": "0.9.0",
+  "description": "FHIR R6 MCP guardrail patterns for AI agent access to clinical data. 10 MCP tools with PHI redaction, step-up authorization, audit trails, and upstream FHIR server proxy.",
+  "author": {
+    "name": "FHIR IQ / Eugene Vestel",
+    "email": "contact@fhiriq.com"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "fhir",
+    "fhir-r6",
+    "hl7",
+    "mcp",
+    "healthcare",
+    "phi-redaction",
+    "hipaa",
+    "guardrails",
+    "clinical-ai",
+    "audit-trail"
+  ],
+  "skills": {
+    "fhir-r6-guardrails": {
+      "path": "skills/fhir-r6-guardrails"
+    },
+    "phi-redaction": {
+      "path": "skills/phi-redaction"
+    },
+    "fhir-upstream-proxy": {
+      "path": "skills/fhir-upstream-proxy"
+    }
+  },
+  "mcp_servers": {
+    "fhir-mcp-guardrails": {
+      "type": "streamable-http",
+      "url": "http://localhost:3001/mcp",
+      "description": "FHIR R6 MCP server with guardrail enforcement. Requires the agent-orchestrator service running locally or via Docker Compose.",
+      "env": {
+        "FHIR_BASE_URL": {
+          "description": "Backend FHIR R6 REST facade URL",
+          "default": "http://localhost:5000/r6/fhir"
+        },
+        "MCP_PORT": {
+          "description": "Port for the MCP server",
+          "default": "3001"
+        },
+        "STEP_UP_SECRET": {
+          "description": "HMAC-SHA256 secret for step-up token signing. Required for write operations.",
+          "required": true
+        },
+        "FHIR_UPSTREAM_URL": {
+          "description": "Upstream FHIR server URL for proxy mode. Leave empty for local SQLite mode.",
+          "default": ""
+        },
+        "ALLOWED_ORIGINS": {
+          "description": "Comma-separated list of allowed CORS origins. Empty = deny all.",
+          "default": ""
+        }
+      },
+      "setup": {
+        "docker": "docker-compose up -d --build",
+        "manual": [
+          "uv sync",
+          "python main.py &",
+          "cd services/agent-orchestrator && npm ci && npm start"
+        ]
+      },
+      "tools": [
+        "context.get",
+        "fhir.read",
+        "fhir.search",
+        "fhir.validate",
+        "fhir.stats",
+        "fhir.lastn",
+        "fhir.permission_evaluate",
+        "fhir.subscription_topics",
+        "fhir.propose_write",
+        "fhir.commit_write"
+      ]
+    }
+  }
+}

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: fhir-r6-guardrails
+version: 0.9.0
+description: >
+  FHIR R6 agent guardrails for secure clinical data access via MCP. Use when:
+  (1) Reading patient data through MCP with automatic PHI redaction,
+  (2) Writing clinical resources with two-phase propose/commit and step-up auth,
+  (3) Proxying requests to real FHIR servers (HAPI, SMART Health IT, Epic),
+  (4) Auditing AI agent access to healthcare data,
+  (5) Evaluating R6 Permission resources for access control decisions.
+  Provides 10 MCP tools with guardrail enforcement on every request.
+metadata:
+  openclaw:
+    requires:
+      env:
+        - STEP_UP_SECRET
+      bins:
+        - node
+        - python3
+    install:
+      - kind: node
+        packages:
+          - "@modelcontextprotocol/sdk"
+          - express
+          - node-fetch
+      - kind: uv
+        packages:
+          - flask
+          - flask-sqlalchemy
+          - httpx
+    primaryEnv: STEP_UP_SECRET
+---
+
+# FHIR R6 MCP Guardrail Patterns
+
+A runtime security layer for AI agent access to FHIR clinical data via Model Context
+Protocol (MCP). This is NOT a knowledge skill — it runs an MCP server that enforces
+PHI redaction, step-up authorization, immutable audit trails, and tenant isolation
+on every request.
+
+## Setup
+
+### Docker Compose (recommended)
+
+```bash
+# Clone the repository
+git clone https://github.com/aks129/fhir-mcp-guardrails.git
+cd fhir-mcp-guardrails
+
+# Set required secret
+export STEP_UP_SECRET=$(openssl rand -hex 32)
+
+# Start all services
+docker-compose up -d --build
+```
+
+### Manual Setup
+
+```bash
+# Python backend (Flask)
+uv sync
+export STEP_UP_SECRET=$(openssl rand -hex 32)
+python main.py &
+
+# MCP server (Node.js)
+cd services/agent-orchestrator
+npm ci
+npm start
+```
+
+### Connect to a Real FHIR Server
+
+```bash
+export FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR4
+# All guardrails apply to upstream responses automatically
+```
+
+## MCP Server Endpoints
+
+- **Streamable HTTP**: `POST http://localhost:3001/mcp` (preferred)
+- **SSE**: `GET http://localhost:3001/sse` (legacy MCP transport)
+- **HTTP bridge**: `POST http://localhost:3001/mcp/rpc` (non-MCP clients)
+
+## Available MCP Tools
+
+### Read Tools (no step-up required)
+
+**`context.get`** — Retrieve a pre-built context envelope with patient-centric FHIR
+resources. Returns bounded, policy-stamped, time-limited context.
+
+**`fhir.read`** — Read a single FHIR resource by type and ID. Response is automatically
+redacted (names to initials, identifiers masked, dates truncated).
+
+**`fhir.search`** — Search FHIR resources with filters: patient, code, status,
+_lastUpdated, _count (max 50), _sort. Returns a redacted Bundle.
+
+**`fhir.validate`** — Validate a proposed FHIR resource against structural rules.
+Returns OperationOutcome with errors and warnings.
+
+**`fhir.stats`** — Compute count/min/max/mean over Observation valueQuantity values.
+Standard FHIR $stats operation (since R4). Filter by patient and/or LOINC code.
+
+**`fhir.lastn`** — Get the last N observations per code. Standard FHIR $lastn.
+Sorted by storage order, not effectiveDateTime.
+
+**`fhir.permission_evaluate`** — Evaluate R6 Permission resources for access control.
+Returns permit/deny with reasoning. Separates access control from consent records.
+
+**`fhir.subscription_topics`** — List available SubscriptionTopics for event-driven
+subscriptions.
+
+### Write Tools (require step-up token)
+
+**`fhir.propose_write`** — Validate and preview a write without committing. Identifies
+clinical resource types that require human-in-the-loop confirmation.
+
+**`fhir.commit_write`** — Commit a proposed write. Requires `X-Step-Up-Token` header
+(HMAC-SHA256, 5-min TTL). Clinical resources also require `X-Human-Confirmed: true`.
+
+## Write Workflow
+
+Always use the two-phase pattern:
+
+1. Call `fhir.propose_write` with the resource and operation type
+2. Check `proposal_status` — must be `"ready"` to proceed
+3. Note `requires_human_confirmation` for clinical types (Observation, Condition, etc.)
+4. Call `fhir.commit_write` with step-up token and human confirmation headers
+
+## Security Guardrails
+
+All guardrails are enforced automatically on every request:
+
+- **PHI Redaction**: Names → initials, identifiers → last 4 chars, addresses stripped,
+  birth dates → year only, photos removed, notes → [Redacted]
+- **Audit Trail**: Append-only AuditEvent for every resource access
+- **Step-Up Auth**: HMAC-SHA256 tokens with nonce, TTL, tenant binding for writes
+- **Tenant Isolation**: X-Tenant-Id enforced at database layer on every query
+- **URL Rewriting**: Upstream server URLs never leak to clients
+- **Medical Disclaimers**: Injected on clinical resource reads
+
+## Supported Resource Types
+
+Patient, Encounter, Observation, AuditEvent, Consent, Permission, SubscriptionTopic,
+Subscription, NutritionIntake, NutritionProduct, DeviceAlert, DeviceAssociation,
+Requirements, ActorDefinition.
+
+## R6-Specific Resources
+
+- **Permission** — Access control resource with $evaluate operation (separate from Consent)
+- **DeviceAlert** — ISO/IEEE 11073 device alarms
+- **NutritionIntake** — Dietary consumption tracking
+- **SubscriptionTopic** — Restructured pub/sub (introduced R5, maturing R6)
+
+## Limitations
+
+- Local mode: SQLite JSON blob storage, table scans for filtering
+- Structural validation only (no StructureDefinition or terminology binding)
+- Human-in-the-loop is header-based, not cryptographic
+- Upstream proxy: no response caching, no cross-version translation
+- SubscriptionTopic stored but notifications not dispatched

--- a/skills/fhir-r6-guardrails/SKILL.md
+++ b/skills/fhir-r6-guardrails/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: fhir-r6-guardrails
+description: >
+  FHIR R6 agent guardrails for clinical data access via MCP. Use when: (1) Reading
+  patient data through MCP tools with automatic PHI redaction, (2) Writing clinical
+  resources with two-phase propose/commit and step-up authorization, (3) Querying
+  observation statistics or recent lab results, (4) Evaluating R6 Permission resources
+  for access control decisions, (5) Auditing agent access to healthcare data. This
+  skill teaches how to use the fhir-mcp-guardrails MCP server's 10 tools safely.
+disable-model-invocation: true
+---
+
+# FHIR R6 MCP Guardrail Patterns
+
+Reference implementation of security and compliance patterns for AI agent access to
+FHIR R6 data via Model Context Protocol (MCP).
+
+**This is a runtime guardrail layer, not a knowledge skill.** It sits between any AI
+agent and FHIR data (local or upstream), enforcing PHI redaction, audit trails,
+step-up authorization, and tenant isolation on every request.
+
+## When to Use This Skill
+
+- You need to read, search, or write FHIR clinical resources through MCP
+- You need PHI to be automatically redacted before the agent sees it
+- You need an immutable audit trail of all agent access
+- You need step-up authorization gates on write operations
+- You need to evaluate R6 Permission resources for access control
+
+## MCP Tools Available (10)
+
+### Read Tools (no step-up required)
+
+| Tool | Purpose |
+|------|---------|
+| `context.get` | Retrieve a pre-built context envelope with patient-centric resources |
+| `fhir.read` | Read a single FHIR resource by type and ID (auto-redacted) |
+| `fhir.search` | Search resources with patient, code, status, date filters |
+| `fhir.validate` | Structural validation of a proposed resource |
+| `fhir.stats` | Observation statistics: count, min, max, mean over valueQuantity |
+| `fhir.lastn` | Most recent N observations per code |
+| `fhir.permission_evaluate` | Evaluate R6 Permission for permit/deny with reasoning |
+| `fhir.subscription_topics` | List available SubscriptionTopics |
+
+### Write Tools (require step-up token)
+
+| Tool | Purpose |
+|------|---------|
+| `fhir.propose_write` | Validate and preview a write without committing |
+| `fhir.commit_write` | Commit a proposed write (requires X-Step-Up-Token) |
+
+## Two-Phase Write Pattern
+
+Writes always follow propose-then-commit:
+
+1. **Propose**: Call `fhir.propose_write` with the resource and operation (create/update).
+   This validates the resource and returns a preview. No data is changed.
+
+2. **Review**: Check the proposal response:
+   - `proposal_status: "ready"` means validation passed
+   - `requires_human_confirmation: true` for clinical resource types
+   - `requires_step_up: true` always for commits
+
+3. **Commit**: Call `fhir.commit_write` with the same resource. Include:
+   - `X-Step-Up-Token` header (HMAC-SHA256 signed, 5-minute TTL)
+   - `X-Human-Confirmed: true` header for clinical resources
+
+### Clinical Resource Types (require human-in-the-loop)
+
+Observation, Condition, MedicationRequest, DiagnosticReport, AllergyIntolerance,
+Procedure, CarePlan, Immunization, NutritionIntake, DeviceAlert.
+
+## Supported FHIR Resource Types
+
+Patient, Encounter, Observation, AuditEvent, Consent, Permission, SubscriptionTopic,
+Subscription, NutritionIntake, NutritionProduct, DeviceAlert, DeviceAssociation,
+Requirements, ActorDefinition.
+
+### R6-Specific Resources
+
+- **Permission** — Access control (separate from Consent). `$evaluate` operation.
+- **DeviceAlert** — ISO/IEEE 11073 device alarms.
+- **NutritionIntake** — Dietary consumption tracking.
+- **DeviceAssociation, NutritionProduct, Requirements, ActorDefinition** — CRUD only.
+
+## Security Guardrails (Always Active)
+
+### PHI Redaction
+Applied on every read path. Names truncated to initials, identifiers masked to
+last 4 characters, addresses stripped to city/state/country, birth dates truncated
+to year, photos removed, notes replaced with [Redacted].
+
+### Audit Trail
+Append-only AuditEvent records for every resource access. Database-level immutability.
+Logs agent ID, tenant ID, resource accessed, and outcome.
+
+### Step-Up Authorization
+HMAC-SHA256 tokens with 128-bit nonce, 5-minute TTL, tenant binding.
+Required for all write operations.
+
+### Tenant Isolation
+`X-Tenant-Id` header enforced on every query at the database layer.
+
+## Search Parameters (Local Mode)
+
+Supported: `patient` (reference), `code` (token), `status` (token),
+`_lastUpdated` (date with ge/le/gt/lt prefix), `_count` (1-200),
+`_sort` (_lastUpdated/-_lastUpdated), `_summary` (count).
+
+Not supported in local mode: chaining, _include, _revinclude, modifiers.
+
+In upstream proxy mode, all query parameters are forwarded to the upstream server.
+
+## Setup
+
+```bash
+# Docker Compose (recommended)
+docker-compose up -d --build
+
+# Manual
+uv sync && python main.py &
+cd services/agent-orchestrator && npm ci && npm start
+```
+
+Required environment variables:
+- `STEP_UP_SECRET` — HMAC secret for step-up tokens
+
+Optional:
+- `FHIR_UPSTREAM_URL` — Connect to a real FHIR server (e.g., https://hapi.fhir.org/baseR4)
+- `FHIR_BASE_URL` — Backend URL (default: http://localhost:5000/r6/fhir)
+- `MCP_PORT` — MCP server port (default: 3001)
+
+## Known Limitations
+
+- Local mode uses SQLite JSON blob storage (not indexed search)
+- Structural validation only (no StructureDefinition or terminology binding)
+- SubscriptionTopic stored but notifications not dispatched
+- Human-in-the-loop is header-based, not cryptographic
+- No historical versioning (version_id increments but old versions not retrievable)
+- Upstream proxy: no response caching, no cross-version translation

--- a/skills/fhir-upstream-proxy/SKILL.md
+++ b/skills/fhir-upstream-proxy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: fhir-upstream-proxy
+description: >
+  Connect to real FHIR servers through the MCP guardrail proxy. Use when:
+  (1) Connecting to HAPI FHIR, SMART Health IT, or Epic sandbox servers,
+  (2) Proxying AI agent requests to production EHR systems with guardrails,
+  (3) Ensuring upstream server URLs never leak to clients,
+  (4) Understanding how redaction, audit, and step-up auth apply to upstream data.
+disable-model-invocation: true
+---
+
+# FHIR Upstream Server Proxy
+
+Connect to real FHIR servers while keeping the full MCP guardrail stack active.
+
+```
+Client -> MCP Server -> Flask (guardrails) -> Upstream FHIR Server
+                             |
+               redaction, audit, step-up,
+               tenant isolation, disclaimers,
+               URL rewriting
+```
+
+## When to Use This Skill
+
+- You need to connect an AI agent to a real FHIR server (HAPI, SMART, Epic)
+- You want automatic PHI redaction on upstream server responses
+- You need audit trails for agent access to production clinical data
+- You want URL rewriting so upstream server details never leak to clients
+
+## Configuration
+
+Set the `FHIR_UPSTREAM_URL` environment variable to enable proxy mode:
+
+```bash
+# HAPI FHIR R4 (open, no auth)
+FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR4 python main.py
+
+# SMART Health IT (open, no auth)
+FHIR_UPSTREAM_URL=https://r4.smarthealthit.org python main.py
+
+# HAPI FHIR R5 (open, no auth)
+FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR5 python main.py
+
+# Local HAPI instance
+FHIR_UPSTREAM_URL=http://localhost:8080/fhir python main.py
+
+# Docker Compose with upstream
+FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR4 docker-compose up -d --build
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FHIR_UPSTREAM_URL` | (empty) | Upstream FHIR server base URL. Enables proxy when set. |
+| `FHIR_UPSTREAM_TIMEOUT` | `15` | HTTP timeout for upstream requests (seconds) |
+| `FHIR_LOCAL_BASE_URL` | (empty) | Local server URL for URL rewriting in responses |
+
+## What the Proxy Does
+
+### Reads
+Fetched from upstream, then redacted + audited + disclaimers added. The agent
+never sees unredacted upstream data.
+
+### Searches
+All query parameters forwarded to upstream. Results redacted per entry.
+Upstream's full search capabilities are available (chaining, _include, etc.).
+
+### Writes
+Validated locally first (structural checks), then forwarded to upstream with
+step-up auth verification. Both local and upstream audit records created.
+
+### URL Rewriting
+All upstream server URLs in responses are replaced with local proxy URLs.
+The agent and client never see the upstream server's hostname or paths.
+
+### Health Check
+`/r6/fhir/health` reports upstream connection status including FHIR version
+and server software name.
+
+### Graceful Fallback
+Network errors return proper FHIR OperationOutcome responses, not stack traces.
+
+## What the Proxy Does NOT Do
+
+- **No caching** — every request hits the upstream server
+- **No SMART-on-FHIR auth forwarding** — uses upstream's native auth model
+- **No cross-version translation** — R4 responses stay R4
+- **No tenant isolation on upstream** — enforced locally only
+- **No response transformation** — upstream resources pass through as-is (after redaction)
+
+## Tested Upstream Servers
+
+| Server | URL | Auth | Status |
+|--------|-----|------|--------|
+| HAPI FHIR R4 | `https://hapi.fhir.org/baseR4` | None | Tested |
+| SMART Health IT | `https://r4.smarthealthit.org` | None | Tested |
+| HAPI FHIR R5 | `https://hapi.fhir.org/baseR5` | None | Tested |
+| Local HAPI | `http://localhost:8080/fhir` | None | Tested |
+| Epic Sandbox | `https://open.epic.com/Interface/FHIR` | OAuth 2.0 | Limited |
+
+## Proxy Implementation
+
+The proxy uses `httpx` for HTTP client operations with:
+- Configurable timeout (default 15 seconds)
+- Automatic redirect following
+- `application/fhir+json` accept header
+- User-Agent identification: `MCP-FHIR-Guardrails/0.9.0`
+
+URL rewriting is recursive — it traverses the entire response JSON tree and
+replaces all occurrences of the upstream URL with the local proxy URL.

--- a/skills/phi-redaction/SKILL.md
+++ b/skills/phi-redaction/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: phi-redaction
+description: >
+  PHI redaction patterns for FHIR resources following HIPAA Safe Harbor. Use when:
+  (1) Redacting patient health information from FHIR resources before AI agent access,
+  (2) Implementing de-identification for clinical data pipelines,
+  (3) Understanding what fields are stripped, masked, or truncated in FHIR resources,
+  (4) Building read paths that automatically protect patient privacy.
+disable-model-invocation: true
+---
+
+# PHI Redaction for FHIR Resources
+
+Standard redaction profile for Protected Health Information (PHI) applied on all
+read paths in the FHIR MCP guardrail stack. Based on HIPAA Safe Harbor method.
+
+## When to Use This Skill
+
+- You need to understand how PHI is stripped from FHIR resources
+- You are building a pipeline that must redact clinical data before AI access
+- You need to implement or audit de-identification logic for FHIR
+
+## Redaction Rules
+
+All redaction is applied at read time, not at storage time.
+
+### Names (`HumanName`)
+- **Family name**: Kept as-is
+- **Given names**: Truncated to first initial + period (e.g., "John" -> "J.")
+- **Text**: Removed
+
+### Identifiers
+- **Value**: Masked to last 4 characters (e.g., "123-45-6789" -> "***6789")
+- **System and type**: Kept for reference
+
+### Addresses
+- **Line and text**: Removed
+- **City, state, country**: Kept (for demographic analysis)
+
+### Telecom (Phone, Email)
+- **Value**: Replaced with `[Redacted]`
+- **System and use**: Kept
+
+### Birth Date
+- **Truncated to year only** (e.g., "1985-03-15" -> "1985")
+
+### Photos
+- **Removed entirely** from the resource
+
+### Text Narratives
+- **Replaced** with: `<div xmlns="http://www.w3.org/1999/xhtml">[Redacted]</div>`
+- **Status** set to `empty`
+
+### Notes and Comments
+- **Replaced** with `[Redacted]`
+
+### Contained Resources
+- All contained resources are redacted recursively
+
+## Implementation Pattern (Python)
+
+```python
+import json
+
+def apply_redaction(resource):
+    """Deep-copy the resource and redact PHI fields."""
+    redacted = json.loads(json.dumps(resource))
+    _redact_fields(redacted)
+    for contained in redacted.get('contained', []):
+        if isinstance(contained, dict):
+            _redact_fields(contained)
+    return redacted
+```
+
+Key implementation notes:
+- Always deep-copy before redacting (never modify the stored resource)
+- Redact contained resources recursively
+- Apply on ALL read paths: direct reads, search results, context envelopes,
+  upstream proxy responses
+
+## HIPAA Safe Harbor Coverage
+
+This redaction profile covers these Safe Harbor identifiers:
+- Names (partial)
+- Geographic data smaller than state (addresses stripped)
+- Dates (birth date truncated to year)
+- Telephone/fax numbers (redacted)
+- Email addresses (redacted)
+- Medical record numbers (masked to last 4)
+
+**Not covered by this profile** (would need additional implementation):
+- Social Security numbers (not typically in FHIR resources)
+- IP addresses, device identifiers (not redacted from extension fields)
+- Biometric identifiers
+- Full-face photographs (removed if in `photo` field, not scanned in attachments)
+
+## Integration with MCP Tools
+
+The redaction is applied automatically by the guardrail stack. MCP tools like
+`fhir.read`, `fhir.search`, `fhir.lastn`, and `context.get` all return
+redacted data. No additional action is needed by the agent.
+
+The `$deidentify` operation provides explicit HIPAA Safe Harbor de-identification
+on demand, useful for export or analysis workflows.


### PR DESCRIPTION
Phase 1: Claude Code Plugin Marketplace
- .claude-plugin/marketplace.json with 3 plugin entries (guardrails, proxy, PHI redaction)
- .claude-plugin/plugin.json with MCP server registration and env config
- skills/fhir-r6-guardrails/SKILL.md: 10-tool MCP server usage guide
- skills/phi-redaction/SKILL.md: HIPAA Safe Harbor redaction patterns
- skills/fhir-upstream-proxy/SKILL.md: upstream FHIR server proxy guide

Phase 2: OpenClaw Skill
- openclaw/SKILL.md with YAML frontmatter compatible with ClawHub registry
- Declares env requirements (STEP_UP_SECRET), binary deps (node, python3)
- Install specs for both npm and uv package managers

Positions the project for submission to anthropics/healthcare marketplace as a runtime complement to the existing fhir-developer knowledge skill.

https://claude.ai/code/session_01LbeabokvxtYPxwzDN5ZQMb