### PR TITLE
feat: Dev Days demo — FHIR control panel, all-sources check, command-center wiring

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,6 +113,18 @@ def r6_dashboard():
     return render_template('r6_dashboard.html')
 
 
+@app.route('/fhir-control-panel')
+def fhir_control_panel():
+    """
+    FHIR Control Panel — live Dev Days demo surface.
+
+    Public page shell (no auth). All data calls are made client-side and
+    carry X-Tenant-Id, hitting the tenant-scoped read-only $inventory,
+    $profile-adherence, and search endpoints under /r6/fhir.
+    """
+    return render_template('fhir_control_panel.html')
+
+
 # Valid tenant_id pattern: alphanumeric, hyphens, underscores, 1-64 chars
 import re as _re
 _TENANT_ID_PATTERN = _re.compile(r'^[a-zA-Z0-9_\-]{1,64}$')

--- a/r6/command_center/projector.py
+++ b/r6/command_center/projector.py
@@ -345,6 +345,161 @@ def data_sources(tenant_id: str) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# All-sources summary (Dev Days "check every connected source" view)
+# ---------------------------------------------------------------------------
+
+# Canonical catalog for the one-shot summary. Order is the display order.
+# `markers` are substrings matched (case-insensitively) against AuditEventRecord
+# .detail / .agent_id to detect a source that has no dedicated table.
+_SUMMARY_SOURCE_CATALOG = [
+    {"id": "fasten",       "name": "Fasten TEFCA"},
+    {"id": "healthex",     "name": "HealthEx"},
+    {"id": "hbo",          "name": "Health Bank One", "markers": ["hbo", "healthbankone", "health bank one"]},
+    {"id": "medent",       "name": "MEDENT",          "markers": ["medent"]},
+    {"id": "flexpa",       "name": "Flexpa",          "markers": ["flexpa"]},
+    {"id": "healthskillz", "name": "Epic / Health Skillz", "markers": ["healthskillz", "health skillz", "epic"]},
+    {"id": "wearables",    "name": "Open Wearables"},
+]
+
+
+def _audit_signal(tenant_id: str, markers: list[str]) -> tuple[bool, str | None]:
+    """
+    Generic audit-event heuristic mirroring `_has_healthex_signal`: a source is
+    "connected" if any recent AuditEventRecord for the tenant carries one of the
+    marker substrings in its detail or agent_id. Returns (connected, last_iso).
+    """
+    if not markers:
+        return False, None
+    conditions = []
+    for m in markers:
+        like = f"%{m}%"
+        conditions.append(AuditEventRecord.detail.ilike(like))
+        conditions.append(AuditEventRecord.agent_id.ilike(like))
+    from sqlalchemy import or_
+    ev = (
+        AuditEventRecord.query
+        .filter(AuditEventRecord.tenant_id == tenant_id)
+        .filter(or_(*conditions))
+        .order_by(desc(AuditEventRecord.recorded))
+        .first()
+    )
+    if ev is None:
+        return False, None
+    return True, (ev.recorded.isoformat() if ev.recorded else None)
+
+
+def _summary_entry(tenant_id: str, spec: dict, table_sources: dict) -> dict:
+    """
+    Build one source entry for the summary. The 5 sources already covered by
+    data_sources() are reused from `table_sources`; the rest are detected via
+    the audit-signal heuristic. Each call is independently guarded by the caller.
+    """
+    sid = spec["id"]
+    name = spec["name"]
+
+    # Reuse the existing per-source detection where data_sources covers it.
+    if sid == "fasten":
+        existing = table_sources.get("fasten")
+        return {
+            "id": "fasten", "name": name,
+            "connected": bool(existing and existing.get("connected")),
+            "detail": existing.get("detail") if existing else "Not configured",
+            "last_activity": existing.get("last_activity") if existing else None,
+        }
+    if sid == "healthex":
+        existing = table_sources.get("healthex")
+        return {
+            "id": "healthex", "name": name,
+            "connected": bool(existing and existing.get("connected")),
+            "detail": existing.get("detail") if existing else "Not connected",
+            "last_activity": existing.get("last_activity") if existing else None,
+        }
+    if sid == "wearables":
+        existing = table_sources.get("wearables")
+        return {
+            "id": "wearables", "name": name,
+            "connected": bool(existing and existing.get("connected")),
+            "detail": existing.get("detail") if existing else "No devices linked",
+            "last_activity": existing.get("last_activity") if existing else None,
+        }
+
+    # HBO / MEDENT / Flexpa / Epic-HealthSkillz — audit-signal heuristic only.
+    connected, last = _audit_signal(tenant_id, spec.get("markers", []))
+    return {
+        "id": sid, "name": name,
+        "connected": connected,
+        "detail": "Detected via audit events" if connected else "Not connected",
+        "last_activity": last,
+    }
+
+
+def sources_summary(tenant_id: str) -> dict:
+    """
+    One-shot "check every connected source" view for the Dev Days demo.
+
+    Reports ALL 7 catalog sources (5 reused from data_sources(), plus HBO,
+    MEDENT, Flexpa, and Epic/Health Skillz via the audit-signal heuristic),
+    plus per-resource-type record counts from the R6Resource store.
+
+    Resilient by design: each source check is independently guarded so one
+    failing detector never breaks the whole response.
+    """
+    # Reuse the existing 5-source detection. Index by id for cheap lookup.
+    table_sources: dict[str, dict] = {}
+    try:
+        for s in data_sources(tenant_id):
+            table_sources[s["id"]] = s
+    except Exception:  # pragma: no cover - defensive
+        table_sources = {}
+
+    sources: list[dict] = []
+    for spec in _SUMMARY_SOURCE_CATALOG:
+        try:
+            sources.append(_summary_entry(tenant_id, spec, table_sources))
+        except Exception:  # pragma: no cover - defensive
+            sources.append({
+                "id": spec["id"], "name": spec["name"],
+                "connected": False, "detail": "check failed",
+                "last_activity": None,
+            })
+
+    # Per-resource-type record counts (grouped) + total.
+    records_by_type: list[dict] = []
+    total_records = 0
+    try:
+        rows = (
+            db.session.query(
+                R6Resource.resource_type,
+                func.count(R6Resource.id),
+            )
+            .filter(
+                R6Resource.tenant_id == tenant_id,
+                R6Resource.is_deleted == False,  # noqa: E712
+            )
+            .group_by(R6Resource.resource_type)
+            .order_by(desc(func.count(R6Resource.id)))
+            .all()
+        )
+        records_by_type = [{"type": rt, "count": int(c)} for rt, c in rows]
+        total_records = sum(r["count"] for r in records_by_type)
+    except Exception:  # pragma: no cover - defensive
+        records_by_type = []
+        total_records = 0
+
+    connected_count = sum(1 for s in sources if s.get("connected"))
+
+    return {
+        "tenant": tenant_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_records": total_records,
+        "sources": sources,
+        "connected_count": connected_count,
+        "source_count": len(sources),
+        "records_by_type": records_by_type,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Skills
 # ---------------------------------------------------------------------------
 

--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -9,6 +9,7 @@ Routes:
     GET  /command-center/api/readiness?tenant=<id>        — 5-stage pipeline
     GET  /command-center/api/actions?tenant=<id>          — audit event stream
     GET  /command-center/api/sources?tenant=<id>          — data sources
+    GET  /command-center/api/sources-summary?tenant=<id>  — all 7 sources + per-type counts
     GET  /command-center/api/skills?tenant=<id>           — skills status
     GET  /command-center/api/agents?tenant=<id>           — agent personas + stats
     GET  /command-center/api/conversations?tenant=<id>    — recent chat turns
@@ -212,6 +213,14 @@ def api_sources():
     if (err := _require_session_or_public()):
         return err
     return jsonify(projector.data_sources(_tenant()))
+
+
+@command_center_blueprint.route("/api/sources-summary", methods=["GET"])
+def api_sources_summary():
+    """All 7 data sources + per-resource-type record counts in one call."""
+    if (err := _require_session_or_public()):
+        return err
+    return jsonify(projector.sources_summary(_tenant()))
 
 
 @command_center_blueprint.route("/api/skills", methods=["GET"])

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2442,6 +2442,203 @@ def share_bundle():
     )
 
 
