### PR TITLE
W0: Postgres CI lane — kill the SQLite-masks-varchar bug class

### DIFF
--- a/.github/REVIEW_STANDARDS.md
+++ b/.github/REVIEW_STANDARDS.md
@@ -36,7 +36,11 @@ review bot reads THIS file, so keep it current.)
 10. **Postgres/SQLite parity trap:** the test suite runs on SQLite, prod is
     Postgres. Schema-affecting changes (column widths, constraints) need a
     model-level assertion test (see `tests/test_ingest_resilience.py`), and
-    new columns rely on `schema_sync` (additive + widen only).
+    new columns rely on `schema_sync` (additive + widen only). The
+    `postgres-tests` CI job runs the DB-shape-sensitive subset
+    (`tests/actions/`, ingest/fasten/models tests) against a real
+    postgres:16 service container — schema-affecting tests belong in that
+    subset, not just under SQLite.
 11. **External payload shapes are pinned by tests** using real captured
     payloads (see `tests/test_fasten_webhook_shape.py`). Handlers for
     webhooks/callbacks must tolerate envelope nesting and fail without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,63 @@ jobs:
       - name: Run Python tests
         run: uv run python -m pytest tests/ -v --tb=short
 
+  # ─────────────────────────────────────────────
+  # Postgres CI lane — the full suite above runs on sqlite:///:memory:
+  # (tests/conftest.py), which does not enforce VARCHAR length or PK
+  # subtleties the way Postgres (prod) does. This repo has shipped 3
+  # Postgres-only truncation bugs that sqlite-based CI could never catch:
+  # oversized Epic resource ids, a narrower AuditEventRecord.resource_id
+  # column poisoning the shared transaction, and an under-width status
+  # column (see tests/test_ingest_resilience.py and
+  # tests/actions/test_state_transitions.py docstrings). Run just the
+  # DB-shape-sensitive subset against real Postgres to close that gap
+  # without doubling total CI time.
+  # ─────────────────────────────────────────────
+  postgres-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install uv
+          uv sync --extra test
+
+      - name: Run DB-shape-sensitive tests against Postgres
+        env:
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/test
+        run: |
+          uv run python -m pytest \
+            tests/actions/ \
+            tests/test_ingest_resilience.py \
+            tests/test_actions_models.py \
+            tests/test_fasten_export_trigger.py \
+            tests/test_fasten_webhook_shape.py \
+            tests/test_fasten_verify_signature.py \
+            tests/test_fasten_job_recovery.py \
+            -v --tb=short
+
   node-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,12 @@ Test fixtures for the R6 FHIR Showcase.
 import os
 import pytest
 
-# Set test environment before importing app — prevents file-based DB creation
+# Set test environment before importing app — prevents file-based DB creation.
+# setdefault (not assignment) so a CI job can pre-set SQLALCHEMY_DATABASE_URI
+# (e.g. to Postgres, for the postgres-tests lane) before pytest starts;
+# sqlite:///:memory: remains the default for local/unconfigured runs.
 os.environ['TESTING'] = '1'
