### PR TITLE
Forms rail (1/9): standard intake Questionnaire (meds/allergies/conditions, NKA-safe)

### DIFF
--- a/r6/sdc/intake.py
+++ b/r6/sdc/intake.py
@@ -1,0 +1,270 @@
+"""The canonical `healthclaw-intake` Questionnaire.
+
+This is the standard new-patient intake the form-fill rail populates from a
+patient's FHIR data via SDC `$populate` and writes back via `$extract`
+(r6/sdc/populate.py, r6/sdc/extract.py).
+
+Sections:
+  - demographics: leaf items with both `definition` (Patient element path,
+    for $extract) and `initialExpression` (FHIRPath, for $populate) — these
+    populate today because populate.py already resolves Patient-based
+    initialExpressions.
+  - medications / allergies / conditions: repeating `<section>.item` groups
+    structured with `definition` pointing at the relevant resource type
+    (MedicationRequest / AllergyIntolerance / Condition). They intentionally
+    carry NO initialExpression yet — populate.py only matches Observations
+    by item.code and Patient-rooted FHIRPath today. Wiring these groups to
+    fill one repeat per matching list resource is Task 2.
+
+NKA (no-known-allergies) invariant — READ THIS BEFORE TOUCHING
+`allergies.no-known-allergies`:
+    "No known allergies" must be a distinct affirmative attestation the
+    patient (or someone on their behalf) explicitly makes. It must NEVER
+    carry an `initial` value and must NEVER be filled by an
+    initialExpression, because silence about allergies is not consent —
+    a default here would let the form-fill rail present "no known
+    allergies" for a patient who was simply never asked, which is a
+    patient-safety hazard. Task 2's list-resource population must not
+    touch this item; it stays operator/patient-entered only.
+    Enforced by tests/test_intake_questionnaire.py::
+    test_no_known_allergies_invariant_never_defaulted.
+"""
+
+import copy
+
+INITIAL_EXPRESSION_URL = (
+    "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
+    "sdc-questionnaire-initialExpression"
+)
+
+# NOTE: the root definitionExtract flag below only ever names ONE target
+# resource type (see r6/sdc/extract.py:_extract_by_definition) — a v1
+# limitation of the existing engine, not something introduced here. It's set
+# to Patient because demographics is the only section that both populates
+# and extracts correctly today. The `definition` values on the medications /
+# allergies / conditions items point at their real target resource types
+# (MedicationRequest / AllergyIntolerance / Condition) for Task 2 to wire up;
+# until then those items simply won't have answers for extract to touch.
+DEFINITION_EXTRACT_URL = (
+    "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
+    "sdc-questionnaire-definitionExtract"
+)
+
+PATIENT_DEF = "http://hl7.org/fhir/StructureDefinition/Patient#Patient"
+MED_REQUEST_DEF = (
+    "http://hl7.org/fhir/StructureDefinition/MedicationRequest#MedicationRequest"
+)
+ALLERGY_DEF = (
+    "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance#AllergyIntolerance"
+)
+CONDITION_DEF = "http://hl7.org/fhir/StructureDefinition/Condition#Condition"
+
+
+def _initial_expr(expression):
+    return [{
+        "url": INITIAL_EXPRESSION_URL,
+        "valueExpression": {"language": "text/fhirpath", "expression": expression},
+    }]
+
+
+INTAKE_QUESTIONNAIRE = {
+    "resourceType": "Questionnaire",
+    "id": "healthclaw-intake",
+    "url": "http://healthclaw.io/fhir/Questionnaire/healthclaw-intake",
+    "version": "1.0.0",
+    "status": "active",
+    "title": "HealthClaw Standard Intake",
+    "extension": [{"url": DEFINITION_EXTRACT_URL, "valueCode": "Patient"}],
+    "item": [
+        {
+            "linkId": "demographics",
+            "type": "group",
+            "text": "Demographics",
+            "item": [
+                {
+                    "linkId": "demographics.given-name",
+                    "type": "string",
+                    "text": "First name",
+                    "definition": f"{PATIENT_DEF}.name.given",
+                    "extension": _initial_expr("%patient.name.given.first()"),
+                },
+                {
+                    "linkId": "demographics.family-name",
+                    "type": "string",
+                    "text": "Last name",
+                    "definition": f"{PATIENT_DEF}.name.family",
+                    "extension": _initial_expr("%patient.name.family"),
+                },
+                {
+                    "linkId": "demographics.birth-date",
+                    "type": "date",
+                    "text": "Date of birth",
+                    "definition": f"{PATIENT_DEF}.birthDate",
+                    "extension": _initial_expr("%patient.birthDate"),
+                },
+                {
+                    "linkId": "demographics.gender",
+                    "type": "choice",
+                    "text": "Administrative gender",
+                    "definition": f"{PATIENT_DEF}.gender",
+                    "extension": _initial_expr("%patient.gender"),
+                    "answerOption": [
+                        {"valueCoding": {
+                            "system": "http://hl7.org/fhir/administrative-gender",
+                            "code": "male", "display": "Male"}},
+                        {"valueCoding": {
+                            "system": "http://hl7.org/fhir/administrative-gender",
+                            "code": "female", "display": "Female"}},
+                        {"valueCoding": {
+                            "system": "http://hl7.org/fhir/administrative-gender",
+                            "code": "other", "display": "Other"}},
+                        {"valueCoding": {
+                            "system": "http://hl7.org/fhir/administrative-gender",
+                            "code": "unknown", "display": "Unknown"}},
+                    ],
+                },
+                {
+                    "linkId": "demographics.phone",
+                    "type": "string",
+                    "text": "Phone number",
+                    "definition": f"{PATIENT_DEF}.telecom",
+                    "extension": _initial_expr(
+                        "%patient.telecom.where(system='phone').value.first()"),
+                },
+                {
+                    "linkId": "demographics.address-line",
+                    "type": "string",
+                    "text": "Street address",
+                    "definition": f"{PATIENT_DEF}.address.line",
+                    "extension": _initial_expr(
+                        "%patient.address.line.first()"),
+                },
+                {
+                    "linkId": "demographics.address-city",
+                    "type": "string",
+                    "text": "City",
+                    "definition": f"{PATIENT_DEF}.address.city",
+                    "extension": _initial_expr("%patient.address.city.first()"),
+                },
+                {
+                    "linkId": "demographics.address-state",
+                    "type": "string",
+                    "text": "State",
+                    "definition": f"{PATIENT_DEF}.address.state",
+                    "extension": _initial_expr(
+                        "%patient.address.state.first()"),
+                },
+                {
+                    "linkId": "demographics.address-postal-code",
+                    "type": "string",
+                    "text": "Postal code",
+                    "definition": f"{PATIENT_DEF}.address.postalCode",
+                    "extension": _initial_expr(
+                        "%patient.address.postalCode.first()"),
+                },
+            ],
+        },
+        {
+            "linkId": "medications",
+            "type": "group",
+            "text": "Current medications",
+            "item": [
+                {
+                    "linkId": "medications.no-current-medications",
+                    "type": "boolean",
+                    "text": "Patient confirms no current medications",
+                },
+                {
+                    "linkId": "medications.item",
+                    "type": "group",
+                    "text": "Medication",
+                    "repeats": True,
+                    "item": [
+                        {
+                            "linkId": "medications.item.name",
+                            "type": "string",
+                            "text": "Medication name",
+                            "definition":
+                                f"{MED_REQUEST_DEF}.medicationCodeableConcept.text",
+                        },
+                        {
+                            "linkId": "medications.item.dose",
+                            "type": "string",
+                            "text": "Dose",
+                            "definition":
+                                f"{MED_REQUEST_DEF}.dosageInstruction.text",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "linkId": "allergies",
+            "type": "group",
+            "text": "Allergies",
+            "item": [
+                {
+                    # CRITICAL INVARIANT — see module docstring. Never add
+                    # `initial` or an initialExpression extension here: NKA
+                    # must stay a distinct affirmative attestation, never a
+                    # default and never inferred from absent allergy data.
+                    "linkId": "allergies.no-known-allergies",
+                    "type": "boolean",
+                    "text": "No known allergies (patient confirmed)",
+                    "required": True,
+                },
+                {
+                    "linkId": "allergies.item",
+                    "type": "group",
+                    "text": "Allergy",
+                    "repeats": True,
+                    "item": [
+                        {
+                            "linkId": "allergies.item.allergen",
+                            "type": "string",
+                            "text": "Allergen",
+                            "definition": f"{ALLERGY_DEF}.code.text",
+                        },
+                        {
+                            "linkId": "allergies.item.reaction",
+                            "type": "string",
+                            "text": "Reaction",
+                            "definition":
+                                f"{ALLERGY_DEF}.reaction.manifestation.text",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "linkId": "conditions",
+            "type": "group",
+            "text": "Problems / conditions",
+            "item": [
+                {
+                    "linkId": "conditions.item",
+                    "type": "group",
+                    "text": "Condition",
+                    "repeats": True,
+                    "item": [
+                        {
+                            "linkId": "conditions.item.name",
+                            "type": "string",
+                            "text": "Condition name",
+                            "definition": f"{CONDITION_DEF}.code.text",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+
+
+def intake_questionnaire() -> dict:
+    """Return a fresh deep copy of the canonical intake Questionnaire.
+
+    Callers (seed.py, tests) get their own copy so nothing accidentally
+    mutates the shared module-level template.
+    """
+    return copy.deepcopy(INTAKE_QUESTIONNAIRE)

--- a/r6/seed.py
+++ b/r6/seed.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from models import db
 from r6.models import R6Resource
 from r6.audit import record_audit_event
+from r6.sdc.intake import intake_questionnaire
 
 logger = logging.getLogger(__name__)
 
@@ -75,59 +76,7 @@ def _built_in_resources() -> list[dict]:
             "subject": {"reference": "Patient/__PATIENT_ID__"},
             "medicationCodeableConcept": {"coding": [{"system": "http://www.nlm.nih.gov/research/umls/rxnorm", "code": "860975", "display": "Metformin 500 MG Oral Tablet"}]},
         },
-        {
-            "resourceType": "Questionnaire",
-            "id": "healthclaw-intake",
-            "url": "https://healthclaw.io/Questionnaire/healthclaw-intake",
-            "version": "1.0.0",
-            "status": "active",
-            "title": "HealthClaw Demo Intake",
-            "extension": [{
-                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
-                       "sdc-questionnaire-definitionExtract",
-                "valueCode": "Patient",
-            }],
-            "item": [
-                {
-                    "linkId": "given-name",
-                    "type": "string",
-                    "text": "First name",
-                    "definition": "http://hl7.org/fhir/StructureDefinition/"
-                                  "Patient#Patient.name.given",
-                    "extension": [{
-                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
-                               "sdc-questionnaire-initialExpression",
-                        "valueExpression": {
-                            "language": "text/fhirpath",
-                            "expression": "%patient.name.given.first()"},
-                    }],
-                },
-                {
-                    "linkId": "family-name",
-                    "type": "string",
-                    "text": "Last name",
-                    "definition": "http://hl7.org/fhir/StructureDefinition/"
-                                  "Patient#Patient.name.family",
-                    "extension": [{
-                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
-                               "sdc-questionnaire-initialExpression",
-                        "valueExpression": {
-                            "language": "text/fhirpath",
-                            "expression": "%patient.name.family"},
-                    }],
-                },
-                {
-                    "linkId": "body-weight",
-                    "type": "quantity",
-                    "text": "Body weight",
-                    "code": [{"system": "http://loinc.org", "code": "29463-7"}],
-                    "extension": [{
-                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
-                               "sdc-questionnaire-observationExtract",
-                        "valueBoolean": True}],
-                },
-            ],
-        },
+        intake_questionnaire(),
     ]
 
 

--- a/tests/test_intake_questionnaire.py
+++ b/tests/test_intake_questionnaire.py
@@ -12,7 +12,7 @@ Covers:
     conditions won't actually fill until Task 2 wires list-resource matching.
 """
 
-from r6.sdc.intake import INTAKE_QUESTIONNAIRE, intake_questionnaire
+from r6.sdc.intake import intake_questionnaire
 from r6.sdc.populate import populate_questionnaire
 
 

--- a/tests/test_intake_questionnaire.py
+++ b/tests/test_intake_questionnaire.py
@@ -1,0 +1,207 @@
+"""Tests for the canonical healthclaw-intake Questionnaire (forms rail Task 1).
+
+Covers:
+  - Valid FHIR R4 Questionnaire shape.
+  - Repeating groups for medications / allergies / conditions exist and are
+    structured with stable linkIds for Task 2 (list-resource population) to
+    fill in later.
+  - The NKA (no-known-allergies) invariant: it is a distinct affirmative
+    attestation, never defaulted and never inferrable from absent data.
+  - $populate still runs end-to-end against the new Questionnaire and mirrors
+    its structure in the QuestionnaireResponse, even though meds/allergies/
+    conditions won't actually fill until Task 2 wires list-resource matching.
+"""
+
+from r6.sdc.intake import INTAKE_QUESTIONNAIRE, intake_questionnaire
+from r6.sdc.populate import populate_questionnaire
+
+
+def _walk(items):
+    for item in items:
+        yield item
+        if "item" in item:
+            yield from _walk(item["item"])
+
+
+def _by_link_id(questionnaire, link_id):
+    for item in _walk(questionnaire.get("item", [])):
+        if item.get("linkId") == link_id:
+            return item
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+def test_valid_fhir_questionnaire_shape():
+    q = intake_questionnaire()
+    assert q["resourceType"] == "Questionnaire"
+    assert q["status"] == "active"
+    assert q["id"] == "healthclaw-intake"
+    assert q["url"] == "http://healthclaw.io/fhir/Questionnaire/healthclaw-intake"
+    assert isinstance(q["item"], list) and q["item"]
+
+
+def test_intake_questionnaire_returns_a_fresh_copy_each_call():
+    a = intake_questionnaire()
+    b = intake_questionnaire()
+    assert a == b
+    a["item"].append({"linkId": "mutated"})
+    assert b != a
+    assert _by_link_id(intake_questionnaire(), "mutated") is None
+
+
+def test_all_linkids_are_unique():
+    q = intake_questionnaire()
+    link_ids = [item["linkId"] for item in _walk(q["item"])]
+    assert len(link_ids) == len(set(link_ids))
+
+
+# ---------------------------------------------------------------------------
+# Demographics
+# ---------------------------------------------------------------------------
+
+def test_demographics_group_present():
+    q = intake_questionnaire()
+    demo = _by_link_id(q, "demographics")
+    assert demo is not None
+    assert demo["type"] == "group"
+    child_ids = {c["linkId"] for c in demo["item"]}
+    assert {
+        "demographics.given-name",
+        "demographics.family-name",
+        "demographics.birth-date",
+        "demographics.gender",
+        "demographics.phone",
+    } <= child_ids
+    # Address is present in some structured form under the demographics group.
+    assert any(cid.startswith("demographics.address") for cid in child_ids)
+
+
+# ---------------------------------------------------------------------------
+# Medications
+# ---------------------------------------------------------------------------
+
+def test_medications_repeating_group_present():
+    q = intake_questionnaire()
+    repeat_group = _by_link_id(q, "medications.item")
+    assert repeat_group is not None
+    assert repeat_group["type"] == "group"
+    assert repeat_group["repeats"] is True
+    child_ids = {c["linkId"] for c in repeat_group["item"]}
+    assert "medications.item.name" in child_ids
+
+
+def test_medications_no_current_medications_boolean():
+    q = intake_questionnaire()
+    item = _by_link_id(q, "medications.no-current-medications")
+    assert item is not None
+    assert item["type"] == "boolean"
+    assert item["text"] == "Patient confirms no current medications"
+
+
+# ---------------------------------------------------------------------------
+# Allergies
+# ---------------------------------------------------------------------------
+
+def test_allergies_repeating_group_present():
+    q = intake_questionnaire()
+    repeat_group = _by_link_id(q, "allergies.item")
+    assert repeat_group is not None
+    assert repeat_group["type"] == "group"
+    assert repeat_group["repeats"] is True
+    child_ids = {c["linkId"] for c in repeat_group["item"]}
+    assert "allergies.item.allergen" in child_ids
+
+
+def test_no_known_allergies_is_required_boolean_with_exact_text():
+    q = intake_questionnaire()
+    item = _by_link_id(q, "allergies.no-known-allergies")
+    assert item is not None
+    assert item["type"] == "boolean"
+    assert item["required"] is True
+    assert item["text"] == "No known allergies (patient confirmed)"
+
+
+def test_no_known_allergies_invariant_never_defaulted():
+    """CRITICAL: 'no known allergies' must be an affirmative attestation.
+
+    It must never carry an `initial` value and must never be populated via
+    an initialExpression — silence about allergies is not consent, and a
+    default here would let the form-fill rail claim NKA for a patient who
+    was simply never asked. This is load-bearing for patient safety.
+    """
+    q = intake_questionnaire()
+    item = _by_link_id(q, "allergies.no-known-allergies")
+    assert "initial" not in item
+
+    initial_expr_url = (
+        "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
+        "sdc-questionnaire-initialExpression"
+    )
+    for ext in item.get("extension", []):
+        assert ext.get("url") != initial_expr_url, (
+            "allergies.no-known-allergies must never be populated by an "
+            "initialExpression — it must be an explicit patient attestation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Problems / conditions
+# ---------------------------------------------------------------------------
+
+def test_conditions_repeating_group_present():
+    q = intake_questionnaire()
+    repeat_group = _by_link_id(q, "conditions.item")
+    assert repeat_group is not None
+    assert repeat_group["type"] == "group"
+    assert repeat_group["repeats"] is True
+    child_ids = {c["linkId"] for c in repeat_group["item"]}
+    assert "conditions.item.name" in child_ids
+
+
+# ---------------------------------------------------------------------------
+# $populate integration
+# ---------------------------------------------------------------------------
+
+def test_populate_mirrors_new_structure():
+    q = intake_questionnaire()
+    patient = {
+        "resourceType": "Patient",
+        "id": "p1",
+        "name": [{"given": ["Ada"], "family": "Lovelace"}],
+        "birthDate": "1815-12-10",
+        "gender": "female",
+        "telecom": [{"system": "phone", "value": "617-555-0198"}],
+        "address": [{"line": ["123 Clinical Ave"], "city": "Boston",
+                     "state": "MA", "postalCode": "02101"}],
+    }
+
+    qr, issues = populate_questionnaire(q, patient, [patient])
+
+    assert qr["resourceType"] == "QuestionnaireResponse"
+    assert issues == []
+
+    demo_group = next(i for i in qr["item"] if i["linkId"] == "demographics")
+    given = next(i for i in demo_group["item"]
+                 if i["linkId"] == "demographics.given-name")
+    assert given["answer"][0]["valueString"] == "Ada"
+    family = next(i for i in demo_group["item"]
+                  if i["linkId"] == "demographics.family-name")
+    assert family["answer"][0]["valueString"] == "Lovelace"
+
+    # Meds/allergies/conditions groups don't populate yet (Task 2), but the
+    # leaf items still mirror the questionnaire's structure with no answer.
+    meds_group = next(i for i in qr["item"] if i["linkId"] == "medications")
+    meds_repeat = next(i for i in meds_group["item"]
+                        if i["linkId"] == "medications.item")
+    meds_name = next(i for i in meds_repeat["item"]
+                      if i["linkId"] == "medications.item.name")
+    assert "answer" not in meds_name
+
+    allergies_group = next(i for i in qr["item"]
+                            if i["linkId"] == "allergies")
+    nka = next(i for i in allergies_group["item"]
+               if i["linkId"] == "allergies.no-known-allergies")
+    assert "answer" not in nka


### PR DESCRIPTION
## Summary

Task 1 of the forms rail: author the canonical `healthclaw-intake` FHIR R4 Questionnaire the form-fill rail populates from a patient's FHIR data. This replaces the 3-field demo (`given-name` / `family-name` / `body-weight`) with a real new-patient intake.

- **`r6/sdc/intake.py`** (new) — exports `INTAKE_QUESTIONNAIRE` (dict) and `intake_questionnaire()` (returns a fresh deep copy). `id: healthclaw-intake`, `status: active`, canonical `url: http://healthclaw.io/fhir/Questionnaire/healthclaw-intake`.
- **`r6/seed.py`** — now seeds `intake_questionnaire()` under `healthclaw-intake` instead of the old 3-field demo.

### Questionnaire shape

- **Demographics** (`demographics`): given name, family name, birth date, gender (choice, administrative-gender), phone, and a decomposed address (line/city/state/postal code). Each leaf carries both `definition` (Patient element path, for `$extract`) and an `initialExpression` (FHIRPath), so this section **populates today** — no engine changes needed, since `populate.py` already resolves Patient-rooted `initialExpression`s.
- **Medications** (`medications`, repeating entries): `medications.item` (`type: group`, `repeats: true`) holds `medications.item.name` / `medications.item.dose`, each tagged with `definition` pointing at `MedicationRequest`. Plus a sibling top-level boolean `medications.no-current-medications` ("Patient confirms no current medications").
- **Allergies** (`allergies`, repeating entries): `allergies.item` (`repeats: true`) holds `allergies.item.allergen` / `allergies.item.reaction`, `definition`-tagged against `AllergyIntolerance`. Plus a **required** boolean `allergies.no-known-allergies` ("No known allergies (patient confirmed)").
- **Problems/conditions** (`conditions`, repeating entries): `conditions.item` (`repeats: true`) holds `conditions.item.name`, `definition`-tagged against `Condition`.

Medications/allergies/conditions items are deliberately structural only (linkId + type + `definition`, no `initialExpression`) — `populate.py` doesn't yet match `AllergyIntolerance`/`MedicationRequest`/`Condition` resources (only `Observation` by `item.code`, and Patient-rooted FHIRPath). Wiring one repeat per matching list resource is **Task 2**.

### NKA (no-known-allergies) invariant — load-bearing

`allergies.no-known-allergies` is authored so it can **never** be a default and **never** be inferred from absent allergy data:
- No `initial` value.
- No `initialExpression` extension.
- `required: true` — the form-fill rail must force an explicit answer.

This is documented in a comment directly above the item in `r6/sdc/intake.py` and enforced by `tests/test_intake_questionnaire.py::test_no_known_allergies_invariant_never_defaulted`. Silence about allergies is not consent; a default here would let the rail claim NKA for a patient who was simply never asked — a patient-safety hazard.

### Grep findings (old 3-field shape)

- `r6/seed.py` — updated to seed the new Questionnaire (this PR).
- `tests/test_seed_demo.py` — asserts only that `healthclaw-intake` resolves by logical id after seeding; doesn't assert on field shape. Passes unmodified.
- `tests/test_sdc_roundtrip.py` — has its own **local, self-contained** `_demo_questionnaire()` fixture (3-field: given-name/family-name/body-weight) that it stores directly into a test tenant, independent of `r6/seed.py`. It never references the real seeded Questionnaire, so it's untouched and still exercises the populate → complete → extract loop against its own fixture.
- Other `29463-7` / "body weight" hits (`test_sdc_routes.py`, `test_sdc_guardrails.py`, `test_sdc_extract.py`, `test_wearables.py`, `r6/wearables/mapper.py`, `scripts/export_healthex_legacy.py`) are generic LOINC-code fixtures unrelated to the intake seed — no changes needed.

## Test plan

- [x] New `tests/test_intake_questionnaire.py` (11 tests): valid FHIR shape, unique linkIds, demographics/medications/allergies/conditions structure, the NKA invariant (no `initial`, no `initialExpression`), and a `$populate` integration test showing demographics fill from a Patient while meds/allergies/conditions leaf items are emitted unfilled (mirroring structure per SDC semantics) pending Task 2.
- [x] Verified `INTAKE_QUESTIONNAIRE` passes the app's own `R6Validator.validate_resource()`.
- [x] Full suite: `uv run python -m pytest tests/ -q` → **1183 passed** (baseline 1172 + 11 new), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)