### PR TITLE
W0: poller 409-storm detection — exit loud instead of thrashing

### DIFF
--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -27,9 +27,12 @@ STEP_UP_SECRET       HMAC secret for step-up tokens.
 import json
 import logging
 import os
+import time
+from collections import deque
 
 import requests
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.error import Conflict
 from telegram.ext import (
     Application,
     CallbackQueryHandler,
@@ -101,6 +104,14 @@ HBO_REDIRECT_URI = os.environ.get(
 HBO_SCOPES = os.environ.get('HBO_SCOPES', 'openid offline_access').strip()
 HBO_MCP_URL = os.environ.get(
     'HBO_MCP_URL', 'https://mcp.app.healthbankone.com/mcp').strip()
+
+# Optional ops-alert destination for mid-run poller-conflict storms (see
+# "Mid-run singleton hardening" below). The bot has no dedicated admin/ops
+# channel otherwise — r6.telegram_push.notify_tenant is patient-facing and
+# needs the Flask app's DB, which this standalone poller process doesn't
+# have. If unset, storm detection still logs CRITICAL and exits; it just
+# can't push a chat alert.
+TELEGRAM_ADMIN_CHAT_ID = os.environ.get('TELEGRAM_ADMIN_CHAT_ID', '').strip()
 
 
 def _persist_turn(update: Update, agent_id: str, role: str, text: str,
@@ -822,6 +833,7 @@ def main() -> None:
     app.add_handler(CommandHandler('hbo_connect', cmd_hbo_connect))
     app.add_handler(CommandHandler('hbo_pull', cmd_hbo_pull))
     app.add_handler(MessageHandler(filters.COMMAND, unknown_command))
+    app.add_error_handler(_on_error)
 
     _preflight_singleton_check()
 
@@ -862,6 +874,109 @@ def _preflight_singleton_check() -> None:
                 'Exiting.')
             raise SystemExit(1)
         return  # 200 (or any non-409): we are the sole poller
+
+
+# ---------------------------------------------------------------------------
+# Mid-run singleton hardening — 409-Conflict storm detection
+# ---------------------------------------------------------------------------
+# _preflight_singleton_check() above only guards startup. If a second poller
+# starts LATER — a stale Railway container that didn't finish shutting down,
+# a forgotten copy left running on the Mac mini or an SSH box — this process
+# keeps polling and Telegram thrashes BOTH pollers with repeated
+# 'Conflict: terminated by other getUpdates request' errors. run_polling
+# retries Conflict internally, so nothing stops on its own: messages are
+# silently dropped or duplicated for as long as nobody notices.
+#
+# Telegram also emits an occasional single Conflict during normal
+# reconnects (network blip, Telegram-side restart), so a lone 409 is not
+# itself a signal — only a STORM (several in quick succession) reliably
+# means a second consumer is holding this token.
+CONFLICT_STORM_THRESHOLD = 3          # this many Conflict errors...
+CONFLICT_STORM_WINDOW_SECONDS = 60.0  # ...within this many seconds = a storm
+
+# Sliding window of Conflict-error timestamps (epoch seconds).
+_conflict_timestamps: deque[float] = deque()
+
+
+def _record_conflict_and_check_storm(now: float | None = None) -> bool:
+    """Record one Conflict-error timestamp; report whether it completes a storm.
+
+    Prunes timestamps older than CONFLICT_STORM_WINDOW_SECONDS, appends
+    `now`, and returns True once CONFLICT_STORM_THRESHOLD or more
+    timestamps remain inside the window. On a storm verdict the window is
+    cleared — the caller is about to exit the process, so there is nothing
+    left to accumulate toward, and a fresh sequence of errors is required
+    before the next verdict (relevant mainly to tests, which call this
+    function directly without actually exiting).
+    """
+    if now is None:
+        now = time.time()
+    cutoff = now - CONFLICT_STORM_WINDOW_SECONDS
+    while _conflict_timestamps and _conflict_timestamps[0] < cutoff:
+        _conflict_timestamps.popleft()
+    _conflict_timestamps.append(now)
+    if len(_conflict_timestamps) >= CONFLICT_STORM_THRESHOLD:
+        _conflict_timestamps.clear()
+        return True
+    return False
+
+
+def _send_admin_alert(message: str) -> None:
+    """Best-effort ops alert for a Conflict storm.
+
+    sendMessage is independent of getUpdates, so this can still reach
+    Telegram even while this process's polling is being rejected with 409s.
+    If TELEGRAM_ADMIN_CHAT_ID isn't configured there is no alerting channel
+    to use — this is a documented no-op and the CRITICAL log line already
+    emitted by the caller is the only signal.
+    """
+    if not TELEGRAM_ADMIN_CHAT_ID:
+        logger.warning(
+            'no TELEGRAM_ADMIN_CHAT_ID configured — skipping admin chat alert '
+            '(the CRITICAL log line above is the only signal for this storm)')
+        return
+    try:
+        requests.post(
+            f'https://api.telegram.org/bot{BOT_TOKEN}/sendMessage',
+            json={'chat_id': TELEGRAM_ADMIN_CHAT_ID, 'text': message},
+            timeout=5,
+        )
+    except requests.RequestException as exc:
+        logger.warning('admin alert send failed: %s', exc)
+
+
+async def _on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Global python-telegram-bot error handler.
+
+    Passes through every error, but watches Conflict (409) errors for a
+    storm (see _record_conflict_and_check_storm). A single Conflict is
+    normal Telegram churn — logged and ignored. A storm means another
+    poller is very likely holding this bot's token: log CRITICAL, send a
+    best-effort admin alert, and exit loudly (SystemExit) so the supervisor
+    (launchd, Railway's restart policy, systemd, ...) surfaces the failure
+    instead of this process quietly thrashing forever.
+    """
+    error = context.error
+    if isinstance(error, Conflict):
+        logger.warning('Telegram Conflict (409) on getUpdates: %s', error)
+        if _record_conflict_and_check_storm():
+            logger.critical(
+                'CONFLICT STORM: %d+ Telegram 409 Conflict errors within '
+                '%.0fs. Another poller is almost certainly holding this bot '
+                'token (stale Railway container, forgotten Mac-mini/SSH '
+                'copy, etc.) — stop it before restarting this one. Exiting '
+                'rather than keep thrashing both pollers.',
+                CONFLICT_STORM_THRESHOLD, CONFLICT_STORM_WINDOW_SECONDS,
+            )
+            _send_admin_alert(
+                '🚨 openclaw poller CONFLICT STORM — exiting.\n'
+                f'tenant={TENANT_ID}\n'
+                'Another process is polling this bot token. Stop it, then '
+                'restart this poller.'
+            )
+            raise SystemExit(1)
+        return
+    logger.error('Unhandled error while processing update: %s', error, exc_info=error)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ test = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "python-telegram-bot>=20.0",
     "reportlab>=4.0",
 ]
 

--- a/tests/test_bot_singleton_hardening.py
+++ b/tests/test_bot_singleton_hardening.py
@@ -122,12 +122,21 @@ class TestOnErrorHandler:
         assert any('CONFLICT STORM' in rec.message for rec in caplog.records)
         mock_alert.assert_called_once()
 
-    def test_three_conflicts_spread_over_more_than_60s_do_not_exit(self):
-        timestamps = [1000.0, 1070.0, 1140.0]
-        with patch.object(bot.time, 'time', side_effect=timestamps):
-            for _ in timestamps:
-                _run(bot._on_error(
-                    None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+    def test_three_conflicts_spread_over_more_than_60s_do_not_exit(self, monkeypatch):
+        # Fake clock at the module seam: bot.py does `import time` and calls
+        # `time.time()`, so replace the `time` attribute in bot's namespace
+        # only. Never patch the global time module with a finite
+        # side_effect list — asyncio/logging internals also call
+        # time.time() (a variable number of times per interpreter version),
+        # and an exhausted mock generator raises StopIteration, which
+        # inside a coroutine becomes RuntimeError (PEP 479). A mutable
+        # clock the test advances is call-count independent.
+        clock = [1000.0]
+        monkeypatch.setattr(bot, 'time', SimpleNamespace(time=lambda: clock[0]))
+        for now in (1000.0, 1070.0, 1140.0):
+            clock[0] = now
+            _run(bot._on_error(
+                None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
         # No SystemExit was raised (loop completed) and the window holds
         # only the most recent timestamp.
         assert len(bot._conflict_timestamps) == 1

--- a/tests/test_bot_singleton_hardening.py
+++ b/tests/test_bot_singleton_hardening.py
@@ -1,0 +1,182 @@
+"""
+tests/test_bot_singleton_hardening.py
+
+W0 item 6 — mid-run poller singleton hardening.
+
+_preflight_singleton_check() (openclaw/bot.py) only guards STARTUP: it
+probes getUpdates once before the bot begins polling. If a second poller
+starts LATER — a stale Railway container still shutting down, a forgotten
+copy left running on the Mac mini or an SSH box — this process keeps
+polling and Telegram thrashes both pollers with repeated
+'Conflict: terminated by other getUpdates request' errors, silently
+dropping/duplicating messages.
+
+These tests cover the mid-run detector wired through python-telegram-bot's
+error-handler hook (_on_error): a sliding window of Conflict-error
+timestamps that declares a STORM (>= CONFLICT_STORM_THRESHOLD errors within
+CONFLICT_STORM_WINDOW_SECONDS) and, on a storm, logs CRITICAL, sends a
+best-effort admin alert, and exits (SystemExit) so the process supervisor
+surfaces the failure instead of the poller quietly thrashing forever.
+
+openclaw/bot.py imports the telegram SDK (python-telegram-bot), which is a
+dev-only test dependency here (see pyproject.toml [dependency-groups.dev])
+— production installs it via openclaw/Dockerfile. TELEGRAM_BOT_TOKEN must
+be set before the module is imported (bot.py reads it at import time).
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'test-token-for-singleton-hardening')
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "openclaw"))
+
+import bot  # noqa: E402
+from telegram.error import Conflict, TimedOut  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_conflict_window():
+    """Every test starts with a clean sliding window."""
+    bot._conflict_timestamps.clear()
+    yield
+    bot._conflict_timestamps.clear()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _ctx_with_error(error):
+    return SimpleNamespace(error=error)
+
+
+# ---------------------------------------------------------------------------
+# Pure sliding-window logic
+# ---------------------------------------------------------------------------
+
+class TestConflictWindow:
+
+    def test_single_conflict_does_not_declare_storm(self):
+        assert bot._record_conflict_and_check_storm(now=1000.0) is False
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_three_within_window_declares_storm(self):
+        assert bot._record_conflict_and_check_storm(now=1000.0) is False
+        assert bot._record_conflict_and_check_storm(now=1010.0) is False
+        assert bot._record_conflict_and_check_storm(now=1020.0) is True
+
+    def test_three_spread_over_more_than_60s_does_not_declare_storm(self):
+        # Each pair is > 60s apart, so the window never holds more than one
+        # timestamp at a time.
+        assert bot._record_conflict_and_check_storm(now=1000.0) is False
+        assert bot._record_conflict_and_check_storm(now=1070.0) is False
+        assert bot._record_conflict_and_check_storm(now=1140.0) is False
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_window_resets_after_storm_verdict(self):
+        assert bot._record_conflict_and_check_storm(now=1000.0) is False
+        assert bot._record_conflict_and_check_storm(now=1010.0) is False
+        assert bot._record_conflict_and_check_storm(now=1020.0) is True
+        assert len(bot._conflict_timestamps) == 0
+
+        # A single Conflict right after the storm verdict is, on its own,
+        # not itself a new storm — the window was cleared.
+        assert bot._record_conflict_and_check_storm(now=1020.5) is False
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_old_timestamps_are_pruned_before_the_new_one_is_added(self):
+        assert bot._record_conflict_and_check_storm(now=1000.0) is False
+        assert bot._record_conflict_and_check_storm(now=1005.0) is False
+        # This one is 61s after the first — the first should be pruned,
+        # leaving only 2 timestamps (not a storm).
+        assert bot._record_conflict_and_check_storm(now=1061.0) is False
+        assert len(bot._conflict_timestamps) == 2
+
+
+# ---------------------------------------------------------------------------
+# Error-handler wiring (_on_error)
+# ---------------------------------------------------------------------------
+
+class TestOnErrorHandler:
+
+    def test_single_conflict_error_does_not_exit(self):
+        _run(bot._on_error(None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_storm_exits_with_systemexit_and_logs_critical(self, caplog):
+        with caplog.at_level(logging.CRITICAL, logger='openclaw'):
+            with patch.object(bot, '_send_admin_alert') as mock_alert:
+                with pytest.raises(SystemExit) as exc_info:
+                    for _ in range(3):
+                        _run(bot._on_error(
+                            None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+                assert exc_info.value.code != 0
+        assert any('CONFLICT STORM' in rec.message for rec in caplog.records)
+        mock_alert.assert_called_once()
+
+    def test_three_conflicts_spread_over_more_than_60s_do_not_exit(self):
+        timestamps = [1000.0, 1070.0, 1140.0]
+        with patch.object(bot.time, 'time', side_effect=timestamps):
+            for _ in timestamps:
+                _run(bot._on_error(
+                    None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+        # No SystemExit was raised (loop completed) and the window holds
+        # only the most recent timestamp.
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_window_resets_after_storm_so_a_lone_conflict_after_exit_does_not_reexit(self):
+        with patch.object(bot, '_send_admin_alert'):
+            with pytest.raises(SystemExit):
+                for _ in range(3):
+                    _run(bot._on_error(
+                        None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+
+        # Window was cleared by the storm verdict — a single subsequent
+        # Conflict must NOT immediately re-trigger a SystemExit.
+        _run(bot._on_error(None, _ctx_with_error(Conflict('terminated by other getUpdates request'))))
+        assert len(bot._conflict_timestamps) == 1
+
+    def test_non_conflict_error_is_logged_and_does_not_touch_the_window(self, caplog):
+        with caplog.at_level(logging.ERROR, logger='openclaw'):
+            _run(bot._on_error(None, _ctx_with_error(TimedOut())))
+        assert len(bot._conflict_timestamps) == 0
+        assert any('Unhandled error' in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Admin alert (best-effort, optional channel)
+# ---------------------------------------------------------------------------
+
+class TestAdminAlert:
+
+    def test_no_admin_chat_configured_logs_and_skips(self, caplog, monkeypatch):
+        monkeypatch.setattr(bot, 'TELEGRAM_ADMIN_CHAT_ID', '')
+        with caplog.at_level(logging.WARNING, logger='openclaw'):
+            with patch.object(bot.requests, 'post') as mock_post:
+                bot._send_admin_alert('test message')
+        mock_post.assert_not_called()
+        assert any('no TELEGRAM_ADMIN_CHAT_ID' in rec.message for rec in caplog.records)
+
+    def test_admin_chat_configured_sends_best_effort_message(self, monkeypatch):
+        monkeypatch.setattr(bot, 'TELEGRAM_ADMIN_CHAT_ID', '999888777')
+        with patch.object(bot.requests, 'post') as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            bot._send_admin_alert('test message')
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert '/sendMessage' in args[0]
+        assert kwargs['json']['chat_id'] == '999888777'
+        assert kwargs['json']['text'] == 'test message'
+
+    def test_admin_alert_network_failure_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr(bot, 'TELEGRAM_ADMIN_CHAT_ID', '999888777')
+        with patch.object(bot.requests, 'post', side_effect=bot.requests.RequestException('boom')):
+            bot._send_admin_alert('test message')  # must not raise

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -489,6 +493,7 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "python-telegram-bot" },
     { name = "reportlab" },
 ]
 
@@ -516,6 +521,7 @@ provides-extras = ["test"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "python-telegram-bot", specifier = ">=20.0" },
     { name = "reportlab", specifier = ">=4.0" },
 ]
 
@@ -1174,6 +1180,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Spec: W0 item 6 (poller singleton hardening).

`_preflight_singleton_check()` in `openclaw/bot.py` only guards **startup** — it probes `getUpdates` once before the bot begins polling. If a second poller starts *later* (a stale Railway container that didn't finish shutting down, a forgotten copy left running on the Mac mini or an SSH box), this process keeps polling indefinitely and Telegram thrashes both pollers with repeated `Conflict: terminated by other getUpdates request` errors. `run_polling` retries `Conflict` internally, so nothing stops on its own — messages are silently dropped or duplicated for as long as nobody notices.

This adds mid-run detection via python-telegram-bot's error-handler hook:

- A module-level sliding window (`deque` of timestamps) tracks `Conflict` (409) errors.
- A single `Conflict` is normal Telegram churn (network blip, Telegram-side restart) — logged at WARNING and ignored.
- **3+ `Conflict` errors within 60 seconds = a storm** — almost certainly a second poller holding this bot's token.
- On a storm: log **CRITICAL** with a clear likely-cause message, send a best-effort admin alert (`TELEGRAM_ADMIN_CHAT_ID` env var — the bot has no other ops-alert channel; `r6.telegram_push.notify_tenant` is patient-facing and needs the Flask app's DB, which this standalone poller process doesn't have), and `raise SystemExit(1)` so the process supervisor (launchd / Railway's restart policy / systemd) surfaces the failure loudly instead of the poller quietly thrashing forever.
- The window resets after a storm verdict (the caller is about to exit; nothing left to accumulate toward).

No existing error handler was registered on the `Application` (checked — `main()` had no `add_error_handler` call), so this adds one rather than extending a duplicate.

`python-telegram-bot` is added as a **dev-only** test dependency (`pyproject.toml` `[dependency-groups.dev]`) so this is actually unit-testable — it was previously not a test dependency at all (see the note in `tests/test_metadata_security.py`), which is why `_preflight_singleton_check` itself shipped without any tests. Production still installs the SDK via `openclaw/Dockerfile`, unchanged.

## Test plan

- [x] New `tests/test_bot_singleton_hardening.py` (13 tests): pure sliding-window logic, `_on_error` wiring, and best-effort admin alert.
  - single 409 → no exit
  - 3 within 60s window → `SystemExit` + CRITICAL log + admin alert called
  - 3 spread over >60s → no exit
  - window resets after a storm verdict (a lone Conflict right after does not re-trigger)
  - old timestamps pruned before the window is re-evaluated
  - non-`Conflict` errors are logged and don't touch the window
  - admin alert: no-op + WARNING log when `TELEGRAM_ADMIN_CHAT_ID` unset; sends when set; swallows network failures
- [x] Full suite green: `uv run python -m pytest -q` → **1066 passed** (1053 baseline + 13 new), 0 failures.
- [x] `ruff check` clean on the new test file and on the diff in `openclaw/bot.py`.
- [x] Confirmed `uv sync --extra test` (what CI's `python-tests` job runs) still resolves `python-telegram-bot` (dev group installs by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)