### PR TITLE
release: v1.8.0 — Real-Actions Foundation + Reliability

### DIFF
--- a/.health-context.yaml
+++ b/.health-context.yaml
@@ -9,7 +9,7 @@
 # that calls into this engine. See ENGINE_CONTRACT.md.
 
 name: HealthClaw Guardrails
-version: 1.7.0
+version: 1.8.0
 role: engine
 
 # Jurisdiction determines which regulatory overlay applies to reads/writes.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Full notes live in **[Releases](https://github.com/aks129/HealthClawGuardrails/r
 
 | Version | Highlights |
 | --- | --- |
+| **v1.8.0** | **Real-actions foundation** — an agent can *propose* a real-world action (call, SMS, form) but `commit` only *submits* it (HTTP 202); execution happens through a separate approval that requires a single-use step-up credential and an expiry-guarded atomic claim, so the agent's own toolchain can never approve its own action (the spoofable `X-Human-Confirmed` header is gone) · **`ActionExecutor` plugin registry** — add a real-world capability behind the full guardrail rail in ~50 lines, no core changes ([extend it](ROADMAP.md#extending-the-action-rail)) · mandatory red-flag emergency screen; fail-loud rails (no silent simulation) · **durable execution** — attempt ledger, provider reconciliation, external-tick reaper, append-only action-event log · **reliability floor** — config preflight (`GET /r6/ops/preflight`), Postgres CI lane, MCP fetch timeouts, poller 409-storm detection, source-aware resource identity `(tenant, type, id)`, Fasten hardening + zombie-job reaper · public [ROADMAP](ROADMAP.md) + contributor on-ramp · fixes: upstream FHIR error fidelity, quality measures default to current year |
 | **v1.7.0** | Preventive care-gaps engine (`Patient/$care-gaps`, USPSTF/ACIP/ADA + eCQM crosswalk) · patient connect flow: identity-verified Fasten onboarding mints a webhook-gated, read-scoped 30-day agent token · prescription transfer requests (`rx_transfer_request`, Schedule II refused) — 29 MCP tools · [per-agent quickstarts](docs/quickstarts/) (Claude/Perplexity/ChatGPT/Telegram) · HBO export→FHIR converter + embedded-XML PHI scrubber · hardening: fail-closed webhook verify, scoped tokens, serverless write guard, live-path contract tests · clinical fixes: SNOMED diabetes detection, inclusive panic thresholds, one-sided-range honesty |
 | **v1.6.0** | Lab reference-range interpreter (`Observation/$interpret`) · NQF 0018 quality measure (`Measure/$evaluate-measure`) · [any-agent-framework adapters](docs/recipes/any-agent-framework.md) (OpenAI/Gemini) · [Medplum-in-front recipe](docs/recipes/healthclaw-in-front-of-medplum.md) · SMBP triage on 2025 AHA/ACC · ruff lint gate · all dependency advisories remediated |
 | v1.5.0 | Read-auth hardening (tenant reads authenticated, not just scoped) · HL7 SDC forms — `$populate` / `$extract` |
@@ -94,7 +95,7 @@ This is a **vendor-neutral guardrail proxy** that sits between any AI agent and 
 - **PHI redaction** — Names truncated to initials, identifiers masked, addresses stripped, birth dates truncated to year
 - **Immutable audit trail** — Every read/write logged with tenant, agent, timestamp
 - **Step-up authorization** — HMAC-SHA256 tokens required for writes
-- **Human-in-the-loop** — Clinical writes blocked until a human confirms (HTTP 428)
+- **Human-in-the-loop** — Clinical writes blocked until a human confirms (HTTP 428); real-world actions (calls, SMS, forms) go further: `commit` only *submits*, and execution requires a **provably out-of-band** single-use approval the agent's own toolchain cannot satisfy
 - **Tenant isolation** — Every query scoped to tenant, cross-tenant access blocked
 - **Medical disclaimers** — Injected on all clinical resource reads
 - **Compiled Truth** — Current state + append-only evidence trail for every resource
