### PR TITLE
W0: resource identity (tenant_id, resource_type, id) — kills the cross-tenant silent-drop bug

### DIFF
--- a/docs/runbooks/resource-identity-migration.md
+++ b/docs/runbooks/resource-identity-migration.md
@@ -1,0 +1,159 @@
+# Runbook: r6_resources identity migration — (tenant_id, resource_type, id)
+
+**Change:** swap the `r6_resources` primary key from the raw FHIR `id`
+(global) to the composite `(tenant_id, resource_type, id)`.
+
+**Why:** FHIR ids are only unique per resource type per source server. With
+the global PK, tenant B importing an id tenant A already held (Synthea
+`example`, Epic numeric ids) collided on the PK and the resource was
+**silently dropped** from the import; `Patient/X` and `Observation/X`
+collided within a single tenant too. Fixed in code by
+`r6/models.py` + `r6/fasten/ingester.py`; this runbook applies the matching
+schema change to the live Railway Postgres.
+
+**Script:** `scripts/migrate_resource_identity.py` — idempotent,
+transactional, Postgres-only, refuses to run unless pre-checks pass.
+
+**Downtime:** none expected. The swap is two `ALTER TABLE` statements in one
+transaction; the `ADD PRIMARY KEY` builds a unique index, which takes an
+exclusive lock on `r6_resources` for the duration of the build (seconds at
+current row counts). Ingest jobs running at that moment will briefly queue.
+
+---
+
+## Deploy ordering (code vs. schema)
+
+Either order is safe — neither step makes anything worse than today:
+
+* **New code + old (un-migrated) DB:** boots fine. `db.create_all()` skips
+  existing tables, and `r6/schema_sync.py` only ADDs missing columns and
+  WIDENs varchars — it never inspects or alters constraints, so the PK
+  mismatch between the ORM model and the live table is invisible at boot.
+  Cross-tenant collisions still fail at the DB level exactly as before
+  (per-resource, rolled back, counted as `failed`) until the migration runs.
+* **Migrated DB + old code:** also fine — old code never inserts a
+  duplicate `id` on purpose, and all reads are plain SELECTs.
+
+Recommended sequence anyway: **snapshot → migrate → deploy code → verify**,
+so the moment the new ingester ships, the schema already accepts what it
+writes.
+
+## 0. Rehearse against a prod COPY first (required before first prod run)
+
+Never run a PK swap against prod without having watched it succeed on a
+copy of prod data the same day.
+
+```bash
+# 1. Dump prod (Railway: get DATABASE_URL from the Postgres service → Connect tab)
+pg_dump "$PROD_DATABASE_URL" -Fc -f /tmp/hcg-prod.dump
+
+# 2. Restore into a scratch DB (local Docker is fine)
+docker run -d --name hcg-rehearsal -e POSTGRES_PASSWORD=rehearse \
+  -p 55432:5432 postgres:16
+export SCRATCH="postgresql://postgres:rehearse@localhost:55432/postgres"
+pg_restore -d "$SCRATCH" --no-owner --no-privileges /tmp/hcg-prod.dump
+
+# 3. Dry-run, then run, against the copy
+SQLALCHEMY_DATABASE_URI="$SCRATCH" python scripts/migrate_resource_identity.py --dry-run
+SQLALCHEMY_DATABASE_URI="$SCRATCH" python scripts/migrate_resource_identity.py
+
+# 4. Run the Postgres-sensitive test subset against the migrated copy
+SQLALCHEMY_DATABASE_URI="$SCRATCH" python -m pytest \
+  tests/test_resource_identity.py tests/test_ingest_resilience.py tests/actions/ -q
+
+# 5. Clean up
+docker rm -f hcg-rehearsal
+```
+
+The test subset matters: `test_ingest_resilience.py` exists precisely
+because two earlier bugs only manifested on Postgres (SQLite doesn't
+enforce varchar lengths), and `tests/actions/` exercises the widest write
+paths.
+
+## 1. Snapshot prod (the rollback)
+
+Railway → the project's **Postgres service → Backups → Create Backup**
+(console), or from a shell with the prod URL:
+
+```bash
+pg_dump "$PROD_DATABASE_URL" -Fc -f hcg-prod-$(date +%Y%m%dT%H%M).dump
+```
+
+Keep the dump until the post-migration smoke checks (step 4) pass and at
+least one real ingest has completed cleanly.
+
+## 2. Dry-run against prod
+
+```bash
+SQLALCHEMY_DATABASE_URI="$PROD_DATABASE_URL" \
+  python scripts/migrate_resource_identity.py --dry-run
+```
+
+Expected output: row count, `current PK: r6_resources_pkey (id)`,
+`pre-checks passed: 0 duplicate identity triples, 0 NULL tenant_id, 0 NULL
+resource_type`, the two ALTER statements, and `--dry-run verdict: safe to
+migrate`. **Any pre-check failure aborts — do not work around it; fix the
+data first.** (NULL `tenant_id` rows would be unreachable by every
+tenant-scoped query in the codebase anyway; investigate how they got there.)
+
+## 3. Run
+
+```bash
+SQLALCHEMY_DATABASE_URI="$PROD_DATABASE_URL" \
+  python scripts/migrate_resource_identity.py
+```
+
+The script re-runs the pre-checks, executes both ALTERs in **one
+transaction**, then verifies the new constraint on a fresh connection.
+Running it twice is safe — the second run prints `already migrated` and
+exits 0.
+
+## 4. Verify
+
+The script already checks `pg_constraint`; belt-and-braces by hand:
+
+```sql
+SELECT conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid = 'r6_resources'::regclass AND contype = 'p';
+-- expect: pk_r6_resources_identity | PRIMARY KEY (tenant_id, resource_type, id)
+```
+
+Smoke read (any live tenant):
+
+```bash
+curl -s -H "X-Tenant-Id: desktop-demo" \
+  https://<prod-host>/r6/fhir/Patient | python -m json.tool | head
+```
+
+Then watch one Fasten ingest complete with `failed=0` where the old
+cross-tenant collisions used to show up as nonzero `failed` counts.
+
+## 5. Rollback = restore the snapshot
+
+**In-place rollback is deliberately not offered.** The constraint swap
+itself is symmetric (drop composite PK, re-add PK on `id`) — but any data
+written **under the composite identity after the migration** may legally
+contain the same `id` in two tenants or two types, which violates the old
+global PK. Re-adding `PRIMARY KEY (id)` would then either fail or force us
+to choose which patient's record to delete. A snapshot restore is the only
+honest rollback:
+
+Railway → Postgres service → **Backups → Restore**, or:
+
+```bash
+pg_restore -d "$PROD_DATABASE_URL" --clean --no-owner hcg-prod-<stamp>.dump
+```
+
+(Accepting the loss of anything written between snapshot and restore — which
+is why the snapshot is taken immediately before the migration and the
+verify happens immediately after.)
+
+---
+
+## W2 note
+
+The `source` column (which upstream server a row came from) and ingest
+Provenance are **explicitly out of scope** for this migration — see the W2
+item in `docs/superpowers/specs/2026-07-11-real-actions-reliability-design.md`
+and the comment on `R6Resource` in `r6/models.py`.

