### PR TITLE
fix(actions): accept BLAND_API_KEY alias so calls dial for real

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ railway up                  # Railway (full-stack)
 vercel deploy --prod        # Vercel (marketing + API serverless)
 ```
 
+**`.env` is NOT auto-loaded** — no code calls `load_dotenv`. Env vars come from the shell (local) or the platform (Railway/Vercel). Running `python main.py` after only editing `.env` won't pick up the new values; export them or source the file yourself. (Consequence: a key present in `.env` but absent from the process env behaves as unset — e.g. a missing provider key silently drops the action layer into simulation mode.)
+
 ## Key Directories
 
 ```text
@@ -228,6 +230,8 @@ Post-ingest Telegram push: `r6.telegram_push.notify_tenant` is called directly v
 - `tenant_headers` — read-only tenant headers
 - Sample resources: `sample_patient`, `sample_observation`, `sample_bundle`, `sample_permission`, `sample_subscription_topic`, `sample_nutrition_intake`, `sample_device_alert`
 
+**Testing write paths against a live server:** `POST /r6/fhir/internal/step-up-token` with `{"tenant_id": "..."}` returns a `token` signed with that server's `STEP_UP_SECRET` — the only way to get a valid token for a deployed server (you can't mint one locally unless the local `STEP_UP_SECRET` matches the deployed one). Use it for action/FHIR commit smoke tests; pass as `X-Step-Up-Token`.
+
 ## CI (`.github/workflows/ci.yml`)
 
 Seven jobs: `python-tests`, `node-tests`, `playwright-tests`, `compose-smoke`, `compliance-gates`, `secret-scan`, `dependency-audit`.
@@ -251,7 +255,7 @@ Real-world actions (phone calls, SMS) behind the same guardrails as FHIR writes.
 - Executors log `type(exc).__name__` and HTTP status codes only — `str(exc)` can leak the secret-bearing webhook URL.
 - No retries on calls — by design.
 
-**Env vars:** `BLAND_AI_API_KEY` (calls), `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN`/`TWILIO_FROM_NUMBER` (SMS — all three or hard-fail), `ACTIONS_WEBHOOK_SECRET` (callbacks 403 without it), `PUBLIC_BASE_URL` (webhook base, defaults to app.healthclaw.io). Absent provider keys → simulation mode (commit completes synchronously).
+**Env vars:** `BLAND_AI_API_KEY` (calls; `BLAND_API_KEY` accepted as an alias — either name dials for real), `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN`/`TWILIO_FROM_NUMBER` (SMS — all three or hard-fail), `ACTIONS_WEBHOOK_SECRET` (callbacks 403 without it), `PUBLIC_BASE_URL` (webhook base, defaults to app.healthclaw.io). Absent provider keys → simulation mode (commit completes synchronously).
 
 **Design docs:** `docs/superpowers/specs/2026-06-12-unified-action-layer-design.md` (full integration spec — phases 2-6 cover skills, Flexpa, ainpi.dev lookup, SHL QR, careagents.cloud rewire) and `docs/superpowers/plans/2026-06-12-action-core.md` (Phase 1 plan, executed).
 

--- a/r6/actions/executors.py
+++ b/r6/actions/executors.py
@@ -47,7 +47,10 @@ def _execute_call(payload, action_id):
     if not phone:
         return ExecutionResult(ok=False, simulated=False,
                                error='phone number is required')
-    api_key = os.environ.get('BLAND_AI_API_KEY')
+    # BLAND_AI_API_KEY is the documented name; BLAND_API_KEY is accepted as an
+    # alias so a key stored under either spelling dials for real instead of
+    # silently falling into simulation mode.
+    api_key = os.environ.get('BLAND_AI_API_KEY') or os.environ.get('BLAND_API_KEY')
     if not api_key:
         return ExecutionResult(ok=True, simulated=True,
                                external_ref='sim-' + secrets.token_hex(6))

--- a/tests/test_actions_executors.py
+++ b/tests/test_actions_executors.py
@@ -6,6 +6,7 @@ from r6.actions.executors import execute_action, ExecutionResult
 
 def test_phone_call_simulated_without_key(monkeypatch):
     monkeypatch.delenv('BLAND_AI_API_KEY', raising=False)
