### PR TITLE
fix(mcp): 15s timeout + structured error on every backend fetch (60s conformance)

### DIFF
--- a/services/agent-orchestrator/src/fetch-timeout.test.ts
+++ b/services/agent-orchestrator/src/fetch-timeout.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for fetchWithTimeout -- the single choke-point for all Flask-backend
+ * HTTP calls made by the MCP tool layer.
+ *
+ * Unlike tools.test.ts, this file does NOT mock node-fetch: it runs the real
+ * fetch against a local HTTP server so the AbortSignal.timeout() abort path
+ * is exercised end-to-end (hanging socket -> AbortError -> BackendTimeoutError).
+ */
+
+import http from "http";
+import { AddressInfo } from "net";
+import {
+  fetchWithTimeout,
+  BackendTimeoutError,
+  backendTimeoutResult,
+  DEFAULT_TIMEOUT_MS,
+} from "./fetch-timeout";
+
+describe("fetchWithTimeout", () => {
+  let fastServer: http.Server;
+  let hangingServer: http.Server;
+  let fastUrl: string;
+  let hangingUrl: string;
+
+  beforeAll((done) => {
+    fastServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    // Never responds — simulates a cold/stuck Flask backend.
+    hangingServer = http.createServer(() => {
+      /* hold the socket open forever */
+    });
+    fastServer.listen(0, () => {
+      fastUrl = `http://127.0.0.1:${(fastServer.address() as AddressInfo).port}/`;
+      hangingServer.listen(0, () => {
+        hangingUrl = `http://127.0.0.1:${(hangingServer.address() as AddressInfo).port}/`;
+        done();
+      });
+    });
+  });
+
+  afterAll((done) => {
+    // closeAllConnections drops the deliberately-hung sockets so jest exits.
+    hangingServer.closeAllConnections();
+    fastServer.close(() => hangingServer.close(() => done()));
+  });
+
+  it("resolves normally when the backend responds within the timeout", async () => {
+    const resp = await fetchWithTimeout(fastUrl, {}, 5_000);
+    expect(resp.ok).toBe(true);
+    expect(await resp.json()).toEqual({ ok: true });
+  });
+
+  it("defaults to a 15s budget", () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(15_000);
+  });
+
+  it("throws BackendTimeoutError when the backend hangs past the timeout", async () => {
+    await expect(fetchWithTimeout(hangingUrl, {}, 150)).rejects.toBeInstanceOf(
+      BackendTimeoutError
+    );
+  });
+
+  it("the typed error carries the budget and never leaks a raw AbortError", async () => {
+    expect.assertions(4);
+    try {
+      await fetchWithTimeout(hangingUrl, {}, 150);
+    } catch (e) {
+      const err = e as BackendTimeoutError;
+      expect(err.name).toBe("BackendTimeoutError");
+      expect(err.timeoutMs).toBe(150);
+      expect(err.message).not.toContain("AbortError");
+      expect(err.message).not.toContain("aborted");
+    }
+  });
+
+  it("non-timeout network errors pass through untouched", async () => {
+    // Port 1 on localhost: connection refused, not a timeout.
+    await expect(
+      fetchWithTimeout("http://127.0.0.1:1/", {}, 5_000)
+    ).rejects.not.toBeInstanceOf(BackendTimeoutError);
+  });
+});
+
+describe("backendTimeoutResult", () => {
+  it("converts the typed error into the structured, non-retry-bait tool result", () => {
+    const result = backendTimeoutResult(new BackendTimeoutError(15_000));
+    expect(result.error).toBe("backend_timeout");
+    expect(result.retryable).toBe(true);
+    expect(result.timeout_ms).toBe(15_000);
+    const message = result.message as string;
+    expect(message).toContain("timed out after 15s");
+    expect(message).toContain("cold-starting");
+    expect(message).toContain("try once more in ~30 seconds");
+    expect(message).not.toContain("AbortError");
+  });
+
+  it("renders the budget in whole seconds (60s for the conformance suite)", () => {
+    const result = backendTimeoutResult(new BackendTimeoutError(60_000));
+    expect(result.message).toContain("timed out after 60s");
+  });
+});

