### PR TITLE
fix(proxy): surface upstream FHIR errors instead of empty results and fake 404s

### DIFF
--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -116,6 +116,221 @@ def _fetch_medplum_token(client_id: str, client_secret: str) -> str:
 # Timeout for upstream requests (seconds)
 _UPSTREAM_TIMEOUT = float(os.environ.get('FHIR_UPSTREAM_TIMEOUT', '15'))
 
+# ---------------------------------------------------------------------------
+# Upstream error sanitization
+#
+# A failed upstream call must surface as a (sanitized) OperationOutcome with
+# the real status — never as an empty bundle or a fake not-found. Raw upstream
+# error bodies are NOT passed through: diagnostics can embed PHI, stack traces,
+# or internal URLs that _rewrite_urls() would not catch.
+# ---------------------------------------------------------------------------
+
+# Statuses that describe the CALLER's request; these pass through unchanged.
+# Upstream 401/403 are deliberately absent: the caller never authenticates to
+# the upstream directly, so those mean the PROXY's credentials or upstream
+# policy failed — surfaced as 502 so the caller doesn't re-auth in a loop.
+_PASSTHROUGH_STATUSES = frozenset({400, 404, 405, 406, 409, 410, 412, 422, 429})
+
+# FHIR issue-type codes allowed through from upstream OperationOutcomes.
+_SAFE_ISSUE_CODES = frozenset({
+    'invalid', 'structure', 'required', 'value', 'invariant',
+    'security', 'login', 'unknown', 'expired', 'forbidden', 'suppressed',
+    'processing', 'not-supported', 'duplicate', 'multiple-matches',
+    'not-found', 'deleted', 'too-long', 'code-invalid', 'extension',
+    'too-costly', 'business-rule', 'conflict', 'transient', 'lock-error',
+    'no-store', 'exception', 'timeout', 'incomplete', 'throttled',
+    'informational',
+})
+_SAFE_SEVERITIES = frozenset({'fatal', 'error', 'warning', 'information'})
+_MAX_SANITIZED_ISSUES = 5
+# Refuse to parse oversized upstream error bodies (memory-exhaustion guard).
+_MAX_ERROR_BODY_BYTES = 1_000_000
+
+# Upstream free text (issue[].details.text / diagnostics) is NEVER forwarded:
+# it can carry patient names, identifiers, or internal hostnames that no URL
+# regex can reliably strip. We keep only the issue `code` (a bounded FHIR
+# value-set token) and synthesize the human-readable message ourselves from
+# this map. Specific, parameter-level correction ("unknown param X, did you
+# mean Y") is produced on the LOCAL search path, where we parse the query and
+# can name the parameter without echoing upstream text.
+_ISSUE_CODE_MESSAGE = {
+    'invalid': 'The upstream FHIR server rejected the request as invalid.',
+    'structure': 'The upstream FHIR server rejected the request structure.',
+    'required': 'The upstream FHIR server reported a missing required element.',
+    'value': 'The upstream FHIR server rejected a submitted value.',
+    'not-supported': 'The upstream FHIR server does not support this request.',
+    'security': 'Upstream authentication or authorization failed.',
+    'forbidden': 'The upstream FHIR server forbade this request.',
+    'not-found': 'The upstream FHIR server reported the resource was not found.',
+    'conflict': 'The request conflicted with the current state upstream.',
+    'duplicate': 'The upstream FHIR server reported a duplicate.',
+    'too-costly': 'The upstream FHIR server refused the request as too costly.',
+    'throttled': 'The upstream FHIR server is rate-limiting requests.',
+    'processing': 'The upstream FHIR server could not process the request.',
+    'transient': 'The upstream FHIR server had a transient error.',
+    'timeout': 'The upstream FHIR server timed out.',
+    'exception': 'The upstream FHIR server encountered an internal error.',
+}
+
+
+def _message_for_code(code: str) -> str:
+    return _ISSUE_CODE_MESSAGE.get(code, 'The upstream FHIR server returned an error.')
+
+
+def _issue_code_for_status(status: int) -> str:
+    """Map an HTTP status to a FHIR issue-type code."""
+    mapping = {
+        400: 'invalid', 401: 'security', 403: 'security',
+        404: 'not-found', 405: 'not-supported', 409: 'conflict',
+        410: 'deleted', 412: 'conflict', 422: 'processing',
+        429: 'throttled',
+    }
+    if status in mapping:
+        return mapping[status]
+    return 'transient' if status >= 500 else 'processing'
+
+
+def _sanitize_issue_list(raw_issues, fallback_code: str) -> list:
+    """Allowlist-sanitize an OperationOutcome issue array.
+
+    Keeps only ``severity`` and ``code`` from upstream (both bounded FHIR
+    value-set tokens) and synthesizes ``details.text`` from the code — the
+    upstream's own free text is never forwarded. Tolerates malformed shapes
+    (null, dict, string, non-dict entries, unhashable fields) by dropping or
+    defaulting them; a hostile or broken upstream must not crash the error
+    path or leak text through it.
+    """
+    issues = []
+    if not isinstance(raw_issues, list):
+        return issues
+    for issue in raw_issues[:_MAX_SANITIZED_ISSUES]:
+        if not isinstance(issue, dict):
+            continue
+        severity = issue.get('severity')
+        code = issue.get('code')
+        # Membership tests must be type-guarded: a list/dict severity or code
+        # is unhashable and would raise inside `in`.
+        safe_severity = severity if isinstance(severity, str) and severity in _SAFE_SEVERITIES else 'error'
+        safe_code = code if isinstance(code, str) and code in _SAFE_ISSUE_CODES else fallback_code
+        issues.append({
+            'severity': safe_severity,
+            'code': safe_code,
+            'details': {'text': _message_for_code(safe_code)},
+        })
+    return issues
+
+
+def sanitize_operation_outcome_resource(oo) -> dict:
+    """Sanitize an OperationOutcome embedded in a SUCCESS response — e.g. a
+    search.mode="outcome" warning entry in a searchset. apply_redaction()
+    targets clinical resources and does not inspect issue[].diagnostics, so
+    outcome entries go through the same allowlist as upstream errors."""
+    raw = oo.get('issue') if isinstance(oo, dict) else None
+    issues = _sanitize_issue_list(raw, 'processing')
+    if not issues:
+        issues = [{'severity': 'information', 'code': 'informational',
+                   'details': {'text': 'The upstream FHIR server returned a warning.'}}]
+    return {'resourceType': 'OperationOutcome', 'issue': issues}
+
+
+def sanitize_upstream_error(resp, caller_auth: bool = False) -> tuple[dict, int]:
+    """Convert a non-2xx upstream response into (OperationOutcome, status).
+
+    Allowlist policy: only issue ``severity`` and ``code`` (bounded FHIR
+    value-set tokens) survive; ``details.text`` is synthesized from the code.
+    Upstream free text, diagnostics, expressions, extensions, and any
+    non-OperationOutcome body are dropped entirely — upstream error text can
+    carry patient names or internal hostnames that scrubbing can't reliably
+    remove.
+
+    Status mapping: caller-attributable 4xx pass through. 401/403 depend on
+    who owns the upstream credential: with ``caller_auth=True`` (SHARP mode —
+    the caller's own SMART token is forwarded) they pass through so the
+    caller can re-authenticate; otherwise they map to 502 because the
+    PROXY's credentials failed and a passthrough 401 would send the caller
+    into a futile re-auth loop. 5xx maps to 502 with a fixed message —
+    upstream server-error text is never forwarded.
+    """
+    upstream_status = resp.status_code
+    if upstream_status in _PASSTHROUGH_STATUSES:
+        status = upstream_status
+    elif caller_auth and upstream_status in (401, 403):
+        status = upstream_status
+    else:
+        status = 502
+
+    if upstream_status in (401, 403) and not caller_auth:
+        # The upstream's auth diagnostics describe the proxy's credentials,
+        # which the caller can neither see nor fix — replace them wholesale.
+        return {
+            'resourceType': 'OperationOutcome',
+            'issue': [{
+                'severity': 'error',
+                'code': 'security',
+                'details': {'text': ('Upstream authentication/authorization '
+                                     f'failed (HTTP {upstream_status} from upstream)')},
+            }],
+        }, status
+
+    issues = []
+    if upstream_status < 500:
+        # 5xx bodies are never parsed: server-error pages/traces have no
+        # corrective value for the caller and the highest leak risk.
+        raw = getattr(resp, 'content', None)
+        try:
+            oversized = raw is not None and len(raw) > _MAX_ERROR_BODY_BYTES
+        except TypeError:  # content has no length — treat as unbounded, don't parse
+            oversized = True
+        body = None
+        if not oversized:
+            try:
+                body = resp.json()
+            except Exception:  # noqa: BLE001 — non-JSON upstream error body
+                body = None
+        if isinstance(body, dict) and body.get('resourceType') == 'OperationOutcome':
+            issues = _sanitize_issue_list(body.get('issue'),
+                                          _issue_code_for_status(upstream_status))
+
+    if not issues:
+        fallback_code = _issue_code_for_status(upstream_status)
+        issues = [{
+            'severity': 'error',
+            'code': fallback_code,
+            'details': {'text': _message_for_code(fallback_code)},
+        }]
+
+    return {'resourceType': 'OperationOutcome', 'issue': issues}, status
+
+
+def malformed_upstream_response_outcome() -> tuple[dict, int]:
+    """(OperationOutcome, 502) for a 2xx upstream response whose body is
+    absent, unparseable, or not a JSON object — a malformed success must not
+    escape as an unhandled 500 downstream (routes assume a dict resource)."""
+    return {
+        'resourceType': 'OperationOutcome',
+        'issue': [{
+            'severity': 'error',
+            'code': 'processing',
+            'details': {'text': 'Upstream FHIR server returned a malformed response body'},
+        }],
+    }, 502
+
+
+def upstream_unreachable_outcome(exc: Exception) -> tuple[dict, int]:
+    """(OperationOutcome, 502) for a network-level upstream failure.
+
+    Only the exception TYPE is disclosed — str(exc) can embed URLs or
+    secret-bearing connection strings.
+    """
+    return {
+        'resourceType': 'OperationOutcome',
+        'issue': [{
+            'severity': 'error',
+            'code': 'transient',
+            'details': {'text': f'Upstream FHIR server unreachable ({type(exc).__name__})'},
+        }],
+    }, 502
+
 
 class FHIRUpstreamProxy:
     """
@@ -125,9 +340,14 @@ class FHIRUpstreamProxy:
     URL rewriting ensures no upstream URLs leak to the client.
     """
 