+# --- FHIR Control Panel Aggregate Operations (read-only) ---
+
+# Cap resources sampled per type in $profile-adherence to bound validation cost.
+_PROFILE_ADHERENCE_SAMPLE_CAP = 50
+
+
+@r6_blueprint.route('/$inventory', methods=['GET'])
+def fhir_inventory():
+    """
+    $inventory — tenant-scoped resource census.
+
+    Returns counts of non-deleted resources grouped by resource_type for the
+    calling tenant, plus an overall total and the tenant's most-recent
+    last_updated timestamp. Powers the FHIR control panel UI.
+
+    Read-only: tenant isolation + audit apply, no step-up required.
+    """
+    tenant_id = request.headers.get('X-Tenant-Id')
+
+    # Efficient grouped count: one query, GROUP BY resource_type.
+    rows = (
+        db.session.query(
+            R6Resource.resource_type,
+            db.func.count(R6Resource.id),
+        )
+        .filter(
+            R6Resource.tenant_id == tenant_id,
+            R6Resource.is_deleted == False,  # noqa: E712
+        )
+        .group_by(R6Resource.resource_type)
+        .all()
+    )
+
+    # Only types with count > 0 (GROUP BY already excludes zero), sorted desc.
+    by_type = sorted(
+        ((rt, count) for rt, count in rows if count > 0),
+        key=lambda x: (-x[1], x[0]),
+    )
+    total = sum(count for _, count in by_type)
+
+    last_updated_dt = (
+        db.session.query(db.func.max(R6Resource.last_updated))
+        .filter(
+            R6Resource.tenant_id == tenant_id,
+            R6Resource.is_deleted == False,  # noqa: E712
+        )
+        .scalar()
+    )
+
+    parameters = [
+        {'name': 'tenant', 'valueString': tenant_id},
+        {'name': 'total', 'valueInteger': total},
+    ]
+    if last_updated_dt is not None:
+        parameters.append({
+            'name': 'lastUpdated',
+            'valueDateTime': last_updated_dt.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+        })
+    parameters.append({
+        'name': 'byType',
+        'part': [
+            {'name': rt, 'valueInteger': count} for rt, count in by_type
+        ],
+    })
+
+    record_audit_event(
+        'read', 'Parameters', 'inventory',
+        agent_id=request.headers.get('X-Agent-Id'),
+        tenant_id=tenant_id,
+        detail=f'$inventory: types={len(by_type)}, total={total}',
+    )
+
+    return jsonify({
+        'resourceType': 'Parameters',
+        'parameter': parameters,
+    })
+
+
+@r6_blueprint.route('/$profile-adherence', methods=['GET'])
+def fhir_profile_adherence():
+    """
+    $profile-adherence — tenant-scoped conformance summary.
+
+    For each resource type present, sample up to _PROFILE_ADHERENCE_SAMPLE_CAP
+    resources and run each through the structural validator (US Core required
+    fields). Aggregates per-type adherence and the most common failing
+    diagnostics, plus an overall adherence ratio across all sampled resources.
+
+    Uses the validator's network-free structural path (_validate_structural)
+    so the operation is fast and deterministic for the demo — it never calls
+    the external HL7 validator even when one is configured.
+
+    Read-only: tenant isolation + audit apply, no step-up required.
+    """
+    tenant_id = request.headers.get('X-Tenant-Id')
+
+    # Distinct types present for this tenant, with totals.
+    type_rows = (
+        db.session.query(
+            R6Resource.resource_type,
+            db.func.count(R6Resource.id),
+        )
+        .filter(
+            R6Resource.tenant_id == tenant_id,
+            R6Resource.is_deleted == False,  # noqa: E712
+        )
+        .group_by(R6Resource.resource_type)
+        .all()
+    )
+
+    by_type_parts = []
+    total_sampled = 0
+    total_conformant = 0
+
+    # Sort by total desc for a stable, useful ordering in the UI.
+    for resource_type, total in sorted(type_rows, key=lambda x: (-x[1], x[0])):
+        if total <= 0:
+            continue
+        sampled_rows = (
+            R6Resource.query.filter_by(
+                resource_type=resource_type,
+                is_deleted=False,
+                tenant_id=tenant_id,
+            )
+            .order_by(R6Resource.last_updated.desc())
+            .limit(_PROFILE_ADHERENCE_SAMPLE_CAP)
+            .all()
+        )
+
+        sampled = len(sampled_rows)
+        conformant = 0
+        issue_counts = {}
+        for row in sampled_rows:
+            try:
+                resource = json.loads(row.resource_json)
+            except (ValueError, TypeError):
+                # Unparseable stored JSON counts as non-conformant.
+                issue_counts['Stored resource is not valid JSON'] = (
+                    issue_counts.get('Stored resource is not valid JSON', 0) + 1
+                )
+                continue
+            resource.setdefault('resourceType', resource_type)
+            # Network-free structural validation only.
+            result = validator._validate_structural(resource)
+            if result.get('valid'):
+                conformant += 1
+            else:
+                for issue in result.get('operation_outcome', {}).get('issue', []):
+                    if issue.get('severity') not in ('error', 'fatal'):
+                        continue
+                    diag = issue.get('diagnostics') or 'Unknown issue'
+                    issue_counts[diag] = issue_counts.get(diag, 0) + 1
+
+        total_sampled += sampled
+        total_conformant += conformant
+
+        adherence = round(conformant / sampled, 2) if sampled else 0.0
+        top_issues = sorted(
+            issue_counts.items(), key=lambda x: (-x[1], x[0])
+        )[:3]
+        top_issues_str = '; '.join(
+            f'{diag} ({count})' for diag, count in top_issues
+        )
+
+        part = [
+            {'name': 'total', 'valueInteger': total},
+            {'name': 'sampled', 'valueInteger': sampled},
+            {'name': 'conformant', 'valueInteger': conformant},
+            {'name': 'adherence', 'valueDecimal': adherence},
+        ]
+        if top_issues_str:
+            part.append({'name': 'topIssues', 'valueString': top_issues_str})
+
+        by_type_parts.append({'name': resource_type, 'part': part})
+
+    overall = round(total_conformant / total_sampled, 2) if total_sampled else 0.0
+
+    record_audit_event(
+        'read', 'Parameters', 'profile-adherence',
+        agent_id=request.headers.get('X-Agent-Id'),
+        tenant_id=tenant_id,
+        detail=(
+            f'$profile-adherence: types={len(by_type_parts)}, '
+            f'sampled={total_sampled}, conformant={total_conformant}'
+        ),
+    )
+
+    return jsonify({
+        'resourceType': 'Parameters',
+        'parameter': [
+            {'name': 'tenant', 'valueString': tenant_id},
+            {'name': 'overallAdherence', 'valueDecimal': overall},
+            {'name': 'byType', 'part': by_type_parts},
+        ],
+    })
+
+
 # --- Helper Functions ---
 
 def _operation_outcome(severity, code, diagnostics):

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -60,6 +60,7 @@ const EXPECTED_TOOL_NAMES = [
   "fhir_subscription_topics",
   "fhir_validate",
   "shl_generate",
+  "sources_check",
   "wearables_sync_status",
 ];
 
@@ -76,6 +77,7 @@ const READ_ONLY_TOOL_NAMES = [
   "fhir_permission_evaluate",
   "fhir_subscription_topics",
   "fhir_compiled_truth",
+  "sources_check",
   "wearables_sync_status",
 ];
 
@@ -91,8 +93,8 @@ describe("Tool Schema Tests", () => {
     schemas = tools.getMCPToolSchemas();
   });
 