--- a/services/agent-orchestrator/src/fetch-timeout.ts
+++ b/services/agent-orchestrator/src/fetch-timeout.ts
@@ -1,0 +1,71 @@
+/**
+ * fetchWithTimeout -- single choke-point for every HTTP call the MCP tool
+ * layer makes to the Flask backend (and the SHL server).
+ *
+ * Why: node-fetch has NO default timeout. A cold or wedged backend used to
+ * hang the tool call until the MCP client gave up, which reads as a dead
+ * demo. Every call site in tools.ts now goes through this helper, which
+ * enforces a budget via AbortSignal.timeout() (Node 18+; repo runs Node 22).
+ *
+ * On abort we throw a typed BackendTimeoutError. executeTool converts it
+ * (via backendTimeoutResult) into a structured, non-retry-bait tool result --
+ * the raw AbortError / DOMException never reaches the model.
+ */
+
+import fetch from "node-fetch";
+import type { RequestInit, Response } from "node-fetch";
+
+/** Default per-request budget for backend calls. */
+export const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** Typed error thrown when a backend call exceeds its budget. */
+export class BackendTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      `The HealthClaw backend timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+        "The service may be cold-starting; try once more in ~30 seconds, or check service status."
+    );
+    this.name = "BackendTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Structured tool result for a backend timeout. Deliberately calm and
+ * non-retry-bait: one suggested retry after a delay, not an invitation to
+ * hammer the backend.
+ */
+export function backendTimeoutResult(e: BackendTimeoutError): Record<string, unknown> {
+  return {
+    error: "backend_timeout",
+    retryable: true,
+    timeout_ms: e.timeoutMs,
+    message: e.message,
+  };
+}
+
+/**
+ * fetch with an enforced timeout. Resolves like fetch; throws
+ * BackendTimeoutError if the budget elapses first. All other errors
+ * (connection refused, DNS, ...) pass through untouched.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<Response> {
+  const signal = AbortSignal.timeout(timeoutMs);
+  try {
+    // Cast: node-fetch v2 declares its own structural AbortSignal interface;
+    // the global (Node 22 / DOM lib) AbortSignal satisfies it at runtime.
+    return await fetch(url, { ...init, signal: signal as unknown as RequestInit["signal"] });
+  } catch (e) {
+    const name = (e as Error | undefined)?.name;
+    if (signal.aborted || name === "AbortError" || name === "TimeoutError") {
+      throw new BackendTimeoutError(timeoutMs);
+    }
+    throw e;
+  }
+}

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -16,6 +16,10 @@ jest.mock("node-fetch", () => jest.fn());
 import fetch from "node-fetch";
 const mockFetch = fetch as unknown as jest.Mock;
 
+// Import as a namespace so jest.spyOn can intercept tools.ts's calls to the
+// helper (CommonJS property access happens at call time).
+import * as fetchTimeoutModule from "./fetch-timeout";
+
 import request from "supertest";
 import { app, closeMCPServerForTests } from "./index";
 
@@ -1382,6 +1386,164 @@ describe("Tool Execution Tests", () => {
 
     expect(result).toHaveProperty("error");
     expect((result.error as string)).toContain("404");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. Backend Timeout Guardrails (W0 item 5)
+// ---------------------------------------------------------------------------
+// Every backend fetch goes through fetchWithTimeout (15s default budget,
+// 60s for the synchronous conformance probe suite, 30s for seed + curatr's
+// external-terminology round trips). A timeout must surface to the model as
+// a STRUCTURED result -- never as a raw AbortError or an unhandled rejection.
+
+describe("Backend Timeout Guardrails", () => {
+  const BASE = "http://localhost:5000/r6/fhir";
+  const tools = new FHIRTools(BASE);
+  let helperSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Spy calls through to the real helper (which uses the mocked node-fetch).
+    helperSpy = jest.spyOn(fetchTimeoutModule, "fetchWithTimeout");
+  });
+
+  afterEach(() => {
+    helperSpy.mockRestore();
+    mockFetch.mockReset();
+  });
+
+  /** node-fetch's abort rejection, as AbortSignal.timeout() produces it. */
+  function abortError(): Error {
+    const e = new Error("The user aborted a request.");
+    e.name = "AbortError";
+    return e;
+  }
+
+  it("fhir_read: hanging backend returns the structured timeout result (no unhandled rejection)", async () => {
+    mockFetch.mockRejectedValueOnce(abortError());
+
+    const result = await tools.executeTool("fhir_read", {
+      resource_type: "Patient",
+      resource_id: "pt-1",
+    });
+
+    expect(result.error).toBe("backend_timeout");
+    expect(result.retryable).toBe(true);
+    expect(result.timeout_ms).toBe(15_000);
+    expect(result.message).toContain("timed out after 15s");
+    expect(result.message).toContain("cold-starting");
+    expect(result.message).toContain("try once more in ~30 seconds");
+  });
+
+  it("timeout result never leaks raw AbortError text or a stack trace to the model", async () => {
+    mockFetch.mockRejectedValueOnce(abortError());
+
+    const result = await tools.executeTool("fhir_read", {
+      resource_type: "Patient",
+      resource_id: "pt-1",
+    });
+
+    const rendered = JSON.stringify(result);
+    expect(rendered).not.toContain("AbortError");
+    expect(rendered).not.toContain("aborted");
+    expect(rendered).not.toContain("at ");
+  });
+
+  it("fhir_search: timeout also converts (central catch covers every tool)", async () => {
+    mockFetch.mockRejectedValueOnce(abortError());
+
+    const result = await tools.executeTool("fhir_search", { resource_type: "Observation" });
+
+    expect(result.error).toBe("backend_timeout");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("non-timeout fetch failures still propagate (not misreported as timeouts)", async () => {
+    const netErr = new Error("connect ECONNREFUSED 127.0.0.1:5000");
+    netErr.name = "FetchError";
+    mockFetch.mockRejectedValueOnce(netErr);
+
+    await expect(
+      tools.executeTool("fhir_read", { resource_type: "Patient", resource_id: "pt-1" })
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("every backend fetch carries an AbortSignal (timeout actually wired)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ resourceType: "Patient", id: "pt-1" }));
+
+    await tools.executeTool("fhir_read", { resource_type: "Patient", resource_id: "pt-1" });
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fhir_read uses the default 15s budget (no per-call override)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ resourceType: "Patient", id: "pt-1" }));
+
+    await tools.executeTool("fhir_read", { resource_type: "Patient", resource_id: "pt-1" });
+
+    expect(helperSpy).toHaveBeenCalledTimes(1);
+    expect(helperSpy.mock.calls[0][2]).toBeUndefined(); // defaults to DEFAULT_TIMEOUT_MS
+  });
+
+  it("guardrail_conformance uses the 60s budget (synchronous probe suite)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ grade: "A" }));
+
+    await tools.executeTool("guardrail_conformance", {});
+
+    expect(helperSpy).toHaveBeenCalledWith(
+      expect.stringContaining("$conformance"),
+      expect.anything(),
+      60_000
+    );
+  });
+
+  it("fhir_seed uses a 30s budget (bulk insert + per-resource audit commits)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ created: [] }));
+
+    await tools.executeTool("fhir_seed", {});
+
+    expect(helperSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/internal/seed"),
+      expect.anything(),
+      30_000
+    );
+  });
+
+  it("curatr_evaluate uses a 30s budget (stacked external terminology calls)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ issue_count: 0, overall_quality: "good" }));
+
+    await tools.executeTool("curatr_evaluate", {
+      resource_type: "Condition",
+      resource_id: "c-1",
+    });
+
+    expect(helperSpy).toHaveBeenCalledWith(
+      expect.stringContaining("$curatr-evaluate"),
+      expect.anything(),
+      30_000
+    );
+  });
+
+  it("curatr_apply_fix uses a 30s budget (re-evaluates via external terminology after fix)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({ issues_fixed: 1 }));
+
+    await tools.executeTool(
+      "curatr_apply_fix",
+      {
+        resource_type: "Condition",
+        resource_id: "c-1",
+        fixes: [{ field_path: "Condition.code.coding[0].system", new_value: "x" }],
+        patient_intent: "fix my record",
+      },
+      { "x-step-up-token": "tok-1" }
+    );
+
+    expect(helperSpy).toHaveBeenCalledWith(
+      expect.stringContaining("$curatr-apply-fix"),
+      expect.anything(),
+      30_000
+    );
   });
 });
 

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -20,7 +20,11 @@
  * All tools include MCP annotations (readOnlyHint, destructiveHint, openWorldHint).
  */
 
-import fetch from "node-fetch";
+import {
+  fetchWithTimeout,
+  BackendTimeoutError,
+  backendTimeoutResult,
+} from "./fetch-timeout";
 import { generateMasterSecret, deriveAuth, deriveKey } from "./ktc/hkdf";
 import { encryptJWE } from "./ktc/jwe";
 import { buildShlink, buildOwnerLink, buildViewerLink } from "./ktc/shlink";
@@ -102,7 +106,7 @@ export class FHIRTools {
     }
 
     try {
-      const resp = await fetch(`${this.serverRoot()}/r6/fhir/internal/step-up-token`, {
+      const resp = await fetchWithTimeout(`${this.serverRoot()}/r6/fhir/internal/step-up-token`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -827,6 +831,24 @@ export class FHIRTools {
     input: Record<string, unknown>,
     headers?: Record<string, string>
   ): Promise<Record<string, unknown>> {
+    // Central timeout conversion: every backend fetch below goes through
+    // fetchWithTimeout, which throws BackendTimeoutError past its budget.
+    // Convert it HERE (one catch path for all ~30 tools) into a structured
+    // tool result so the model sees calm, actionable text instead of a raw
+    // AbortError stack or a JSON-RPC "Internal error".
+    try {
+      return await this.executeToolInner(toolName, input, headers);
+    } catch (e) {
+      if (e instanceof BackendTimeoutError) return backendTimeoutResult(e);
+      throw e;
+    }
+  }
+
+  private async executeToolInner(
+    toolName: string,
+    input: Record<string, unknown>,
+    headers?: Record<string, string>
+  ): Promise<Record<string, unknown>> {
     const tool = this.getToolSchemas().find((t) => t.name === toolName);
     if (!tool) {
       return { error: `Unknown tool: ${toolName}` };
@@ -1018,7 +1040,7 @@ export class FHIRTools {
         // or a token minted for desktop-demo gets rejected when the actual
         // call runs as another tenant ("Token tenant mismatch").
         const tokenTenant = (input.tenant_id as string) || tenantId;
-        const resp = await fetch(`${this.baseUrl}/internal/step-up-token`, {
+        const resp = await fetchWithTimeout(`${this.baseUrl}/internal/step-up-token`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -1040,11 +1062,18 @@ export class FHIRTools {
 
       case "fhir_seed": {
         const seedTenant = (input.tenant_id as string) || tenantId;
-        const resp = await fetch(`${this.baseUrl}/internal/seed`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...fwdHeaders },
-          body: JSON.stringify({ tenant_id: seedTenant }),
-        });
+        // 30s budget: seeding inserts the whole demo bundle with a
+        // per-resource audit-event commit each (r6/seed.py), which can
+        // legitimately exceed 15s on a cold backend + cold database.
+        const resp = await fetchWithTimeout(
+          `${this.baseUrl}/internal/seed`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json", ...fwdHeaders },
+            body: JSON.stringify({ tenant_id: seedTenant }),
+          },
+          30_000
+        );
         const data = (await resp.json()) as Record<string, unknown>;
         if (!resp.ok) return { error: "Seed failed", detail: data };
         return {
@@ -1086,7 +1115,7 @@ export class FHIRTools {
     contextId: string,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/context/${encodeURIComponent(contextId)}`,
       { headers }
     );