-    def __init__(self, upstream_url: str, local_base_url: str = ''):
+    def __init__(self, upstream_url: str, local_base_url: str = '',
+                 caller_auth: bool = False):
         self.upstream_url = upstream_url.rstrip('/')
         self.local_base_url = local_base_url.rstrip('/')
+        # True when the CALLER's own credential is forwarded upstream (SHARP
+        # mode) — upstream 401/403 then belong to the caller and pass
+        # through, instead of mapping to 502 (proxy-credential failure).
+        self.caller_auth = caller_auth
         self._client = httpx.Client(
             base_url=self.upstream_url,
             timeout=_UPSTREAM_TIMEOUT,
@@ -167,35 +387,73 @@ class FHIRUpstreamProxy:
                 'error': str(e),
             }
 
-    def read(self, resource_type: str, resource_id: str) -> dict | None:
-        """Read a single resource from the upstream server."""
+    def _success_body(self, resp):
+        """Parse a 2xx upstream body and require it to be a JSON object.
+
+        Returns (rewritten_dict, None) on success, or (None, malformed
+        outcome tuple) when the body is unparseable or not an object —
+        downstream route code assumes a dict resource/Bundle, so an array
+        or scalar 200 would otherwise crash after the guardrail boundary.
+        """
+        try:
+            data = resp.json()
+        except Exception:  # noqa: BLE001 — unparseable body
+            return None, malformed_upstream_response_outcome()
+        if not isinstance(data, dict):
+            return None, malformed_upstream_response_outcome()
+        return self._rewrite_urls(data), None
+
+    def read(self, resource_type: str, resource_id: str) -> tuple[dict | None, int]:
+        """Read a single resource from the upstream server.
+
+        Returns (resource, 200) on success, (None, 404) when the upstream
+        says the resource does not exist, and (sanitized OperationOutcome,
+        status) for every other failure — an upstream 401/500 must not
+        masquerade as "not found" (#74).
+        """
         path = f'/{resource_type}/{resource_id}'
         try:
             resp = self._client.get(path)
-            if resp.status_code == 200:
-                data = resp.json()
-                return self._rewrite_urls(data)
-            if resp.status_code == 404:
-                return None
-            logger.warning(f'Upstream read {path} returned {resp.status_code}')
-            return None
-        except Exception as e:
-            logger.error(f'Upstream read {path} failed: {e}')
-            return None
+        except Exception as e:  # noqa: BLE001 — network-level failure
+            # Log the resource type only — the path embeds the resource id,
+            # which for person resources is PHI-adjacent.
+            logger.error(f'Upstream read {resource_type} failed: {type(e).__name__}')
+            return upstream_unreachable_outcome(e)
+        if resp.status_code == 200:
+            data, malformed = self._success_body(resp)
+            if malformed is not None:
+                logger.warning(f'Upstream read {resource_type} returned a malformed 200 body')
+                return malformed
+            return data, 200
+        if resp.status_code == 404:
+            return None, 404
+        logger.warning(f'Upstream read {resource_type} returned {resp.status_code}')
+        return sanitize_upstream_error(resp, caller_auth=self.caller_auth)
 
-    def search(self, resource_type: str, params: dict) -> dict:
-        """Search resources on the upstream server. Returns a Bundle."""
+    def search(self, resource_type: str, params: dict) -> tuple[dict, int]:
+        """Search resources on the upstream server.
+
+        Returns (Bundle, 200) on success and (sanitized OperationOutcome,
+        status) on failure — a rejected search must not be reported as an
+        empty result set (#74).
+        """
         path = f'/{resource_type}'
         try:
             resp = self._client.get(path, params=params)
-            if resp.status_code == 200:
-                data = resp.json()
-                return self._rewrite_urls(data)
-            logger.warning(f'Upstream search {path} returned {resp.status_code}')
-            return self._empty_bundle()
-        except Exception as e:
-            logger.error(f'Upstream search {path} failed: {e}')
-            return self._empty_bundle()
+        except Exception as e:  # noqa: BLE001 — network-level failure
+            logger.error(f'Upstream search {resource_type} failed: {type(e).__name__}')
+            return upstream_unreachable_outcome(e)
+        if resp.status_code == 200:
+            data, malformed = self._success_body(resp)
+            if malformed is not None or data.get('resourceType') != 'Bundle':
+                # A search MUST return a Bundle; a bare resource (or other
+                # shape) would make the route synthesize a misleading empty
+                # searchset. Treat anything else as a malformed response.
+                logger.warning(f'Upstream search {resource_type} returned a non-Bundle 200 body')
+                return malformed if malformed is not None else malformed_upstream_response_outcome()
+            return data, 200
+        logger.warning(f'Upstream search {resource_type} returned {resp.status_code}')
+        return sanitize_upstream_error(resp, caller_auth=self.caller_auth)
 
     def create(self, resource_type: str, resource: dict) -> tuple[dict | None, int]:
         """Create a resource on the upstream server. Returns (resource, status_code)."""
