### PR TITLE
fix(mcp): fhir_get_token honors X-Tenant-Id (was hardcoded desktop-demo)

### DIFF
--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -202,6 +202,37 @@ describe("Tool Execution Tests", () => {
 
   // -- fhir.search --
 
+  // -- fhir_get_token tenant binding (regression: tokens were always minted
+  //    for desktop-demo, ignoring X-Tenant-Id → "Token tenant mismatch" on
+  //    writes for any other tenant, e.g. the personas' ev-personal) --
+
+  it("fhir_get_token binds the token to the X-Tenant-Id header when no arg given", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ token: "tok-abc" }));
+
+    const result = await tools.executeTool(
+      "fhir_get_token",
+      {},
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/internal/step-up-token");
+    expect(JSON.parse(opts.body).tenant_id).toBe("ev-personal");
+    expect((result as Record<string, unknown>).tenant_id).toBe("ev-personal");
+  });
+
+  it("fhir_get_token honors an explicit tenant_id argument over the header", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ token: "tok-xyz" }));
+
+    await tools.executeTool(
+      "fhir_get_token",
+      { tenant_id: "explicit-tenant" },
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).tenant_id).toBe("explicit-tenant");
+  });
+
   it("fhir.search builds correct query params and adds _mcp_summary", async () => {
     const bundle = {
       resourceType: "Bundle",

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -718,34 +718,39 @@ export class FHIRTools {
         );
 
       case "fhir_get_token": {
-        const tenantId = (input.tenant_id as string) || "desktop-demo";
+        // Token MUST be bound to the same tenant the write will run as.
+        // Fall back to the request's X-Tenant-Id (resolved above as
+        // header → TENANT_ID env → desktop-demo) — NOT a hardcoded default,
+        // or a token minted for desktop-demo gets rejected when the actual
+        // call runs as another tenant ("Token tenant mismatch").
+        const tokenTenant = (input.tenant_id as string) || tenantId;
         const resp = await fetch(`${this.baseUrl}/internal/step-up-token`, {
           method: "POST",
           headers: { "Content-Type": "application/json", ...fwdHeaders },
-          body: JSON.stringify({ tenant_id: tenantId }),
+          body: JSON.stringify({ tenant_id: tokenTenant }),
         });
         const data = (await resp.json()) as Record<string, unknown>;
         if (!resp.ok) return { error: "Failed to issue token", detail: data };
         return {
           token: data.token,
-          tenant_id: tenantId,
+          tenant_id: tokenTenant,
           expires_in_seconds: 300,
-          _mcp_summary: "Step-up token issued (5-min TTL). Pass it as _stepUpToken in fhir_propose_write, fhir_commit_write, or curatr_apply_fix.",
+          _mcp_summary: "Step-up token issued (5-min TTL). Pass it as _stepUpToken in fhir_propose_write, fhir_commit_write, action_commit, shl_generate, or curatr_apply_fix.",
         };
       }
 
       case "fhir_seed": {
-        const tenantId = (input.tenant_id as string) || "desktop-demo";
+        const seedTenant = (input.tenant_id as string) || tenantId;
         const resp = await fetch(`${this.baseUrl}/internal/seed`, {
           method: "POST",
           headers: { "Content-Type": "application/json", ...fwdHeaders },
-          body: JSON.stringify({ tenant_id: tenantId }),
+          body: JSON.stringify({ tenant_id: seedTenant }),
         });
         const data = (await resp.json()) as Record<string, unknown>;
         if (!resp.ok) return { error: "Seed failed", detail: data };
         return {
           ...data,
-          _mcp_summary: `Seeded ${(data.created as unknown[])?.length ?? 0} resources into tenant '${tenantId}'. The step_up_token is ready for write operations.`,
+          _mcp_summary: `Seeded ${(data.created as unknown[])?.length ?? 0} resources into tenant '${seedTenant}'. The step_up_token is ready for write operations.`,
         };
       }
 


### PR DESCRIPTION
Personas configured for tenant `ev-personal` got a `desktop-demo`-bound step-up token, so every write tool (shl_generate, action_commit) failed Flask's `validate_step_up_token` with 'Token tenant mismatch'. `fhir_get_token`/`fhir_seed` now fall back to the request's resolved tenant (header → env → desktop-demo) like every other tool. +2 regression tests; 67 Node tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)