@@ -1109,7 +1138,7 @@ export class FHIRTools {
     resourceId: string,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}`,
       { headers }
     );
@@ -1139,7 +1168,7 @@ export class FHIRTools {
     if (searchParams._sort) params.set("_sort", searchParams._sort);
     params.set("_count", searchParams._count.toString());
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}?${params.toString()}`,
       { headers }
     );
@@ -1173,7 +1202,7 @@ export class FHIRTools {
     if (!resourceType) {
       return { error: "Resource must have a resourceType" };
     }
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/$validate`,
       {
         method: "POST",
@@ -1246,7 +1275,7 @@ export class FHIRTools {
 
     let resp;
     if (operation === "create") {
-      resp = await fetch(`${this.baseUrl}/${encodeURIComponent(resourceType)}`, {
+      resp = await fetchWithTimeout(`${this.baseUrl}/${encodeURIComponent(resourceType)}`, {
         method: "POST",
         headers,
         body: JSON.stringify(resource),
@@ -1256,7 +1285,7 @@ export class FHIRTools {
       if (!resourceId) {
         return { error: "Resource ID required for update" };
       }
-      resp = await fetch(
+      resp = await fetchWithTimeout(
         `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}`,
         {
           method: "PUT",
@@ -1282,7 +1311,7 @@ export class FHIRTools {
     if (code) params.set("code", code);
     if (patient) params.set("patient", patient);
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/Observation/$stats?${params.toString()}`,
       { headers }
     );