@@ -207,13 +465,15 @@ class FHIRUpstreamProxy:
                 headers={'Content-Type': 'application/fhir+json'},
             )
             if resp.status_code in (200, 201):
-                data = resp.json()
-                return self._rewrite_urls(data), resp.status_code
-            logger.warning(f'Upstream create {path} returned {resp.status_code}: {resp.text[:200]}')
-            return resp.json() if resp.headers.get('content-type', '').startswith('application/') else None, resp.status_code
+                data, malformed = self._success_body(resp)
+                if malformed is not None:
+                    return malformed
+                return data, resp.status_code
+            logger.warning(f'Upstream create {resource_type} returned {resp.status_code}')
+            return sanitize_upstream_error(resp, caller_auth=self.caller_auth)
         except Exception as e:
-            logger.error(f'Upstream create {path} failed: {e}')
-            return None, 502
+            logger.error(f'Upstream create {resource_type} failed: {type(e).__name__}')
+            return upstream_unreachable_outcome(e)
 
     def update(self, resource_type: str, resource_id: str, resource: dict,
                if_match: str | None = None) -> tuple[dict | None, int]:
@@ -225,13 +485,15 @@ class FHIRUpstreamProxy:
         try:
             resp = self._client.put(path, json=resource, headers=headers)
             if resp.status_code in (200, 201):
-                data = resp.json()
-                return self._rewrite_urls(data), resp.status_code
-            logger.warning(f'Upstream update {path} returned {resp.status_code}')
-            return resp.json() if resp.headers.get('content-type', '').startswith('application/') else None, resp.status_code
+                data, malformed = self._success_body(resp)
+                if malformed is not None:
+                    return malformed
+                return data, resp.status_code
+            logger.warning(f'Upstream update {resource_type} returned {resp.status_code}')
+            return sanitize_upstream_error(resp, caller_auth=self.caller_auth)
         except Exception as e:
-            logger.error(f'Upstream update {path} failed: {e}')
-            return None, 502
+            logger.error(f'Upstream update {resource_type} failed: {type(e).__name__}')
+            return upstream_unreachable_outcome(e)
 
     def operation(self, path: str, method: str = 'GET',
                   params: dict | None = None,
@@ -487,8 +749,15 @@ def _sharp_url_from_request():
 def make_sharp_proxy(server_url: str,
                      access_token: str | None,
                      local_base_url: str = '') -> FHIRUpstreamProxy:
-    """Create a per-request FHIR proxy from SHARP context headers."""
-    proxy = FHIRUpstreamProxy(server_url, local_base_url)
+    """Create a per-request FHIR proxy from SHARP context headers.
+
+    caller_auth is set only when a SMART token is actually forwarded: then
+    upstream 401/403 belong to the caller and pass through for re-auth. With
+    no token forwarded, a 401/403 is not the caller's to fix, so it maps to
+    502 like any other proxy-side failure.
+    """
+    proxy = FHIRUpstreamProxy(server_url, local_base_url,
+                              caller_auth=bool(access_token))
     if access_token:
         token = access_token.strip()
         if token.lower().startswith('bearer '):

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -44,6 +44,7 @@ from r6.fhir_proxy import (
     is_proxy_enabled,
     is_sharp_context_active,
     close_request_proxy,
+    sanitize_operation_outcome_resource,
     SHARP_SERVER_URL_HEADER,
 )
 from r6.curatr import (
@@ -537,7 +538,13 @@ def create_resource(resource_type):
             response = jsonify(result)
             response.status_code = status_code
             return response
-        # Upstream rejected the create
+        # Upstream rejected the create — audit the failure and surface the
+        # sanitized OperationOutcome with its real status.
+        record_audit_event('create', resource_type, None,
+                           agent_id=request.headers.get('X-Agent-Id'),
+                           tenant_id=tenant_id,
+                           outcome='failure',
+                           detail=f'create (upstream): rejected HTTP {status_code}')
         if result:
             return jsonify(result), status_code
         return _operation_outcome('error', 'exception',
@@ -586,10 +593,29 @@ def read_resource(resource_type, resource_id):
     # --- Upstream proxy mode: fetch from real FHIR server ---
     proxy = get_proxy_for_request()
     if proxy:
-        fhir_json = proxy.read(resource_type, resource_id)
-        if not fhir_json:
+        fhir_json, upstream_status = proxy.read(resource_type, resource_id)
+        if upstream_status == 404:
+            # Not-found is still an access attempt — audit it (every FHIR
+            # resource access emits an AuditEvent, failures included).
+            record_audit_event('read', resource_type, resource_id,
+                               agent_id=request.headers.get('X-Agent-Id'),
+                               context_id=request.headers.get('X-Context-Id'),
+                               tenant_id=tenant_id,
+                               outcome='failure',
+                               detail='read (upstream): HTTP 404 not found')
             return _operation_outcome('error', 'not-found',
                                       f'{resource_type}/{resource_id} not found'), 404
+        if upstream_status != 200:
+            # Surface the (sanitized) upstream failure with its real status —
+            # a 401/500 must not masquerade as not-found — and audit the
+            # failed access so denied/failed reads are visible in the trail.
+            record_audit_event('read', resource_type, resource_id,
+                               agent_id=request.headers.get('X-Agent-Id'),
+                               context_id=request.headers.get('X-Context-Id'),
+                               tenant_id=tenant_id,
+                               outcome='failure',
+                               detail=f'read (upstream): HTTP {upstream_status}')
+            return jsonify(fhir_json), upstream_status
 
         record_audit_event('read', resource_type, resource_id,
                            agent_id=request.headers.get('X-Agent-Id'),
@@ -703,6 +729,13 @@ def update_resource(resource_type, resource_id):
             result = add_disclaimer(result, resource_type)
             result['_source'] = 'upstream'
             return jsonify(result)
+        # Upstream rejected the update — audit the failure and surface the
+        # sanitized OperationOutcome with its real status.
+        record_audit_event('update', resource_type, resource_id,
+                           agent_id=request.headers.get('X-Agent-Id'),
+                           tenant_id=tenant_id,
+                           outcome='failure',
+                           detail=f'update (upstream): rejected HTTP {status_code}')
         if result:
             return jsonify(result), status_code
         return _operation_outcome('error', 'exception',
@@ -763,19 +796,60 @@ def search_resources(resource_type):
         params = dict(request.args)
         # Remove context-id (local concept, not upstream)
         params.pop('context-id', None)
-        bundle = proxy.search(resource_type, params)
+        bundle, upstream_status = proxy.search(resource_type, params)
+        if upstream_status != 200:
+            # Surface the (sanitized) upstream rejection with its real status —
+            # a failed search must not be reported as an empty result set —
+            # and audit it as a failure, not a zero-result success.
+            record_audit_event('read', resource_type, None,
+                               agent_id=request.headers.get('X-Agent-Id'),
+                               tenant_id=tenant_id,
+                               outcome='failure',
+                               detail=f'search (upstream): rejected HTTP {upstream_status}')
+            return jsonify(bundle), upstream_status
 
-        # Apply guardrails to each entry from upstream
+        # Apply guardrails to each entry from upstream. Tolerate a malformed
+        # bundle (null/non-list entry, non-dict entries or resources) rather
+        # than 500 — the upstream is not fully trusted.
         entries = []
-        for entry in bundle.get('entry', []):
-            resource_data = entry.get('resource', {})
-            redacted = apply_redaction(resource_data)
-            redacted = add_disclaimer(redacted, resource_type)
+        bundle_entries = bundle.get('entry')
+        if not isinstance(bundle_entries, list):
+            bundle_entries = []
+        for entry in bundle_entries:
+            if not isinstance(entry, dict):
+                continue
+            resource_data = entry.get('resource')
+            if not isinstance(resource_data, dict):
+                continue
+            if resource_data.get('resourceType') == 'OperationOutcome':
+                # Warning entries (search.mode="outcome") carry free-text
+                # issue fields apply_redaction() does not inspect — run them
+                # through the same allowlist as upstream errors.
+                redacted = sanitize_operation_outcome_resource(resource_data)
+            else:
+                redacted = apply_redaction(resource_data)
+                redacted = add_disclaimer(redacted, resource_type)
             redacted['_source'] = 'upstream'
-            entries.append({
+            new_entry = {
                 'fullUrl': entry.get('fullUrl', ''),
                 'resource': redacted,
-            })
+            }
+            # Preserve entry.search so mode="outcome" warnings survive — but
+            # allowlist it to scalar mode/score: `search` can carry
+            # extensions, and even under mode/score keys a hostile upstream
+            # could nest an object holding PHI or internal URLs.
+            search_info = entry.get('search')
+            if isinstance(search_info, dict):
+                allowed = {}
+                mode = search_info.get('mode')
+                if mode in ('match', 'include', 'outcome'):
+                    allowed['mode'] = mode
+                score = search_info.get('score')
+                if isinstance(score, (int, float)) and not isinstance(score, bool):
+                    allowed['score'] = score
+                if allowed:
+                    new_entry['search'] = allowed
+            entries.append(new_entry)
 
         result = {
             'resourceType': 'Bundle',

--- a/tests/test_fhir_proxy.py
+++ b/tests/test_fhir_proxy.py
@@ -14,6 +14,8 @@ from unittest.mock import patch, MagicMock
 from r6.fhir_proxy import (
     FHIRUpstreamProxy, MedplumProxy, get_proxy, reset_proxy, is_proxy_enabled,
     _fetch_medplum_token, _medplum_cache,
+    sanitize_upstream_error, upstream_unreachable_outcome,
+    _SAFE_SEVERITIES,
 )
 
 
@@ -84,28 +86,104 @@ class TestFHIRUpstreamProxy:
         }
         self.proxy._client.get = MagicMock(return_value=mock_resp)
 
-        result = self.proxy.read('Patient', '123')
+        result, status = self.proxy.read('Patient', '123')
+        assert status == 200
         assert result is not None
         assert result['resourceType'] == 'Patient'
         assert result['id'] == '123'
 
     @patch.object(FHIRUpstreamProxy, '_client', create=True)
     def test_read_not_found(self, mock_client):
-        """Read returns None for 404."""
+        """Read returns (None, 404) only for a true upstream 404."""
         mock_resp = MagicMock()
         mock_resp.status_code = 404
         self.proxy._client.get = MagicMock(return_value=mock_resp)
 
-        result = self.proxy.read('Patient', 'nonexistent')
+        result, status = self.proxy.read('Patient', 'nonexistent')
         assert result is None
+        assert status == 404
 
     @patch.object(FHIRUpstreamProxy, '_client', create=True)
     def test_read_network_error(self, mock_client):
-        """Read returns None on network error."""
+        """Network failure surfaces as (OperationOutcome, 502) — not a fake 404.
+
+        Regression for #74: this used to return None, which the route turned
+        into "Patient/123 not found".
+        """
         self.proxy._client.get = MagicMock(side_effect=Exception('Connection refused'))
 
-        result = self.proxy.read('Patient', '123')
-        assert result is None
+        result, status = self.proxy.read('Patient', '123')
+        assert status == 502
+        assert result['resourceType'] == 'OperationOutcome'
+        assert result['issue'][0]['code'] == 'transient'
+
+    @patch.object(FHIRUpstreamProxy, '_client', create=True)
+    def test_read_auth_failure_is_not_a_404(self, mock_client):
+        """Upstream 401 surfaces as a security outcome, never as not-found.
+
+        Regression for #74: an expired proxy token used to be reported to the
+        caller as "this resource does not exist".
+        """
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.json.return_value = {
+            'resourceType': 'OperationOutcome',
+            'issue': [{'severity': 'error', 'code': 'login',
+                       'details': {'text': 'Invalid access token'}}],
+        }
+        self.proxy._client.get = MagicMock(return_value=mock_resp)
+
+        result, status = self.proxy.read('Patient', '123')
+        assert status == 502  # proxy-credential failure, not the caller's 401
+        assert result['resourceType'] == 'OperationOutcome'
+        assert result['issue'][0]['code'] == 'security'
+        # The upstream's auth diagnostics describe OUR credentials — dropped
+        assert 'Invalid access token' not in json.dumps(result)
+
+    @patch.object(FHIRUpstreamProxy, '_client', create=True)
+    def test_malformed_200_body_surfaces_as_502(self, mock_client):
+        """A 2xx response whose body fails to parse must not escape as an
+        unhandled exception — it becomes a processing outcome."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.side_effect = ValueError('not json')
+        self.proxy._client.get = MagicMock(return_value=mock_resp)
+
+        result, status = self.proxy.read('Patient', '1')
+        assert status == 502
+        assert result['issue'][0]['code'] == 'processing'
+        result, status = self.proxy.search('Patient', {})
+        assert status == 502
+        assert result['issue'][0]['code'] == 'processing'
+
+    @patch.object(FHIRUpstreamProxy, '_client', create=True)
+    def test_wrong_shape_200_body_surfaces_as_502(self, mock_client):
+        """A parseable-but-non-object 200 (array/scalar) must not reach the
+        route, which assumes a dict resource/Bundle — it maps to 502."""
+        for shape in ([], 'a string', 42, None):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = shape
+            self.proxy._client.get = MagicMock(return_value=mock_resp)
+            result, status = self.proxy.read('Patient', '1')
+            assert status == 502, f'read shape {shape!r}'
+            assert result['issue'][0]['code'] == 'processing'
+            result, status = self.proxy.search('Patient', {})
+            assert status == 502, f'search shape {shape!r}'
+
+    @patch.object(FHIRUpstreamProxy, '_client', create=True)
+    def test_search_non_bundle_dict_surfaces_as_502(self, mock_client):
+        """A dict 200 that isn't a Bundle (e.g. a bare Patient) must not reach
+        the route, which would synthesize a misleading empty searchset."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {'resourceType': 'Patient', 'id': 'p1'}
+        self.proxy._client.get = MagicMock(return_value=mock_resp)
+
+        result, status = self.proxy.search('Patient', {})
+        assert status == 502
+        assert result['resourceType'] == 'OperationOutcome'
+        assert result['issue'][0]['code'] == 'processing'
 
     @patch.object(FHIRUpstreamProxy, '_client', create=True)
     def test_search_success(self, mock_client):
@@ -120,18 +198,49 @@ class TestFHIRUpstreamProxy:
         }
         self.proxy._client.get = MagicMock(return_value=mock_resp)
 
-        result = self.proxy.search('Patient', {'name': 'Smith'})
+        result, status = self.proxy.search('Patient', {'name': 'Smith'})
+        assert status == 200
         assert result['total'] == 1
         assert len(result['entry']) == 1
 
     @patch.object(FHIRUpstreamProxy, '_client', create=True)
-    def test_search_error_returns_empty_bundle(self, mock_client):
-        """Search error returns an empty bundle, not an exception."""
+    def test_search_network_error_returns_outcome(self, mock_client):
+        """Network failure surfaces as (OperationOutcome, 502) — never as an
+        empty result set (#74: a failed search used to come back as total=0)."""
         self.proxy._client.get = MagicMock(side_effect=Exception('Timeout'))
 
-        result = self.proxy.search('Patient', {})
-        assert result['total'] == 0
-        assert result['entry'] == []
+        result, status = self.proxy.search('Patient', {})
+        assert status == 502
+        assert result['resourceType'] == 'OperationOutcome'
+        assert result['issue'][0]['code'] == 'transient'
+
+    @patch.object(FHIRUpstreamProxy, '_client', create=True)
+    def test_search_upstream_rejection_passes_through_status(self, mock_client):
+        """An upstream 400 OperationOutcome surfaces as a sanitized 400 with
+        the real status and machine-readable code — but the upstream's own
+        free text (which could carry PHI) is NOT forwarded (#74)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.json.return_value = {
+            'resourceType': 'OperationOutcome',
+            'issue': [{'severity': 'error', 'code': 'invalid',
+                       'details': {'text': 'Patient Rosa Hernandez already exists'},
+                       'diagnostics': 'stack trace with https://internal:5432/db'}],
+        }
+        self.proxy._client.get = MagicMock(return_value=mock_resp)
+
+        result, status = self.proxy.search('Observation', {'datetime': 'x'})
+        assert status == 400
+        assert result['resourceType'] == 'OperationOutcome'
+        assert result['issue'][0]['code'] == 'invalid'  # code (safe enum) survives
+        # Synthesized message, NOT the upstream text
+        assert result['issue'][0]['details']['text'] == \
+            'The upstream FHIR server rejected the request as invalid.'
+        # Nothing from the upstream body transits: not the name, not the trace
+        blob = json.dumps(result)
+        assert 'Rosa Hernandez' not in blob
+        assert 'internal:5432' not in blob
+        assert 'diagnostics' not in result['issue'][0]
 
     @patch.object(FHIRUpstreamProxy, '_client', create=True)
     def test_healthy_connected(self, mock_client):
@@ -188,6 +297,159 @@ class TestFHIRUpstreamProxy:
 
 
 # --- Module-level singleton tests ---
+
+class TestUpstreamErrorSanitization:
+    """Unit tests for the allowlist OperationOutcome sanitizer (#74).
+
+    Only the FHIR value-set tokens severity/code survive from upstream; the
+    human-readable text is synthesized from the code. Upstream free text is
+    never forwarded (it can carry patient names or internal hostnames).
+    """
+
+    @staticmethod
+    def _resp(status, body=None, json_error=False):
+        resp = MagicMock()
+        resp.status_code = status
+        # A real, small bytes .content so the size guard measures a length
+        # (a bare MagicMock has no len() and would read as unbounded).
+        resp.content = json.dumps(body).encode() if body is not None else b'{}'
+        if json_error:
+            resp.json.side_effect = ValueError('not json')
+        else:
+            resp.json.return_value = body
+        return resp
+
+    def test_unknown_severity_and_code_are_mapped(self):
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'catastrophic', 'code': 'made-up-code',
+                         'details': {'text': 'bad thing'}}]}
+        result, status = sanitize_upstream_error(self._resp(400, oo))
+        assert status == 400
+        assert result['issue'][0]['severity'] == 'error'
+        assert result['issue'][0]['code'] == 'invalid'  # mapped from HTTP 400
+
+    def test_only_severity_code_and_synthesized_text_survive(self):
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'error', 'code': 'invalid',
+                         'details': {'text': 'Rosa Hernandez at db.internal', 'coding': [{'code': 'x'}]},
+                         'diagnostics': 'trace', 'expression': ['Patient.name'],
+                         'extension': [{'url': 'x'}]}]}
+        result, _ = sanitize_upstream_error(self._resp(400, oo))
+        issue = result['issue'][0]
+        assert set(issue.keys()) == {'severity', 'code', 'details'}
+        assert set(issue['details'].keys()) == {'text'}
+        # text is synthesized from the code, not copied from upstream
+        assert issue['details']['text'] == 'The upstream FHIR server rejected the request as invalid.'
+        assert 'Rosa Hernandez' not in json.dumps(result)
+        assert 'db.internal' not in json.dumps(result)
+
+    def test_upstream_free_text_never_forwarded_for_any_form(self):
+        # None of these upstream free-text payloads may reach the caller —
+        # names, hosts, IPs, encoded URLs are all replaced by synthesized text.
+        for leak in ('patient Rosa Hernandez was seen', 'host clinic.internal',
+                     '10.0.0.7', 'db.internal/path', 'https%3A%2F%2Fx.internal'):
+            oo = {'resourceType': 'OperationOutcome',
+                  'issue': [{'severity': 'error', 'code': 'invalid',
+                             'details': {'text': f'error: {leak}'}}]}
+            result, _ = sanitize_upstream_error(self._resp(400, oo))
+            assert leak not in json.dumps(result), f'leaked: {leak!r}'
+
+    def test_issue_count_is_bounded(self):
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'error', 'code': 'invalid'}] * 20}
+        result, _ = sanitize_upstream_error(self._resp(400, oo))
+        assert len(result['issue']) == 5
+
+    def test_non_json_body_is_synthesized(self):
+        result, status = sanitize_upstream_error(self._resp(500, json_error=True))
+        assert status == 502
+        assert result['issue'][0]['code'] == 'transient'
+        assert result['issue'][0]['details']['text'] == 'The upstream FHIR server had a transient error.'
+
+    def test_non_operationoutcome_json_is_synthesized(self):
+        result, status = sanitize_upstream_error(
+            self._resp(429, {'error': 'rate limited', 'internal': 'stuff'}))
+        assert status == 429
+        assert result['issue'][0]['code'] == 'throttled'
+        assert 'stuff' not in json.dumps(result)
+
+    def test_401_maps_to_502_and_drops_upstream_text(self):
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'error', 'code': 'login',
+                         'details': {'text': 'client_id cid-12345 token expired'}}]}
+        result, status = sanitize_upstream_error(self._resp(401, oo))
+        assert status == 502
+        assert result['issue'][0]['code'] == 'security'
+        assert 'cid-12345' not in json.dumps(result)
+
+    def test_caller_attributable_statuses_pass_through(self):
+        for upstream, expected in ((400, 400), (404, 404), (422, 422),
+                                   (429, 429), (500, 502), (503, 502)):
+            _, status = sanitize_upstream_error(self._resp(upstream, json_error=True))
+            assert status == expected, f'HTTP {upstream} should map to {expected}'
+
+    def test_unreachable_outcome_discloses_type_only(self):
+        exc = ConnectionError('https://user:pass@internal:5432 refused')
+        result, status = upstream_unreachable_outcome(exc)
+        assert status == 502
+        assert result['issue'][0]['code'] == 'transient'
+        assert 'ConnectionError' in result['issue'][0]['details']['text']
+        assert 'internal:5432' not in json.dumps(result)
+
+    def test_malformed_issue_shapes_do_not_crash(self):
+        # Whole-array malformations AND per-field malformations (unhashable
+        # severity/code would raise inside a membership test).
+        bad_arrays = (None, 'a string', {'severity': 'error'}, 42,
+                      [None, 'x', 42, {'severity': 'error', 'code': 'invalid'}])
+        bad_fields = (
+            [{'severity': [], 'code': {}}],
+            [{'severity': {'x': 1}, 'code': ['a']}],
+            [{'severity': 5, 'code': 5, 'details': {'text': ['not', 'a', 'string']}}],
+        )
+        for bad_issue in (*bad_arrays, *bad_fields):
+            oo = {'resourceType': 'OperationOutcome', 'issue': bad_issue}
+            result, status = sanitize_upstream_error(self._resp(400, oo))
+            assert status == 400
+            assert result['resourceType'] == 'OperationOutcome'
+            assert len(result['issue']) >= 1
+            # non-string severity/code fall back to safe defaults
+            for issue in result['issue']:
+                assert issue['severity'] in _SAFE_SEVERITIES
+                assert isinstance(issue['code'], str)
+
+    def test_oversized_error_body_is_not_parsed(self):
+        resp = self._resp(400, {'resourceType': 'OperationOutcome',
+                                'issue': [{'severity': 'error', 'code': 'invalid',
+                                           'details': {'text': 'should not appear'}}]})
+        resp.content = b'x' * 2_000_000
+        result, status = sanitize_upstream_error(resp)
+        assert status == 400
+        assert 'should not appear' not in json.dumps(result)
+        resp.json.assert_not_called()
+
+    def test_5xx_body_text_is_never_forwarded(self):
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'error', 'code': 'exception',
+                         'details': {'text': 'NullPointerException at PatientDao.java:88'}}]}
+        resp = self._resp(500, oo)
+        result, status = sanitize_upstream_error(resp)
+        assert status == 502
+        assert 'PatientDao' not in json.dumps(result)
+        assert result['issue'][0]['details']['text'] == 'The upstream FHIR server had a transient error.'
+        resp.json.assert_not_called()  # 5xx bodies are never parsed at all
+
+    def test_caller_auth_401_passes_through_for_sharp(self):
+        """SHARP mode forwards the CALLER's SMART token — an upstream 401
+        belongs to the caller, who must see the status to re-authenticate.
+        The code passes through; the upstream text still does not."""
+        oo = {'resourceType': 'OperationOutcome',
+              'issue': [{'severity': 'error', 'code': 'expired',
+                         'details': {'text': 'Token expired for user jsmith@clinic.internal'}}]}
+        result, status = sanitize_upstream_error(self._resp(401, oo), caller_auth=True)
+        assert status == 401  # caller can see the 401 and re-auth
+        assert result['issue'][0]['code'] == 'expired'
+        assert 'jsmith@clinic.internal' not in json.dumps(result)  # text still not forwarded
+
 
 class TestProxySingleton:
     """Tests for the module-level proxy singleton."""
@@ -257,7 +519,7 @@ class TestProxyRouteIntegration:
 
         with patch('r6.routes.get_proxy_for_request') as mock_get:
             mock_proxy = MagicMock()
-            mock_proxy.read.return_value = upstream_patient
+            mock_proxy.read.return_value = (upstream_patient, 200)
             mock_get.return_value = mock_proxy
 
             resp = self.client.get('/r6/fhir/Patient/upstream-pt-1',
@@ -279,7 +541,7 @@ class TestProxyRouteIntegration:
 
         with patch('r6.routes.get_proxy_for_request') as mock_get:
             mock_proxy = MagicMock()
-            mock_proxy.read.return_value = None
+            mock_proxy.read.return_value = (None, 404)
             mock_get.return_value = mock_proxy
 
             resp = self.client.get('/r6/fhir/Patient/nonexistent',
@@ -311,7 +573,7 @@ class TestProxyRouteIntegration:
 
         with patch('r6.routes.get_proxy_for_request') as mock_get:
             mock_proxy = MagicMock()
-            mock_proxy.search.return_value = upstream_bundle
+            mock_proxy.search.return_value = (upstream_bundle, 200)
             mock_get.return_value = mock_proxy
 
             resp = self.client.get('/r6/fhir/Patient?name=Smith',

--- a/tests/test_medplum_in_front.py
+++ b/tests/test_medplum_in_front.py
@@ -69,3 +69,145 @@ def test_medplum_write_gated_by_step_up_before_upstream(client, tenant_headers):
     # No step-up token -> blocked by the guardrail BEFORE any Medplum call
     assert resp.status_code == 401
     proxy._client.post.assert_not_called()
+
+
+# --- Error fidelity through the facade (#74) --------------------------------
+# A Medplum rejection must surface as a sanitized error with its real status,
+# never as an empty result set or a fake 404 — and it must be audited as a
+# failure, with no PHI or internal URLs transiting the guardrail boundary.
+
+MEDPLUM_REJECTION_WITH_LEAKY_DIAGNOSTICS = {
+    "resourceType": "OperationOutcome",
+    "issue": [{
+        "severity": "error", "code": "invalid",
+        "details": {"text": "Unknown search parameter: datetime"},
+        # Neither the patient name nor the internal URL may transit
+        "diagnostics": ("while searching for Rosa Hernandez see "
+                        "https://db.internal:5432/trace/8842"),
+    }],
+}
+
+
+def test_medplum_search_rejection_surfaces_not_empty_bundle(client, tenant_headers,
+                                                            tenant_id, app):
+    proxy = _medplum_proxy_returning(MEDPLUM_REJECTION_WITH_LEAKY_DIAGNOSTICS, 400)
+    with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+        resp = client.get("/r6/fhir/Observation?datetime=ge2024-01-01",
+                          headers=tenant_headers)
+
+    # The rejection surfaces with its real status and a machine-readable code
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["resourceType"] == "OperationOutcome"
+    assert body["issue"][0]["code"] == "invalid"
+    # ... the message is synthesized, and NOTHING from the upstream body
+    # transits (not the corrective text, not the planted name/URL)
+    blob = json.dumps(body)
+    assert "Unknown search parameter" not in blob
+    assert "Rosa Hernandez" not in blob
+    assert "db.internal" not in blob
+
+    # Audited as a failure, not a zero-result success
+    with app.app_context():
+        rec = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, resource_type="Observation",
+            event_type="read", outcome="failure").first()
+        assert rec is not None
+        assert "rejected HTTP 400" in rec.detail
+
+
+def test_medplum_auth_failure_read_is_not_a_404_and_is_audited(client, tenant_headers,
+                                                               tenant_id, app):
+    proxy = _medplum_proxy_returning(
+        {"resourceType": "OperationOutcome",
+         "issue": [{"severity": "error", "code": "login",
+                    "details": {"text": "Invalid access token"}}]}, 401)
+    with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+        resp = client.get("/r6/fhir/Patient/pt-medplum", headers=tenant_headers)
+
+    # NOT "Patient/pt-medplum not found" — the resource may well exist
+    assert resp.status_code == 502
+    body = resp.get_json()
+    assert body["resourceType"] == "OperationOutcome"
+    assert body["issue"][0]["code"] == "security"
+    assert "not found" not in json.dumps(body)
+
+    # The failed access attempt is visible in the audit trail
+    with app.app_context():
+        rec = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, resource_type="Patient",
+            event_type="read", outcome="failure").first()
+        assert rec is not None
+        assert "HTTP 502" in rec.detail
+
+
+def test_medplum_search_preserves_and_sanitizes_outcome_warning_entries(client, tenant_headers):
+    bundle = {
+        "resourceType": "Bundle", "type": "searchset", "total": 1,
+        "entry": [
+            {"fullUrl": "https://api.medplum.com/fhir/R4/Observation/obs-1",
+             "resource": {"resourceType": "Observation", "id": "obs-1",
+                          "status": "final", "code": {"text": "A1c"}},
+             "search": {"mode": "match"}},
+            {"resource": {"resourceType": "OperationOutcome",
+                          "issue": [{"severity": "warning", "code": "not-supported",
+                                     "details": {"text": "ignored parameter foo"},
+                                     # neither may transit through a 200 bundle
+                                     "diagnostics": ("Rosa Hernandez trace at "
+                                                     "https://db.internal:5432/q")}]},
+             # search carries an extension AND nested objects under the
+             # allowlisted mode/score keys — only scalar mode/score survive
+             "search": {"mode": "outcome",
+                        "score": {"nested": "Rosa Hernandez"},
+                        "extension": [{"url": "https://internal/ext", "valueString": "x"}]}},
+        ],
+    }
+    proxy = _medplum_proxy_returning(bundle, 200)
+    with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+        resp = client.get("/r6/fhir/Observation?code=4548-4", headers=tenant_headers)
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    entries = body["entry"]
+    modes = [e.get("search", {}).get("mode") for e in entries]
+    assert "match" in modes
+    assert "outcome" in modes  # upstream warnings survive the entry rebuild
+
+    outcome_entry = next(e for e in entries
+                         if e["resource"]["resourceType"] == "OperationOutcome")
+    # the machine-readable code survives; the upstream free text, diagnostics,
+    # extensions, and the nested object smuggled under `score` do not
+    assert outcome_entry["resource"]["issue"][0]["code"] == "not-supported"
+    blob = json.dumps(body)
+    assert "ignored parameter foo" not in blob   # upstream text not forwarded
+    assert "Rosa Hernandez" not in blob
+    assert "db.internal" not in blob
+    assert "extension" not in outcome_entry.get("search", {})
+    assert "score" not in outcome_entry.get("search", {})  # nested value dropped
+
+
+def test_medplum_not_found_read_is_audited(client, tenant_headers, tenant_id, app):
+    proxy = _medplum_proxy_returning(None, 404)
+    with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+        resp = client.get("/r6/fhir/Patient/gone", headers=tenant_headers)
+
+    assert resp.status_code == 404
+    # A not-found access attempt is still an access attempt — audited
+    with app.app_context():
+        rec = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, resource_type="Patient",
+            event_type="read", outcome="failure").first()
+        assert rec is not None
+        assert "404" in rec.detail
+
+
+def test_medplum_non_bundle_search_result_does_not_500(client, tenant_headers):
+    """A 200 that is a bare resource instead of a Bundle must surface as a
+    502 error, not crash the route or become a misleading empty searchset."""
+    proxy = _medplum_proxy_returning({"resourceType": "Patient", "id": "p1"}, 200)
+    with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+        resp = client.get("/r6/fhir/Observation?code=x", headers=tenant_headers)
+
+    assert resp.status_code == 502
+    body = resp.get_json()
+    assert body["resourceType"] == "OperationOutcome"

--- a/tests/test_public_fhir_servers.py
+++ b/tests/test_public_fhir_servers.py
@@ -73,7 +73,7 @@ class TestHAPIFHIRProxy:
     @skip_hapi
     def test_patient_search(self):
         """Search for patients returns a valid Bundle."""
-        result = self.proxy.search('Patient', {'_count': '3'})
+        result, _ = self.proxy.search('Patient', {'_count': '3'})
         assert result['resourceType'] == 'Bundle'
         assert result['type'] == 'searchset'
         assert 'total' in result or 'entry' in result
@@ -81,7 +81,7 @@ class TestHAPIFHIRProxy:
     @skip_hapi
     def test_patient_search_with_params(self):
         """Search with specific parameters is forwarded correctly."""
-        result = self.proxy.search('Patient', {'_count': '2', '_summary': 'true'})
+        result, _ = self.proxy.search('Patient', {'_count': '2', '_summary': 'true'})
         assert result['resourceType'] == 'Bundle'
         # Summary mode returns fewer fields per resource
         if result.get('entry'):
@@ -91,14 +91,14 @@ class TestHAPIFHIRProxy:
     @skip_hapi
     def test_observation_search(self):
         """Search for observations returns valid results."""
-        result = self.proxy.search('Observation', {'_count': '3'})
+        result, _ = self.proxy.search('Observation', {'_count': '3'})
         assert result['resourceType'] == 'Bundle'
         assert result['type'] == 'searchset'
 
     @skip_hapi
     def test_url_rewriting_on_real_response(self):
         """Upstream URLs in real HAPI responses are rewritten to local proxy."""
-        result = self.proxy.search('Patient', {'_count': '1'})
+        result, _ = self.proxy.search('Patient', {'_count': '1'})
         serialized = json.dumps(result)
         # No upstream URLs should leak
         assert 'hapi.fhir.org/baseR4' not in serialized
@@ -110,13 +110,14 @@ class TestHAPIFHIRProxy:
     @skip_hapi
     def test_read_nonexistent_patient(self):
         """Reading a nonexistent patient returns None."""
-        result = self.proxy.read('Patient', 'definitely-does-not-exist-xyz-99999')
+        result, status = self.proxy.read('Patient', 'definitely-does-not-exist-xyz-99999')
         assert result is None
+        assert status == 404
 
     @skip_hapi
     def test_condition_search(self):
         """Search for conditions works against HAPI."""
-        result = self.proxy.search('Condition', {'_count': '2'})
+        result, _ = self.proxy.search('Condition', {'_count': '2'})
         assert result['resourceType'] == 'Bundle'
 
     @skip_hapi
@@ -156,39 +157,40 @@ class TestSMARTHealthITProxy:
     @skip_smart
     def test_patient_search(self):
         """Search for patients returns a valid Bundle."""
-        result = self.proxy.search('Patient', {'_count': '3'})
+        result, _ = self.proxy.search('Patient', {'_count': '3'})
         assert result['resourceType'] == 'Bundle'
         assert result['type'] == 'searchset'
 
     @skip_smart
     def test_patient_search_by_name(self):
         """Search by name parameter forwards correctly."""
-        result = self.proxy.search('Patient', {'name': 'Smith', '_count': '3'})
+        result, _ = self.proxy.search('Patient', {'name': 'Smith', '_count': '3'})
         assert result['resourceType'] == 'Bundle'
 
     @skip_smart
     def test_observation_search(self):
         """Search for observations on SMART Health IT."""
-        result = self.proxy.search('Observation', {'_count': '3'})
+        result, _ = self.proxy.search('Observation', {'_count': '3'})
         assert result['resourceType'] == 'Bundle'
 
     @skip_smart
     def test_url_rewriting_on_real_response(self):
         """SMART Health IT URLs are rewritten to local proxy."""
-        result = self.proxy.search('Patient', {'_count': '1'})
+        result, _ = self.proxy.search('Patient', {'_count': '1'})
         serialized = json.dumps(result)
         assert 'r4.smarthealthit.org' not in serialized
 
     @skip_smart
     def test_read_nonexistent_returns_none(self):
         """Reading a nonexistent resource returns None."""
-        result = self.proxy.read('Patient', 'nonexistent-id-xyz-99999')
+        result, status = self.proxy.read('Patient', 'nonexistent-id-xyz-99999')
         assert result is None
+        assert status == 404
 
     @skip_smart
     def test_encounter_search(self):
         """Search for encounters on SMART Health IT."""
-        result = self.proxy.search('Encounter', {'_count': '2'})
+        result, _ = self.proxy.search('Encounter', {'_count': '2'})
         assert result['resourceType'] == 'Bundle'
 
     @skip_smart
@@ -220,8 +222,8 @@ class TestCrossServerComparison:
                         reason='Both FHIR servers must be reachable')
     def test_both_servers_return_valid_bundles(self):
         """Both servers return structurally valid search Bundles."""
-        hapi_result = self.hapi.search('Patient', {'_count': '2'})
-        smart_result = self.smart.search('Patient', {'_count': '2'})
+        hapi_result, _ = self.hapi.search('Patient', {'_count': '2'})
+        smart_result, _ = self.smart.search('Patient', {'_count': '2'})
 
         for result in [hapi_result, smart_result]:
             assert result['resourceType'] == 'Bundle'
@@ -242,8 +244,8 @@ class TestCrossServerComparison:
                         reason='Both FHIR servers must be reachable')
     def test_url_rewriting_prevents_upstream_leakage(self):
         """Neither server's URLs leak through the proxy."""
-        hapi_result = self.hapi.search('Patient', {'_count': '1'})
-        smart_result = self.smart.search('Patient', {'_count': '1'})
+        hapi_result, _ = self.hapi.search('Patient', {'_count': '1'})
+        smart_result, _ = self.smart.search('Patient', {'_count': '1'})
 
         hapi_json = json.dumps(hapi_result)
         smart_json = json.dumps(smart_result)

--- a/tests/test_sharp_on_mcp.py
+++ b/tests/test_sharp_on_mcp.py
@@ -124,7 +124,7 @@ class TestSharpTenantDerivation:
         expected_digest = hashlib.sha256(sharp_url.encode('utf-8')).hexdigest()[:16]
         expected_tenant = f'sharp-{expected_digest}'
 
-        with patch('r6.fhir_proxy.FHIRUpstreamProxy.read', return_value=None) as mock_read:
+        with patch('r6.fhir_proxy.FHIRUpstreamProxy.read', return_value=(None, 404)) as mock_read:
             resp = client.get(
                 '/r6/fhir/Patient/upstream-only-id',
                 headers={
@@ -156,7 +156,7 @@ class TestSharpProxyRouting:
         }
         with patch(
             'r6.fhir_proxy.FHIRUpstreamProxy.read',
-            return_value=upstream_resource,
+            return_value=(upstream_resource, 200),
         ) as mock_read:
             resp = client.get(
                 '/r6/fhir/Patient/patient-from-upstream',


### PR DESCRIPTION
Fixes #74.

## What was happening

`FHIRUpstreamProxy` collapsed every upstream failure into a success-shaped response: `search()` returned an empty bundle for any non-200 (a rejected query read as "no results"), and `read()` returned `None` for any non-200 except 404, which the facade reported as `404 not found` (an expired proxy token read as "this resource does not exist"). The audit trail recorded failed searches as zero-result successes (outcome code 0), and 401-failed reads produced no AuditEvent at all — full live transcript in #74.

## What this changes

1. **`search()`/`read()` return `(payload, status)`** — the tuple shape `create()`/`update()` already use. `read()` returns `(None, 404)` only for a true upstream 404.
2. **Every non-2xx becomes a *sanitized* OperationOutcome.** Only the FHIR value-set tokens `severity` and `code` survive from the upstream body; `details.text` is **synthesized from the code**, and the upstream's own free text is never forwarded. This is the load-bearing PHI decision: upstream error text (`details.text`, `diagnostics`) can carry patient names or internal hostnames that no URL-scrubber removes reliably — a `code`-only contract is the one that provably can't leak. Parameter-level correction ("unknown param X, did you mean Y") is produced on the **local** search path instead, where the query is parsed here and the param can be named without echoing anything upstream. Also: malformed issue arrays/fields are tolerated (type-guarded before value-set membership); bodies over 1MB and all 5xx bodies are never parsed; a 2xx body that is unparseable or not a JSON object → 502 `processing`; a search 200 that isn't a Bundle → 502 (else the route would synthesize a misleading empty searchset). `create()`/`update()` error bodies — previously returned raw and un-rewritten — go through the same sanitizer.
3. **Status mapping** — one deliberate judgment call to review:
   - Caller-attributable statuses pass through: 400, 404, 405, 406, 409, 410, 412, 422, 429.
   - **401/403 depend on who owns the upstream credential.** SHARP per-request proxies forward the *caller's* SMART token (`caller_auth=True`), so 401/403 pass through — the caller must see them to re-authenticate. On env-configured proxies (`FHIR_UPSTREAM_URL`/Medplum client-credentials) they map to **502** with issue code `security`: the *proxy's* credentials failed, and a passthrough 401 would tell an agent its own facade token is bad and trigger wrong re-auth loops. Happy to adjust either side of this split.
   - Network failures and 5xx map to 502 / `transient`; upstream logs disclose only `type(exc).__name__` and the resource type — no resource ids, no paths (REVIEW_STANDARDS #1).
4. **Failed accesses are audited**: failed upstream reads — including not-found — searches, creates, and updates now emit AuditEvents with `outcome='failure'` and a status-only detail (`search (upstream): rejected HTTP 400`) — no query params or PHI in detail strings. This closes the gap where 401-failed reads left no audit trace (REVIEW_STANDARDS #3: every access emits an AuditEvent).
5. **`entry.search` preserved with a `mode`/`score` allowlist** when the facade rebuilds searchset entries, so upstream `search.mode="outcome"` warning entries survive the guardrail pass — and those embedded OperationOutcome entries are themselves sanitized through the same allowlist, since `apply_redaction()` doesn't inspect issue-level free text.

## Verification

- **994 tests pass** (repo was at 985 before this branch); **69/69 affected tests pass**; ruff clean on touched files; all touched Python parses with the Python 3.11 grammar.
- **31/31 live public-server integration tests pass** against HAPI FHIR R4 and SMART Health IT R4 (2026-07-12). The exact 400/401 failure cases remain deterministic in the mock-Medplum harness below.
- New regression tests: rejected search surfaces as 400 with synthesized safe text (not an empty bundle); 401 read is not a 404 and IS audited; 404 read IS audited; hostile names, hosts, IPs, and encoded URLs planted across upstream details/diagnostics/extensions never transit (error path AND success-bundle outcome entries); SHARP 401 passthrough; malformed issue shapes and malformed 200 bodies don't crash; oversized bodies not parsed; 5xx bodies never parsed or forwarded; `entry.search` allowlisted; exception-type-only disclosure.
- The diff was also adversarially reviewed across four rounds before opening. Findings from earlier rounds (SHARP credential semantics, malformed-shape crashes, free-text scrubbing being structurally insufficient, missing 404-read audit, success-bundle outcome-entry leak, unbounded body parse) are all addressed above; the final round found no new defects.
- **Live before/after** against the same mock-Medplum harness from #74 (this branch built from the repo Dockerfile, `FHIR_UPSTREAM_URL` set):

| Request | Upstream returned | Facade before (#74) | Facade after (this PR) |
| --- | --- | --- | --- |
| `Observation?datetime=ge2024-01-01` | 400 OperationOutcome "Unknown search parameter: datetime" | **200**, `total: 0` | **400**, OperationOutcome `code: invalid` (synthesized message; upstream text not forwarded) |
| `Patient/pt-1` | 401 OperationOutcome | **404** "not found" | **502**, `code: security`, "Upstream authentication/authorization failed" |
| `Observation?code=4548-4` (control) | 200 searchset | 200, redacted + disclaimed | 200, unchanged |
| Audit trail | — | failed search logged as Success (0); failed read not logged | both logged as Serious failure (8); control logged as Success |

## Known residual (disclosed, not hidden)

On **successful** proxied bundles, `_rewrite_urls()` is a no-op when `FHIR_LOCAL_BASE_URL` is unset (the default), so an upstream `fullUrl`/`Bundle.link`/`meta.source` pointing at an internal host is passed through on the happy path. This is **pre-existing** behavior (predates this PR and affects every proxied read/search today) and lives in the redaction layer, not the error path — so I've deliberately left it out of scope rather than expand an error-handling PR into `redaction.py`. Flagging it as a candidate for its own issue; happy to take that separately.

## Scope boundaries

- The MCP orchestrator's handling of these (now non-empty) error responses is deliberately untouched — that's the `isError`/OperationOutcome passthrough discussion in #75, separate concern.
- `operation()` (used by `$stats`/`$lastn`/`$validate` passthrough) already returned `(body, status)` and is unchanged; routing its error bodies through the sanitizer would be a sensible follow-up but is out of scope here.
- No changes to write semantics, step-up, clinical redaction profiles, or local mode.
