### PR TITLE
fix(security): close read-auth suffix-exemption bypass + arm token-mint guard

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -12,6 +12,7 @@ Validation: structural checks for required fields. Falls back when external
 validator unavailable. No StructureDefinition or terminology binding validation.
 """
 
+import hmac
 import json
 import logging
 import os
@@ -104,23 +105,51 @@ _PATIENT_REF_PATTERN = re.compile(r'^Patient/[A-Za-z0-9\-.]{1,64}$')
 
 # --- Tenant Enforcement ---
 
+_R6_PREFIX = '/r6/fhir'
+
+# Discovery/public endpoints exempt from tenant + read-auth enforcement.
+# EXACT full paths — never suffix-matched.
+_EXEMPT_EXACT_PATHS = frozenset({
+    f'{_R6_PREFIX}/metadata',   # CapabilityStatement
+    f'{_R6_PREFIX}/health',     # health check
+})
+
+# Genuinely-namespaced sub-trees exempt from tenant + read-auth enforcement.
+# These are prefix-matched because every path under them is non-clinical and
+# no FHIR resource read can introduce one of these segments: a resource read is
+# /{prefix}/{ResourceType}/{id}, where ResourceType is a single bare segment —
+# it can never be "internal", ".well-known", "oauth", "mcp-apps", or "demo"
+# *followed by another '/segment'*. (e.g. /r6/fhir/demo/agent-loop is the demo
+# endpoint; /r6/fhir/Demo is a — nonexistent — resource type but still a single
+# segment, so it would NOT match these prefixes.)
+_EXEMPT_PATH_PREFIXES = (
+    f'{_R6_PREFIX}/internal/',
+    f'{_R6_PREFIX}/.well-known/',
+    f'{_R6_PREFIX}/oauth/',
+    f'{_R6_PREFIX}/mcp-apps/',
+    f'{_R6_PREFIX}/demo/',
+)
+
+
+def _is_exempt_discovery_path(path):
+    """True if `path` is a public discovery/namespaced endpoint.
+
+    Exact-match the literal discovery routes (/metadata, /health) and
+    prefix-match the namespaced sub-trees. Crucially this does NOT use a
+    suffix test, so a FHIR read like /r6/fhir/Patient/metadata (resource id
+    "metadata") is NOT treated as discovery and stays fully gated.
+    """
+    if path in _EXEMPT_EXACT_PATHS:
+        return True
+    return any(path.startswith(p) for p in _EXEMPT_PATH_PREFIXES)
+
+
 @r6_blueprint.before_request
 def enforce_tenant_id():
     """Require X-Tenant-Id header on all endpoints except public discovery."""
-    # Public discovery endpoints (no tenant required)
-    if request.path.endswith('/metadata'):
-        return None
-    if request.path.endswith('/health'):
-        return None
-    if '/internal/' in request.path or '/demo/' in request.path:
-        return None
-    if '/.well-known/' in request.path:
-        return None
-    if '/oauth/' in request.path:
-        return None
-    # MCP App HTML renders without a tenant header; tenant arrives via
-    # query string or is supplied by the MCP client's outer session.
-    if '/mcp-apps/' in request.path:
+    # Public discovery endpoints (exact path / namespaced prefix — never a
+    # suffix test, which a resource id like Patient/metadata could exploit).
+    if _is_exempt_discovery_path(request.path):
         return None
     tenant_id = request.headers.get('X-Tenant-Id')
     # SHARP-on-MCP: requests bearing X-FHIR-Server-URL carry their own
@@ -1483,8 +1512,19 @@ def health_check():
 def issue_step_up_token():
     """
     Issue a step-up token for the dashboard demo.
