### PR TITLE
feat(adapters): LangChain example script (bridge already supports it)

### DIFF
--- a/adapters/examples/langchain_agent.py
+++ b/adapters/examples/langchain_agent.py
@@ -1,0 +1,68 @@
+"""Minimal example: HealthClaw tools on a LangChain tool-calling loop.
+
+Requires: `pip install "langchain-core>=1.0" langchain-openai` (v1 accepts a
+JSON-Schema dict as args_schema directly) and OPENAI_API_KEY. Reference
+example (not run in CI). Guardrails enforced by HealthClaw server-side.
+
+    python adapters/examples/langchain_agent.py \
+        --mcp-base https://mcp-server-production-5112.up.railway.app \
+        --tenant desktop-demo --prompt "List the patient's active conditions"
+"""
+import argparse
+import json
+import sys
+
+sys.path.insert(0, __file__.rsplit("/adapters/", 1)[0])
+from adapters.healthclaw_bridge import (  # noqa: E402
+    load_manifest, HealthClawClient,
+)
+
+
+def to_langchain_tools(manifest, hc):
+    """Manifest -> LangChain StructuredTools relaying through HealthClawClient."""
+    from langchain_core.tools import StructuredTool
+    tools = []
+    for t in (manifest["tools"] if isinstance(manifest, dict) else manifest):
+        def _run(_name=t["name"], **kwargs):
+            return json.dumps(hc.call(_name, kwargs))[:12000]
+        tools.append(StructuredTool.from_function(
+            func=_run, name=t["name"], description=t.get("description", ""),
+            args_schema=t.get("inputSchema", {"type": "object", "properties": {}}),
+        ))
+    return tools
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mcp-base", required=True)
+    ap.add_argument("--tenant", required=True)
+    ap.add_argument("--step-up-token")
+    ap.add_argument("--prompt", required=True)
+    ap.add_argument("--model", default="gpt-4o")
+    args = ap.parse_args()
+
+    from langchain_core.messages import HumanMessage, ToolMessage
+    from langchain_openai import ChatOpenAI
+
+    hc = HealthClawClient(args.mcp_base, args.tenant, args.step_up_token,
+                          agent_id="langchain-example")
+    tools = to_langchain_tools(load_manifest(), hc)
+    tool_map = {t.name: t for t in tools}
+    llm = ChatOpenAI(model=args.model).bind_tools(tools)
+    messages = [HumanMessage(args.prompt)]
+
+    for _ in range(6):  # bounded tool loop
+        ai = llm.invoke(messages)
+        messages.append(ai)
+        if not ai.tool_calls:
+            print(ai.content)
+            return
+        for tc in ai.tool_calls:
+            tool = tool_map.get(tc["name"])
+            result = (tool.invoke(tc["args"]) if tool
+                      else f"error: unknown tool {tc['name']}")
+            messages.append(ToolMessage(content=result, tool_call_id=tc["id"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/recipes/any-agent-framework.md
+++ b/docs/recipes/any-agent-framework.md
@@ -1,6 +1,6 @@
 # Recipe: run HealthClaw tools on any agent framework
 
-**Goal:** use the 23 guardrailed HealthClaw tools from an agent built on
+**Goal:** use the 29 guardrailed HealthClaw tools from an agent built on
 **OpenAI**, **Google Gemini**, **LangChain**, or plain HTTP — not just Claude/MCP.
 The guardrails (redaction, audit, step-up, tenant isolation) are enforced
 **server-side**, so every framework gets the same safety; the client side is just
@@ -13,12 +13,12 @@ a tool-schema shim.
 | **Claude Desktop / Code, Hermes** | Native MCP (`/mcp` streamable HTTP or stdio) | none — already works |
 | **OpenAI (Agents SDK / Responses API)** | (a) point its **remote-MCP connector** at `POST /mcp`, or (b) `adapters` bridge below | XS |
 | **Gemini (Vertex / Gemini API)** | `adapters` bridge (no native remote-MCP connector) | S |
-| **LangChain / LlamaIndex** | community MCP adapters, or the bridge | XS |
+| **LangChain / LlamaIndex** | community MCP adapters, or the bridge (`adapters/examples/langchain_agent.py`) | XS |
 | **Anything (any language)** | `POST /mcp/rpc` JSON-RPC bridge directly | XS |
 
 ## The bridge (`adapters/`)
 
-- `adapters/tools.manifest.json` — the 23 tools as JSON Schema (regenerate any time
+- `adapters/tools.manifest.json` — the 29 tools as JSON Schema (regenerate any time
   from the MCP server: `POST /mcp/rpc {"method":"tools/list"}`).
 - `adapters/healthclaw_bridge.py`:
   - `to_openai_tools(manifest)` → OpenAI function tools
@@ -60,6 +60,16 @@ Two paths:
    `adapters/examples/gemini_agent.py` maps `to_gemini_declarations(...)` into a
    `Tool(function_declarations=...)`, and relays each `functionCall` to `/mcp/rpc`,
    returning the result as a `functionResponse`.
+
+## LangChain
+
+Use the bridge: `adapters/examples/langchain_agent.py` wraps each manifest tool
+as a `StructuredTool` (langchain-core >= 1.0 accepts the manifest's JSON Schema
+directly as `args_schema`), binds the tools to a tool-calling chat model, and
+dispatches each tool call through `HealthClawClient` to `/mcp/rpc`. The example
+binds the tools via `langchain-openai`'s `ChatOpenAI`; the tool-wrapping helper
+(`to_langchain_tools`) is model-agnostic, so swapping in another LangChain
+tool-calling chat model is a one-line change.
 
 ## Skills
 


### PR DESCRIPTION
Closes #63.

Adds `adapters/examples/langchain_agent.py`, mirroring the existing `openai_agent.py` / `gemini_agent.py` (~65 lines, argparse, reference-only, not run in CI): loads the manifest, wraps each tool as a langchain-core `StructuredTool` dispatching through `HealthClawClient`, and runs a bounded tool-calling loop.

## Notes

- **langchain-core v1+** accepts the manifest's JSON Schema directly as `args_schema`, so no pydantic model generation is needed. (Verified empirically: dict schemas are rejected on 0.3.29 and accepted on 0.3.44+ / 1.x, so the docs say `>= 1.0` to keep the guidance unambiguous.)
- Tool dispatch uses `tool_map.get(name)` and returns an explicit error string for an unknown tool name instead of raising `KeyError`.
- The example binds tools via `langchain-openai`'s `ChatOpenAI`; the `to_langchain_tools` helper is model-agnostic, so swapping in another LangChain chat model is a one-line change.
- `docs/recipes/any-agent-framework.md` gains a LangChain section, the three-doors table points at the example, and the stale tool count is corrected **23 → 29** to match `adapters/tools.manifest.json`.

## Scope boundary (deliberate)

Not hardened past the existing OpenAI/Gemini examples — no network timeouts, response-size caps, `X-Human-Confirmed` threading, or arg sanitization. Those are properties of the shared `HealthClawClient` bridge, not this ~65-line reference script, and the issue asks to mirror the existing examples' style/size. Happy to open a separate issue/PR on bridge hardening if useful.

## Verified

Against the public `desktop-demo` tenant:
- all **29** manifest tools wrap cleanly
- a wrapped `fhir_search` invocation returns a redacted, disclaimer-injected Bundle through `/mcp/rpc`
- the unknown-tool guard returns the error string rather than raising

`ruff` clean; full repo suite green (971 Python, 92 Node) after rebase onto current `main`.

Signed off under DCO.
