### PR TITLE
[codex] Fix agent orchestrator Jest teardown

### DIFF
--- a/services/agent-orchestrator/package.json
+++ b/services/agent-orchestrator/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "jest --forceExit",
+    "test": "jest",
     "lint": "tsc --noEmit"
   },
   "dependencies": {

--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -376,7 +376,7 @@ app.delete("/mcp", (req, res) => {
 });
 
 // --- Session cleanup: expire sessions after 30 minutes of inactivity ---
-setInterval(() => {
+const sessionCleanupInterval = setInterval(() => {
   // In production, sessions would have last-activity timestamps
   // For now, cap total sessions to prevent memory exhaustion
   const MAX_SESSIONS = 1000;
@@ -389,6 +389,7 @@ setInterval(() => {
     }
   }
 }, 60_000);
+sessionCleanupInterval.unref?.();
 
 // --- SSE Transport (legacy MCP, still supported) ---
 
@@ -538,4 +539,11 @@ if (require.main === module) {
   });
 }
 
-export { app };
+function closeMCPServerForTests(): void {
+  clearInterval(sessionCleanupInterval);
+  rateLimitMap.clear();
+  streamableSessions.clear();
+  activeSessions.clear();
+}
+
+export { app, closeMCPServerForTests };

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { FHIRTools, MCPToolSchema } from "./tools";
+import http from "http";
 
 // Mock node-fetch before importing anything that uses it.
 // jest.mock is hoisted, so the factory must not reference outer variables.
@@ -16,15 +17,10 @@ import fetch from "node-fetch";
 const mockFetch = fetch as unknown as jest.Mock;
 
 import request from "supertest";
-import { app } from "./index";
+import { app, closeMCPServerForTests } from "./index";
 
-// The index module starts a setInterval for session cleanup. Use fake timers
-// so Jest can exit cleanly without --forceExit.
-beforeAll(() => {
-  jest.useFakeTimers();
-});
 afterAll(() => {
-  jest.useRealTimers();
+  closeMCPServerForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -1524,29 +1520,52 @@ describe("Express App Tests", () => {
   // -- SSE transport --
 
   describe("GET /sse", () => {
-    it("starts SSE connection with text/event-stream content type", (done) => {
-      request(app)
-        .get("/sse")
-        .buffer(false)
-        .parse((res: any, callback: any) => {
-          expect(res.headers["content-type"]).toContain("text/event-stream");
-          let data = "";
-          res.on("data", (chunk: Buffer) => {
-            data += chunk.toString();
-            if (data.length > 0) {
-              res.destroy();
+    it("starts SSE connection with text/event-stream content type", async () => {
+      await new Promise<void>((resolve, reject) => {
+        const server = http.createServer(app);
+        let req: http.ClientRequest | undefined;
+        let finished = false;
+
+        const finish = (error?: Error) => {
+          if (finished) return;
+          finished = true;
+          req?.destroy();
+          server.close((closeError) => {
+            if (error) {
+              reject(error);
+            } else if (closeError) {
+              reject(closeError);
+            } else {
+              resolve();
             }
           });
-          res.on("end", () => callback(null, data));
-          res.on("error", () => callback(null, data));
-          setTimeout(() => {
-            res.destroy();
-            callback(null, data);
-          }, 500);
-        })
-        .end(() => {
-          done();
+        };
+
+        server.listen(0, () => {
+          const address = server.address();
+          if (!address || typeof address === "string") {
+            finish(new Error("Expected test server to listen on a TCP port"));
+            return;
+          }
+
+          req = http.get(
+            { hostname: "127.0.0.1", port: address.port, path: "/sse" },
+            (res) => {
+              try {
+                expect(res.statusCode).toBe(200);
+                expect(res.headers["content-type"]).toContain("text/event-stream");
+                res.destroy();
+                finish();
+              } catch (error) {
+                res.destroy();
+                finish(error as Error);
+              }
+            }
+          );
+          req.on("error", (error) => finish(error));
         });
+        server.on("error", (error) => finish(error));
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Keep a handle to the agent-orchestrator session cleanup interval and expose a test teardown helper that clears in-memory state.
- Remove the Jest `--forceExit` workaround now that the suite can exit cleanly.
- Update the SSE endpoint test so its temporary HTTP server, request, and response are closed deterministically.

## Root cause

`src/index.ts` created a module-level `setInterval` before tests could install fake timers, so Jest reported the timer as an open handle. The SSE streaming test also left a `supertest` request handle visible to `--detectOpenHandles`.

## Validation

From `services/agent-orchestrator`:

- `npx tsc --noEmit`
- `npm test`
- `npm test -- --detectOpenHandles`

All passed locally. This change uses only synthetic test data and does not touch PHI, clinical semantics, access control, redaction, audit, or security disclosure paths.

AI assistance disclosure: this PR was prepared with Codex.

Closes #58