--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -217,9 +217,19 @@ def _ingest_one(resource: dict, tenant_id: str) -> tuple[str, str | None]:
     resource_id = resource.get('id') or str(uuid.uuid4())
     resource_json = json.dumps(resource, separators=(',', ':'))
 
-    existing = db.session.get(R6Resource, resource_id)
-    if existing and existing.tenant_id == tenant_id and not existing.is_deleted:
+    # Identity is (tenant_id, resource_type, id) — composite PK. The same
+    # FHIR id held by ANOTHER tenant (or another type in this tenant) is a
+    # different row entirely, so the old cross-tenant PK collision (which
+    # silently dropped the resource from the import) cannot occur.
+    existing = R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type=resource_type, id=resource_id
+    ).first()
+    if existing:
+        # Re-ingest of a row we already hold — including one that was
+        # soft-deleted: a fresh import of the same (tenant, type, id)
+        # revives it rather than colliding with the tombstone.
         existing.update_resource(resource_json)
+        existing.is_deleted = False
     else:
         new_res = R6Resource(
             resource_type=resource_type,
@@ -262,8 +272,11 @@ def _run_curatr_scan(
 
     for resource_type, resource_id in eligible[:100]:  # cap at 100 per import
         try:
-            res_obj = db.session.get(R6Resource, resource_id)
-            if not res_obj or res_obj.tenant_id != tenant_id:
+            res_obj = R6Resource.query.filter_by(
+                tenant_id=tenant_id, resource_type=resource_type,
+                id=resource_id,
+            ).first()
+            if not res_obj:
                 continue
             resource = json.loads(res_obj.resource_json)
             result = evaluator.evaluate(resource)

--- a/r6/models.py
+++ b/r6/models.py
@@ -19,17 +19,30 @@ class R6Resource(db.Model):
     """
     __tablename__ = 'r6_resources'
 
+    # Resource identity is (tenant_id, resource_type, id) — COMPOSITE.
+    # FHIR ids are only unique per resource type per source server, and this
+    # store holds many tenants: with the old global single-column PK, tenant
+    # B importing an id tenant A already held (Synthea 'example', Epic
+    # numeric ids) hit a PK collision and the resource was silently dropped
+    # from the import. Patient/X and Observation/X collided within one
+    # tenant, too. Column order here fixes the PK order in the DDL —
+    # (tenant_id, resource_type, id) — matching
+    # scripts/migrate_resource_identity.py for live Postgres databases.
+    #
+    # W2 (planned, NOT this migration): a `source` column + ingest
+    # Provenance will record which upstream server each row came from, so
+    # the same logical resource pulled via two connections can be told apart.
+    tenant_id = db.Column(db.String(64), primary_key=True, index=True)
+    resource_type = db.Column(db.String(64), primary_key=True, index=True)
     # Real EHR resource ids (Epic in particular) routinely exceed the FHIR
     # 64-char id limit — 65/250 in a live Epic export, max 109. 255 gives
     # headroom while preserving the full id so intra-bundle references
     # (subject.reference "Patient/<id>") still resolve.
     id = db.Column(db.String(255), primary_key=True)
-    resource_type = db.Column(db.String(64), nullable=False, index=True)
     version_id = db.Column(db.Integer, nullable=False, default=1)
     last_updated = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     resource_json = db.Column(db.Text, nullable=False)
     sha256 = db.Column(db.String(64), nullable=False)
-    tenant_id = db.Column(db.String(64), nullable=True, index=True)
     is_deleted = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
 

--- a/scripts/migrate_resource_identity.py
+++ b/scripts/migrate_resource_identity.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+"""Migrate r6_resources to the composite identity PK (tenant_id, resource_type, id).
+
+Why: the original schema's PRIMARY KEY was the raw FHIR id alone — global
+across tenants AND resource types. FHIR ids are only unique per resource
+type per source server, so a second tenant importing an id the first tenant
+already held (Synthea 'example', Epic numeric ids) collided on the PK and
+the resource was silently dropped from the import. See
+tests/test_resource_identity.py and
+docs/runbooks/resource-identity-migration.md.
+
+Usage:
+    SQLALCHEMY_DATABASE_URI=postgresql://... python scripts/migrate_resource_identity.py --dry-run
+    SQLALCHEMY_DATABASE_URI=postgresql://... python scripts/migrate_resource_identity.py
+
+Properties:
+  * Postgres-only. Aborts on any other dialect (SQLite dev DBs are
+    recreated from the model by create_all() and never need this).
+  * Idempotent. If the PK is already (tenant_id, resource_type, id) it
+    exits 0 without touching anything.
+  * Pre-checked. Refuses to run if any rows would violate the new PK:
+      - duplicate (tenant_id, resource_type, id) triples
+        (impossible under the old global PK, but VERIFIED, never assumed)
+      - NULL tenant_id or resource_type (PK columns must be NOT NULL)
+  * Transactional. The constraint swap runs in a single transaction; any
+    failure rolls the whole swap back.
+  * Verified. After commit, the new constraint is read back from
+    pg_constraint and its column list checked exactly.
+  * --dry-run prints the pre-check results and the exact statements
+    without executing the swap.
+
+Exit codes: 0 ok / already migrated; 1 precondition or verification failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+TABLE = "r6_resources"
+NEW_PK_COLUMNS = ["tenant_id", "resource_type", "id"]
+NEW_PK_NAME = "pk_r6_resources_identity"
+
+# The swap, as executed (inside one transaction). {old_pk} is discovered
+# from pg_constraint at runtime — Flask-SQLAlchemy's create_all() named it
+# r6_resources_pkey, but we never assume.
+SWAP_STATEMENTS = [
+    'ALTER TABLE {table} DROP CONSTRAINT "{old_pk}"',
+    'ALTER TABLE {table} ADD CONSTRAINT "{new_pk}" '
+    "PRIMARY KEY (tenant_id, resource_type, id)",
+]
+
+
+def _fail(msg: str) -> None:
+    print(f"ABORT: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _get_engine():
+    uri = (os.environ.get("SQLALCHEMY_DATABASE_URI")
+           or os.environ.get("DATABASE_URL"))
+    if not uri:
+        _fail("SQLALCHEMY_DATABASE_URI (or DATABASE_URL) must be set")
+    # Railway hands out postgres:// which SQLAlchemy 2.x rejects
+    if uri.startswith("postgres://"):
+        uri = uri.replace("postgres://", "postgresql://", 1)
+    engine = create_engine(uri)
+    if engine.dialect.name != "postgresql":
+        _fail(f"this migration is Postgres-only (dialect: {engine.dialect.name}). "
+              "SQLite databases are rebuilt from the model and never need it.")
+    return engine
+
+
+def _current_pk(conn) -> tuple[str, list[str]] | None:
+    """Return (constraint_name, [columns in PK order]) or None if no PK."""
+    row = conn.execute(text("""
+        SELECT c.conname,
+               ARRAY(
+                   SELECT a.attname
+                   FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+                   JOIN pg_attribute a
+                     ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+                   ORDER BY k.ord
+               ) AS cols
+        FROM pg_constraint c
+        WHERE c.conrelid = :table ::regclass
+          AND c.contype = 'p'
+    """), {"table": TABLE}).fetchone()
+    if row is None:
+        return None
+    return row[0], list(row[1])
+
+
+def _precheck(conn) -> list[str]:
+    """Return a list of blocking problems (empty = safe to migrate)."""
+    problems = []
+
+    dup_rows = conn.execute(text(f"""
+        SELECT tenant_id, resource_type, id, COUNT(*) AS n
+        FROM {TABLE}
+        GROUP BY tenant_id, resource_type, id
+        HAVING COUNT(*) > 1
+        LIMIT 20
+    """)).fetchall()
+    if dup_rows:
+        problems.append(
+            f"{len(dup_rows)}+ duplicate (tenant_id, resource_type, id) "
+            f"triples exist — first few: "
+            + ", ".join(f"({r[0]!r},{r[1]!r},{r[2]!r})x{r[3]}" for r in dup_rows[:5])
+            + ". The old global PK should have made this impossible; "
+            "investigate before migrating."
+        )
+
+    null_counts = conn.execute(text(f"""
+        SELECT
+            COUNT(*) FILTER (WHERE tenant_id IS NULL)     AS null_tenant,
+            COUNT(*) FILTER (WHERE resource_type IS NULL) AS null_type
+        FROM {TABLE}
+    """)).fetchone()
+    if null_counts[0]:
+        problems.append(
+            f"{null_counts[0]} rows have NULL tenant_id — PK columns must be "
+            "NOT NULL. Backfill or delete these orphaned rows first "
+            "(a NULL tenant is unreachable by every tenant-scoped query)."
+        )
+    if null_counts[1]:
+        problems.append(f"{null_counts[1]} rows have NULL resource_type — "
+                        "PK columns must be NOT NULL.")
+
+    return problems
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print pre-check results and the exact statements "
+                             "without executing the swap")
+    args = parser.parse_args()
+
+    engine = _get_engine()
+
+    # Phase 1 — inspect + pre-check, then CLOSE the connection. The swap
+    # needs an ACCESS EXCLUSIVE lock; a still-open pre-check transaction
+    # (even read-only) holds ACCESS SHARE on the table and would deadlock
+    # the migration against itself.
+    with engine.connect() as conn:
+        pk = _current_pk(conn)
+        if pk is None:
+            _fail(f"table {TABLE} has no primary key — refusing to guess; "
+                  "inspect the schema by hand.")
+        old_pk_name, old_cols = pk
+
+        row_count = conn.execute(
+            text(f"SELECT COUNT(*) FROM {TABLE}")).scalar()
+        print(f"table {TABLE}: {row_count} rows")
+        print(f"current PK: {old_pk_name} ({', '.join(old_cols)})")
+
+        if old_cols == NEW_PK_COLUMNS:
+            print("already migrated — PK is (tenant_id, resource_type, id). "
+                  "Nothing to do.")
+            return
+
+        if old_cols != ["id"]:
+            _fail(f"unexpected current PK columns {old_cols} — expected ['id'] "
+                  "(pre-migration) or the composite key (post-migration). "
+                  "Inspect by hand before proceeding.")
+
+        print("running pre-checks ...")
+        problems = _precheck(conn)
+        for p in problems:
+            print(f"  PRE-CHECK FAILED: {p}", file=sys.stderr)
+        if not problems:
+            print("  pre-checks passed: 0 duplicate identity triples, "
+                  "0 NULL tenant_id, 0 NULL resource_type")
+        conn.rollback()  # end the read transaction; release ACCESS SHARE
+
+    statements = [
+        s.format(table=TABLE, old_pk=old_pk_name, new_pk=NEW_PK_NAME)
+        for s in SWAP_STATEMENTS
+    ]
+
+    if args.dry_run:
+        print("\n--dry-run: would execute in ONE transaction:")
+        for s in statements:
+            print(f"  {s};")
+        if problems:
+            print("\n--dry-run verdict: WOULD ABORT (pre-checks failed)",
+                  file=sys.stderr)
+            sys.exit(1)
+        print("\n--dry-run verdict: safe to migrate")
+        return
+
+    if problems:
+        _fail("pre-checks failed — not migrating")
+
+    # Phase 2 — the swap, in ONE transaction on a fresh connection. Even if
+    # rows changed between pre-check and now, ADD PRIMARY KEY re-validates
+    # uniqueness and NOT NULL itself: a violation fails the transaction and
+    # everything rolls back — the pre-check is a courtesy, Postgres is the
+    # enforcement.
+    print("swapping PK (single transaction) ...")
+    with engine.begin() as tx:  # BEGIN ... COMMIT (rollback on error)
+        for s in statements:
+            print(f"  {s};")
+            tx.execute(text(s))
+    print("committed.")
+
+    # Post-commit verification on a FRESH connection — prove the catalog
+    # really holds the new constraint, not just that our transaction thinks so.
+    with engine.connect() as conn:
+        pk = _current_pk(conn)
+        if pk is None or pk[0] != NEW_PK_NAME or pk[1] != NEW_PK_COLUMNS:
+            _fail(f"post-commit verification FAILED — pg_constraint reports "
+                  f"{pk!r}, expected ({NEW_PK_NAME!r}, {NEW_PK_COLUMNS!r}). "
+                  "RESTORE FROM SNAPSHOT and investigate.")
+        verified_count = conn.execute(
+            text(f"SELECT COUNT(*) FROM {TABLE}")).scalar()
+        print(f"verified: PK is now {pk[0]} ({', '.join(pk[1])}); "
+              f"{verified_count} rows present.")
+    print("migration complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,10 @@ import os
 import pytest
 
 # Set test environment before importing app — prevents file-based DB creation.
-# setdefault (not assignment) so a CI job can pre-set SQLALCHEMY_DATABASE_URI
-# (e.g. to Postgres, for the postgres-tests lane) before pytest starts;
-# sqlite:///:memory: remains the default for local/unconfigured runs.
+# setdefault (not assignment) so a pre-set SQLALCHEMY_DATABASE_URI wins: the
+# postgres-tests CI lane points here, and the resource-identity migration
+# rehearsal (docs/runbooks/resource-identity-migration.md) points the suite at
+# a migrated Postgres copy. sqlite:///:memory: is the local/unconfigured default.
 os.environ['TESTING'] = '1'
 os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
 os.environ['STEP_UP_SECRET'] = 'test-secret-for-hmac-validation'
@@ -26,10 +27,8 @@ def app():
     """Create a test Flask application."""
     from main import app as flask_app
     flask_app.config['TESTING'] = True
-    # Respect the module-level env var (sqlite by default, Postgres when the
-    # postgres-tests CI lane pre-sets SQLALCHEMY_DATABASE_URI) rather than
-    # forcing sqlite here — main.py already read it into app.config at
-    # import time, so this just keeps them in sync.
+    # Respect the module-level env var (sqlite by default, Postgres when a CI
+    # lane or migration rehearsal pre-sets SQLALCHEMY_DATABASE_URI).
     flask_app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['SQLALCHEMY_DATABASE_URI']
 
     from models import db

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -27,7 +27,8 @@ def test_long_id_resource_stores_and_round_trips(client, tenant_id):
                      resource_id=long_id, tenant_id=tenant_id)
     db.session.add(res)
     db.session.commit()
-    got = db.session.get(R6Resource, long_id)
+    got = R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation", id=long_id).first()
     assert got is not None and got.id == long_id
 
 
@@ -43,7 +44,8 @@ def test_ingest_error_rolls_back_session_so_next_resource_succeeds(client, tenan
     db.session.add(good1)
     db.session.commit()
 
-    # Force a failure (duplicate PK) then the ingester's recovery: rollback.
+    # Force a failure (duplicate composite PK — same tenant, type, AND id)
+    # then the ingester's recovery: rollback.
     dup = R6Resource(resource_type="Observation",
                      resource_json="{}", resource_id="ir-good-1",
                      tenant_id=tenant_id)
@@ -59,7 +61,9 @@ def test_ingest_error_rolls_back_session_so_next_resource_succeeds(client, tenan
                        tenant_id=tenant_id)
     db.session.add(good2)
     db.session.commit()
-    assert db.session.get(R6Resource, "ir-good-2") is not None
+    assert R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation",
+        id="ir-good-2").first() is not None
 
 
 def test_audit_resource_id_column_fits_real_ehr_ids():

--- a/tests/test_resource_identity.py
+++ b/tests/test_resource_identity.py
@@ -1,0 +1,159 @@
+"""Resource identity is (tenant_id, resource_type, id) — not the bare FHIR id.
+
+Two audits found the same live bug: R6Resource's primary key was the raw
+FHIR id ALONE (global). FHIR ids are only unique per resource type per
+server — Synthea exports reuse 'example', Epic reuses numeric ids across
+types — so:
+
+  1. Tenant B importing a resource whose id tenant A already stored hit a
+     PK collision; the ingester's per-resource IntegrityError recovery
+     caught it and the resource was SILENTLY DROPPED from tenant B's import.
+  2. Patient/abc and Observation/abc collided even within a single tenant.
+
+These tests pin the fixed identity model. They were written BEFORE the fix
+(TDD) and demonstrably failed against the global-PK schema.
+
+NOTE (W2): a `source` column + ingest Provenance are deliberately NOT part
+of this migration — see the real-actions reliability design doc.
+"""
+
+import json
+
+from models import db
+from r6.models import R6Resource
+
+
+def _resource(resource_type: str, resource_id: str, marker: str = 'v1') -> dict:
+    return {
+        'resourceType': resource_type,
+        'id': resource_id,
+        # Marker lives in `language`, not `meta` — to_fhir_json() rebuilds the
+        # meta envelope on read, so a meta marker would be invisible via the API.
+        'language': marker,
+    }
+
+
+def _ingest(resource: dict, tenant: str) -> tuple:
+    from r6.fasten.ingester import _ingest_one
+    result = _ingest_one(resource, tenant)
+    db.session.commit()
+    return result
+
+
+def _row(tenant: str, resource_type: str, resource_id: str) -> R6Resource | None:
+    return R6Resource.query.filter_by(
+        tenant_id=tenant, resource_type=resource_type, id=resource_id
+    ).first()
+
+
+class TestCrossTenantSameId:
+    """The silent-drop bug: same FHIR id in two tenants must coexist."""
+
+    def test_second_tenant_ingest_is_not_dropped(self, app):
+        # Synthea's canonical 'example' id — the exact live collision.
+        status_a, _ = _ingest(_resource('Patient', 'example', 'tenant-a-copy'),
+                              'test-tenant')
+        status_b, _ = _ingest(_resource('Patient', 'example', 'tenant-b-copy'),
+                              'other-tenant')
+        assert status_a == 'ok'
+        assert status_b == 'ok'  # was: IntegrityError -> silently dropped
+
+        row_a = _row('test-tenant', 'Patient', 'example')
+        row_b = _row('other-tenant', 'Patient', 'example')
+        assert row_a is not None
+        assert row_b is not None
+        # Distinct rows, each holding its own tenant's content.
+        assert json.loads(row_a.resource_json)['language'] == 'tenant-a-copy'
+        assert json.loads(row_b.resource_json)['language'] == 'tenant-b-copy'
+
+    def test_both_tenants_can_read_their_copy_via_api(
+            self, client, tenant_headers, other_tenant_headers):
+        _ingest(_resource('Patient', 'example', 'a'), 'test-tenant')
+        _ingest(_resource('Patient', 'example', 'b'), 'other-tenant')
+
+        resp_a = client.get('/r6/fhir/Patient/example', headers=tenant_headers)
+        resp_b = client.get('/r6/fhir/Patient/example',
+                            headers=other_tenant_headers)
+        assert resp_a.status_code == 200
+        assert resp_b.status_code == 200
+        assert resp_a.get_json()['language'] == 'a'
+        assert resp_b.get_json()['language'] == 'b'
+
+    def test_second_tenant_ingest_does_not_mutate_first_tenants_row(self, app):
+        _ingest(_resource('Observation', '42', 'original'), 'test-tenant')
+        _ingest(_resource('Observation', '42', 'other'), 'other-tenant')
+
+        row_a = _row('test-tenant', 'Observation', '42')
+        assert row_a.version_id == 1  # untouched by the other tenant's import
+        assert json.loads(row_a.resource_json)['language'] == 'original'
+
+
+class TestSameIdAcrossTypesOneTenant:
+    """FHIR ids are only unique per TYPE: Patient/X and Observation/X coexist."""
+
+    def test_patient_and_observation_share_an_id(self, app, tenant_id):
+        status_p, _ = _ingest(_resource('Patient', 'abc'), tenant_id)
+        status_o, _ = _ingest(_resource('Observation', 'abc'), tenant_id)
+        assert status_p == 'ok'
+        assert status_o == 'ok'
+
+        assert _row(tenant_id, 'Patient', 'abc') is not None
+        assert _row(tenant_id, 'Observation', 'abc') is not None
+
+    def test_typed_read_returns_the_right_resource(self, client, tenant_id,
+                                                   tenant_headers):
+        _ingest(_resource('Patient', 'abc', 'the-patient'), tenant_id)
+        _ingest(_resource('Observation', 'abc', 'the-obs'), tenant_id)
+
+        pt = client.get('/r6/fhir/Patient/abc', headers=tenant_headers)
+        obs = client.get('/r6/fhir/Observation/abc', headers=tenant_headers)
+        assert pt.status_code == 200
+        assert obs.status_code == 200
+        assert pt.get_json()['resourceType'] == 'Patient'
+        assert obs.get_json()['resourceType'] == 'Observation'
+
+
+class TestReIngestIsUpdate:
+    """Same (tenant, type, id) re-ingested updates in place — no duplicate."""
+
+    def test_reingest_updates_not_duplicates(self, app, tenant_id):
+        _ingest(_resource('Condition', 'c-1', 'v1'), tenant_id)
+        _ingest(_resource('Condition', 'c-1', 'v2'), tenant_id)
+
+        rows = R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type='Condition', id='c-1').all()
+        assert len(rows) == 1
+        assert rows[0].version_id == 2
+        assert json.loads(rows[0].resource_json)['language'] == 'v2'
+
+
+class TestSoftDeleteReIngest:
+    """A soft-deleted resource re-ingests cleanly (revived, not PK-collided)."""
+
+    def test_deleted_resource_reingests(self, app, tenant_id):
+        _ingest(_resource('Immunization', 'imm-1', 'v1'), tenant_id)
+        row = _row(tenant_id, 'Immunization', 'imm-1')
+        row.is_deleted = True
+        db.session.commit()
+
+        status, _ = _ingest(_resource('Immunization', 'imm-1', 'v2'), tenant_id)
+        assert status == 'ok'  # was: re-add() -> PK collision -> dropped
+
+        rows = R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type='Immunization', id='imm-1').all()
+        assert len(rows) == 1
+        assert rows[0].is_deleted is False
+        assert json.loads(rows[0].resource_json)['language'] == 'v2'
+
+
+class TestSchemaIdentity:
+    """Pin the composite PK itself so it can't silently regress."""
+
+    def test_primary_key_is_tenant_type_id(self):
+        pk_cols = [c.name for c in R6Resource.__table__.primary_key.columns]
+        assert set(pk_cols) == {'tenant_id', 'resource_type', 'id'}
+
+    def test_tenant_id_is_not_nullable(self):
+        # PK membership implies NOT NULL — a NULL tenant would make the row
+        # unreachable by every tenant-scoped query in the codebase.
+        assert R6Resource.__table__.c.tenant_id.nullable is False