+    monkeypatch.delenv('BLAND_API_KEY', raising=False)
     result = execute_action(
         kind='phone-call',
         payload={'phone': '617-555-0100', 'body': 'script', 'to': 'CVS'},
@@ -45,6 +46,25 @@ def test_phone_call_real_contract(monkeypatch):
     assert kwargs['json']['phone_number'] == '617-555-0100'
     assert kwargs['json']['task'] == 'script'
     assert 'act-1' in kwargs['json']['webhook']
+
+
+def test_phone_call_dials_with_legacy_alias(monkeypatch):
+    """BLAND_API_KEY (alias) dials for real — not simulation."""
+    monkeypatch.delenv('BLAND_AI_API_KEY', raising=False)
+    monkeypatch.setenv('BLAND_API_KEY', 'alias-key')
+    fake = MagicMock()
+    fake.status_code = 200
+    fake.json.return_value = {'call_id': 'bl-alias'}
+    with patch('r6.actions.executors.requests.post', return_value=fake) as post:
+        result = execute_action(
+            kind='phone-call',
+            payload={'phone': '617-555-0100', 'body': 'script'},
+            action_id='act-2',
+        )
+    assert result.simulated is False
+    assert result.external_ref == 'bl-alias'
+    _, kwargs = post.call_args
+    assert kwargs['headers']['Authorization'] == 'alias-key'
 
 
 def test_phone_call_provider_error(monkeypatch):

--- a/tests/test_actions_routes.py
+++ b/tests/test_actions_routes.py
@@ -100,6 +100,7 @@ def test_commit_requires_human_confirmation(client, tenant_headers, auth_headers
 def test_commit_executes_in_simulation(client, tenant_headers, auth_headers,
                                         app, monkeypatch):
     monkeypatch.delenv('BLAND_AI_API_KEY', raising=False)
+    monkeypatch.delenv('BLAND_API_KEY', raising=False)
     action_id = _propose(client, tenant_headers)
     headers = dict(auth_headers)
     headers['X-Human-Confirmed'] = 'true'
@@ -134,6 +135,7 @@ def test_commit_expired_returns_410(client, tenant_headers, auth_headers, app):
 def test_commit_double_commit_conflict(client, tenant_headers, auth_headers,
                                         monkeypatch):
     monkeypatch.delenv('BLAND_AI_API_KEY', raising=False)
+    monkeypatch.delenv('BLAND_API_KEY', raising=False)
     action_id = _propose(client, tenant_headers)
     headers = dict(auth_headers)
     headers['X-Human-Confirmed'] = 'true'


### PR DESCRIPTION
## What

The Bland.ai phone-call executor only read `BLAND_AI_API_KEY`, but the key is commonly stored under `BLAND_API_KEY` (e.g. in `.env`). When the names mismatched, the executor silently fell into **simulation mode** — `commit` returned `200 / completed` with no call placed — instead of dialing. This makes either spelling dial for real.

## Why it matters

`.env` is not auto-loaded anywhere in the codebase (no `load_dotenv`), so a key present in `.env` but absent from the process env reads as unset. Combined with the name mismatch, a misconfigured-looking-but-present key silently disabled real calls. Discovered while testing the action layer.

## Changes

- **`r6/actions/executors.py`** — `BLAND_AI_API_KEY or BLAND_API_KEY` (documented name stays primary).
- **Tests** — new `test_phone_call_dials_with_legacy_alias` (asserts the alias dials, not simulates); the two sim-mode tests now clear *both* names so a real key in the env can't satisfy the fallback and break them.
- **`CLAUDE.md`** — documents the alias, the `.env`-not-auto-loaded gotcha (root cause), and `POST /r6/fhir/internal/step-up-token` for minting valid step-up tokens against a live server.

## Verification

`uv run python -m pytest tests/test_actions_executors.py tests/test_actions_routes.py -q` → **28 passed**. Production (which already has `BLAND_AI_API_KEY` set) was validated end-to-end with a real test call through the deployed propose→commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)