@@ -1325,7 +1354,7 @@ export class FHIRTools {
     if (patient) params.set("patient", patient);
     params.set("max", max.toString());
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/Observation/$lastn?${params.toString()}`,
       { headers }
     );
@@ -1350,7 +1379,7 @@ export class FHIRTools {
     resource: string | undefined,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/Permission/$evaluate`,
       {
         method: "POST",
@@ -1380,7 +1409,7 @@ export class FHIRTools {
     const path = questionnaireId
       ? `/Questionnaire/${encodeURIComponent(questionnaireId)}/$populate`
       : `/Questionnaire/$populate`;
-    const resp = await fetch(`${this.baseUrl}${path}`, {
+    const resp = await fetchWithTimeout(`${this.baseUrl}${path}`, {
       method: "POST",
       headers,
       body: JSON.stringify({ resourceType: "Parameters", parameter }),
@@ -1403,7 +1432,7 @@ export class FHIRTools {
     if (questionnaire) parameter.push({ name: "questionnaire", resource: questionnaire });
 
     const url = `${this.baseUrl}/QuestionnaireResponse/$extract?dryRun=${dryRun}`;
-    const resp = await fetch(url, {
+    const resp = await fetchWithTimeout(url, {
       method: "POST",
       headers,
       body: JSON.stringify({ resourceType: "Parameters", parameter }),
@@ -1417,7 +1446,7 @@ export class FHIRTools {
   private async listSubscriptionTopics(
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/SubscriptionTopic/$list`,
       { headers }
     );
@@ -1464,7 +1493,7 @@ export class FHIRTools {
     const url = `${root}/wearables/sync-status?tenant_id=${encodeURIComponent(tenantId)}`;
     let status: Record<string, unknown>;
     try {
-      const resp = await fetch(url, { headers });
+      const resp = await fetchWithTimeout(url, { headers });
       status = (await resp.json()) as Record<string, unknown>;
       if (!resp.ok) {
         return {
@@ -1473,6 +1502,7 @@ export class FHIRTools {
         };
       }
     } catch (e) {
+      if (e instanceof BackendTimeoutError) throw e; // converted centrally in executeTool
       return {
         error: "wearables status request failed",
         detail: String(e),
@@ -1542,8 +1572,9 @@ export class FHIRTools {
     const url = `${root}/command-center/api/sources-summary?tenant=${encodeURIComponent(tenantId)}`;
     let resp;
     try {
-      resp = await fetch(url, { headers });
+      resp = await fetchWithTimeout(url, { headers });
     } catch (e) {
+      if (e instanceof BackendTimeoutError) throw e; // converted centrally in executeTool
       return { error: "sources_check request failed", detail: String(e) };
     }
 
@@ -1576,7 +1607,7 @@ export class FHIRTools {
     resourceId: string,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}/$compiled-truth`,
       { headers }
     );
@@ -1628,7 +1659,7 @@ export class FHIRTools {
     if (subject) params.set("subject", subject);
     const query = params.toString();
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/Observation/$interpret${query ? `?${query}` : ""}`,
       {
         method: "POST",
@@ -1650,7 +1681,7 @@ export class FHIRTools {
     if (subject) params.set("subject", subject);
     const query = params.toString();
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/Patient/$care-gaps${query ? `?${query}` : ""}`,
       { method: "POST", headers, body: JSON.stringify({}) }
     );
@@ -1667,7 +1698,10 @@ export class FHIRTools {
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
     const url = `${this.baseUrl}/$conformance${fresh ? "?fresh=1" : ""}`;
-    const resp = await fetch(url, { headers });
+    // 60s budget: the conformance endpoint runs the entire guardrail probe
+    // suite synchronously (6 probes, each doing several backend round trips,
+    // with 25s-per-request internal budgets) before responding.
+    const resp = await fetchWithTimeout(url, { headers }, 60_000);
     // 503 = graded below A — still return the scorecard body, it explains why.
     const body = (await resp.json()) as Record<string, unknown>;
     if (!resp.ok && !("grade" in body)) {
@@ -1681,9 +1715,13 @@ export class FHIRTools {
     resourceId: string,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const resp = await fetch(
+    // 30s budget: Flask validates each coding against public terminology
+    // services (tx.fhir.org, NLM, RXNAV) at 5s apiece (r6/curatr.py) — a
+    // resource with several codings can legitimately stack past 15s.
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}/$curatr-evaluate`,
-      { headers }
+      { headers },
+      30_000
     );
     if (!resp.ok) {
       return { error: `Curatr evaluate failed with status ${resp.status}` };
@@ -1743,13 +1781,18 @@ export class FHIRTools {
       };
     }
 
-    const resp = await fetch(
+    // 30s budget: after applying, Flask re-evaluates the fixed resource via
+    // the same external terminology services as $curatr-evaluate
+    // (r6/routes.py calls _curatr_engine.evaluate(fresh)), so the stacked
+    // 5s-per-service calls can legitimately exceed 15s.
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}/$curatr-apply-fix`,
       {
         method: "POST",
         headers: { ...headers, "X-Human-Confirmed": "true" },
         body: JSON.stringify({ fixes, patient_intent: patientIntent }),
-      }
+      },
+      30_000
     );
     if (!resp.ok) {
       return { error: `Curatr apply-fix failed with status ${resp.status}` };
@@ -1781,7 +1824,7 @@ export class FHIRTools {
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
     const root = this.serverRoot();
-    const resp = await fetch(`${root}/r6/actions/propose`, {
+    const resp = await fetchWithTimeout(`${root}/r6/actions/propose`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
       body: JSON.stringify({ kind, payload }),
@@ -1812,7 +1855,7 @@ export class FHIRTools {
     if (Array.isArray(input.medication_names) && input.medication_names.length) {
       body.medication_names = input.medication_names;
     }
-    const resp = await fetch(`${root}/r6/actions/rx-transfer/propose`, {
+    const resp = await fetchWithTimeout(`${root}/r6/actions/rx-transfer/propose`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -1840,7 +1883,7 @@ export class FHIRTools {
     // returns 202 {status: 'awaiting_confirmation'}; nothing executes on
     // this call, so there is nothing for the agent to retry into existing.
     const root = this.serverRoot();
-    const resp = await fetch(`${root}/r6/actions/${encodeURIComponent(actionId)}/commit`, {
+    const resp = await fetchWithTimeout(`${root}/r6/actions/${encodeURIComponent(actionId)}/commit`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
     });
@@ -1886,7 +1929,7 @@ export class FHIRTools {
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
     const root = this.serverRoot();
-    const resp = await fetch(`${root}/r6/actions/${encodeURIComponent(actionId)}`, {
+    const resp = await fetchWithTimeout(`${root}/r6/actions/${encodeURIComponent(actionId)}`, {
       headers,
     });
     if (!resp.ok) {
@@ -1915,7 +1958,7 @@ export class FHIRTools {
     const label = typeof input.label === "string" ? input.label.slice(0, 80) : undefined;
 
     // Step 1: Fetch the guardrailed share-bundle from Flask
-    const bundleResp = await fetch(`${root}/r6/fhir/$share-bundle`, {
+    const bundleResp = await fetchWithTimeout(`${root}/r6/fhir/$share-bundle`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1959,7 +2002,7 @@ export class FHIRTools {
     const exp = nowSeconds + days * 86400;
 
     // Step 4: Create the SHL link on the server
-    const createLinkResp = await fetch(`${SHL_BASE}/api/links`, {
+    const createLinkResp = await fetchWithTimeout(`${SHL_BASE}/api/links`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -1985,7 +2028,7 @@ export class FHIRTools {
       { cty: "application/fhir+json", deflate: true }
     );
 
-    const uploadResp = await fetch(`${SHL_BASE}/api/manage/files`, {
+    const uploadResp = await fetchWithTimeout(`${SHL_BASE}/api/manage/files`, {
       method: "POST",
       headers: {
         "Content-Type": "application/jose",
@@ -2082,7 +2125,7 @@ export class FHIRTools {
     );
     params.set("_count", clampedCount.toString());
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}?${params.toString()}`,
       { headers }
     );
@@ -2124,7 +2167,7 @@ export class FHIRTools {
       return { error: "id must be in 'ResourceType/id' format" };
     }
 
-    const resp = await fetch(
+    const resp = await fetchWithTimeout(
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}`,
       { headers }
     );


### PR DESCRIPTION
## Summary

W0 item 5 (MCP fetch timeouts). Audit finding: **33 tools, zero timeouts** — every tool handler in `services/agent-orchestrator/src/tools.ts` called `node-fetch` with no AbortSignal/timeout, so a cold or wedged Flask backend hung the tool call until the MCP client gave up, which reads as a dead demo.

## What changed

- **New `src/fetch-timeout.ts`** — single choke-point `fetchWithTimeout(url, init, timeoutMs = 15_000)` using `AbortSignal.timeout()` (Node 18+; repo runs Node 22, tsconfig target ES2022). Past the budget it throws a typed `BackendTimeoutError`; `backendTimeoutResult()` renders it as a structured, non-retry-bait tool result:
  ```json
  {
    "error": "backend_timeout",
    "retryable": true,
    "timeout_ms": 15000,
    "message": "The HealthClaw backend timed out after 15s. The service may be cold-starting; try once more in ~30 seconds, or check service status."
  }
  ```
  The raw `AbortError`/stack never reaches the model.
- **All 32 fetch call sites** in `tools.ts` now go through the helper (verified: zero bare `fetch(` remain in `src/`; `index.ts` and `ktc/` make no HTTP calls).
- **One central catch** in `executeTool` converts the typed error for every tool (DRY — no per-call-site timeout handling). The two pre-existing local catches (`wearables_sync_status`, `sources_check`) rethrow the typed error instead of stringifying it.

## Non-default budgets (each justified by its Flask counterpart)

| Tool | Budget | Why |
|------|--------|-----|
| `guardrail_conformance` | 60s | runs the whole probe suite synchronously; internal HTTP probes use 25s each (`r6/conformance/probes.py`) |
| `fhir_seed` | 30s | bulk demo-bundle insert with a per-resource audit-event commit (`r6/seed.py`) |
| `curatr_evaluate` | 30s | validates codings against tx.fhir.org / NLM / RXNAV at 5s apiece — several codings stack past 15s (`r6/curatr.py`) |
| `curatr_apply_fix` | 30s | re-evaluates the fixed resource via the same external terminology services (`r6/routes.py`) |

Everything else: 15s default.

## Tests (TDD)

- 7 new helper tests in `fetch-timeout.test.ts` — real (unmocked) node-fetch against a deliberately hanging local HTTP server: resolves under budget, `BackendTimeoutError` past it, typed error carries the budget, non-timeout network errors pass through.
- 10 new tool-level tests in `tools.test.ts` — `fhir_read` with an aborting fetch returns the structured timeout result with no unhandled rejection and no raw AbortError text; central catch covers `fhir_search` too; spy on the helper asserts `guardrail_conformance` → 60_000, `fhir_seed`/`curatr_evaluate`/`curatr_apply_fix` → 30_000, `fhir_read` → default; every backend fetch carries an AbortSignal.
- **112 total pass** (95 pre-existing + 17 new), `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)