### PR DESCRIPTION
## The bug (found by two independent audits)

`R6Resource`'s primary key was the **raw FHIR id alone** — global across tenants and resource types. FHIR logical ids are only unique per resource type per source, so:
- A second tenant importing an id the first tenant already held (Synthea `example`, Epic numeric ids) **collided on the PK, the IntegrityError was caught per-resource, and the resource was silently dropped from the import.**
- `Patient/abc` and `Observation/abc` within one tenant collided too.

This is a data-integrity failure a guardrails project cannot have, and it becomes a *when* (not if) as one patient connects multiple EHRs.

## The fix (W1 scope of the SPLIT migration)

Identity becomes **`(tenant_id, resource_type, id)`**. Ingester lookup switches to the tenant+type-scoped query; the collision path disappears (same id in two tenants now coexists). The `source` column + ingest Provenance are deliberately **later (W2)** — a comment marks the seam.

## What's here

- `r6/models.py`: composite PK; all lookups tenant+type-scoped.
- `r6/fasten/ingester.py`: `_ingest_one` looks up by the composite key; soft-delete re-ingest path updated.
- `tests/test_resource_identity.py` (9 tests, TDD — written red against the old global PK): two tenants / same id both persist + isolated; Patient/X vs Observation/X coexist; re-ingest updates not duplicates; soft-deleted re-ingest.
- `scripts/migrate_resource_identity.py`: idempotent, Postgres-only, pre-checked (duplicate + NULL guards), single-transaction swap, post-commit catalog verification, `--dry-run`. Discovers the old PK name from `pg_constraint`; handles the ACCESS SHARE/EXCLUSIVE self-deadlock.
- `docs/runbooks/resource-identity-migration.md`: prod steps (Railway snapshot → dry-run → migrate → verify → smoke read), rehearsal-on-a-copy procedure, snapshot-based rollback rationale.

## Tests
- SQLite full suite: **1146 passed**
- Postgres-sensitive subset was rehearsed against a live `postgres:16` by the implementer (62 tests) before a mid-run interruption; a fresh reviewer rehearsal is requested on this PR.

## Prod cutover
**Not executed here.** The cutover runs manually against a fresh Railway snapshot, on a scheduled window, per the runbook — never autonomously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)