@@ -276,7 +277,7 @@ Both R4 and R6 resources flow through the same guardrail stack (PHI redaction, a
 ## Testing
 
 ```bash
-# Python tests (840+ across 40+ files; includes SDC, quality, and labs suites)
+# Python tests (1,170+ across 80+ files; includes action-rail, SDC, quality, labs, ops suites)
 uv run python -m pytest tests/ -v
 uv run python -m pytest tests/test_r6_routes.py::test_name -v   # single test
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <br/>
 
 <!-- Project -->
-[![Release](https://img.shields.io/badge/release-v1.7.0-f97316?style=flat-square)](https://github.com/aks129/HealthClawGuardrails/releases)
+[![Release](https://img.shields.io/badge/release-v1.8.0-f97316?style=flat-square)](https://github.com/aks129/HealthClawGuardrails/releases)
 [![License](https://img.shields.io/badge/license-MIT-2dd4bf?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/aks129/HealthClawGuardrails/ci.yml?branch=main&style=flat-square&label=CI&logo=github)](https://github.com/aks129/HealthClawGuardrails/actions/workflows/ci.yml)
 [![Code size](https://img.shields.io/github/languages/code-size/aks129/HealthClawGuardrails?style=flat-square&color=0ea5e9)](https://github.com/aks129/HealthClawGuardrails)
@@ -25,7 +25,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/aks129/HealthClawGuardrails?style=flat-square&color=64748b)](https://github.com/aks129/HealthClawGuardrails/commits/main)
 
 <!-- Stack & scope -->
-[![Tests](https://img.shields.io/badge/tests-840%2B%20Python%20%2B%2088%20Node-22c55e?style=flat-square)](#testing)
+[![Tests](https://img.shields.io/badge/tests-1170%2B%20Python%20%2B%20112%20Node-22c55e?style=flat-square)](#testing)
 [![MCP tools](https://img.shields.io/badge/MCP%20tools-29-6366f1?style=flat-square&logo=anthropic)](#mcp-tools-29)
 [![FHIR](https://img.shields.io/badge/FHIR-R4%20US%20Core%20v9-0ea5e9?style=flat-square)](#fhir-version-support)
 [![Guardrail conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.healthclaw.io%2Fr6%2Ffhir%2F%24conformance%3Fformat%3Dshields&style=flat-square)](#prove-it-guardrail-conformance)
@@ -35,7 +35,7 @@
 
 <br/>
 
-**[Quick Start](#quick-start)** · **[MCP Tools](#mcp-tools-29)** · **[Recipes](docs/recipes/)** · **[Roadmap](docs/ROADMAP.md)** · **[Claude Plugin](#install-as-a-claude-plugin)** · **[Architecture](#what-it-does)** · **[healthclaw.io](https://healthclaw.io)** · **[Contributing](CONTRIBUTING.md)** · **[Dev Guide](docs/development.md)**
+**[Quick Start](#quick-start)** · **[MCP Tools](#mcp-tools-29)** · **[Recipes](docs/recipes/)** · **[Roadmap](ROADMAP.md)** · **[Claude Plugin](#install-as-a-claude-plugin)** · **[Architecture](#what-it-does)** · **[healthclaw.io](https://healthclaw.io)** · **[Contributing](CONTRIBUTING.md)** · **[Dev Guide](docs/development.md)**
 
 </div>
 
@@ -48,7 +48,7 @@
 
 **This is a community effort.** It's most useful when implementers, clinicians, and standards folks poke holes in it. Issues, PRs, and "you got the SDC extraction wrong" critiques are all welcome — start with **[CONTRIBUTING.md](CONTRIBUTING.md)** and the **[Code of Conduct](CODE_OF_CONDUCT.md)**.
 
-**At a glance:** v1.7.0 · 950+ Python + 92 Node tests · 29 MCP tools · FHIR R4 US Core v9 + R6 v6.0.0-ballot3 · HL7 SDC forms (`$populate`/`$extract`) · NQF 0018 quality measure · lab interpreter (`$interpret`) · care-gaps reminders (`$care-gaps`) · ChatGPT-connector `search`/`fetch` · Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT · Open Wearables · real-world actions (calls/SMS) · SMART Health Links · Claude Code plugin · OpenAI/Gemini adapters
+**At a glance:** v1.8.0 · 1,170+ Python + 112 Node tests · 29 MCP tools · real-world action rail (provably out-of-band gate) · FHIR R4 US Core v9 + R6 v6.0.0-ballot3 · HL7 SDC forms (`$populate`/`$extract`) · NQF 0018 quality measure · lab interpreter (`$interpret`) · care-gaps reminders (`$care-gaps`) · ChatGPT-connector `search`/`fetch` · Fasten TEFCA · HealthEx · HBO · Flexpa · Epic · MEDENT · Open Wearables · real-world actions (calls/SMS) · SMART Health Links · Claude Code plugin · OpenAI/Gemini adapters
 
 ## Try it in 60 seconds — no clone, no keys
 
@@ -646,7 +646,7 @@ with different vantage points pressure-test it. We especially want:
 - **Standards people** (HL7 / SDC / SMART) — tell us where we've diverged from the spec, especially on `$populate`/`$extract`.
 - **Anyone** — open an issue, file a "you got this wrong," or send a PR.
 
-Start here: **[CONTRIBUTING.md](CONTRIBUTING.md)** · **[Roadmap](docs/ROADMAP.md)** · **[Dev Guide](docs/development.md)** · **[Code of Conduct](CODE_OF_CONDUCT.md)** · **[CHANGELOG.md](CHANGELOG.md)** · **[Security policy](SECURITY.md)**
+Start here: **[CONTRIBUTING.md](CONTRIBUTING.md)** · **[Roadmap](ROADMAP.md)** · **[Dev Guide](docs/development.md)** · **[Code of Conduct](CODE_OF_CONDUCT.md)** · **[CHANGELOG.md](CHANGELOG.md)** · **[Security policy](SECURITY.md)**
 
 Good first contributions are labeled in the issue tracker. Contributions are DCO-signed (`git commit -s`) under the [MIT license](LICENSE) — see [LICENSING.md](LICENSING.md) for the project's licensing posture going forward.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,73 +1,7 @@
 # Roadmap
 
-The working plan, in the open. The **issue tracker is the canonical log** —
-everything here links to a tracked issue where one exists. Contributions
-welcome on all of it: several items are labeled
-[`good first issue`](https://github.com/aks129/HealthClawGuardrails/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+The roadmap has moved to the repository root: **[../ROADMAP.md](../ROADMAP.md)**.
 
-## Near term (v1.7)
-
-**Clinical intelligence**
-- Lab interpreter: broader analyte table — TSH, liver panel, vitamin D ([#53](https://github.com/aks129/HealthClawGuardrails/issues/53))
-- Lab interpreter: unit conversion (mg/dL ↔ mmol/L) with cited factors ([#54](https://github.com/aks129/HealthClawGuardrails/issues/54))
-- Lab interpreter: trend/delta interpretation across successive results ([#62](https://github.com/aks129/HealthClawGuardrails/issues/62))
-- Quality measures: complete the CMS165 denominator exclusion set ([#55](https://github.com/aks129/HealthClawGuardrails/issues/55)); current-year default period ([#52](https://github.com/aks129/HealthClawGuardrails/issues/52))
-- Clinical review of the `LOINC_RANGES` reference table before it is presented
-  as authoritative in live demos
-- Care-gaps interpreter ✅ shipped v1.7.0 (`Patient/$care-gaps` + `care_gaps`
-  tool, eCQM crosswalk). Follow-ups: risk-adjusted cadence, condition-driven
-  rules beyond diabetes A1c, optional Da Vinci DEQM-shaped output
-- Prescription transfers ✅ phase 1 shipped v1.7.0 (`rx_transfer_request` —
-  guardrailed call to the receiving pharmacy, Schedule II refused).
-  Phase 2: Walgreens Prescription Refill & Transfer API (prefilled handoff);
-  phase 3: CVS Health100 ecosystem when it opens
-- Own-data onboarding ✅ shipped v1.7.0 (identity-verified Fasten connect →
-  webhook-gated 30-day read-scoped agent token → per-agent quickstarts)
-
-**Demos & workflows**
-- SMBP phase 2: BP-cuff photo OCR intake; wire the reminder scheduler to a
-  send cadence ([#61](https://github.com/aks129/HealthClawGuardrails/issues/61))
-- SMART Health Links: adopt upstream QR rendering + revocation
-
-**Engineering health**
-- Carve `r6/routes.py` into the established `register_*` module pattern ([#56](https://github.com/aks129/HealthClawGuardrails/issues/56))
-- Split the MCP server's `tools.ts` into definitions + executors ([#57](https://github.com/aks129/HealthClawGuardrails/issues/57))
-- Jest teardown open-handle fix ([#58](https://github.com/aks129/HealthClawGuardrails/issues/58))
-
-## Ecosystem & interoperability
-
-- **Catalog presence:** official MCP Registry (✅ published), ClawHub skills
-  (✅ published), Gemini CLI extension (✅ in-repo), Hermes `optional-mcps`
-  catalog (PR open), skill discovery at
-  `/.well-known/agent-skills/index.json` (✅ live)
-- **Upstream contributions:** fixes and implementer feedback to Medplum,
-  SMART Health Links tooling, open-wearables, HL7 SDC
-  ([FHIR-57806](https://jira.hl7.org/browse/FHIR-57806)), and the Tuva
-  Project's quality-measure mart
-- **Partner integrations:** deepen the Health Bank One pairing (structured
-  coded records + OAuth scope authorization — see
-  [the design doc](design/oauth-scope-mapping-hbo.md)) and the
-  Medplum-in-front recipe
-- **CMS-0057-F prior-auth (2027 mandate):** position the existing SDC
-  `$populate`/`$extract` engine as the guardrailed documentation layer for
-  Da Vinci DTR — redaction on egress, audit, human-in-the-loop, verifiable
-  `$conformance`. Scope, gaps (CQL bridge), and phasing in
-  [the design doc](design/cms-0057-prior-auth-dtr.md)
-
-## Honesty ledger (deliberate scope limits)
-
-These are documented limits, not oversights:
-
-- The NQF 0018 measure is a **calculator, not a certified eCQM** (partial
-  exclusions; see #55)
-- Lab interpretation is **decision support, never diagnosis**; adult
-  population defaults only (no pediatric/pregnancy ranges yet)
-- Claims/coverage data is stored and audited but **not analyzed** (no
-  cost/denial analytics)
-- Validation is structural, not full StructureDefinition/terminology
-  conformance
-
-## How to influence this
-
-Open an issue, comment on an existing one, or bring implementer experience —
-the fastest-moving items are the ones users push on.
+It's organized Now / Next / Later, links the `area:*` labels and good-first
+issues, and documents the `ActionExecutor` extension point — the highest-leverage
+way to contribute. The issue tracker remains the canonical log of tracked work.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "healthclaw-guardrails",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Guardrailed FHIR access for AI agents: PHI redaction, immutable audit, step-up auth, tenant isolation over a remote MCP server.",
   "mcpServers": {
     "healthclaw": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "healthclaw-guardrails"
-version = "1.7.0"
+version = "1.8.0"
 description = "HealthClaw Guardrails — FHIR R4 US Core v9 + R6 MCP guardrail proxy (healthclaw.io)"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/aks129/HealthClawGuardrails",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "websiteUrl": "https://healthclaw.io",
   "remotes": [
     {

--- a/services/agent-orchestrator/package.json
+++ b/services/agent-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-mcp-guardrails",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "MCP server for FHIR R6 agent orchestration with Claude",
   "main": "dist/index.js",
   "scripts": {

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
                     </li>
                 </ul>
                 <div class="d-flex align-items-center gap-2">
-                    <span class="badge bg-secondary" style="font-size:0.7rem">v1.7.0</span>
+                    <span class="badge bg-secondary" style="font-size:0.7rem">v1.8.0</span>
                     <span class="badge bg-success" style="font-size:0.7rem">R4 US Core v9</span>
                     <span class="badge bg-info" style="font-size:0.7rem">R6 ballot3</span>
                 </div>


### PR DESCRIPTION
Version bump + README for the v1.8.0 release. Everything in the release already merged via #77–#84, #76, #81, #88; this cuts the version.

Highlights: the provably out-of-band action gate, the ActionExecutor plugin registry, durable execution, the reliability floor (preflight/reaper/Postgres-CI/timeouts/identity), and the public roadmap + contributor on-ramp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)