-  it("getMCPToolSchemas() returns exactly 20 tools", () => {
-    expect(schemas).toHaveLength(20);
+  it("getMCPToolSchemas() returns exactly 21 tools", () => {
+    expect(schemas).toHaveLength(21);
   });
 
   it("every tool has required MCP fields: name, description, inputSchema, annotations", () => {
@@ -111,7 +113,7 @@ describe("Tool Schema Tests", () => {
     }
   });
 
-  it("all 20 tool names match the expected set", () => {
+  it("all 21 tool names match the expected set", () => {
     const actualNames = schemas.map((t) => t.name).sort();
     expect(actualNames).toEqual(EXPECTED_TOOL_NAMES);
   });
@@ -740,6 +742,69 @@ describe("Tool Execution Tests", () => {
     expect(result).toEqual(statusBody);
   });
 
+  // -- sources_check --
+
+  it("sources_check calls the sources-summary URL with the tenant and returns the parsed summary", async () => {
+    const summary = {
+      tenant: "ev-personal",
+      total_records: 177,
+      connected_count: 3,
+      source_count: 7,
+      sources: [
+        { id: "fasten", name: "Fasten", connected: true, detail: "", last_activity: null },
+        { id: "medent", name: "MEDENT", connected: true, detail: "", last_activity: null },
+      ],
+      records_by_type: [
+        { type: "Condition", count: 57 },
+        { type: "Observation", count: 120 },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce(fakeResponse(summary));
+
+    const result = await tools.executeTool(
+      "sources_check",
+      {},
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/command-center/api/sources-summary");
+    expect(url).toContain("tenant=ev-personal");
+    expect(result).toHaveProperty("sources");
+    expect(result).toHaveProperty("_mcp_summary");
+    expect(result._mcp_summary as string).toContain("3 of 7 sources connected");
+  });
+
+  it("sources_check forwards X-Step-Up-Token when provided", async () => {
+    const summary = { tenant: "ev-personal", total_records: 0, connected_count: 0, source_count: 7, sources: [], records_by_type: [] };
+    mockFetch.mockResolvedValueOnce(fakeResponse(summary));
+
+    await tools.executeTool(
+      "sources_check",
+      {},
+      { "x-tenant-id": "ev-personal", "x-step-up-token": "tok-stepup-1" }
+    );
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers["X-Step-Up-Token"]).toBe("tok-stepup-1");
+    expect(opts.headers["X-Tenant-Id"]).toBe("ev-personal");
+  });
+
+  it("sources_check on 401 returns requires_step_up", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ error: "unauthorized" }, 401));
+
+    const result = await tools.executeTool(
+      "sources_check",
+      {},
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    expect(result).toHaveProperty("error");
+    expect((result.error as string)).toContain("401");
+    expect(result).toHaveProperty("requires_step_up", true);
+  });
+
   // -- shl_generate --
 
   it("shl_generate without step-up token returns requires_step_up (no fetch made)", async () => {
@@ -919,14 +984,14 @@ describe("Express App Tests", () => {
       expect(sessionId.length).toBeGreaterThan(0);
     });
 
-    it("tools/list returns all 20 tool schemas", async () => {
+    it("tools/list returns all 21 tool schemas", async () => {
       const res = await request(app)
         .post("/mcp")
         .send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
 
       expect(res.status).toBe(200);
       expect(res.body.result).toBeDefined();
-      expect(res.body.result.tools).toHaveLength(20);
+      expect(res.body.result.tools).toHaveLength(21);
 
       const names = new Set<string>(
         res.body.result.tools.map((t: { name: string }) => t.name)
@@ -1101,13 +1166,13 @@ describe("Express App Tests", () => {
   // -- Legacy HTTP Bridge /mcp/rpc --
 
   describe("POST /mcp/rpc", () => {
-    it("tools/list returns all 20 tool schemas", async () => {
+    it("tools/list returns all 21 tool schemas", async () => {
       const res = await request(app)
         .post("/mcp/rpc")
         .send({ jsonrpc: "2.0", id: 1, method: "tools/list" });
 
       expect(res.status).toBe(200);
-      expect(res.body.result.tools).toHaveLength(20);
+      expect(res.body.result.tools).toHaveLength(21);
     });
 
     it("tools/call executes the tool and returns result directly (not wrapped)", async () => {

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -386,6 +386,19 @@ export class FHIRTools {
           required: [],
         },
       },
+      // --- Sources: survey ALL connected health data sources at once ---
+      {
+        name: "sources_check",
+        description:
+          "Survey ALL connected health data sources (Fasten, HealthEx, Health Bank One, MEDENT, Flexpa, Epic/Health Skillz, wearables) at once — returns each source's connection status and the patient's record counts by type. Use when the patient asks what's connected or to check for data across services.",
+        tier: "read",
+        annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
       // --- Compiled Truth: current state + evidence timeline ---
       {
         name: "fhir_compiled_truth",
@@ -687,6 +700,9 @@ export class FHIRTools {
 
       case "fhir_subscription_topics":
         return this.listSubscriptionTopics(fwdHeaders);
+
+      case "sources_check":
+        return this.sourcesCheck(tenantId, fwdHeaders);
 
       case "fhir_compiled_truth":
         return this.compiledTruth(
@@ -1165,6 +1181,45 @@ export class FHIRTools {
     const hrs = Math.round(mins / 60);
     if (hrs < 24) return `${hrs} h ago`;
     return `${Math.round(hrs / 24)} d ago`;
+  }
+
+  // --- Sources: survey ALL connected health data sources at once ---
+
+  private async sourcesCheck(
+    tenantId: string,
+    headers: Record<string, string>
+  ): Promise<Record<string, unknown>> {
+    const root = this.serverRoot();
+    const url = `${root}/command-center/api/sources-summary?tenant=${encodeURIComponent(tenantId)}`;
+    let resp;
+    try {
+      resp = await fetch(url, { headers });
+    } catch (e) {
+      return { error: "sources_check request failed", detail: String(e) };
+    }
+
+    let data: Record<string, unknown>;
+    try {
+      data = (await resp.json()) as Record<string, unknown>;
+    } catch {
+      data = {};
+    }
+
+    if (!resp.ok) {
+      const result: Record<string, unknown> = {
+        error: `sources_check failed with status ${resp.status}`,
+        detail: data,
+      };
+      if (resp.status === 401) result.requires_step_up = true;
+      return result;
+    }
+
+    const connected = (data.connected_count as number) ?? 0;
+    const sourceCount = (data.source_count as number) ?? 7;
+    const totalRecords = (data.total_records as number) ?? 0;
+    data._mcp_summary = `${connected} of ${sourceCount} sources connected; ${totalRecords} total records.`;
+
+    return data;
   }
 
   private async compiledTruth(

--- a/skills/check-sources/SKILL.md
+++ b/skills/check-sources/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: check-sources
+description: >
+  Survey ALL connected health data sources at once. Use when the patient asks:
+  (1) "what's connected" or "what services are linked", (2) "check all my
+  services / all my data", (3) "do you have my records" or "what records do you
+  have", (4) "did my data come through from <Fasten/MEDENT/HealthEx/Health Bank
+  One/Flexpa/Epic/wearables>". Calls fhir_get_token (for protected tenants) then
+  sources_check, and presents connection status + record counts by type.
+  Connection status and counts only — never clinical values.
+metadata: {"openclaw":{"requires":{"env":["STEP_UP_SECRET"]},"primaryEnv":"STEP_UP_SECRET"}}
+---
+
+# Check Connected Sources
+
+Give the patient a one-shot survey of every health data source HealthClaw can
+pull from — which ones are connected, when each last had activity, and how many
+records of each type are on file. This answers "what do you actually have?" in a
+single call instead of probing each integration one at a time.
+
+The seven sources surveyed:
+
+- **Fasten** — Fasten Connect / TEFCA QHIN aggregation
+- **HealthEx** — HealthEx upstream
+- **Health Bank One** — patient-controlled platform (HBO)
+- **MEDENT** — MEDENT SMART on FHIR
+- **Flexpa** — payer / claims data
+- **Epic / Health Skillz** — Epic-sourced records
+- **Wearables** — Apple Health / Fitbit / Garmin / Oura etc.
+
+---
+
+## Hard Guardrails
+
+These apply always. Not overridable by persona or patient request.
+
+### Counts and source names only — no clinical detail
+
+`sources_check` returns connection status and record **counts by type**. That is
+the entire surface you may present from this skill. You may say "57 Conditions,
+120 Observations." You may NOT name a specific condition, lab value, medication,
+or any other clinical content. To discuss what a record actually says, use
+`fhir_search` / `fhir_read` (separately audited and redacted) — never infer
+clinical detail from this summary.
+
+### Don't fabricate connections
+
+Report only what `sources_check` returns. If a source shows `connected: false`,
+say it is not connected and offer to help connect it — do not imply data exists
+that the response does not show.
+
+---
+
+## Flow
+
+### Step 1 — Get a step-up token (protected tenants)
+
+Public/demo tenants (e.g. `desktop-demo`) work without a token. For protected
+tenants (e.g. `ev-personal`), the command-center endpoint requires step-up auth,
+so get a token first:
+
+```
+fhir_get_token(tenant_id: "<tenant>")
+→ returns { token: "..." }
+```
+
+### Step 2 — Survey the sources
+
+```
+sources_check({ _stepUpToken: "<token from step 1>" })
+```
+
+`sources_check` takes no required arguments — the tenant comes from the request
+context. Pass `_stepUpToken` so it forwards to the protected endpoint. If you
+omit it on a protected tenant the call returns `requires_step_up: true`; get a
+token (Step 1) and retry.
+
+### Step 3 — Present the result
+
+The response includes:
+
+- `connected_count` / `source_count` — e.g. 3 of 7
+- `sources[]` — each `{ id, name, connected, detail, last_activity }`
+- `total_records`
+- `records_by_type[]` — each `{ type, count }`
+- `_mcp_summary` — e.g. "3 of 7 sources connected; 177 total records."
+
+Present it tidily:
+
+```
+Connected: 3/7 — Fasten ✓, MEDENT ✓, Wearables ✓
+Not connected: HealthEx, Health Bank One, Flexpa, Epic/Health Skillz
+
+You have 177 records on file:
+  • 57 Conditions
+  • 120 Observations
+```
+
+### Step 4 — Offer next steps
+
+- "Want me to pull anything from a connected source?" (then `fhir_search`)
+- "Want to connect <not-connected source>?" (hand off to that integration)
+- "You can also see all of this on your dashboard."
+
+---
+
+## Worked Example
+
+```
+Patient: What's connected? Do you actually have my records?
+
+Sally:   Let me check all your data sources at once.
+         [fhir_get_token(tenant_id: "ev-personal") → { token: "..." }]
+         [sources_check({ _stepUpToken: "..." }) → {
+            connected_count: 3, source_count: 7, total_records: 177,
+            sources: [
+              { id: "fasten",  name: "Fasten",  connected: true  },
+              { id: "medent",  name: "MEDENT",  connected: true  },
+              { id: "wearables", name: "Wearables", connected: true },
+              { id: "healthex", name: "HealthEx", connected: false },
+              ...
+            ],
+            records_by_type: [
+              { type: "Condition", count: 57 },
+              { type: "Observation", count: 120 }
+            ]
+         }]
+
+         Connected: 3 of 7 sources — Fasten, MEDENT, and your wearables.
+         Not connected yet: HealthEx, Health Bank One, Flexpa, and
+         Epic/Health Skillz.
+
+         You have 177 records on file: 57 Conditions and 120 Observations.
+
+         Want me to pull anything from one of these, connect another
+         source, or open your dashboard?
+```
+
+---
+
+## Caveats
+
+- This is a status + counts surface, not a data export. For actual record
+  content, use `fhir_search` / `fhir_read`.
+- A source showing `connected: true` with 0 records means the link is live but
+  no data has arrived yet — say so rather than implying records exist.
+- On a protected tenant without `_stepUpToken`, the call returns
+  `requires_step_up: true`; get a token and retry.

--- a/static/css/fhir-control-panel.css
+++ b/static/css/fhir-control-panel.css
@@ -1,0 +1,225 @@
+/* FHIR Control Panel — layers on top of command-center.css (reuses :root vars) */
+
+.fcp-hero {
+    grid-template-rows: auto auto;
+}
+
+.fcp-hero-right {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.55rem;
+}
+
+.fcp-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    background: rgba(16, 185, 129, 0.15);
+    color: var(--cc-ok);
+    border: 1px solid rgba(16, 185, 129, 0.3);
+    white-space: nowrap;
+}
+
+.fcp-cap-link {
+    font-size: 0.8rem;
+    color: var(--cc-accent);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.fcp-cap-link:hover { color: #7dd3fc; text-decoration: underline; }
+
+.fcp-last-refresh {
+    margin-left: auto;
+    font-size: 0.78rem;
+    color: var(--cc-text-muted);
+}
+
+/* ------- Inventory ------- */
+.fcp-inventory-banner {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    color: var(--cc-text-dim);
+    font-size: 0.9rem;
+}
+.fcp-banner-num {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--cc-accent);
+}
+.fcp-banner-updated { font-size: 0.8rem; color: var(--cc-text-muted); }
+
+.fcp-inventory-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+}
+
+.fcp-tile {
+    background: var(--cc-card);
+    border: 1px solid var(--cc-border);
+    border-radius: 10px;
+    padding: 1rem 0.9rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s, border-color 0.15s, transform 0.1s;
+    color: var(--cc-text);
+}
+.fcp-tile:hover {
+    background: var(--cc-card-hover);
+    border-color: var(--cc-accent-dim);
+    transform: translateY(-1px);
+}
+.fcp-tile.selected {
+    border-color: var(--cc-accent);
+    background: linear-gradient(180deg, rgba(56, 189, 248, 0.12) 0%, var(--cc-card) 70%);
+}
+.fcp-tile-count {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--cc-accent);
+    line-height: 1;
+}
+.fcp-tile-name {
+    font-size: 0.82rem;
+    color: var(--cc-text-dim);
+    word-break: break-word;
+}
+
+/* ------- Profile adherence ------- */
+.fcp-adherence-layout {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+@media (max-width: 800px) {
+    .fcp-adherence-layout { grid-template-columns: 1fr; }
+}
+
+.fcp-gauge {
+    background: var(--cc-card);
+    border: 1px solid var(--cc-border);
+    border-radius: 14px;
+    padding: 1.5rem 1.75rem;
+    text-align: center;
+    min-width: 170px;
+}
+.fcp-gauge-num { font-size: 2.8rem; font-weight: 800; line-height: 1; }
+.fcp-gauge-lbl {
+    margin-top: 0.4rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--cc-text-muted);
+}
+.fcp-gauge.good { border-color: rgba(16, 185, 129, 0.5); }
+.fcp-gauge.good .fcp-gauge-num { color: var(--cc-ok); }
+.fcp-gauge.warn { border-color: rgba(245, 158, 11, 0.5); }
+.fcp-gauge.warn .fcp-gauge-num { color: var(--cc-pending); }
+.fcp-gauge.bad { border-color: rgba(239, 68, 68, 0.5); }
+.fcp-gauge.bad .fcp-gauge-num { color: var(--cc-blocked); }
+
+.fcp-adherence-table-wrap { overflow-x: auto; }
+
+/* ------- Tables ------- */
+.fcp-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--cc-card);
+    border: 1px solid var(--cc-border);
+    border-radius: 12px;
+    overflow: hidden;
+    font-size: 0.85rem;
+}
+.fcp-table th {
+    text-align: left;
+    padding: 0.7rem 0.9rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--cc-text-muted);
+    background: rgba(255, 255, 255, 0.02);
+    border-bottom: 1px solid var(--cc-border);
+}
+.fcp-table td {
+    padding: 0.65rem 0.9rem;
+    border-bottom: 1px solid var(--cc-border);
+    color: var(--cc-text);
+    vertical-align: top;
+}
+.fcp-table tbody tr:last-child td { border-bottom: none; }
+
+.fcp-num { white-space: nowrap; }
+.fcp-mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
+.fcp-none { color: var(--cc-text-muted); }
+.fcp-issues { color: var(--cc-text-dim); font-size: 0.8rem; }
+
+.fcp-type-link, .fcp-open {
+    background: none;
+    border: none;
+    color: var(--cc-accent);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: none;
+}
+.fcp-type-link:hover { text-decoration: underline; }
+
+.fcp-adh-pill {
+    display: inline-block;
+    padding: 0.12rem 0.55rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.78rem;
+}
+.fcp-adh-pill.good { background: rgba(16, 185, 129, 0.18); color: var(--cc-ok); }
+.fcp-adh-pill.warn { background: rgba(245, 158, 11, 0.18); color: var(--cc-pending); }
+.fcp-adh-pill.bad { background: rgba(239, 68, 68, 0.18); color: var(--cc-blocked); }
+
+/* ------- Explorer ------- */
+.fcp-explorer-type {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--cc-text-dim);
+}
+.fcp-redaction-note {
+    font-size: 0.8rem;
+    color: var(--cc-text-muted);
+    margin: -0.4rem 0 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.fcp-explorer-meta {
+    font-size: 0.8rem;
+    color: var(--cc-text-muted);
+    margin-bottom: 0.6rem;
+}
+.fcp-res-table tbody tr.fcp-res-row { cursor: pointer; transition: background 0.12s; }
+.fcp-res-table tbody tr.fcp-res-row:hover { background: var(--cc-card-hover); }
+.fcp-open:hover { color: #7dd3fc; }
+
+/* ------- Errors ------- */
+.fcp-error {
+    padding: 0.9rem 1.1rem;
+    border-radius: 10px;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+    color: #fca5a5;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}

--- a/static/js/fhir-control-panel.js
+++ b/static/js/fhir-control-panel.js
@@ -1,0 +1,341 @@
+/**
+ * fhir-control-panel.js — FHIR Control Panel (Dev Days demo).
+ *
+ * Vanilla fetch + DOM, no framework. Manual refresh only (no auto-poll).
+ * Every data call carries X-Tenant-Id. Each section is fault-tolerant:
+ * a failure in one section shows an inline error and never blanks the page.
+ *
+ * Backend (tenant-scoped, GET, no step-up):
+ *   GET /r6/fhir/$inventory          -> Parameters {total, lastUpdated, byType.part[]}
+ *   GET /r6/fhir/$profile-adherence  -> Parameters {overallAdherence, byType.part[]}
+ *   GET /r6/fhir/<Type>?_count=20&_sort=-_lastUpdated -> searchset Bundle
+ */
+
+(function () {
+    'use strict';
+
+    const DEFAULT_TENANT = 'desktop-demo';
+    const EXPLORER_COUNT = 20;
+
+    const tenantInput = document.getElementById('fcp-tenant-input');
+    const refreshBtn = document.getElementById('fcp-refresh');
+    const lastRefreshLabel = document.getElementById('fcp-last-refresh');
+    const explorerTypeLabel = document.getElementById('fcp-explorer-type');
+
+    function queryTenant() {
+        const m = new URLSearchParams(window.location.search).get('tenant');
+        return (m && m.trim()) || DEFAULT_TENANT;
+    }
+
+    let currentTenant = queryTenant();
+    let selectedType = null;
+    tenantInput.value = currentTenant;
+
+    // --- helpers ---------------------------------------------------------
+
+    function escape(s) {
+        if (s === null || s === undefined) return '';
+        return String(s).replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function setHTML(id, html) {
+        const el = document.getElementById(id);
+        if (el) el.innerHTML = html;
+    }
+
+    async function fetchFHIR(path) {
+        const resp = await fetch(`/r6/fhir/${path}`, {
+            headers: {
+                'Accept': 'application/json',
+                'X-Tenant-Id': currentTenant,
+            },
+        });
+        if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+        return resp.json();
+    }
+
+    function errorBlock(msg) {
+        return `<div class="fcp-error"><i class="fas fa-triangle-exclamation"></i> ${escape(msg)}</div>`;
+    }
+
+    // Extract a top-level Parameters value by name (valueInteger/Decimal/String/DateTime).
+    function paramValue(params, name) {
+        const p = (params || []).find((x) => x.name === name);
+        if (!p) return undefined;
+        if ('valueInteger' in p) return p.valueInteger;
+        if ('valueDecimal' in p) return p.valueDecimal;
+        if ('valueString' in p) return p.valueString;
+        if ('valueDateTime' in p) return p.valueDateTime;
+        return p;
+    }
+
+    function paramByType(params) {
+        const p = (params || []).find((x) => x.name === 'byType');
+        return (p && p.part) || [];
+    }
+
+    // Read a named child part's value out of a part[] list.
+    function partValue(parts, name) {
+        const p = (parts || []).find((x) => x.name === name);
+        if (!p) return undefined;
+        if ('valueInteger' in p) return p.valueInteger;
+        if ('valueDecimal' in p) return p.valueDecimal;
+        if ('valueString' in p) return p.valueString;
+        if ('valueDateTime' in p) return p.valueDateTime;
+        return undefined;
+    }
+
+    function fmtDateTime(iso) {
+        if (!iso) return '—';
+        const d = new Date(iso);
+        if (isNaN(d.getTime())) return escape(iso);
+        return d.toLocaleString();
+    }
+
+    function adherenceClass(ratio) {
+        if (ratio >= 0.9) return 'good';
+        if (ratio >= 0.7) return 'warn';
+        return 'bad';
+    }
+
+    function pct(ratio) {
+        return `${Math.round((ratio || 0) * 100)}%`;
+    }
+
+    // --- inventory -------------------------------------------------------
+
+    async function loadInventory() {
+        setHTML('fcp-inventory-banner', '<div class="cc-loading">Loading…</div>');
+        setHTML('fcp-inventory-grid', '');
+        try {
+            const data = await fetchFHIR('$inventory');
+            const params = data.parameter || [];
+            const total = paramValue(params, 'total') || 0;
+            const lastUpdated = paramValue(params, 'lastUpdated');
+            const byType = paramByType(params);
+
+            if (!byType.length) {
+                setHTML('fcp-inventory-banner',
+                    '<div class="cc-empty">No data for this tenant yet.</div>');
+                return;
+            }
+
+            // byType.part[] sorted desc server-side; sort again defensively.
+            const tiles = byType
+                .map((p) => ({ name: p.name, count: p.valueInteger || 0 }))
+                .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+            setHTML('fcp-inventory-banner', `
+                <div class="fcp-banner-stat"><span class="fcp-banner-num">${total.toLocaleString()}</span> resources across ${tiles.length} type${tiles.length === 1 ? '' : 's'}</div>
+                <div class="fcp-banner-updated">Last updated: ${escape(fmtDateTime(lastUpdated))}</div>
+            `);
+
+            const grid = tiles.map((t) => `
+                <button type="button" class="fcp-tile${selectedType === t.name ? ' selected' : ''}" data-type="${escape(t.name)}">
+                    <span class="fcp-tile-count">${t.count.toLocaleString()}</span>
+                    <span class="fcp-tile-name">${escape(t.name)}</span>
+                </button>
+            `).join('');
+            setHTML('fcp-inventory-grid', grid);
+
+            document.querySelectorAll('#fcp-inventory-grid .fcp-tile').forEach((btn) => {
+                btn.addEventListener('click', () => selectType(btn.dataset.type));
+            });
+        } catch (err) {
+            setHTML('fcp-inventory-banner', errorBlock(`Inventory failed: ${err.message}`));
+        }
+    }
+
+    // --- profile adherence ----------------------------------------------
+
+    async function loadAdherence() {
+        setHTML('fcp-adherence', '<div class="cc-loading">Loading…</div>');
+        try {
+            const data = await fetchFHIR('$profile-adherence');
+            const params = data.parameter || [];
+            const overall = paramValue(params, 'overallAdherence');
+            const byType = paramByType(params);
+
+            if (!byType.length) {
+                setHTML('fcp-adherence', '<div class="cc-empty">No data for this tenant yet.</div>');
+                return;
+            }
+
+            const overallRatio = overall || 0;
+            const gauge = `
+                <div class="fcp-gauge ${adherenceClass(overallRatio)}">
+                    <div class="fcp-gauge-num">${pct(overallRatio)}</div>
+                    <div class="fcp-gauge-lbl">Overall adherence</div>
+                </div>`;
+
+            const rows = byType.map((p) => {
+                const parts = p.part || [];
+                const sampled = partValue(parts, 'sampled') || 0;
+                const conformant = partValue(parts, 'conformant') || 0;
+                const adherence = partValue(parts, 'adherence') || 0;
+                const topIssues = partValue(parts, 'topIssues') || '';
+                const cls = adherenceClass(adherence);
+                return `
+                    <tr>
+                        <td><button type="button" class="fcp-type-link" data-type="${escape(p.name)}">${escape(p.name)}</button></td>
+                        <td class="fcp-num">${conformant} / ${sampled}</td>
+                        <td class="fcp-num">
+                            <span class="fcp-adh-pill ${cls}">${pct(adherence)}</span>
+                        </td>
+                        <td class="fcp-issues">${topIssues ? escape(topIssues) : '<span class="fcp-none">— none —</span>'}</td>
+                    </tr>`;
+            }).join('');
+
+            setHTML('fcp-adherence', `
+                <div class="fcp-adherence-layout">
+                    ${gauge}
+                    <div class="fcp-adherence-table-wrap">
+                        <table class="fcp-table">
+                            <thead>
+                                <tr><th>Resource type</th><th>Conformant / sampled</th><th>Adherence</th><th>Top issues</th></tr>
+                            </thead>
+                            <tbody>${rows}</tbody>
+                        </table>
+                    </div>
+                </div>
+            `);
+
+            document.querySelectorAll('#fcp-adherence .fcp-type-link').forEach((btn) => {
+                btn.addEventListener('click', () => selectType(btn.dataset.type));
+            });
+        } catch (err) {
+            setHTML('fcp-adherence', errorBlock(`Profile adherence failed: ${err.message}`));
+        }
+    }
+
+    // --- resource explorer ----------------------------------------------
+
+    // Derive a generic, redaction-tolerant summary from a FHIR resource JSON.
+    function summarizeCode(res) {
+        const c = res.code;
+        if (c) {
+            if (c.text) return c.text;
+            if (Array.isArray(c.coding) && c.coding.length) {
+                return c.coding[0].display || c.coding[0].code || '';
+            }
+        }
+        // Patient/Practitioner-style fallback: name
+        if (Array.isArray(res.name) && res.name.length) {
+            const n = res.name[0];
+            if (n.text) return n.text;
+            const parts = [(n.given || []).join(' '), n.family].filter(Boolean);
+            if (parts.length) return parts.join(' ');
+        }
+        if (res.vaccineCode) {
+            const v = res.vaccineCode;
+            if (v.text) return v.text;
+            if (Array.isArray(v.coding) && v.coding.length) return v.coding[0].display || v.coding[0].code || '';
+        }
+        if (res.medicationCodeableConcept) {
+            const m = res.medicationCodeableConcept;
+            if (m.text) return m.text;
+            if (Array.isArray(m.coding) && m.coding.length) return m.coding[0].display || m.coding[0].code || '';
+        }
+        return '';
+    }
+
+    function summarizeSubject(res) {
+        const ref = res.subject || res.patient;
+        if (ref && ref.reference) return ref.reference;
+        return '';
+    }
+
+    function selectType(type) {
+        selectedType = type;
+        explorerTypeLabel.textContent = type ? `· ${type}` : '';
+        // Reflect selection in the inventory tiles.
+        document.querySelectorAll('#fcp-inventory-grid .fcp-tile').forEach((t) => {
+            t.classList.toggle('selected', t.dataset.type === type);
+        });
+        loadExplorer(type);
+    }
+
+    async function loadExplorer(type) {
+        setHTML('fcp-explorer', '<div class="cc-loading">Loading…</div>');
+        try {
+            const bundle = await fetchFHIR(
+                `${encodeURIComponent(type)}?_count=${EXPLORER_COUNT}&_sort=-_lastUpdated`);
+            const entries = bundle.entry || [];
+
+            if (!entries.length) {
+                setHTML('fcp-explorer',
+                    `<div class="cc-empty">No ${escape(type)} resources for this tenant yet.</div>`);
+                return;
+            }
+
+            const rows = entries.map((e) => {
+                const res = e.resource || {};
+                const id = res.id || '';
+                const code = summarizeCode(res);
+                const status = res.status || res.clinicalStatus?.coding?.[0]?.code || '';
+                const subject = summarizeSubject(res);
+                const lastUpdated = res.meta && res.meta.lastUpdated;
+                const detailUrl = `/r6/fhir/mcp-apps/compiled-truth/${encodeURIComponent(type)}/${encodeURIComponent(id)}`;
+                return `
+                    <tr class="fcp-res-row" data-url="${escape(detailUrl)}">
+                        <td class="fcp-mono">${escape(id)}</td>
+                        <td>${code ? escape(code) : '<span class="fcp-none">—</span>'}</td>
+                        <td>${status ? `<span class="cc-badge">${escape(status)}</span>` : '<span class="fcp-none">—</span>'}</td>
+                        <td class="fcp-mono">${subject ? escape(subject) : '<span class="fcp-none">—</span>'}</td>
+                        <td class="fcp-mono">${escape(fmtDateTime(lastUpdated))}</td>
+                        <td><a class="fcp-open" href="${escape(detailUrl)}" target="_blank" rel="noopener" title="Open compiled-truth detail"><i class="fas fa-arrow-up-right-from-square"></i></a></td>
+                    </tr>`;
+            }).join('');
+
+            setHTML('fcp-explorer', `
+                <div class="fcp-explorer-meta">
+                    Showing ${entries.length} most-recent ${escape(type)} (total ${(bundle.total ?? entries.length).toLocaleString()}). Values PHI-redacted.
+                </div>
+                <table class="fcp-table fcp-res-table">
+                    <thead>
+                        <tr><th>ID</th><th>Summary</th><th>Status</th><th>Subject</th><th>Last updated</th><th></th></tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            `);
+
+            // Row click opens detail in a new tab (ignore clicks on the explicit link).
+            document.querySelectorAll('#fcp-explorer .fcp-res-row').forEach((row) => {
+                row.addEventListener('click', (ev) => {
+                    if (ev.target.closest('a')) return;
+                    window.open(row.dataset.url, '_blank', 'noopener');
+                });
+            });
+        } catch (err) {
+            setHTML('fcp-explorer', errorBlock(`Explorer (${type}) failed: ${err.message}`));
+        }
+    }
+
+    // --- refresh orchestration ------------------------------------------
+
+    function refreshAll() {
+        currentTenant = (tenantInput.value || '').trim() || DEFAULT_TENANT;
+        tenantInput.value = currentTenant;
+        loadInventory();
+        loadAdherence();
+        if (selectedType) loadExplorer(selectedType);
+        lastRefreshLabel.textContent = new Date().toLocaleTimeString();
+    }
+
+    refreshBtn.addEventListener('click', refreshAll);
+    tenantInput.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter') {
+            // Switching tenant invalidates the current selection.
+            selectedType = null;
+            explorerTypeLabel.textContent = '';
+            setHTML('fcp-explorer',
+                '<div class="cc-empty">Select a resource type above to explore its resources.</div>');
+            refreshAll();
+        }
+    });
+
+    // initial load
+    refreshAll();
+})();

--- a/templates/fhir_control_panel.html
+++ b/templates/fhir_control_panel.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}FHIR Control Panel — HealthClaw Guardrails{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/command-center.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/fhir-control-panel.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="cc-container fcp" id="fcp-root">
+
+    <!-- Header -->
+    <section class="cc-hero fcp-hero">
+        <div class="cc-hero-title">
+            <i class="fas fa-sliders cc-hero-icon"></i>
+            <div>
+                <h1>FHIR Control Panel</h1>
+                <p class="cc-hero-sub" id="fcp-subtitle">Resource inventory · explorer · profile adherence</p>
+            </div>
+        </div>
+        <div class="cc-hero-stats fcp-hero-right">
+            <span class="fcp-badge"><i class="fas fa-circle-check"></i> FHIR R4 · US Core v9</span>
+            <a class="fcp-cap-link" id="fcp-metadata-link" href="/r6/fhir/metadata" target="_blank" rel="noopener">
+                <i class="fas fa-file-lines"></i> CapabilityStatement
+            </a>
+        </div>
+        <div class="cc-tenant-selector">
+            <label for="fcp-tenant-input">Tenant:</label>
+            <input id="fcp-tenant-input" type="text" placeholder="desktop-demo" />
+            <button type="button" id="fcp-refresh" class="btn btn-sm btn-outline-light">
+                <i class="fas fa-rotate"></i> Refresh
+            </button>
+            <span class="fcp-last-refresh">Last refresh <span id="fcp-last-refresh">—</span></span>
+        </div>
+    </section>
+
+    <!-- Inventory -->
+    <section class="cc-section">
+        <h2 class="cc-section-title"><i class="fas fa-database"></i> Resource Inventory</h2>
+        <div class="fcp-inventory-banner" id="fcp-inventory-banner">
+            <div class="cc-loading">Loading…</div>
+        </div>
+        <div class="cc-system-grid fcp-inventory-grid" id="fcp-inventory-grid"></div>
+    </section>
+
+    <!-- Profile adherence -->
+    <section class="cc-section">
+        <h2 class="cc-section-title"><i class="fas fa-clipboard-check"></i> Profile Adherence</h2>
+        <div class="fcp-adherence" id="fcp-adherence">
+            <div class="cc-loading">Loading…</div>
+        </div>
+    </section>
+
+    <!-- Resource explorer -->
+    <section class="cc-section">
+        <h2 class="cc-section-title">
+            <i class="fas fa-table-list"></i> Resource Explorer
+            <span class="fcp-explorer-type" id="fcp-explorer-type"></span>
+        </h2>
+        <p class="fcp-redaction-note">
+            <i class="fas fa-user-shield"></i> Reads are PHI-redacted. Click a row to open the compiled-truth detail.
+        </p>
+        <div class="fcp-explorer" id="fcp-explorer">
+            <div class="cc-empty">Select a resource type above to explore its resources.</div>
+        </div>
+    </section>
+
+</div>
+
+<script src="{{ url_for('static', filename='js/fhir-control-panel.js') }}"></script>
+{% endblock %}

--- a/tests/test_fhir_control_panel.py
+++ b/tests/test_fhir_control_panel.py
@@ -1,0 +1,178 @@
+"""
+Tests for FHIR control panel aggregate endpoints:
+  - GET /r6/fhir/$inventory
+  - GET /r6/fhir/$profile-adherence
+
+Both are read-only, tenant-scoped, and emit counts-only audit events
+(no PHI in the audit detail).
+"""
+
+import json
+
+from r6.models import R6Resource, AuditEventRecord
+from models import db
+
+
+def _seed(resource_type, resource, tenant_id):
+    """Persist a single FHIR resource for a tenant via R6Resource directly."""
+    row = R6Resource(
+        resource_type=resource_type,
+        resource_json=json.dumps(resource),
+        tenant_id=tenant_id,
+    )
+    db.session.add(row)
+    return row
+
+
+def _param(parameters, name):
+    """Pluck a parameter dict by name from a Parameters resource."""
+    for p in parameters:
+        if p.get('name') == name:
+            return p
+    return None
+
+
+# --- $inventory ---------------------------------------------------------
+
+
+def test_inventory_requires_tenant(client):
+    resp = client.get('/r6/fhir/$inventory')
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body['resourceType'] == 'OperationOutcome'
+    assert 'X-Tenant-Id' in body['issue'][0]['diagnostics']
+
+
+def test_inventory_grouped_counts(client, app, tenant_headers, tenant_id):
+    with app.app_context():
+        for i in range(2):
+            _seed('Patient', {'resourceType': 'Patient', 'id': f'p{i}',
+                              'gender': 'male'}, tenant_id)
+        for i in range(3):
+            _seed('Observation', {'resourceType': 'Observation', 'id': f'o{i}',
+                                 'status': 'final',
+                                 'code': {'coding': [{'code': 'x'}]}}, tenant_id)
+        db.session.commit()
+
+    resp = client.get('/r6/fhir/$inventory', headers=tenant_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['resourceType'] == 'Parameters'
+
+    params = body['parameter']
+    assert _param(params, 'tenant')['valueString'] == tenant_id
+    assert _param(params, 'total')['valueInteger'] == 5
+    assert _param(params, 'lastUpdated')['valueDateTime'].endswith('Z')
+
+    by_type = _param(params, 'byType')['part']
+    counts = {p['name']: p['valueInteger'] for p in by_type}
+    assert counts == {'Observation': 3, 'Patient': 2}
+    # Sorted desc by count: Observation (3) before Patient (2).
+    assert [p['name'] for p in by_type] == ['Observation', 'Patient']
+
+
+def test_inventory_tenant_isolation(client, app, tenant_headers, tenant_id):
+    with app.app_context():
+        _seed('Patient', {'resourceType': 'Patient', 'id': 'mine'}, tenant_id)
+        _seed('Observation', {'resourceType': 'Observation', 'id': 'other',
+                             'status': 'final',
+                             'code': {'coding': [{'code': 'x'}]}},
+              'some-other-tenant')
+        db.session.commit()
+
+    resp = client.get('/r6/fhir/$inventory', headers=tenant_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    params = body['parameter']
+    assert _param(params, 'total')['valueInteger'] == 1
+    by_type = _param(params, 'byType')['part']
+    counts = {p['name']: p['valueInteger'] for p in by_type}
+    assert counts == {'Patient': 1}
+    assert 'Observation' not in counts
+
+
+def test_inventory_emits_audit_no_phi(client, app, tenant_headers, tenant_id):
+    with app.app_context():
+        _seed('Patient', {'resourceType': 'Patient', 'id': 'p0',
+                          'name': [{'family': 'Secret', 'given': ['Person']}]},
+              tenant_id)
+        db.session.commit()
+
+    resp = client.get('/r6/fhir/$inventory', headers=tenant_headers)
+    assert resp.status_code == 200
+
+    with app.app_context():
+        events = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, resource_id='inventory'
+        ).all()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.event_type == 'read'
+        assert ev.resource_type == 'Parameters'
+        # Counts only — no PHI (names) leaked into detail.
+        assert 'Secret' not in (ev.detail or '')
+        assert 'Person' not in (ev.detail or '')
+
+
+# --- $profile-adherence -------------------------------------------------
+
+
+def test_profile_adherence_requires_tenant(client):
+    resp = client.get('/r6/fhir/$profile-adherence')
+    assert resp.status_code == 400
+
+
+def test_profile_adherence_per_type(client, app, tenant_headers, tenant_id):
+    with app.app_context():
+        # One conformant Observation (status + code present).
+        _seed('Observation', {'resourceType': 'Observation', 'id': 'good',
+                             'status': 'final',
+                             'code': {'coding': [{'code': 'x'}]}}, tenant_id)
+        # One non-conformant Observation (missing status).
+        _seed('Observation', {'resourceType': 'Observation', 'id': 'bad',
+                             'code': {'coding': [{'code': 'x'}]}}, tenant_id)
+        db.session.commit()
+
+    resp = client.get('/r6/fhir/$profile-adherence', headers=tenant_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['resourceType'] == 'Parameters'
+
+    params = body['parameter']
+    assert _param(params, 'tenant')['valueString'] == tenant_id
+    # 1 of 2 conformant overall.
+    assert _param(params, 'overallAdherence')['valueDecimal'] == 0.5
+
+    by_type = _param(params, 'byType')['part']
+    obs = next(p for p in by_type if p['name'] == 'Observation')
+    obs_parts = obs['part']
+    assert _param(obs_parts, 'total')['valueInteger'] == 2
+    assert _param(obs_parts, 'sampled')['valueInteger'] == 2
+    assert _param(obs_parts, 'conformant')['valueInteger'] == 1
+    assert _param(obs_parts, 'adherence')['valueDecimal'] == 0.5
+    top_issues = _param(obs_parts, 'topIssues')['valueString']
+    assert 'Observation.status is required' in top_issues
+    assert '(1)' in top_issues
+
+
+def test_profile_adherence_emits_audit_no_phi(client, app, tenant_headers,
+                                              tenant_id):
+    with app.app_context():
+        _seed('Patient', {'resourceType': 'Patient', 'id': 'p0',
+                          'name': [{'family': 'Secret', 'given': ['Person']}]},
+              tenant_id)
+        db.session.commit()
+
+    resp = client.get('/r6/fhir/$profile-adherence', headers=tenant_headers)
+    assert resp.status_code == 200
+
+    with app.app_context():
+        events = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, resource_id='profile-adherence'
+        ).all()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.event_type == 'read'
+        assert ev.resource_type == 'Parameters'
+        assert 'Secret' not in (ev.detail or '')
+        assert 'Person' not in (ev.detail or '')

--- a/tests/test_sources_summary.py
+++ b/tests/test_sources_summary.py
@@ -1,0 +1,198 @@
+"""
+tests/test_sources_summary.py
+
+Coverage for the Dev Days "check every connected source" endpoint:
+
+    GET /command-center/api/sources-summary
+
+Mirrors the auth/tenant model of the existing /api/sources tests in
+test_command_center.py: `test-tenant` is public in the test env (set in
+conftest via PUBLIC_TENANTS), so a bare ?tenant=test-tenant is accepted.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from models import db
+from r6.models import R6Resource, AuditEventRecord
+from r6.command_center import projector
+
+TENANT = "test-tenant"
+OTHER_TENANT = "other-tenant"
+
+# The 7 canonical source ids the summary must always report.
+EXPECTED_SOURCE_IDS = {
+    "fasten", "healthex", "hbo", "medent",
+    "flexpa", "healthskillz", "wearables",
+}
+
+
+def _seed_resource(resource_type: str, tenant: str = TENANT):
+    db.session.add(R6Resource(
+        resource_type=resource_type,
+        resource_json="{}",
+        tenant_id=tenant,
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Projector — sources_summary()
+# ---------------------------------------------------------------------------
+
+class TestSourcesSummaryProjector:
+
+    def test_reports_all_seven_sources(self, app):
+        with app.app_context():
+            out = projector.sources_summary(TENANT)
+            ids = {s["id"] for s in out["sources"]}
+            assert ids == EXPECTED_SOURCE_IDS
+            assert out["source_count"] == 7
+            assert out["tenant"] == TENANT
+            assert "generated_at" in out
+
+    def test_records_by_type_and_total(self, app):
+        with app.app_context():
+            for _ in range(3):
+                _seed_resource("Condition")
+            for _ in range(2):
+                _seed_resource("Observation")
+            _seed_resource("Immunization")
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            assert out["total_records"] == 6
+            by_type = {r["type"]: r["count"] for r in out["records_by_type"]}
+            assert by_type == {"Condition": 3, "Observation": 2, "Immunization": 1}
+
+    def test_deleted_resources_excluded(self, app):
+        with app.app_context():
+            r = R6Resource(resource_type="Condition", resource_json="{}",
+                           tenant_id=TENANT)
+            r.is_deleted = True
+            db.session.add(r)
+            _seed_resource("Observation")
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            assert out["total_records"] == 1
+            by_type = {r["type"]: r["count"] for r in out["records_by_type"]}
+            assert by_type == {"Observation": 1}
+
+    def test_tenant_isolation(self, app):
+        with app.app_context():
+            _seed_resource("Condition", tenant=OTHER_TENANT)
+            _seed_resource("Condition", tenant=OTHER_TENANT)
+            _seed_resource("Observation", tenant=TENANT)
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            assert out["total_records"] == 1
+            assert {r["type"] for r in out["records_by_type"]} == {"Observation"}
+
+    def test_audit_signal_marks_hbo_connected(self, app):
+        with app.app_context():
+            db.session.add(AuditEventRecord(
+                event_type="read",
+                resource_type="Condition",
+                tenant_id=TENANT,
+                detail="pulled from hbo upstream",
+                recorded=datetime.now(timezone.utc),
+            ))
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            sources = {s["id"]: s for s in out["sources"]}
+            assert sources["hbo"]["connected"] is True
+            assert sources["hbo"]["last_activity"] is not None
+            # A source with no signal stays disconnected.
+            assert sources["flexpa"]["connected"] is False
+            assert out["connected_count"] >= 1
+
+    def test_audit_signal_matches_agent_id(self, app):
+        with app.app_context():
+            db.session.add(AuditEventRecord(
+                event_type="read",
+                tenant_id=TENANT,
+                agent_id="medent-export-agent",
+                detail="generic export",
+                recorded=datetime.now(timezone.utc),
+            ))
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            sources = {s["id"]: s for s in out["sources"]}
+            assert sources["medent"]["connected"] is True
+
+    def test_audit_signal_is_tenant_isolated(self, app):
+        with app.app_context():
+            db.session.add(AuditEventRecord(
+                event_type="read",
+                tenant_id=OTHER_TENANT,
+                detail="flexpa pull",
+                recorded=datetime.now(timezone.utc),
+            ))
+            db.session.commit()
+
+            out = projector.sources_summary(TENANT)
+            sources = {s["id"]: s for s in out["sources"]}
+            assert sources["flexpa"]["connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Route — GET /command-center/api/sources-summary
+# ---------------------------------------------------------------------------
+
+class TestSourcesSummaryRoute:
+
+    def test_api_returns_all_seven(self, client):
+        resp = client.get(
+            "/command-center/api/sources-summary",
+            query_string={"tenant": TENANT},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        ids = {s["id"] for s in body["sources"]}
+        assert ids == EXPECTED_SOURCE_IDS
+        assert body["source_count"] == 7
+        assert body["tenant"] == TENANT
+
+    def test_api_reflects_seeded_records(self, app, client):
+        with app.app_context():
+            for _ in range(5):
+                _seed_resource("Condition")
+            db.session.commit()
+
+        resp = client.get(
+            "/command-center/api/sources-summary",
+            query_string={"tenant": TENANT},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["total_records"] == 5
+        by_type = {r["type"]: r["count"] for r in body["records_by_type"]}
+        assert by_type == {"Condition": 5}
+
+    def test_api_requires_auth_for_nonpublic_tenant(self, client):
+        resp = client.get(
+            "/command-center/api/sources-summary",
+            query_string={"tenant": "private-no-auth-tenant"},
+        )
+        assert resp.status_code == 401
+
+    def test_api_allows_nonpublic_tenant_with_step_up(self, app, client):
+        from r6.stepup import generate_step_up_token
+        tenant = "private-no-auth-tenant"
+        with app.app_context():
+            _seed_resource("Observation", tenant=tenant)
+            db.session.commit()
+        token = generate_step_up_token(tenant)
+        resp = client.get(
+            "/command-center/api/sources-summary",
+            query_string={"tenant": tenant},
+            headers={"X-Tenant-Id": tenant, "X-Step-Up-Token": token},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tenant"] == tenant
+        assert body["total_records"] == 1


### PR DESCRIPTION
Three demo surfaces for Dev Days:

## 1. FHIR Control Panel (new UI) — `/fhir-control-panel?tenant=<id>`
FHIR server visualization: resource-type **inventory grid**, click-through **resource explorer** (PHI-redacted, links to compiled-truth detail), and a **profile-adherence scorecard** (overall % + per-type conformant/sampled + top missing US Core fields). Backed by two new read endpoints:
- `GET /r6/fhir/$inventory` — counts by type, total, lastUpdated
- `GET /r6/fhir/$profile-adherence` — per-type adherence via the network-free structural validator (50/type cap), top issues

## 2. Sally checks all sources at once
- `GET /command-center/api/sources-summary` — all 7 sources (Fasten, HealthEx, HBO, MEDENT, Flexpa, Epic/Health Skillz, wearables) + per-type record counts in one call
- `sources_check` MCP tool (21 tools now) + `check-sources` skill — Sally surveys everything in one shot

## 3. Command center
Already live (5s polling). This branch adds the sources-summary feed; ev-personal stays token-gated (signed link for the demo).

## Tests
634 Python + 70 Node, tsc clean. Control panel visually QA'd locally (inventory + adherence + explorer render against seeded data).

## Deploy
Flask auto-deploys on merge. mcp-server needs manual deploy (sources_check) per the staging-dir procedure in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)