### PR TITLE
feat: SMART Health Links — adopt jmandel/kill-the-clipboard (zero-knowledge SHL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,10 +145,10 @@ Column names differ from what you might guess:
 
 ## MCP Server
 
-**19 tools in three groups:**
+**20 tools in three groups:**
 
 - **Read** (no step-up): `context_get`, `fhir_read`, `fhir_search`, `fhir_validate`, `fhir_stats`, `fhir_lastn`, `fhir_permission_evaluate`, `fhir_subscription_topics`, `curatr_evaluate`, `action_status`
-- **Write** (require step-up): `fhir_propose_write`, `fhir_commit_write`, `curatr_apply_fix`, `action_propose`, `action_commit`
+- **Write** (require step-up): `fhir_propose_write`, `fhir_commit_write`, `curatr_apply_fix`, `action_propose`, `action_commit`, `shl_generate`
 - **Utility**: `fhir_compiled_truth`, `fhir_get_token`, `fhir_seed`
 
 Tool names use underscores (`fhir_search`, not `fhir.search`).
@@ -242,3 +242,14 @@ Real-world actions (phone calls, SMS) behind the same guardrails as FHIR writes.
 **Env vars:** `BLAND_AI_API_KEY` (calls), `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN`/`TWILIO_FROM_NUMBER` (SMS — all three or hard-fail), `ACTIONS_WEBHOOK_SECRET` (callbacks 403 without it), `PUBLIC_BASE_URL` (webhook base, defaults to app.healthclaw.io). Absent provider keys → simulation mode (commit completes synchronously).
 
 **Design docs:** `docs/superpowers/specs/2026-06-12-unified-action-layer-design.md` (full integration spec — phases 2-6 cover skills, Flexpa, ainpi.dev lookup, SHL QR, careagents.cloud rewire) and `docs/superpowers/plans/2026-06-12-action-core.md` (Phase 1 plan, executed).
+
+## SMART Health Links
+
+Adopted **jmandel/kill-the-clipboard-skill** (MIT, pinned `fa0020d`) as the SHL storage server rather than building bespoke — it implements SHL STU 1 and is zero-knowledge (the server stores only ciphertext + `sha256(auth)`; it can never read PHI).
+
+- **Storage server** — Docker Compose service `shl-server` (profile `shl`); exposes port 8000; SQLite at `/data/db.sqlite` (named volume `shl-data`); `SHL_PUBLIC_URL` env sets `BASE_URL`.
+- **MCP client-side crypto** — vendored into `src/ktc/`; keep diffable against upstream. AES-256-GCM encryption happens in the MCP server before anything is uploaded to the storage server.
+- **Flask `$share-bundle`** operation — profiles: `intake` (default, US Core R4 clinical) and `deidentified` (HIPAA Safe Harbor). Feeds the SHL server.
+- **`shl_generate` MCP tool** — step-up gated (Write group); clinical export + Coverage + latest wearable Observations → patient-controlled redaction → encrypted SHL with TTL + revocation → QR PNG to chat/web.
+- **`SHL_SERVER_URL` env** on the MCP server — absent → simulation mode (link generated locally, not persisted).
+- **Zero-knowledge property:** storage server sees only ciphertext + `sha256(auth)`; PHI never leaves the MCP server unencrypted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ Adopted **jmandel/kill-the-clipboard-skill** (MIT, pinned `fa0020d`) as the SHL 
 
 - **Storage server** — Docker Compose service `shl-server` (profile `shl`); exposes port 8000; SQLite at `/data/db.sqlite` (named volume `shl-data`); `SHL_PUBLIC_URL` env sets `BASE_URL`.
 - **MCP client-side crypto** — vendored into `src/ktc/`; keep diffable against upstream. AES-256-GCM encryption happens in the MCP server before anything is uploaded to the storage server.
-- **Flask `$share-bundle`** operation — profiles: `intake` (default, US Core R4 clinical) and `deidentified` (HIPAA Safe Harbor). Feeds the SHL server.
-- **`shl_generate` MCP tool** — step-up gated (Write group); clinical export + Coverage + latest wearable Observations → patient-controlled redaction → encrypted SHL with TTL + revocation → QR PNG to chat/web.
+- **Flask `$share-bundle`** operation — profiles: `intake` (default, US Core R4 clinical; name/DOB/address preserved, SSN-class identifiers and free-text stripped) and `deidentified` (apply_patient_controlled_redaction — preserves birthDate, differs from HIPAA Safe Harbor). Feeds the SHL server.
+- **`shl_generate` MCP tool** — step-up gated (Write group); clinical export + Coverage + Observations (incl. wearable-sourced) → patient-controlled redaction → encrypted SHL with TTL; returns shlink/viewer/manage links. QR-image rendering and link revocation via the manage page on the SHL server are PLANNED.
 - **`SHL_SERVER_URL` env** on the MCP server — absent → simulation mode (link generated locally, not persisted).
 - **Zero-knowledge property:** storage server sees only ciphertext + `sha256(auth)`; PHI never leaves the MCP server unencrypted.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The security layer between AI agents and clinical data. A [healthclaw.io](https://healthclaw.io) open source project.
 
-**v1.5.0** | 597 tests | 19 MCP tools | FHIR R4 US Core v9 + R6 v6.0.0-ballot3 | Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT | Open Wearables | Real-world actions (calls/SMS) | Claude Code plugin
+**v1.5.0** | 597 tests | 20 MCP tools | FHIR R4 US Core v9 + R6 v6.0.0-ballot3 | Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT | Open Wearables | Real-world actions (calls/SMS) | SMART Health Links | Claude Code plugin
 
 > FHIR standardized how health data is structured. MCP standardized how AI connects to tools.
 > Nobody standardized the guardrails in between. This project does.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The security layer between AI agents and clinical data. A [healthclaw.io](https://healthclaw.io) open source project.
 
-**v1.5.0** | 597 tests | 20 MCP tools | FHIR R4 US Core v9 + R6 v6.0.0-ballot3 | Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT | Open Wearables | Real-world actions (calls/SMS) | SMART Health Links | Claude Code plugin
+**v1.5.0** | 614 Python + 65 Node tests | 20 MCP tools | FHIR R4 US Core v9 + R6 v6.0.0-ballot3 | Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT | Open Wearables | Real-world actions (calls/SMS) | SMART Health Links | Claude Code plugin
 
 > FHIR standardized how health data is structured. MCP standardized how AI connects to tools.
 > Nobody standardized the guardrails in between. This project does.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,9 +159,31 @@ services:
     profiles:
       - wearables
 
+  # ─── SMART Health Links storage server (opt-in via `--profile shl`) ───
+  # jmandel/kill-the-clipboard-skill (MIT, pinned fa0020d).
+  # Zero-knowledge: the server stores only ciphertext + sha256(auth) — it
+  # cannot read PHI. MCP does client-side AES-256-GCM before uploading.
+  shl-server:
+    build:
+      context: ./services/shl-server
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - BASE_URL=${SHL_PUBLIC_URL:-http://localhost:8000}
+      - DB_PATH=/data/db.sqlite
+    volumes:
+      - shl-data:/data
+    restart: unless-stopped
+    networks:
+      - fhir-net
+    profiles:
+      - shl
+
 networks:
   fhir-net:
     driver: bridge
 
 volumes:
   wearables-pg-data:
+  shl-data:

--- a/docs/superpowers/specs/2026-06-12-unified-action-layer-design.md
+++ b/docs/superpowers/specs/2026-06-12-unified-action-layer-design.md
@@ -111,6 +111,7 @@ skills stop asking.
 8. **QR share** — `shl_generate`: clinical export + Coverage + latest
    wearable Observations → patient-controlled redaction → encrypted SHL with
    TTL + revocation ("revoke that QR" kills the link) → QR PNG to chat/web.
+   Implemented 2026-06-12 by adopting jmandel/kill-the-clipboard-skill (SHL STU 1, zero-knowledge storage) rather than building bespoke — see CLAUDE.md SMART Health Links section.
 
 ## Action lifecycle
 

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2254,19 +2254,45 @@ def mcp_app_wearables():
 
 # --- $share-bundle Export (SMART Health Link feed) ---
 
+def _intake_strip(res):
+    """Intake profile: identified for clinic check-in (name/DOB/address/telecom
+    preserved) but SSN-class identifiers and clinician free-text never ship."""
+    res.pop('note', None)
+    res.pop('text', None)
+    _SSN_SYSTEMS = ('http://hl7.org/fhir/sid/us-ssn', 'urn:oid:2.16.840.1.113883.4.1')
+    idents = res.get('identifier')
+    if isinstance(idents, list):
+        kept = [i for i in idents if not (isinstance(i, dict) and i.get('system') in _SSN_SYSTEMS)]
+        if kept:
+            res['identifier'] = kept
+        else:
+            res.pop('identifier', None)
+    return res
+
+
 @r6_blueprint.route('/$share-bundle', methods=['POST'])
 def share_bundle():
     """
     Export a patient-controlled FHIR collection Bundle for SMART Health Link
-    generation.  The bundle is IDENTIFIED data released under step-up
-    authorisation with patient-controlled redaction: institutional identifiers
-    and free-text notes are stripped, but name/DOB/clinical codes are
-    preserved so a receiving clinic can intake the record.
+    generation.
+
+    Profiles:
+        intake (default) — identified; name/DOB/address/insurance preserved;
+                           SSN-class identifiers (http://hl7.org/fhir/sid/us-ssn
+                           and urn:oid:2.16.840.1.113883.4.1), narrative text
+                           (text), and free-text notes (note) stripped; meta.tag
+                           stamped intake-identified.
+        deidentified    — apply_patient_controlled_redaction; strips name/
+                          telecom/address/notes, preserves birthDate and clinical
+                          codes, injects healthclaw canonical identifier; stamps
+                          meta.tag patient-controlled.  NOTE: this is
+                          patient-controlled redaction, not HIPAA Safe Harbor
+                          (birthDate is preserved, which Safe Harbor strips).
 
     Body (all optional JSON):
-        patient_id      — if given, restrict to resources whose subject/patient
-                          reference resolves to this patient id, plus the
-                          Patient resource itself.
+        patient_id      — if given, restrict to resources whose subject/patient/
+                          beneficiary reference resolves to this patient id, plus
+                          the Patient resource itself.
         resource_types  — list of FHIR resource types to include; defaults to
                           the SHL intake set.
 
@@ -2344,7 +2370,13 @@ def share_bundle():
                 data = json.loads(row.resource_json)
                 subject = data.get('subject', {}) or {}
                 patient_ref = data.get('patient', {}) or {}
-                ref = subject.get('reference') or patient_ref.get('reference') or ''
+                beneficiary_ref = data.get('beneficiary', {}) or {}
+                ref = (
+                    subject.get('reference')
+                    or patient_ref.get('reference')
+                    or beneficiary_ref.get('reference')
+                    or ''
+                )
                 if ref == f'Patient/{patient_id}':
                     filtered.append(row)
         all_rows = filtered
@@ -2364,9 +2396,9 @@ def share_bundle():
             )
             resource = apply_patient_controlled_redaction(fhir_json, redact_pid)
         else:
-            # intake profile: pass through unredacted; stamp meta.tag so
-            # receivers know this is an identified share.
-            resource = fhir_json
+            # intake profile: strip SSN-class identifiers and free-text, then
+            # stamp meta.tag so receivers know this is an identified share.
+            resource = _intake_strip(fhir_json)
             meta = resource.setdefault('meta', {})
             tags = meta.setdefault('tag', [])
             intake_tag = {
@@ -2377,6 +2409,12 @@ def share_bundle():
                 tags.append(intake_tag)
         entries.append({'resource': resource})
         type_set.add(row.resource_type)
+
+    # Detect multi-patient tenant when no patient_id filter was applied
+    patient_rows = [r for r in all_rows if r.resource_type == 'Patient']
+    multi_patient_note = ''
+    if not patient_id and len(patient_rows) > 1:
+        multi_patient_note = ' [multi-patient tenant, no patient filter]'
 
     bundle = {
         'resourceType': 'Bundle',
@@ -2393,7 +2431,7 @@ def share_bundle():
         tenant_id=tenant_id,
         detail=(
             f'share-bundle export (profile={profile}): {len(entries)} resources '
-            f'across {len(type_set)} type(s)'
+            f'across {len(type_set)} type(s){multi_patient_note}'
         ),
     )
 

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2252,6 +2252,133 @@ def mcp_app_wearables():
     return resp
 
 
+# --- $share-bundle Export (SMART Health Link feed) ---
+
+@r6_blueprint.route('/$share-bundle', methods=['POST'])
+def share_bundle():
+    """
+    Export a patient-controlled FHIR collection Bundle for SMART Health Link
+    generation.  The bundle is IDENTIFIED data released under step-up
+    authorisation with patient-controlled redaction: institutional identifiers
+    and free-text notes are stripped, but name/DOB/clinical codes are
+    preserved so a receiving clinic can intake the record.
+
+    Body (all optional JSON):
+        patient_id      — if given, restrict to resources whose subject/patient
+                          reference resolves to this patient id, plus the
+                          Patient resource itself.
+        resource_types  — list of FHIR resource types to include; defaults to
+                          the SHL intake set.
+
+    Returns: application/fhir+json  Bundle{type:collection}
+    """
+    DEFAULT_TYPES = [
+        'Patient', 'Condition', 'AllergyIntolerance',
+        'MedicationRequest', 'Immunization', 'Observation', 'Coverage',
+    ]
+
+    tenant_id = request.headers.get('X-Tenant-Id')
+
+    # Step-up required — this bundle carries identified patient data
+    step_up_token = request.headers.get('X-Step-Up-Token')
+    if not step_up_token:
+        return _operation_outcome(
+            'error', 'security',
+            '$share-bundle requires X-Step-Up-Token header'
+        ), 401
+
+    valid, err = validate_step_up_token(step_up_token, tenant_id)
+    if not valid:
+        return _operation_outcome(
+            'error', 'security',
+            f'Step-up token rejected: {err}'
+        ), 401
+
+    body = request.get_json(silent=True) or {}
+    patient_id = body.get('patient_id') or None
+    requested_types = body.get('resource_types')
+
+    if requested_types is None:
+        resource_types = list(DEFAULT_TYPES)
+    else:
+        if not isinstance(requested_types, list):
+            return _operation_outcome(
+                'error', 'invalid',
+                'resource_types must be a JSON array'
+            ), 400
+        unknown = [t for t in requested_types if t not in R6Resource.SUPPORTED_TYPES]
+        if unknown:
+            return _operation_outcome(
+                'error', 'not-supported',
+                f'Unknown resource type(s): {", ".join(unknown)}'
+            ), 400
+        resource_types = list(requested_types)
+
+    # Query resources for this tenant
+    query = R6Resource.query.filter(
+        R6Resource.tenant_id == tenant_id,
+        R6Resource.is_deleted == False,  # noqa: E712
+        R6Resource.resource_type.in_(resource_types),
+    )
+
+    all_rows = query.all()
+
+    # Apply patient filter when patient_id is supplied
+    if patient_id:
+        filtered = []
+        for row in all_rows:
+            if row.resource_type == 'Patient':
+                # Include the Patient resource whose stored id matches
+                data = json.loads(row.resource_json)
+                if data.get('id') == patient_id or row.id == patient_id:
+                    filtered.append(row)
+            else:
+                data = json.loads(row.resource_json)
+                subject = data.get('subject', {}) or {}
+                patient_ref = data.get('patient', {}) or {}
+                ref = subject.get('reference') or patient_ref.get('reference') or ''
+                if ref == f'Patient/{patient_id}':
+                    filtered.append(row)
+        all_rows = filtered
+
+    # Apply patient-controlled redaction to every resource
+    entries = []
+    type_set = set()
+    for row in all_rows:
+        fhir_json = row.to_fhir_json()
+        # Determine the patient_id to pass to redaction; for Patient resources
+        # the resource itself is the patient.
+        redact_pid = patient_id or fhir_json.get('id') if row.resource_type == 'Patient' else patient_id or ''
+        redacted = apply_patient_controlled_redaction(fhir_json, redact_pid)
+        entries.append({'resource': redacted})
+        type_set.add(row.resource_type)
+
+    bundle = {
+        'resourceType': 'Bundle',
+        'type': 'collection',
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+        'entry': entries,
+    }
+
+    record_audit_event(
+        'read',
+        resource_type='Bundle',
+        resource_id='share-bundle',
+        agent_id=request.headers.get('X-Agent-Id'),
+        tenant_id=tenant_id,
+        detail=(
+            f'share-bundle export: {len(entries)} resources '
+            f'across {len(type_set)} type(s)'
+        ),
+    )
+
+    return Response(
+        json.dumps(bundle),
+        status=200,
+        mimetype='application/fhir+json',
+    )
+
+
 # --- Helper Functions ---
 
 def _operation_outcome(severity, code, diagnostics):

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2297,6 +2297,14 @@ def share_bundle():
     body = request.get_json(silent=True) or {}
     patient_id = body.get('patient_id') or None
     requested_types = body.get('resource_types')
+    profile = body.get('profile', 'intake')
+
+    VALID_PROFILES = ('intake', 'deidentified')
+    if profile not in VALID_PROFILES:
+        return _operation_outcome(
+            'error', 'invalid',
+            f'Invalid profile "{profile}". Valid values: {", ".join(VALID_PROFILES)}'
+        ), 400
 
     if requested_types is None:
         resource_types = list(DEFAULT_TYPES)
@@ -2341,16 +2349,33 @@ def share_bundle():
                     filtered.append(row)
         all_rows = filtered
 
-    # Apply patient-controlled redaction to every resource
+    # Apply profile-appropriate handling to every resource
     entries = []
     type_set = set()
     for row in all_rows:
         fhir_json = row.to_fhir_json()
-        # Determine the patient_id to pass to redaction; for Patient resources
-        # the resource itself is the patient.
-        redact_pid = patient_id or fhir_json.get('id') if row.resource_type == 'Patient' else patient_id or ''
-        redacted = apply_patient_controlled_redaction(fhir_json, redact_pid)
-        entries.append({'resource': redacted})
+        if profile == 'deidentified':
+            # Determine the patient_id to pass to redaction; for Patient resources
+            # the resource itself is the patient.
+            redact_pid = (
+                (patient_id or fhir_json.get('id'))
+                if row.resource_type == 'Patient'
+                else (patient_id or '')
+            )
+            resource = apply_patient_controlled_redaction(fhir_json, redact_pid)
+        else:
+            # intake profile: pass through unredacted; stamp meta.tag so
+            # receivers know this is an identified share.
+            resource = fhir_json
+            meta = resource.setdefault('meta', {})
+            tags = meta.setdefault('tag', [])
+            intake_tag = {
+                'system': 'https://healthclaw.io/share-profile',
+                'code': 'intake-identified',
+            }
+            if intake_tag not in tags:
+                tags.append(intake_tag)
+        entries.append({'resource': resource})
         type_set.add(row.resource_type)
 
     bundle = {
@@ -2367,7 +2392,7 @@ def share_bundle():
         agent_id=request.headers.get('X-Agent-Id'),
         tenant_id=tenant_id,
         detail=(
-            f'share-bundle export: {len(entries)} resources '
+            f'share-bundle export (profile={profile}): {len(entries)} resources '
             f'across {len(type_set)} type(s)'
         ),
     )

--- a/services/agent-orchestrator/src/ktc/encoding.ts
+++ b/services/agent-orchestrator/src/ktc/encoding.ts
@@ -1,0 +1,23 @@
+// Vendored from https://github.com/jmandel/kill-the-clipboard-skill
+// @ fa0020dcc03e5daa2470462c404a1e69c637b474 (MIT). Local changes: import-extension
+// adjustments only — keep diffable against upstream.
+
+// base64url helpers shared by every component (server, app, skill scripts).
+
+export function b64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+export function b64urlDecode(s: string): Uint8Array {
+  const b64 = s.replaceAll('-', '+').replaceAll('_', '/');
+  const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
+  const bin = atob(b64 + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+export const utf8Decode = (b: Uint8Array): string => new TextDecoder().decode(b);

--- a/services/agent-orchestrator/src/ktc/hkdf.ts
+++ b/services/agent-orchestrator/src/ktc/hkdf.ts
@@ -1,0 +1,45 @@
+// Vendored from https://github.com/jmandel/kill-the-clipboard-skill
+// @ fa0020dcc03e5daa2470462c404a1e69c637b474 (MIT). Local changes: import-extension
+// adjustments only — keep diffable against upstream.
+
+// Capability derivation (docs/DESIGN.md §3).
+//
+// One 32-byte owner master secret M. Two one-way derivations:
+//   auth = HKDF-SHA256(M, info="ktc-shl/v1/auth")  → control capability, registered with server
+//   key  = HKDF-SHA256(M, info="ktc-shl/v1/key")   → SHL encryption key, never leaves the client
+// Empty salt; 32-byte outputs; base64url encoding (43 chars).
+
+import { b64url, utf8 } from './encoding';
+
+export const INFO_AUTH = 'ktc-shl/v1/auth';
+export const INFO_KEY = 'ktc-shl/v1/key';
+
+export function generateMasterSecret(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(32));
+}
+
+export async function hkdf(ikm: Uint8Array, info: string, length = 32): Promise<Uint8Array> {
+  const keyMaterial = await crypto.subtle.importKey('raw', ikm as BufferSource, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: utf8(info) as BufferSource },
+    keyMaterial,
+    length * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+/** Control capability presented to the server (server stores only its sha256). */
+export async function deriveAuth(m: Uint8Array): Promise<string> {
+  return b64url(await hkdf(m, INFO_AUTH));
+}
+
+/** SHL encryption key (the `key` field of the shlink payload). */
+export async function deriveKey(m: Uint8Array): Promise<string> {
+  return b64url(await hkdf(m, INFO_KEY));
+}
+
+/** What the server stores for lookup: sha256(auth), hex. */
+export async function authHash(auth: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', utf8(auth) as BufferSource);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/services/agent-orchestrator/src/ktc/jwe.ts
+++ b/services/agent-orchestrator/src/ktc/jwe.ts
@@ -1,0 +1,90 @@
+// Vendored from https://github.com/jmandel/kill-the-clipboard-skill
+// @ fa0020dcc03e5daa2470462c404a1e69c637b474 (MIT). Local changes: import-extension
+// adjustments only — keep diffable against upstream.
+
+// JWE compact serialization for SHL files (base spec: alg "dir", enc "A256GCM";
+// optional zip "DEF" = raw DEFLATE before encryption). Hand-rolled on WebCrypto so the
+// skill zip carries no crypto dependency; cross-checked against `jose` in dev tests only.
+//
+// Compact form with direct key agreement: <protected>..<iv>.<ciphertext>.<tag>
+// (encrypted-key segment is empty). AAD = ASCII bytes of the protected header segment.
+// The same key is reused across files/updates of one SHL → a fresh random IV per
+// encryption operation is mandatory (spec SHALL).
+
+import { b64url, b64urlDecode, utf8, utf8Decode } from './encoding';
+
+export interface JweHeader {
+  alg: 'dir';
+  enc: 'A256GCM';
+  cty?: string;
+  zip?: 'DEF';
+  [k: string]: unknown;
+}
+
+async function importKey(keyB64url: string): Promise<CryptoKey> {
+  const raw = b64urlDecode(keyB64url);
+  if (raw.length !== 32) throw new Error(`SHL key must be 32 bytes (got ${raw.length})`);
+  return crypto.subtle.importKey('raw', raw as BufferSource, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+async function pipe(data: Uint8Array, stream: CompressionStream | DecompressionStream): Promise<Uint8Array> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const out = await new Response(new Blob([data as any]).stream().pipeThrough(stream as any)).arrayBuffer();
+  return new Uint8Array(out);
+}
+
+export async function encryptJWE(
+  plaintext: Uint8Array,
+  keyB64url: string,
+  opts: { cty?: string; deflate?: boolean } = {},
+): Promise<string> {
+  const header: JweHeader = { alg: 'dir', enc: 'A256GCM' };
+  if (opts.cty) header.cty = opts.cty;
+  let body = plaintext;
+  if (opts.deflate) {
+    header.zip = 'DEF';
+    body = await pipe(plaintext, new CompressionStream('deflate-raw'));
+  }
+  const protectedB64 = b64url(utf8(JSON.stringify(header)));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await importKey(keyB64url);
+  const sealed = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource, additionalData: utf8(protectedB64) as BufferSource, tagLength: 128 },
+      key,
+      body as BufferSource,
+    ),
+  );
+  const ct = sealed.slice(0, -16);
+  const tag = sealed.slice(-16);
+  return `${protectedB64}..${b64url(iv)}.${b64url(ct)}.${b64url(tag)}`;
+}
+
+export async function decryptJWE(
+  jwe: string,
+  keyB64url: string,
+): Promise<{ plaintext: Uint8Array; header: JweHeader }> {
+  const parts = jwe.trim().split('.');
+  if (parts.length !== 5) throw new Error('not a compact JWE (expected 5 segments)');
+  const [protectedB64, encKey, ivB64, ctB64, tagB64] = parts as [string, string, string, string, string];
+  if (encKey !== '') throw new Error('expected empty encrypted-key segment (alg dir)');
+  const header = JSON.parse(utf8Decode(b64urlDecode(protectedB64))) as JweHeader;
+  if (header.alg !== 'dir' || header.enc !== 'A256GCM') {
+    throw new Error(`unsupported JWE alg/enc: ${header.alg}/${header.enc}`);
+  }
+  const key = await importKey(keyB64url);
+  const ct = b64urlDecode(ctB64);
+  const tag = b64urlDecode(tagB64);
+  const sealed = new Uint8Array(ct.length + tag.length);
+  sealed.set(ct);
+  sealed.set(tag, ct.length);
+  let plaintext: Uint8Array = new Uint8Array(
+    await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: b64urlDecode(ivB64) as BufferSource, additionalData: utf8(protectedB64) as BufferSource, tagLength: 128 },
+      key,
+      sealed as BufferSource,
+    ),
+  );
+  if (header.zip === 'DEF') plaintext = await pipe(plaintext, new DecompressionStream('deflate-raw'));
+  return { plaintext, header };
+}

--- a/services/agent-orchestrator/src/ktc/ktc.test.ts
+++ b/services/agent-orchestrator/src/ktc/ktc.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Crypto round-trip tests for the vendored kill-the-clipboard crypto lib.
+ */
+
+import { encryptJWE, decryptJWE } from "./jwe";
+import { deriveAuth, deriveKey, generateMasterSecret } from "./hkdf";
+import { utf8, utf8Decode } from "./encoding";
+
+describe("ktc crypto round-trip", () => {
+  it("encryptJWE then decryptJWE returns original bytes", async () => {
+    const M = generateMasterSecret();
+    const key = await deriveKey(M);
+
+    const originalText = "Hello, SMART Health Link!";
+    const plaintext = utf8(originalText);
+
+    const jwe = await encryptJWE(plaintext, key);
+    const { plaintext: decrypted } = await decryptJWE(jwe, key);
+
+    expect(utf8Decode(decrypted)).toBe(originalText);
+  });
+
+  it("encryptJWE with deflate round-trips correctly", async () => {
+    const M = generateMasterSecret();
+    const key = await deriveKey(M);
+
+    const originalText = JSON.stringify({ resourceType: "Bundle", type: "collection", entry: [] });
+    const plaintext = utf8(originalText);
+
+    const jwe = await encryptJWE(plaintext, key, { cty: "application/fhir+json", deflate: true });
+
+    // JWE must be 5 segments
+    expect(jwe.split(".").length).toBe(5);
+
+    const { plaintext: decrypted, header } = await decryptJWE(jwe, key);
+    expect(utf8Decode(decrypted)).toBe(originalText);
+    expect(header.zip).toBe("DEF");
+    expect(header.cty).toBe("application/fhir+json");
+  });
+
+  it("JWE compact serialization has exactly 5 segments (dir alg with empty encrypted-key slot)", async () => {
+    const M = generateMasterSecret();
+    const key = await deriveKey(M);
+
+    const jwe = await encryptJWE(utf8("test payload"), key);
+    const segments = jwe.split(".");
+    expect(segments.length).toBe(5);
+    // segment[1] is the empty encrypted-key slot for alg=dir
+    expect(segments[1]).toBe("");
+  });
+
+  it("deriveAuth and deriveKey produce different 43-char base64url outputs from the same M", async () => {
+    const M = generateMasterSecret();
+
+    const auth = await deriveAuth(M);
+    const key = await deriveKey(M);
+
+    // Both should be 43 chars (256 bits in base64url without padding)
+    expect(auth.length).toBe(43);
+    expect(key.length).toBe(43);
+
+    // They must be different
+    expect(auth).not.toBe(key);
+
+    // Must be valid base64url (no +, /, or =)
+    expect(auth).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("deriveAuth and deriveKey are deterministic for the same M", async () => {
+    const M = new Uint8Array(32).fill(42); // fixed M for determinism
+
+    const auth1 = await deriveAuth(M);
+    const auth2 = await deriveAuth(M);
+    const key1 = await deriveKey(M);
+    const key2 = await deriveKey(M);
+
+    expect(auth1).toBe(auth2);
+    expect(key1).toBe(key2);
+  });
+
+  it("different M values produce different auth and key", async () => {
+    const M1 = generateMasterSecret();
+    const M2 = generateMasterSecret();
+
+    const auth1 = await deriveAuth(M1);
+    const auth2 = await deriveAuth(M2);
+    const key1 = await deriveKey(M1);
+    const key2 = await deriveKey(M2);
+
+    expect(auth1).not.toBe(auth2);
+    expect(key1).not.toBe(key2);
+  });
+});

--- a/services/agent-orchestrator/src/ktc/shlink.ts
+++ b/services/agent-orchestrator/src/ktc/shlink.ts
@@ -1,0 +1,69 @@
+// Vendored from https://github.com/jmandel/kill-the-clipboard-skill
+// @ fa0020dcc03e5daa2470462c404a1e69c637b474 (MIT). Local changes: import-extension
+// adjustments only — keep diffable against upstream.
+
+// SHLink payload construction/parsing (base spec) + owner-link fragments (docs/DESIGN.md §3).
+
+import { b64url, b64urlDecode, utf8, utf8Decode } from './encoding';
+
+export interface ShlinkPayload {
+  url: string;
+  key: string;
+  exp?: number; // Epoch SECONDS (KTC profile: required)
+  flag?: string; // single chars, alphabetical order: L, P, U
+  label?: string; // ≤80 chars
+  v?: number;
+  [k: string]: unknown;
+}
+
+export function buildShlink(p: ShlinkPayload): string {
+  if (p.url.length > 128) throw new Error(`payload url exceeds 128 chars (${p.url.length})`);
+  if (b64urlDecode(p.key).length !== 32) throw new Error('key must decode to 32 bytes');
+  if (p.label !== undefined && p.label.length > 80) throw new Error(`label exceeds 80 chars (${p.label.length})`);
+  if (p.flag !== undefined) {
+    if (p.flag.includes('U') && p.flag.includes('P')) throw new Error('flags U and P cannot be combined');
+    const sorted = [...p.flag].sort().join('');
+    if (sorted !== p.flag) throw new Error(`flags must be in alphabetical order ("${sorted}", not "${p.flag}")`);
+  }
+  return 'shlink:/' + b64url(utf8(JSON.stringify(p)));
+}
+
+/** Accepts a bare `shlink:/...` or a viewer-prefixed `https://...#shlink:/...`. */
+export function parseShlink(s: string): ShlinkPayload {
+  const m = s.trim().match(/shlink:\/(.+)$/);
+  if (!m?.[1]) throw new Error('not a shlink');
+  const payload = JSON.parse(utf8Decode(b64urlDecode(m[1]))) as ShlinkPayload;
+  if (typeof payload.url !== 'string' || typeof payload.key !== 'string') {
+    throw new Error('shlink payload missing url/key');
+  }
+  return payload;
+}
+
+// --- Handoff-page fragments ------------------------------------------------------------
+// Owner page:  <base>/m#<base64url(M)>            (43-char token → manage + reconstruct QR)
+// Viewer page: <base>/v#shlink:/...               (standard SHL viewer-prefix convention)
+// The app routes by fragment shape, so /s remains a working legacy alias server-side.
+
+export function buildOwnerLink(baseUrl: string, masterSecret: Uint8Array): string {
+  return `${baseUrl.replace(/\/$/, '')}/m#${b64url(masterSecret)}`;
+}
+
+export function buildViewerLink(baseUrl: string, shlink: string): string {
+  return `${baseUrl.replace(/\/$/, '')}/v#${shlink}`;
+}
+
+export type FragmentParse =
+  | { mode: 'owner'; masterSecret: Uint8Array; api?: string }
+  | { mode: 'viewer'; payload: ShlinkPayload };
+
+/** Parse a handoff-page fragment (without leading '#'). */
+export function parseFragment(fragment: string): FragmentParse {
+  const frag = fragment.replace(/^#/, '');
+  if (frag.includes('shlink:/')) return { mode: 'viewer', payload: parseShlink(frag) };
+  const params = frag.includes('&') ? frag.split('&') : [frag];
+  const token = params[0] ?? '';
+  const api = params.slice(1).find((p) => p.startsWith('api='))?.slice(4);
+  const masterSecret = b64urlDecode(token);
+  if (masterSecret.length !== 32) throw new Error('owner token must decode to 32 bytes');
+  return { mode: 'owner', masterSecret, ...(api ? { api: decodeURIComponent(api) } : {}) };
+}

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -59,6 +59,7 @@ const EXPECTED_TOOL_NAMES = [
   "fhir_stats",
   "fhir_subscription_topics",
   "fhir_validate",
+  "shl_generate",
   "wearables_sync_status",
 ];
 
@@ -90,8 +91,8 @@ describe("Tool Schema Tests", () => {
     schemas = tools.getMCPToolSchemas();
   });
 
-  it("getMCPToolSchemas() returns exactly 19 tools", () => {
-    expect(schemas).toHaveLength(19);
+  it("getMCPToolSchemas() returns exactly 20 tools", () => {
+    expect(schemas).toHaveLength(20);
   });
 
   it("every tool has required MCP fields: name, description, inputSchema, annotations", () => {
@@ -110,7 +111,7 @@ describe("Tool Schema Tests", () => {
     }
   });
 
-  it("all 19 tool names match the expected set", () => {
+  it("all 20 tool names match the expected set", () => {
     const actualNames = schemas.map((t) => t.name).sort();
     expect(actualNames).toEqual(EXPECTED_TOOL_NAMES);
   });
@@ -707,6 +708,118 @@ describe("Tool Execution Tests", () => {
     expect(url).not.toContain("/commit");
     expect(result).toEqual(statusBody);
   });
+
+  // -- shl_generate --
+
+  it("shl_generate without step-up token returns requires_step_up (no fetch made)", async () => {
+    const result = await tools.executeTool(
+      "shl_generate",
+      { label: "Test Clinic" },
+      {} // no step-up token
+    );
+
+    expect(result).toHaveProperty("error", "Step-up authorization required");
+    expect(result).toHaveProperty("requires_step_up", true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("shl_generate simulation mode: SHL_SERVER_URL unset → simulated: true, no second fetch", async () => {
+    const prevShl = process.env.SHL_SERVER_URL;
+    delete process.env.SHL_SERVER_URL;
+
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [{ resource: { resourceType: "Patient" } }, { resource: { resourceType: "Observation" } }],
+    };
+    mockFetch.mockResolvedValueOnce(fakeResponse(bundle));
+
+    try {
+      const result = await tools.executeTool(
+        "shl_generate",
+        { label: "Clinic Visit", profile: "intake" },
+        { "x-step-up-token": "valid-token-abc", "x-tenant-id": "tenant-xyz" }
+      );
+
+      // Only the share-bundle fetch should have been made (not SHL server)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain("$share-bundle");
+
+      expect(result).toHaveProperty("simulated", true);
+      expect(result).toHaveProperty("shlink", "shlink:/SIMULATED");
+      expect(result).toHaveProperty("resource_count", 2);
+      expect((result.note as string)).toContain("2 resources");
+    } finally {
+      if (prevShl !== undefined) process.env.SHL_SERVER_URL = prevShl;
+    }
+  });
+
+  it("shl_generate real mode: creates shlink with correct structure, manage_link, and JWE upload", async () => {
+    const prevShl = process.env.SHL_SERVER_URL;
+    process.env.SHL_SERVER_URL = "http://shl.test";
+
+    const bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: [{ resource: { resourceType: "Patient" } }],
+    };
+    const linkData = { id: "abc", url: "http://shl.test/shl/abc" };
+    const fileData = { fileId: "f1" };
+
+    mockFetch
+      .mockResolvedValueOnce(fakeResponse(bundle))          // share-bundle
+      .mockResolvedValueOnce(fakeResponse(linkData))        // POST /api/links
+      .mockResolvedValueOnce(fakeResponse(fileData));       // POST /api/manage/files
+
+    try {
+      const result = await tools.executeTool(
+        "shl_generate",
+        { label: "Records for Winters Healthcare", expires_in_days: 14 },
+        { "x-step-up-token": "valid-token-abc", "x-tenant-id": "tenant-xyz" }
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      // Verify /api/links call had Bearer auth
+      const [linksUrl, linksOpts] = mockFetch.mock.calls[1];
+      expect(linksUrl).toContain("/api/links");
+      expect((linksOpts.headers as Record<string, string>)["Authorization"]).toMatch(/^Bearer /);
+
+      // Verify /api/manage/files POST body is a 5-segment JWE
+      const [filesUrl, filesOpts] = mockFetch.mock.calls[2];
+      expect(filesUrl).toContain("/api/manage/files");
+      const jweBody = filesOpts.body as string;
+      expect(jweBody.split(".").length).toBe(5);
+      expect((filesOpts.headers as Record<string, string>)["Content-Type"]).toBe("application/jose");
+
+      // Verify returned shlink parses with correct url and flag
+      expect(result).not.toHaveProperty("error");
+      const shlink = result.shlink as string;
+      expect(typeof shlink).toBe("string");
+      expect(shlink).toMatch(/^shlink:\//);
+
+      // Parse the shlink and verify fields
+      const { parseShlink } = await import("./ktc/shlink");
+      const parsed = parseShlink(shlink);
+      expect(parsed.url).toBe("http://shl.test/shl/abc");
+      expect(parsed.flag).toBe("U");
+      expect(typeof parsed.key).toBe("string");
+      expect(parsed.key.length).toBeGreaterThan(0);
+
+      // manage_link starts with base URL + /m#
+      const manageLink = result.manage_link as string;
+      expect(manageLink).toMatch(/^http:\/\/shl\.test\/m#/);
+
+      // viewer_link contains the shlink
+      expect(result.viewer_link as string).toContain(shlink);
+
+      expect(result.resource_count).toBe(1);
+    } finally {
+      if (prevShl !== undefined) process.env.SHL_SERVER_URL = prevShl;
+      else delete process.env.SHL_SERVER_URL;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -775,14 +888,14 @@ describe("Express App Tests", () => {
       expect(sessionId.length).toBeGreaterThan(0);
     });
 
-    it("tools/list returns all 19 tool schemas", async () => {
+    it("tools/list returns all 20 tool schemas", async () => {
       const res = await request(app)
         .post("/mcp")
         .send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
 
       expect(res.status).toBe(200);
       expect(res.body.result).toBeDefined();
-      expect(res.body.result.tools).toHaveLength(19);
+      expect(res.body.result.tools).toHaveLength(20);
 
       const names = new Set<string>(
         res.body.result.tools.map((t: { name: string }) => t.name)
@@ -957,13 +1070,13 @@ describe("Express App Tests", () => {
   // -- Legacy HTTP Bridge /mcp/rpc --
 
   describe("POST /mcp/rpc", () => {
-    it("tools/list returns all 19 tool schemas", async () => {
+    it("tools/list returns all 20 tool schemas", async () => {
       const res = await request(app)
         .post("/mcp/rpc")
         .send({ jsonrpc: "2.0", id: 1, method: "tools/list" });
 
       expect(res.status).toBe(200);
-      expect(res.body.result.tools).toHaveLength(19);
+      expect(res.body.result.tools).toHaveLength(20);
     });
 
     it("tools/call executes the tool and returns result directly (not wrapped)", async () => {

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -21,7 +21,7 @@
  */
 
 import fetch from "node-fetch";
-import { deriveAuth, deriveKey } from "./ktc/hkdf";
+import { generateMasterSecret, deriveAuth, deriveKey } from "./ktc/hkdf";
 import { encryptJWE } from "./ktc/jwe";
 import { buildShlink, buildOwnerLink, buildViewerLink } from "./ktc/shlink";
 import { utf8 } from "./ktc/encoding";
@@ -1429,7 +1429,7 @@ export class FHIRTools {
     }
 
     // Step 3: Generate master secret, derive auth + key
-    const M = crypto.getRandomValues(new Uint8Array(32));
+    const M = generateMasterSecret();
     const auth = await deriveAuth(M);
     const key = await deriveKey(M);
     const nowSeconds = Math.floor(Date.now() / 1000);

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -21,6 +21,10 @@
  */
 
 import fetch from "node-fetch";
+import { deriveAuth, deriveKey } from "./ktc/hkdf";
+import { encryptJWE } from "./ktc/jwe";
+import { buildShlink, buildOwnerLink, buildViewerLink } from "./ktc/shlink";
+import { utf8 } from "./ktc/encoding";
 
 export type ToolTier = "read" | "write";
 
@@ -551,6 +555,23 @@ export class FHIRTools {
           required: ["action_id"],
         },
       },
+      {
+        name: "shl_generate",
+        description:
+          "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — pass _stepUpToken), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
+        tier: "write",
+        annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            label: { type: "string", description: "Short label shown in SHL viewers (<=80 chars), e.g. 'Records for Winters Healthcare'. No PHI beyond what the patient approves." },
+            expires_in_days: { type: "number", description: "Link lifetime in days (default 7, max 90)" },
+            profile: { type: "string", enum: ["intake", "deidentified"], description: "intake = identified record for clinic check-in (default); deidentified = strips name/contact/institutional IDs" },
+            patient_id: { type: "string", description: "Optional patient id filter for multi-patient tenants" },
+          },
+          required: [],
+        },
+      },
     ];
   }
 
@@ -564,8 +585,8 @@ export class FHIRTools {
       return { error: `Unknown tool: ${toolName}` };
     }
 
-    // Enforce step-up for commit_write and action_commit
-    if (tool.tier === "write" && (toolName === "fhir_commit_write" || toolName === "action_commit")) {
+    // Enforce step-up for commit_write, action_commit, and shl_generate (releases full record)
+    if (tool.tier === "write" && (toolName === "fhir_commit_write" || toolName === "action_commit" || toolName === "shl_generate")) {
       const stepUpToken = headers?.["x-step-up-token"];
       if (!stepUpToken) {
         return {
@@ -740,6 +761,9 @@ export class FHIRTools {
 
       case "action_status":
         return this.getActionStatus(input.action_id as string, fwdHeaders);
+
+      case "shl_generate":
+        return this.generateShl(input, fwdHeaders);
 
       default:
         return { error: `Unimplemented tool: ${toolName}` };
@@ -1352,5 +1376,128 @@ export class FHIRTools {
       return { error: `action_status failed with status ${resp.status}`, detail };
     }
     return (await resp.json()) as Record<string, unknown>;
+  }
+
+  // --- SMART Health Links (SHL) ---
+
+  private async generateShl(
+    input: Record<string, unknown>,
+    headers: Record<string, string>
+  ): Promise<Record<string, unknown>> {
+    const root = this.serverRoot();
+    const profile = (input.profile as string | undefined) || "intake";
+    const patientId = input.patient_id as string | undefined;
+    const rawDays = typeof input.expires_in_days === "number" ? input.expires_in_days : 7;
+    const days = Math.min(Math.max(1, Math.round(rawDays)), 90);
+    const label = typeof input.label === "string" ? input.label.slice(0, 80) : undefined;
+
+    // Step 1: Fetch the guardrailed share-bundle from Flask
+    const bundleResp = await fetch(`${root}/r6/fhir/$share-bundle`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(profile !== "intake" ? { profile } : {}),
+        ...(patientId ? { patient_id: patientId } : {}),
+      }),
+    });
+
+    if (!bundleResp.ok) {
+      let detail: unknown = null;
+      try { detail = await bundleResp.json(); } catch {
+        try { detail = await bundleResp.text(); } catch { detail = null; }
+      }
+      const result: Record<string, unknown> = {
+        error: `share-bundle fetch failed with status ${bundleResp.status}`,
+        detail,
+      };
+      if (bundleResp.status === 401) result.requires_step_up = true;
+      return result;
+    }
+
+    const bundle = (await bundleResp.json()) as Record<string, unknown>;
+    const resourceCount = (bundle.entry as unknown[] | undefined)?.length ?? 0;
+
+    // Step 2: Simulation mode — SHL_SERVER_URL not configured
+    const SHL_BASE = process.env.SHL_SERVER_URL;
+    if (!SHL_BASE) {
+      return {
+        simulated: true,
+        shlink: "shlink:/SIMULATED",
+        note: `SHL_SERVER_URL not configured — returned stub. Bundle contained ${resourceCount} resources.`,
+        resource_count: resourceCount,
+      };
+    }
+
+    // Step 3: Generate master secret, derive auth + key
+    const M = crypto.getRandomValues(new Uint8Array(32));
+    const auth = await deriveAuth(M);
+    const key = await deriveKey(M);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const exp = nowSeconds + days * 86400;
+
+    // Step 4: Create the SHL link on the server
+    const createLinkResp = await fetch(`${SHL_BASE}/api/links`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${auth}`,
+      },
+      body: JSON.stringify({ flag: "U", exp }),
+    });
+
+    if (!createLinkResp.ok) {
+      let detail: unknown = null;
+      try { detail = await createLinkResp.json(); } catch {
+        try { detail = await createLinkResp.text(); } catch { detail = null; }
+      }
+      return { error: `SHL /api/links failed with status ${createLinkResp.status}`, detail };
+    }
+
+    const linkData = (await createLinkResp.json()) as { id: string; url: string };
+
+    // Step 5: Encrypt the bundle and upload ciphertext
+    const jwe = await encryptJWE(
+      utf8(JSON.stringify(bundle)),
+      key,
+      { cty: "application/fhir+json", deflate: true }
+    );
+
+    const uploadResp = await fetch(`${SHL_BASE}/api/manage/files`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/jose",
+        "Authorization": `Bearer ${auth}`,
+      },
+      body: jwe,
+    });
+
+    if (!uploadResp.ok) {
+      let detail: unknown = null;
+      try { detail = await uploadResp.json(); } catch {
+        try { detail = await uploadResp.text(); } catch { detail = null; }
+      }
+      return { error: `SHL /api/manage/files failed with status ${uploadResp.status}`, detail };
+    }
+
+    // Step 6: Build the shlink URI
+    const shlink = buildShlink({
+      url: linkData.url,
+      key,
+      exp,
+      flag: "U",
+      ...(label ? { label } : {}),
+      v: 1,
+    });
+
+    // Step 7: Return result — NEVER log or persist M, key, or auth
+    const expiresAt = new Date(exp * 1000).toISOString();
+    return {
+      shlink,
+      viewer_link: buildViewerLink(SHL_BASE, shlink),
+      manage_link: buildOwnerLink(SHL_BASE, M),
+      expires_at: expiresAt,
+      resource_count: resourceCount,
+      _mcp_summary: `SMART Health Link created (expires ${expiresAt}). Give the manage link ONLY to the patient.`,
+    };
   }
 }

--- a/services/agent-orchestrator/tsconfig.json
+++ b/services/agent-orchestrator/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2022", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/services/shl-server/Dockerfile
+++ b/services/shl-server/Dockerfile
@@ -1,0 +1,12 @@
+# SMART Health Links storage server — jmandel/kill-the-clipboard-skill (MIT)
+# Pinned to a reviewed SHA; the server stores only ciphertext + hashed auth
+# capabilities (zero-knowledge: it can never read PHI).
+FROM oven/bun:1.2
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
+ARG KTC_SHA=fa0020dcc03e5daa2470462c404a1e69c637b474
+RUN git clone https://github.com/jmandel/kill-the-clipboard-skill /app \
+    && cd /app && git checkout "$KTC_SHA"
+WORKDIR /app
+RUN bun install --frozen-lockfile
+EXPOSE 8000
+CMD ["bun", "run", "server/src/index.ts"]

--- a/tests/test_share_bundle.py
+++ b/tests/test_share_bundle.py
@@ -118,13 +118,13 @@ def test_share_bundle_returns_collection(client, auth_headers, app):
 
 
 def test_share_bundle_patient_controlled_redaction_applied(client, auth_headers, app):
-    """Patient-controlled redaction: name/telecom/address removed, birthDate preserved."""
+    """Deidentified profile: name/telecom/address removed, birthDate preserved."""
     _seed_resource(app, 'Patient', PATIENT_RESOURCE)
 
     resp = client.post(
         '/r6/fhir/$share-bundle',
         headers=auth_headers,
-        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient']},
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient'], 'profile': 'deidentified'},
     )
     assert resp.status_code == 200
     bundle = json.loads(resp.data)
@@ -144,6 +144,44 @@ def test_share_bundle_patient_controlled_redaction_applied(client, auth_headers,
     tags = patient.get('meta', {}).get('tag', [])
     codes = {t.get('code') for t in tags}
     assert 'patient-controlled' in codes
+
+
+def test_share_bundle_intake_profile_keeps_demographics(client, auth_headers, app):
+    """Default (intake) profile: Patient.name survives and meta.tag contains intake-identified."""
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient']},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert len(bundle['entry']) == 1
+
+    patient = bundle['entry'][0]['resource']
+    # Demographics must be preserved
+    assert 'name' in patient
+    assert patient['name'][0]['family'] == 'Vestel'
+    # meta.tag must flag identified share
+    tags = patient.get('meta', {}).get('tag', [])
+    tagged_systems = {t.get('system') for t in tags}
+    tagged_codes = {t.get('code') for t in tags}
+    assert 'https://healthclaw.io/share-profile' in tagged_systems
+    assert 'intake-identified' in tagged_codes
+
+
+def test_share_bundle_bogus_profile_400(client, auth_headers):
+    """Unknown profile value must return 400 OperationOutcome."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'resource_types': ['Patient'], 'profile': 'bogus'},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data['resourceType'] == 'OperationOutcome'
+    assert 'bogus' in data['issue'][0]['diagnostics']
 
 
 def test_share_bundle_rejects_unknown_type(client, auth_headers):

--- a/tests/test_share_bundle.py
+++ b/tests/test_share_bundle.py
@@ -1,0 +1,238 @@
+"""
+Tests for POST /r6/fhir/$share-bundle.
+
+The share-bundle endpoint exports a patient-controlled FHIR collection Bundle
+for SMART Health Link generation.  It requires:
+  - X-Tenant-Id  (enforced by r6_blueprint.before_request)
+  - X-Step-Up-Token  (step-up gate inside the route)
+
+Redaction applied: apply_patient_controlled_redaction — strips name/telecom/
+address/notes, preserves DOB and clinical codes, injects healthclaw canonical
+identifier, stamps meta.tag.
+"""
+
+import json
+import pytest
+
+from models import db
+from r6.models import R6Resource, AuditEventRecord
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_resource(app, resource_type, resource_json_dict, tenant_id='test-tenant'):
+    """Directly insert an R6Resource row into the test DB."""
+    with app.app_context():
+        rj = json.dumps(resource_json_dict)
+        row = R6Resource(
+            resource_type=resource_type,
+            resource_json=rj,
+            resource_id=resource_json_dict.get('id'),
+            tenant_id=tenant_id,
+        )
+        db.session.add(row)
+        db.session.commit()
+        return row.id
+
+
+# Minimal FHIR resources with subject references
+
+PATIENT_ID = 'share-pt-001'
+
+PATIENT_RESOURCE = {
+    'resourceType': 'Patient',
+    'id': PATIENT_ID,
+    'name': [{'family': 'Vestel', 'given': ['Eugene']}],
+    'birthDate': '1985-06-12',
+    'gender': 'male',
+    'identifier': [
+        {'system': 'http://example.org/mrn', 'value': 'MRN99887766'}
+    ],
+    'telecom': [{'system': 'phone', 'value': '555-123-4567'}],
+    'address': [{'line': ['100 Main St'], 'city': 'Austin', 'state': 'TX'}],
+}
+
+CONDITION_RESOURCE = {
+    'resourceType': 'Condition',
+    'id': 'share-cond-001',
+    'clinicalStatus': {
+        'coding': [{'system': 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+                    'code': 'active'}]
+    },
+    'code': {
+        'coding': [{'system': 'http://snomed.info/sct', 'code': '44054006',
+                    'display': 'Diabetes mellitus type 2'}]
+    },
+    'subject': {'reference': f'Patient/{PATIENT_ID}'},
+}
+
+OTHER_TENANT_CONDITION = {
+    'resourceType': 'Condition',
+    'id': 'other-tenant-cond',
+    'code': {'coding': [{'system': 'http://snomed.info/sct', 'code': '123456'}]},
+    'subject': {'reference': f'Patient/{PATIENT_ID}'},
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_share_bundle_requires_step_up(client, tenant_headers):
+    """Request without X-Step-Up-Token must get 401."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=tenant_headers,
+        json={},
+    )
+    assert resp.status_code == 401
+    data = resp.get_json()
+    assert data['resourceType'] == 'OperationOutcome'
+    assert any('step-up' in (i.get('diagnostics', '').lower()) for i in data['issue'])
+
+
+def test_share_bundle_returns_collection(client, auth_headers, app):
+    """Seeded Patient + Condition must appear in the returned collection Bundle."""
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE)
+    _seed_resource(app, 'Condition', CONDITION_RESOURCE)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient', 'Condition']},
+    )
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/fhir+json'
+
+    bundle = json.loads(resp.data)
+    assert bundle['resourceType'] == 'Bundle'
+    assert bundle['type'] == 'collection'
+    assert 'timestamp' in bundle
+
+    types_returned = {e['resource']['resourceType'] for e in bundle['entry']}
+    assert 'Patient' in types_returned
+    assert 'Condition' in types_returned
+    assert len(bundle['entry']) == 2
+
+
+def test_share_bundle_patient_controlled_redaction_applied(client, auth_headers, app):
+    """Patient-controlled redaction: name/telecom/address removed, birthDate preserved."""
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient']},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert len(bundle['entry']) == 1
+
+    patient = bundle['entry'][0]['resource']
+    # name, telecom, address should be stripped
+    assert 'name' not in patient
+    assert 'telecom' not in patient
+    assert 'address' not in patient
+    # birthDate preserved
+    assert patient.get('birthDate') == '1985-06-12'
+    # healthclaw canonical identifier injected
+    systems = [i['system'] for i in patient.get('identifier', [])]
+    assert 'https://healthclaw.io/patient-id' in systems
+    # meta.tag stamped
+    tags = patient.get('meta', {}).get('tag', [])
+    codes = {t.get('code') for t in tags}
+    assert 'patient-controlled' in codes
+
+
+def test_share_bundle_rejects_unknown_type(client, auth_headers):
+    """resource_types containing an unsupported type must return 400."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'resource_types': ['Teleport']},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data['resourceType'] == 'OperationOutcome'
+    diag = data['issue'][0]['diagnostics']
+    assert 'Teleport' in diag
+
+
+def test_share_bundle_tenant_isolation(client, auth_headers, app):
+    """Resource belonging to a different tenant must not appear in the bundle."""
+    # Seed a condition under a different tenant
+    _seed_resource(app, 'Condition', OTHER_TENANT_CONDITION, tenant_id='other-tenant')
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,  # scoped to 'test-tenant'
+        json={'resource_types': ['Condition']},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    ids = [e['resource'].get('id') for e in bundle['entry']]
+    assert 'other-tenant-cond' not in ids
+
+
+def test_share_bundle_emits_audit(client, auth_headers, app):
+    """An AuditEventRecord must be written; detail has counts, no patient name."""
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient']},
+    )
+    assert resp.status_code == 200
+
+    with app.app_context():
+        events = AuditEventRecord.query.filter_by(
+            tenant_id='test-tenant',
+            resource_id='share-bundle',
+        ).all()
+        assert len(events) >= 1
+        detail = events[-1].detail or ''
+        # Detail must contain count info
+        assert 'resource' in detail
+        # Detail must NOT contain the patient's name
+        assert 'Vestel' not in detail
+        assert 'Eugene' not in detail
+
+
+def test_share_bundle_empty_ok(client, auth_headers):
+    """When no resources match, return an empty collection Bundle (200)."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'resource_types': ['Coverage']},  # nothing seeded
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert bundle['resourceType'] == 'Bundle'
+    assert bundle['type'] == 'collection'
+    assert bundle['entry'] == []
+
+
+def test_share_bundle_default_types(client, auth_headers, app):
+    """Omitting resource_types uses the default SHL intake set (no 400)."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert bundle['resourceType'] == 'Bundle'
+    assert bundle['type'] == 'collection'
+
+
+def test_share_bundle_invalid_resource_types_not_list(client, auth_headers):
+    """resource_types must be a list, not a string."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'resource_types': 'Patient'},  # string, not list
+    )
+    assert resp.status_code == 400

--- a/tests/test_share_bundle.py
+++ b/tests/test_share_bundle.py
@@ -274,3 +274,81 @@ def test_share_bundle_invalid_resource_types_not_list(client, auth_headers):
         json={'resource_types': 'Patient'},  # string, not list
     )
     assert resp.status_code == 400
+
+
+def test_intake_profile_strips_ssn_note_text_keeps_name_and_mrn(client, auth_headers, app):
+    """Intake profile must strip SSN-class identifiers, note, and text but keep
+    name/demographics and non-SSN identifiers (e.g. MRN)."""
+    patient_with_ssn = {
+        'resourceType': 'Patient',
+        'id': 'ssn-strip-pt-001',
+        'name': [{'family': 'Smith', 'given': ['Alice']}],
+        'birthDate': '1990-03-15',
+        'identifier': [
+            {'system': 'http://example.org/mrn', 'value': 'MRN-12345'},
+            {'system': 'http://hl7.org/fhir/sid/us-ssn', 'value': '123-45-6789'},
+        ],
+        'note': [{'text': 'Patient is anxious about procedures.'}],
+        'text': {'status': 'generated', 'div': '<div>Alice Smith</div>'},
+    }
+    _seed_resource(app, 'Patient', patient_with_ssn)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': 'ssn-strip-pt-001', 'resource_types': ['Patient']},
+        # profile defaults to 'intake'
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert len(bundle['entry']) == 1
+
+    patient = bundle['entry'][0]['resource']
+
+    # Name must be preserved (intake = identified)
+    assert 'name' in patient
+    assert patient['name'][0]['family'] == 'Smith'
+
+    # birthDate must be preserved
+    assert patient.get('birthDate') == '1990-03-15'
+
+    # SSN identifier must be stripped
+    identifiers = patient.get('identifier', [])
+    systems = [i.get('system') for i in identifiers]
+    assert 'http://hl7.org/fhir/sid/us-ssn' not in systems
+
+    # Non-SSN (MRN) identifier must be kept
+    assert 'http://example.org/mrn' in systems
+
+    # note and text must be stripped
+    assert 'note' not in patient
+    assert 'text' not in patient
+
+    # meta.tag must be stamped
+    tags = patient.get('meta', {}).get('tag', [])
+    assert any(t.get('code') == 'intake-identified' for t in tags)
+
+
+def test_coverage_beneficiary_survives_patient_filter(client, auth_headers, app):
+    """Coverage resources that reference the patient via beneficiary.reference
+    must survive the patient_id filter (not just subject/patient references)."""
+    coverage = {
+        'resourceType': 'Coverage',
+        'id': 'cov-beneficiary-001',
+        'status': 'active',
+        'beneficiary': {'reference': f'Patient/{PATIENT_ID}'},
+        'payor': [{'display': 'ACME Insurance'}],
+    }
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE)
+    _seed_resource(app, 'Coverage', coverage)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers=auth_headers,
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient', 'Coverage']},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+
+    ids = [e['resource'].get('id') for e in bundle['entry']]
+    assert 'cov-beneficiary-001' in ids


### PR DESCRIPTION
## Summary
Implements use-case 8 (QR health sharing) by **adopting Josh Mandel's [kill-the-clipboard-skill](https://github.com/jmandel/kill-the-clipboard-skill)** (MIT, pinned `fa0020d`) rather than building bespoke — it's a full SHL STU 1 implementation (U-flag + manifest protocol) with a zero-knowledge storage server (HKDF capability split; server stores only ciphertext + sha256(auth)), by the SHL spec's author.

**Division of labor:** HealthClaw governs *what enters the bundle* (tenant isolation, step-up, share profiles, audit); KTC governs *how it's shared* (client-side JWE, links, revocation, viewer).

- Flask `POST /r6/fhir/$share-bundle` — step-up gated; profiles: `intake` (identified for clinic check-in; SSN-class identifiers + notes/narrative stripped per security rules) / `deidentified` (patient-controlled redaction); audited (counts only)
- MCP `shl_generate` (20 tools now) — vendored KTC crypto in `src/ktc/` (import-extension changes only, diffable against upstream); fetch bundle → HKDF split → JWE dir/A256GCM → upload ciphertext → `shlink:/` + viewer + patient-only manage link; `SHL_SERVER_URL` absent → explicit simulation stub; owner secret never persisted or logged
- `services/shl-server/` Dockerfile (pinned SHA) + compose profile `shl`

## QA
- 616 Python + 65 Node tests, tsc clean
- Upstream KTC suite at the pinned SHA: 259 pass / 0 fail
- **Live round-trip** against the real KTC server: create link → upload our JWE → clinic-role U-flag fetch with `recipient` → decrypt → byte-identical bundle; wrong auth capability → 404 (no oracle)

## Deploy notes
- Nothing changes by default: `shl-server` is behind the `shl` compose profile, and without `SHL_SERVER_URL` the MCP tool returns a simulation stub
- ⚠️ The Dockerfile builds third-party code (reviewed at the pinned SHA) — flagging explicitly for sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)