-os.environ['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
 os.environ['STEP_UP_SECRET'] = 'test-secret-for-hmac-validation'
 # Command-center tests assume desktop-demo is publicly readable (mirrors
 # the healthclaw.io demo host). In production on Railway this env var is
@@ -23,7 +26,11 @@ def app():
     """Create a test Flask application."""
     from main import app as flask_app
     flask_app.config['TESTING'] = True
-    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    # Respect the module-level env var (sqlite by default, Postgres when the
+    # postgres-tests CI lane pre-sets SQLALCHEMY_DATABASE_URI) rather than
+    # forcing sqlite here — main.py already read it into app.config at
+    # import time, so this just keeps them in sync.
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['SQLALCHEMY_DATABASE_URI']
 
     from models import db
     with flask_app.app_context():
@@ -32,6 +39,13 @@ def app():
         from r6.rate_limit import _rate_limits
         _rate_limits.clear()
         yield flask_app
+        # Release the scoped session's connection/transaction before DDL.
+        # On SQLite (StaticPool, single shared connection) drop_all() reuses
+        # the same connection as db.session so this was never load-bearing —
+        # but on Postgres, drop_all() opens a separate pooled connection,
+        # and a still-open session transaction (e.g. from an uncommitted
+        # SELECT during the test) blocks its DROP TABLE indefinitely.
+        db.session.remove()
         db.drop_all()
 
 


### PR DESCRIPTION
## Summary

W0 item 7: the whole Python suite runs on `sqlite:///:memory:` (`tests/conftest.py`), which does not enforce VARCHAR length or real cross-connection locking the way Postgres (prod) does. This repo has shipped 3 Postgres-only truncation bugs that sqlite-based CI could never catch (found live 2026-07-08 against a real Epic export, 966 green tests notwithstanding — see the docstrings in `tests/test_ingest_resilience.py` and `tests/actions/test_state_transitions.py`):

1. Oversized Epic resource ids (up to ~109 chars) overflowing a `varchar(64)` id column.
2. A narrower `AuditEventRecord.resource_id` column than `R6Resource.id`, so an audit-insert truncation rolled back the resource write in the shared transaction (only 2/56 observations survived).
3. An under-width `status`/`from_status` column that didn't fit every legal state / worst-case join.

### Changes

- **New `postgres-tests` CI job** (`.github/workflows/ci.yml`) — a health-checked `postgres:16` GitHub Actions service container, running the DB-shape-sensitive subset: `tests/actions/` (whole package — it has its own width-sensitive tests) plus the ingest/fasten/models pattern matches: `test_ingest_resilience.py`, `test_actions_models.py`, `test_fasten_export_trigger.py`, `test_fasten_webhook_shape.py`, `test_fasten_verify_signature.py`, `test_fasten_job_recovery.py`. `psycopg2-binary` is already a core dependency in `pyproject.toml`, so no extra CI-only install was needed.
- **`tests/conftest.py`** (required for the above to work, not just cosmetic):
  - `os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')` instead of a force-assignment, so the CI job's pre-set env var isn't clobbered on import. sqlite stays the local default.
  - The `app` fixture now sets `flask_app.config['SQLALCHEMY_DATABASE_URI']` from the env instead of hardcoding sqlite, for the same reason.
  - `db.session.remove()` before `db.drop_all()` in fixture teardown. This was never load-bearing on SQLite (StaticPool, single shared connection — `drop_all()` reuses the same connection as `db.session`), but on Postgres `drop_all()` opens a separate pooled connection, and a still-open session transaction blocks its `DROP TABLE` indefinitely. **This deadlocked during local verification before the fix** — a real finding, not a hypothetical.
- **`.github/REVIEW_STANDARDS.md`** item 10 (Postgres/SQLite parity trap) now points at the `postgres-tests` job.

### Verification

Docker was available locally, so this was verified end-to-end rather than just configured:
- Ran the selected 122-test subset against a real `postgres:16` container (`localhost:5433`, mirroring the CI job's connection shape) — **122 passed in ~7s**.
- Ran the full 1053-test suite on the sqlite default (no env override) — **1053 passed**, confirming the conftest changes don't disturb local/default behavior.
- `ruff check` clean on `tests/conftest.py`; workflow YAML parses.

## Test plan

- [x] `uv run python -m pytest tests/actions/ tests/test_ingest_resilience.py tests/test_actions_models.py tests/test_fasten_export_trigger.py tests/test_fasten_webhook_shape.py tests/test_fasten_verify_signature.py tests/test_fasten_job_recovery.py -v --tb=short` against a live `postgres:16` container — 122 passed
- [x] `uv run python -m pytest tests/ -q` on the sqlite default — 1053 passed
- [ ] CI run on this PR (postgres-tests job, new) — will confirm the GitHub Actions service-container wiring end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)