### PR TITLE
[codex] Default quality measure periods to current year

### DIFF
--- a/r6/quality/routes.py
+++ b/r6/quality/routes.py
@@ -5,6 +5,7 @@ Read-shaped: tenant-read-authenticated + AuditEvent. Computes the measure from
 the tenant's stored Patient / Condition / Observation resources.
 """
 
+import datetime as dt
 import logging
 
 from flask import request, jsonify
@@ -19,6 +20,11 @@ from r6.quality.report import (
 logger = logging.getLogger(__name__)
 
 MEASURE_ID = "nqf0018-controlling-high-bp"
+
+
+def _default_measurement_period(today=None):
+    today = today or dt.date.today()
+    return f"{today.year}-01-01", f"{today.year}-12-31"
 
 
 def register_quality_routes(blueprint, deps):
@@ -59,10 +65,13 @@ def register_quality_routes(blueprint, deps):
             return auth_err[0], auth_err[1]
 
         params = request.get_json(silent=True) or {}
+        default_start, default_end = _default_measurement_period()
         period_start = (_param(params, "periodStart")
-                        or request.args.get("periodStart", "2026-01-01"))
+                        or request.args.get("periodStart")
+                        or default_start)
         period_end = (_param(params, "periodEnd")
-                      or request.args.get("periodEnd", "2026-12-31"))
+                      or request.args.get("periodEnd")
+                      or default_end)
         subject = (_param(params, "subject")
                    or request.args.get("subject"))
 

--- a/scripts/seed_quality_demo.py
+++ b/scripts/seed_quality_demo.py
@@ -32,6 +32,12 @@ _PANEL = [
 ]
 
 
+def _demo_observation_date(today=None):
+    today = today or date.today()
+    start_of_year = date(today.year, 1, 1)
+    return max(today - timedelta(days=45), start_of_year).isoformat()
+
+
 def build_quality_cohort():
     """Pure: return the cohort as (patient, condition, [pregnancy?], observation)
     groups plus the expected NQF 0018 numbers."""
@@ -56,7 +62,7 @@ def build_quality_cohort():
             # ~6 weeks ago: recent enough to count for any current measurement
             # period, and never in the future (a future "last done" date reads
             # wrong in demos and makes care-gaps output look broken).
-            "effectiveDateTime": (date.today() - timedelta(days=45)).isoformat(),
+            "effectiveDateTime": _demo_observation_date(),
             "component": [
                 {"code": {"coding": [{"system": "http://loinc.org", "code": "8480-6"}]},
                  "valueQuantity": {"value": sys_v, "unit": "mm[Hg]"}},

--- a/tests/test_quality_routes.py
+++ b/tests/test_quality_routes.py
@@ -1,6 +1,9 @@
 import json
+import datetime as dt
 
+import r6.quality.routes as quality_routes
 from r6.models import R6Resource, db
+from r6.quality.routes import _default_measurement_period
 
 
 def _store(app, resource, tenant_id):
@@ -13,7 +16,8 @@ def _store(app, resource, tenant_id):
         db.session.commit()
 
 
-def _seed_controlled_patient(app, tenant_id, pid="p1", sys_v=132, dia_v=82):
+def _seed_controlled_patient(app, tenant_id, pid="p1", sys_v=132, dia_v=82,
+                             observed_on="2026-09-01"):
     _store(app, {"resourceType": "Patient", "id": pid, "birthDate": "1970-06-01"},
            tenant_id)
     _store(app, {"resourceType": "Condition", "id": f"c-{pid}",
@@ -24,7 +28,7 @@ def _seed_controlled_patient(app, tenant_id, pid="p1", sys_v=132, dia_v=82):
     _store(app, {"resourceType": "Observation", "id": f"o-{pid}", "status": "final",
                  "code": {"coding": [{"system": "http://loinc.org", "code": "85354-9"}]},
                  "subject": {"reference": f"Patient/{pid}"},
-                 "effectiveDateTime": "2026-09-01",
+                 "effectiveDateTime": observed_on,
                  "component": [
                      {"code": {"coding": [{"system": "http://loinc.org", "code": "8480-6"}]},
                       "valueQuantity": {"value": sys_v}},
@@ -38,6 +42,11 @@ def _pop(report, code):
             if p["code"]["coding"][0]["code"] == code:
                 return p["count"]
     return None
+
+
+def test_default_measurement_period_uses_current_calendar_year():
+    assert _default_measurement_period(dt.date(2027, 6, 15)) == (
+        "2027-01-01", "2027-12-31")
 
 
 def test_measure_resource_endpoint(client, tenant_headers):
@@ -89,6 +98,23 @@ def test_population_evaluate_rate(client, app, tenant_id, tenant_headers):
     assert _pop(rep, "denominator") == 2
     assert _pop(rep, "numerator") == 1
     assert rep["group"][0]["measureScore"]["value"] == 0.5
+
+
+def test_population_evaluate_defaults_to_current_year(client, app, tenant_id,
+                                                      tenant_headers,
+                                                      monkeypatch):
+    monkeypatch.setattr(quality_routes, "_default_measurement_period",
+                        lambda: ("2027-01-01", "2027-12-31"))
+    _seed_controlled_patient(app, tenant_id, observed_on="2027-09-01")
+    resp = client.post(
+        "/r6/fhir/Measure/nqf0018-controlling-high-bp/$evaluate-measure",
+        headers=tenant_headers,
+        json={"resourceType": "Parameters", "parameter": []})
+    assert resp.status_code == 200
+    rep = resp.get_json()
+    assert rep["period"] == {"start": "2027-01-01", "end": "2027-12-31"}
+    assert _pop(rep, "denominator") == 1
+    assert _pop(rep, "numerator") == 1
 
 
 def test_evaluate_requires_read_auth_nonpublic(client, app, monkeypatch):

--- a/tests/test_quality_seed.py
+++ b/tests/test_quality_seed.py
@@ -1,6 +1,13 @@
-from scripts.seed_quality_demo import build_quality_cohort
+from datetime import date
+
+from scripts.seed_quality_demo import build_quality_cohort, _demo_observation_date
 from r6.smbp.monitoring import build_bp_observation  # noqa: F401  (namespace-package import check)
 from r6.quality.measures import evaluate_population
+
+
+def test_demo_observation_date_stays_in_current_year():
+    assert _demo_observation_date(date(2027, 1, 15)) == "2027-01-01"
+    assert _demo_observation_date(date(2027, 7, 15)).startswith("2027-")
 
 
 def test_cohort_yields_believable_rate():
@@ -17,7 +24,12 @@ def test_cohort_yields_believable_rate():
                  for cd in g["conditions"]]
         obs = [{**g["observation"], "subject": {"reference": f"Patient/{g['label']}"}}]
         bundle.append({"patient": patient, "conditions": conds, "observations": obs})
-    pop = evaluate_population(bundle, "2026-01-01", "2026-12-31")
+    current_year = date.today().year
+    for item in bundle:
+        assert item["observations"][0]["effectiveDateTime"].startswith(
+            f"{current_year}-")
+    pop = evaluate_population(bundle, f"{current_year}-01-01",
+                              f"{current_year}-12-31")
     assert pop["denominator"] == 11   # gross (pre-exclusion) per HL7 convention
     assert pop["exclusions"] == 1     # 1 pregnancy exclusion
     assert pop["numerator"] == 7      # 7 controlled


### PR DESCRIPTION
## Summary
- Default NQF 0018 evaluate-measure periodStart/periodEnd to the current calendar year when omitted.
- Keep the quality demo seed observation dates inside the current year, including early January.
- Add regression coverage for future-year defaults and seed invariants.
- Remove two unused test imports so the documented ruff CI scope is clean.

## Validation
- uvx ruff check r6/ tests/ scripts/ main.py app.py
- uv run python -m pytest tests/ -v --tb=short

## Notes
- Uses synthetic demo data only.
- AI assistance was used to prepare this change.

Closes #52