### PR TITLE
fix(docker-compose): healthcheck for the agent-orchestrator (MCP) service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,16 @@ services:
       - RATE_LIMIT_MAX=${RATE_LIMIT_MAX:-120}
     depends_on:
       - fhir-mcp-guardrails
+    # node:20-slim ships no curl, so the probe uses node's global fetch.
+    # tools/list on the /mcp/rpc bridge is the strongest liveness signal:
+    # it exercises the Express stack, JSON-RPC dispatch, and the tool
+    # registry (asserts a non-empty tools array), not just process-up.
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/mcp/rpc',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({jsonrpc:'2.0',id:1,method:'tools/list'})}).then(r=>r.json()).then(b=>process.exit(b.result&&Array.isArray(b.result.tools)&&b.result.tools.length>0?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
     networks:
       - fhir-net
 


### PR DESCRIPTION
Closes #65.

Adds the missing container healthcheck to the `agent-orchestrator` service, mirroring the existing `shl-server` pattern.

## What

```yaml
healthcheck:
  test: ["CMD", "node", "-e", "fetch('http://localhost:3001/mcp/rpc', ... method:'tools/list' ...) → exit 0 if tools.length > 0 else 1"]
  interval: 30s
  timeout: 5s
  start_period: 15s
  retries: 3
```

## Two deliberate deviations from the issue text

- **`node -e` instead of `curl`.** The `agent-orchestrator` image is `node:20-slim`, which ships no `curl`. A curl-based probe (like `shl-server`'s) would fail silently forever. The probe uses node's built-in global `fetch` instead.
- **Asserts a non-empty `tools` array, not a hardcoded count.** The issue suggested "returning 27 tools"; the registry has since grown to 29, so a count assertion would break on every new tool. `tools.length > 0` is the stable invariant.

## Verified

Built the TS server locally, ran it, and executed the exact probe command:
- against the running server → **exit 0**, reports **29 tools**
- against a dead port → **exit 1**
- `docker compose config` parses the modified file

## One honest caveat

`tools/list` is served from the in-memory tool registry and does not reach upstream Flask/`FHIR_BASE_URL`. This probe therefore proves the **orchestrator process is up and serving MCP**, i.e. a liveness check — it is not a readiness check of the whole stack (Flask could be down while this reports healthy). That matches the issue's framing ("tools/list ... is the strongest liveness signal"); wiring `depends_on: service_healthy` or upstream-reachability checks would be a separate, larger change and is intentionally out of scope here.

Signed off under DCO.
