### PR TITLE
chore: add security-baseline scanner + dependabot + gitignore baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Keep CI actions up to date — minimal risk, weekly cadence
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+
+  # If this repo has Node dependencies, uncomment the block below + remove the comment marker
+  # - package-ecosystem: npm
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
+  #   open-pull-requests-limit: 5
+  #   labels:
+  #     - dependencies
+  #   groups:
+  #     minor-and-patch:
+  #       update-types:
+  #         - minor
+  #         - patch
+
+  # If this repo has Python dependencies, uncomment + adapt path:
+  # - package-ecosystem: pip
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -1,0 +1,5 @@
+name: security-baseline
+on: [pull_request, push]
+jobs:
+  scan:
+    uses: aks129/security-baseline/.github/workflows/scan-reusable.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,20 @@ healthclaw-bundle-*.json
 exports/
 
 .vercel
+
+# --- security-baseline additions ---
+# Claude Code / agent workspace state (never commit)
+.claude/
+.superpowers/
+claude-*.tmp
+
+# Strategy + outreach drafts (gitignored — local-only)
+.private/
+
+# Environment files (use .env.example for templates instead)
+.env
+.env.local
+.env.*.local
+
+# GCP/GitHub Actions service-account creds written by google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Inherits the shared baseline from [aks129/security-baseline](https://github.com/aks129/security-baseline) and [aks129/repo-template](https://github.com/aks129/repo-template).

## What this adds

- **`.github/workflows/security-baseline.yml`** — 5-line caller that runs the reusable scanner on every push and PR. Catches committed credentials, Claude Code workspace files (`.claude/`, `.superpowers/`), and new imports of paid SDKs (warnings).
- **`.github/dependabot.yml`** — weekly GitHub Actions updates. npm/pip blocks are commented; uncomment whichever ecosystems this repo uses.
- **`.gitignore` additions** — blocks `.claude/`, `.superpowers/`, `.private/`, `.env*`, and agent workspace temp files. Appended to existing entries, not overwritten.

## Why

Rules live in one place (`aks129/security-baseline`) — change them once, every consumer repo inherits the change on its next CI run. No per-repo maintenance of scanner logic.

## Updates to the rules

When `aks129/security-baseline` ships a new rule, this repo picks it up automatically on the next push/PR. No action needed here.