-    In production, this would be gated behind an admin auth flow.
+
+    Token-mint oracle protection: if INTERNAL_TOKEN_MINT_SECRET is set, the
+    caller must present a matching X-Internal-Secret header (constant-time
+    compare) — otherwise 403. With read-auth enabled, an open mint endpoint
+    would be a trivial bypass (anyone could mint a tenant-bound read token).
+    If the env var is unset, behavior is unchanged (open) for dev/demo.
     """
+    mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
+    if mint_secret:
+        provided = request.headers.get('X-Internal-Secret', '')
+        if not hmac.compare_digest(provided, mint_secret):
+            return jsonify({'error': 'forbidden'}), 403
+
     body = request.get_json(silent=True) or {}
     tenant_id = body.get('tenant_id') or request.headers.get('X-Tenant-Id', 'default')
     try:

--- a/tests/test_read_auth.py
+++ b/tests/test_read_auth.py
@@ -118,6 +118,55 @@ def test_internal_step_up_token_endpoint_still_reachable(client):
 
 # --- Phase 2: CapabilityStatement advertises SMART OAuth security ---
 
+# --- Exemption is exact-path / prefix, never a suffix (bypass closed) ---
+
+def test_resource_named_metadata_is_not_exempt(client):
+    """A FHIR read whose resource id is literally 'metadata' must NOT be
+    treated as the discovery /metadata endpoint — the old endswith() check let
+    /Patient/metadata bypass auth entirely."""
+    resp = client.get('/r6/fhir/Patient/metadata',
+                      headers={'X-Tenant-Id': PRIVATE_TENANT})
+    assert resp.status_code == 401
+
+
+def test_resource_named_health_is_not_exempt(client):
+    resp = client.get('/r6/fhir/Observation/health',
+                      headers={'X-Tenant-Id': PRIVATE_TENANT})
+    assert resp.status_code == 401
+
+
+def test_exact_metadata_and_health_still_public(client):
+    assert client.get('/r6/fhir/metadata').status_code == 200
+    assert client.get('/r6/fhir/health').status_code in (200, 503)
+
+
+# --- Token-mint oracle protection (dormant until env var set) ---
+
+def test_mint_open_when_secret_unset(client, monkeypatch):
+    monkeypatch.delenv('INTERNAL_TOKEN_MINT_SECRET', raising=False)
+    resp = client.post('/r6/fhir/internal/step-up-token',
+                       json={'tenant_id': PRIVATE_TENANT})
+    assert resp.status_code == 200
+    assert resp.get_json()['token']
+
+
+def test_mint_requires_secret_when_set(client, monkeypatch):
+    monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', 's3cr3t')
+    # no header -> 403
+    assert client.post('/r6/fhir/internal/step-up-token',
+                       json={'tenant_id': PRIVATE_TENANT}).status_code == 403
+    # wrong header -> 403
+    assert client.post('/r6/fhir/internal/step-up-token',
+                       json={'tenant_id': PRIVATE_TENANT},
+                       headers={'X-Internal-Secret': 'nope'}).status_code == 403
+    # correct header -> 200
+    ok = client.post('/r6/fhir/internal/step-up-token',
+                     json={'tenant_id': PRIVATE_TENANT},
+                     headers={'X-Internal-Secret': 's3cr3t'})
+    assert ok.status_code == 200
+    assert ok.get_json()['token']
+
+
 def test_capability_statement_declares_smart_security(client):
     resp = client.get('/r6/fhir/metadata')
     rest = resp.get_json()['rest'][0]

--- a/tests/test_share_bundle.py
+++ b/tests/test_share_bundle.py
@@ -117,6 +117,40 @@ def test_share_bundle_returns_collection(client, auth_headers, app):
     assert len(bundle['entry']) == 2
 
 
+def test_share_bundle_works_for_non_public_tenant_with_token(client, app):
+    """The SHL feed must keep working for a real (non-public) tenant under the
+    read-auth gate, as long as a valid step-up token is supplied — this is the
+    path shl_generate drives (forward the patient's step-up token to
+    $share-bundle). Both the read-auth gate and the route's own step-up check
+    must accept it."""
+    from r6.stepup import generate_step_up_token
+    tenant = 'shl-private-clinic'  # NOT in PUBLIC_TENANTS
+    _seed_resource(app, 'Patient', PATIENT_RESOURCE, tenant_id=tenant)
+    _seed_resource(app, 'Condition', CONDITION_RESOURCE, tenant_id=tenant)
+
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers={'X-Tenant-Id': tenant,
+                 'X-Step-Up-Token': generate_step_up_token(tenant)},
+        json={'patient_id': PATIENT_ID, 'resource_types': ['Patient', 'Condition']},
+    )
+    assert resp.status_code == 200
+    bundle = json.loads(resp.data)
+    assert {e['resource']['resourceType'] for e in bundle['entry']} == {'Patient', 'Condition'}
+
+
+def test_share_bundle_non_public_tenant_rejected_without_token(client, app):
+    """A non-public tenant with NO token is stopped by the read-auth gate (401)
+    before the route runs — the SHL feed never leaks identified data to an
+    unauthenticated caller."""
+    resp = client.post(
+        '/r6/fhir/$share-bundle',
+        headers={'X-Tenant-Id': 'shl-private-clinic'},
+        json={},
+    )
+    assert resp.status_code == 401
+
+
 def test_share_bundle_patient_controlled_redaction_applied(client, auth_headers, app):
     """Deidentified profile: name/telecom/address removed, birthDate preserved."""
     _seed_resource(app, 'Patient', PATIENT_RESOURCE)


### PR DESCRIPTION
Urgent follow-up to the merged read-auth gate (#38), which shipped with two bypasses. Mirrors the reviewed fixes from the `security/hardening` branch (#35) **byte-for-byte** so there's no conflict when #35 is reconciled.

## 1. Suffix-exemption bypass — **fixed, effective immediately**
`enforce_tenant_id` exempted discovery endpoints with `endswith('/metadata')` / substring `in` checks. A FHIR read whose resource id is literally `metadata` — `GET /r6/fhir/Patient/metadata` — matched the suffix and **bypassed auth entirely**. Replaced with:
- exact-path match for `/metadata` and `/health`
- prefix match for genuinely-namespaced sub-trees (`/internal/`, `/.well-known/`, `/oauth/`, `/mcp-apps/`, `/demo/`)

A resource read is `/{prefix}/{Type}/{id}` (single `Type` segment), so it can never match a namespaced prefix. Zero caller impact.

## 2. Token-mint oracle — **guard shipped dormant**
`POST /internal/step-up-token` minted a tenant-bound token for **anyone, unauthenticated** — a trivial read-auth bypass (mint a token → read any tenant). Added an `INTERNAL_TOKEN_MINT_SECRET` guard: when set, the caller must present a matching `X-Internal-Secret` (constant-time), else `403`. **Unset ⇒ unchanged (open)**, so deploying this is a no-op.

⚠️ **Activation is NOT in this PR.** The endpoint has 15+ callers — including the browser dashboard (`static/js/r6-dashboard.js`), which cannot hold a secret. Setting `INTERNAL_TOKEN_MINT_SECRET` without reconciling those callers would break the dashboard. Full activation (server-side token issuance / consumer updates) is handled in the `security/hardening` branch. **Until that lands, the token-mint bypass remains open in prod.**

## Tests
`tests/test_read_auth.py`: `Patient/metadata` & `Observation/health` now `401`; exact `/metadata` `/health` still public; mint open when secret unset, `403`/`200` when set. **650 Python tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)