### PR TITLE
feat(demo): Claude Code proof terminal — live telemetry watcher + driven flow

### DIFF
--- a/docs/demos/dev-days-claude-code-proof.md
+++ b/docs/demos/dev-days-claude-code-proof.md
@@ -1,0 +1,120 @@
+# Dev Days — Claude Code as the "Proof Terminal" + driven demo flow
+
+The move: **Telegram shows the patient experience; Claude Code shows the proof.**
+While Sally runs the flow in Telegram, a second screen — your Claude Code session —
+streams the live guardrail telemetry: every FHIR read, redaction, step-up write,
+and real-world action landing in the immutable audit trail in real time. That is
+the dev-cred shot — the agent isn't a black box, every move is audited and visible.
+
+---
+
+## How to run the telemetry in Claude Code
+
+`scripts/demo_telemetry.py` tails the audit trail + record inventory for a tenant.
+It shells out to `curl` (system CA store) so it works on any machine regardless of
+the local Python SSL config. Reads use the tenant header only — nothing it does can
+mutate data; you're watching the same redacted, audited surface an agent sees.
+
+**Option A — stream it INTO Claude Code (recommended).** In your stage Claude Code
+session, ask Claude to run it via the **Monitor** tool so each audit event arrives
+as a live line in the conversation:
+
+> "Monitor the demo telemetry: `python3 scripts/demo_telemetry.py --tenant ev-personal`
+>  — emit each audit line, keep running until I stop it."
+
+Claude starts the watcher as a persistent monitor; as Sally acts in Telegram, the
+events stream into the session. This is the most "live coding" presentation — the
+audit trail scrolling in the same tool you built the system with.
+
+**Option B — a terminal split.** Just run it directly next to Claude Code:
+
+```bash
+python3 scripts/demo_telemetry.py --tenant ev-personal
+# desktop-demo (synthetic) needs no token; ev-personal works with the tenant header for reads
+```
+
+What a line looks like:
+```
+  14:02:11  👁  read      Condition/abc123        sally-pcp              ✅
+  14:02:14  ✏️  create    ProposedAction/9f..     sally-pcp              ✅      ← phone call proposed
+  14:02:20  ✎  update     ProposedAction/9f..     sally-pcp              ✅      ← step-up + human confirm → executing
+  📊 ev-personal: 315 resources  |  Observation:140  Condition:57  ...
+```
+
+Pre-flight: print one snapshot to prove it's wired before you walk on:
+```bash
+python3 scripts/demo_telemetry.py --tenant ev-personal --snapshot-every 1 --interval 3   # Ctrl-C after the first line
+```
+
+---
+
+## The driven flow (Telegram, narrated by the Claude Code feed)
+
+Run these as natural prompts to Sally. Each step produces audit telemetry that
+appears in the Claude Code proof terminal.
+
+### 1. Connect — walk every source
+> "Connect my health data. Go through each source."
+
+Sally offers the connect links (Fasten TEFCA, Health Bank One, MEDENT, Flexpa,
+Epic/Health Skillz) and confirms what's already connected. Then:
+
+> "Now check all my connected services for data."
+
+Sally calls `fhir_get_token` → `sources_check` (one call) → "Connected N/7; 315 records
+(57 Conditions, 140 Observations, …)." **Telemetry:** the `sources_check` read +
+per-source reads stream in Claude Code.
+
+### 2. Review & report using the skills
+> "Review my record and tell me what stands out."
+
+Sally uses the FHIR read tools + Curatr (`curatr_evaluate`) + clinical-context skills
+to summarize conditions/meds/trends and flag data-quality issues — administrative
+framing, no diagnosis. **Telemetry:** a burst of `read` + `validate` events.
+
+### 3. Phone call — dial the (simulated) doctor's office
+> "Call the doctor's office to follow up. Here's the number: <YOUR PHONE>."
+
+(You play the doctor's office — give your own number.) Sally drafts the call script,
+shows it, you confirm; she runs `action_propose` → `fhir_get_token` →
+`action_commit` (step-up + human-confirm). **Telemetry:** `ProposedAction` create
+then update — the propose→confirm→execute lifecycle, audited. Your phone rings.
+
+> ⚠️ **A real dial requires `BLAND_AI_API_KEY` on the Flask service.** Without it the
+> action completes in **simulation mode** (full propose→commit→audit telemetry, but
+> no actual call). To ring your phone on stage, set it the morning of:
+> `railway variables --service HealthClawGuardrails --set BLAND_AI_API_KEY=<key>`
+> (`ACTIONS_WEBHOOK_SECRET` is already set, so callbacks/outcome will record too.)
+
+### 4. Fill the 40-page intake form
+> "The new clinic needs this intake form filled out: <FORM URL>."
+
+(Supply any dummy patient-intake page/PDF.) Sally fetches the form, pulls your
+demographics, insurance, medications, and allergies from FHIR (via the MCP tools),
+fills the fields, and returns the completed form for your review. **Telemetry:** the
+FHIR reads that populate the form stream in Claude Code — visible proof the answers
+came from your actual record, not invented.
+
+> Note: form-fill here is **agent-driven** (Sally fetches + maps + fills). A
+> first-class `form-fill` *action* (audited propose/commit + AcroForm PDF output)
+> is the planned executor — not required for this demo; the FHIR-read telemetry is
+> the proof either way.
+
+---
+
+## One-glance stage layout
+
+| Screen | Shows | Source |
+|---|---|---|
+| Telegram | Sally + the patient (you) | phone / web.telegram.org |
+| Claude Code | live audit telemetry feed | `demo_telemetry.py` via Monitor |
+| Browser tab A | Command Center (live stats) | signed link (`generate-link`) |
+| Browser tab B | FHIR Control Panel | `/fhir-control-panel?tenant=ev-personal` |
+
+The story: *patient talks to Sally (Telegram) → every guarded move proves out in the
+audit feed (Claude Code) → the same data and conformance are inspectable (Control
+Panel) and the whole system's health is live (Command Center).*
+
+## The one thing to set for a real phone call
+`BLAND_AI_API_KEY` on the `HealthClawGuardrails` Flask service. Everything else
+(MCP tools, step-up, audit, signed link, control panel) is already live.

--- a/scripts/demo_telemetry.py
+++ b/scripts/demo_telemetry.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Live guardrail telemetry for stage demos — run this in Claude Code (or any
+terminal) while the Telegram agent drives the patient flow. Each guarded
+operation the agent performs (FHIR read, redaction, step-up write, real-world
+action) lands in the immutable audit trail; this tails that trail and prints a
+clean, readable line per event, plus a periodic record-inventory snapshot.
+
+Auth: reads use the tenant header only (no secret) — every line you see is the
+same redacted, audited surface an agent gets. Nothing here can mutate data.
+
+Usage:
+  python3 scripts/demo_telemetry.py --tenant ev-personal
+  python3 scripts/demo_telemetry.py --tenant desktop-demo --interval 2 --base-url https://app.healthclaw.io
+
+Run it via Claude Code's Monitor tool to stream each event into the session
+live (one chat line per audit event) — that is the "proof terminal" on stage.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+ICON = {
+    "read": "👁  read",
+    "create": "✏️  create",
+    "update": "✎  update",
+    "delete": "🗑  delete",
+    "validate": "✔  validate",
+}
+
+
+def _get(url, tenant, timeout=8):
+    """Fetch via curl — uses the system CA store, so it works on any machine
+    regardless of the local Python's SSL/cert configuration (a common macOS
+    Python.framework gotcha that would otherwise break this on stage)."""
+    out = subprocess.run(
+        ["curl", "-s", "--max-time", str(timeout),
+         "-H", f"X-Tenant-Id: {tenant}", "-H", "Accept: application/json", url],
+        capture_output=True, text=True, timeout=timeout + 4,
+    )
+    if out.returncode != 0 or not out.stdout:
+        raise RuntimeError(f"curl rc={out.returncode}")
+    return json.loads(out.stdout)
+
+
+def _event_line(ev):
+    """Format a FHIR AuditEvent into one stage-readable line."""
+    etype = (ev.get("type") or {}).get("display") or "?"
+    icon = ICON.get(etype, f"•  {etype}")
+    when = (ev.get("recorded") or "")[11:19]  # HH:MM:SS
+    ent = (ev.get("entity") or [{}])[0]
+    what = (ent.get("what") or {}).get("reference") or ""
+    agent = ((ev.get("agent") or [{}])[0].get("who") or {}).get("display") or "system"
+    outcome = (ev.get("outcome") or {}).get("code", {}).get("display", "")
+    flag = "✅" if outcome == "Success" else ("⚠️ " + outcome if outcome else "")
+    return f"  {when}  {icon:<12} {what:<28} {agent:<22} {flag}"
+
+
+def _inventory_line(base, tenant):
+    try:
+        data = _get(f"{base}/r6/fhir/$inventory", tenant)
+        p = {x["name"]: x for x in data.get("parameter", [])}
+        total = p.get("total", {}).get("valueInteger", 0)
+        by = p.get("byType", {}).get("part", [])
+        top = "  ".join(
+            f"{x['name']}:{x['valueInteger']}" for x in by[:6]
+        )
+        return f"📊 {tenant}: {total} resources  |  {top}"
+    except Exception as exc:  # noqa: BLE001
+        return f"📊 {tenant}: (inventory unavailable: {type(exc).__name__})"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tenant", required=True)
+    ap.add_argument("--base-url", default="https://app.healthclaw.io")
+    ap.add_argument("--interval", type=float, default=2.0, help="poll seconds")
+    ap.add_argument("--snapshot-every", type=int, default=15,
+                    help="print inventory snapshot every N polls")
+    args = ap.parse_args()
+    base = args.base_url.rstrip("/")
+
+    print(f"── HealthClaw live telemetry · tenant={args.tenant} · {base} ──", flush=True)
+    print(_inventory_line(base, args.tenant), flush=True)
+    print("── watching audit trail (Ctrl-C to stop) ──", flush=True)
+
+    seen = set()
+    # Prime: mark existing events as seen so we only show NEW activity.
+    try:
+        b = _get(f"{base}/r6/fhir/AuditEvent?_count=50&_sort=-_lastUpdated", args.tenant)
+        for e in b.get("entry", []):
+            rid = (e.get("resource") or {}).get("id")
+            if rid:
+                seen.add(rid)
+    except Exception:  # noqa: BLE001
+        pass
+
+    polls = 0
+    while True:
+        polls += 1
+        try:
+            b = _get(f"{base}/r6/fhir/AuditEvent?_count=50&_sort=-_lastUpdated", args.tenant)
+            fresh = [e.get("resource") or {} for e in b.get("entry", [])]
+            fresh = [r for r in fresh if r.get("id") and r["id"] not in seen]
+            for r in reversed(fresh):  # oldest-first for readable chronology
+                seen.add(r["id"])
+                print(_event_line(r), flush=True)
+        except Exception as exc:  # noqa: BLE001 — never let a blip kill the feed
+            print(f"  (poll error: {type(exc).__name__})", flush=True)
+
+        if polls % args.snapshot_every == 0:
+            print(_inventory_line(base, args.tenant), flush=True)
+
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n── telemetry stopped ──", flush=True)
+        sys.exit(0)


### PR DESCRIPTION
Adds scripts/demo_telemetry.py (live audit+inventory feed, curl-based for any-machine SSL) and a runbook for using Claude Code as the on-stage 'proof terminal' via the Monitor tool, plus the 4-step driven flow (connect → report → phone call → form-fill). Flags BLAND_AI_API_KEY as the one thing to set for a real dial. 🤖 Generated with [Claude Code](https://claude.com/claude-code)