### PR TITLE
Forms rail (4/9): render QuestionnaireResponse to PDF (reportlab, provenance footer)

### DIFF
--- a/r6/sdc/pdf.py
+++ b/r6/sdc/pdf.py
@@ -1,0 +1,191 @@
+"""Render a completed FHIR QuestionnaireResponse to PDF — pure compute.
+
+render_questionnaire_response_pdf() walks the QuestionnaireResponse item
+tree (groups -> repeating groups -> leaf items with answer[]) and lays it
+out with reportlab, mirroring the SimpleDocTemplate/Paragraph/Spacer
+pattern used by r6/smbp/report.py::render_pdf. No DB, no Flask.
+
+Unanswered leaf items are rendered as a blank field (not omitted) — an
+intake form shows the field even when nothing was entered, which matters
+most for `allergies.no-known-allergies` (see r6/sdc/intake.py module
+docstring): a blank there must never be mistaken for an affirmative "Yes".
+
+Every rendered form carries a provenance footer stating the form was
+populated automatically, whether/when the patient reviewed it, and that it
+is a draft — not a medical record.
+"""
+
+import html as _html
+import io
+
+_BLANK = "—"  # em dash — unanswered marker
+
+
+def render_questionnaire_response_pdf(questionnaire_response, questionnaire=None, *,
+                                       reviewed_on=None, subject_label=None):
+    """Render `questionnaire_response` (a QuestionnaireResponse dict) to PDF bytes.
+
+    questionnaire: optional Questionnaire dict, used to fill in item labels
+        (and the document title) when the QuestionnaireResponse item itself
+        has no `text`.
+    reviewed_on: optional date/datetime string shown in the provenance footer.
+    subject_label: optional patient display name for the title.
+    """
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.units import inch
+    from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
+    from reportlab.lib.styles import getSampleStyleSheet
+
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=letter, title="Intake Form")
+    styles = getSampleStyleSheet()
+
+    q_index = _index_questionnaire_items(questionnaire) if questionnaire else {}
+
+    elems = [
+        Paragraph(_html.escape(_title(questionnaire, subject_label)), styles["Title"]),
+        Spacer(1, 0.2 * inch),
+    ]
+    elems.extend(_render_items(questionnaire_response.get("item") or [],
+                                q_index, styles, level=0))
+    elems.append(Spacer(1, 0.3 * inch))
+    elems.append(Paragraph(_html.escape(_footer_text(reviewed_on)), styles["Italic"]))
+
+    doc.build(elems)
+    return buf.getvalue()
+
+
+def _title(questionnaire, subject_label):
+    base = (questionnaire or {}).get("title") or "Intake Form"
+    if subject_label:
+        return f"{base} — {subject_label}"
+    return base
+
+
+def _footer_text(reviewed_on):
+    reviewed = reviewed_on or "(not yet reviewed)"
+    return (
+        "Populated from the patient's health records by an automated system. "
+        f"Reviewed by patient on {reviewed}. "
+        "This is a draft intake form, not a medical record."
+    )
+
+
+def _index_questionnaire_items(questionnaire):
+    """Flatten a Questionnaire's item tree into {linkId: item} for label lookup."""
+    index = {}
+
+    def walk(items):
+        for it in items or []:
+            link_id = it.get("linkId")
+            if link_id:
+                index[link_id] = it
+            walk(it.get("item"))
+
+    walk(questionnaire.get("item") if questionnaire else None)
+    return index
+
+
+def _label_for(item, q_index):
+    link_id = item.get("linkId")
+    text = item.get("text")
+    if text:
+        return text
+    q_item = q_index.get(link_id)
+    if q_item and q_item.get("text"):
+        return q_item["text"]
+    return link_id or "(unlabeled)"
+
+
+def _is_group(item):
+    # QR groups (including repeating-group instances) carry a nested `item[]`;
+    # leaves carry only `answer[]` (or nothing, if unanswered). This mirrors
+    # the shape r6/sdc/populate.py produces.
+    return item.get("item") is not None
+
+
+def _render_items(items, q_index, styles, level):
+    """Render a sibling list of QR items, numbering repeated-linkId groups."""
+    totals = {}
+    for it in items:
+        link_id = it.get("linkId")
+        totals[link_id] = totals.get(link_id, 0) + 1
+
+    elems = []
+    seen = {}
+    for it in items:
+        link_id = it.get("linkId")
+        seen[link_id] = seen.get(link_id, 0) + 1
+        occurrence = seen[link_id] if totals[link_id] > 1 else None
+        elems.extend(_render_item(it, q_index, styles, level, occurrence))
+    return elems
+
+
+def _render_item(item, q_index, styles, level, occurrence):
+    from reportlab.platypus import Paragraph, Spacer
+    from reportlab.lib.units import inch
+
+    label = _label_for(item, q_index)
+    if occurrence is not None:
+        label = f"{label} {occurrence}"
+
+    if _is_group(item):
+        heading_style = _heading_style(styles, level)
+        elems = [Spacer(1, 0.12 * inch), Paragraph(_html.escape(label), heading_style)]
+        elems.extend(_render_items(item.get("item") or [], q_index, styles, level + 1))
+        return elems
+
+    answer_text = _format_answer(item)
+    row = f"<b>{_html.escape(label)}:</b> {_html.escape(answer_text)}"
+    return [Paragraph(row, styles["Normal"])]
+
+
+def _heading_style(styles, level):
+    name = f"Heading{min(level + 2, 4)}"
+    return styles.get(name, styles["Heading2"])
+
+
+def _format_answer(item):
+    """Format a leaf QR item's answer[] into display text.
+
+    Unanswered leaves (no `answer` key, or an empty one) render as the blank
+    marker — they must never be silently dropped or mistaken for a default
+    value (see r6/sdc/intake.py on `allergies.no-known-allergies`).
+    """
+    answers = item.get("answer") or []
+    if not answers:
+        return _BLANK
+    parts = [p for p in (_format_value(a) for a in answers) if p is not None]
+    if not parts:
+        return _BLANK
+    return ", ".join(parts)
+
+
+def _format_value(answer):
+    if "valueBoolean" in answer:
+        return "Yes" if answer["valueBoolean"] else "No"
+    if "valueString" in answer:
+        return str(answer["valueString"])
+    if "valueDate" in answer:
+        return str(answer["valueDate"])
+    if "valueDateTime" in answer:
+        return str(answer["valueDateTime"])
+    if "valueTime" in answer:
+        return str(answer["valueTime"])
+    if "valueInteger" in answer:
+        return str(answer["valueInteger"])
+    if "valueDecimal" in answer:
+        return str(answer["valueDecimal"])
+    if "valueUri" in answer:
+        return str(answer["valueUri"])
+    if "valueQuantity" in answer:
+        quantity = answer["valueQuantity"]
+        value = quantity.get("value")
+        if value is None:
+            return None
+        unit = quantity.get("unit") or quantity.get("code") or ""
+        return f"{value} {unit}".strip()
+    if "valueCoding" in answer:
+        coding = answer["valueCoding"]
+        return coding.get("display") or coding.get("code") or _BLANK
+    return None

--- a/tests/test_sdc_pdf.py
+++ b/tests/test_sdc_pdf.py
@@ -1,0 +1,186 @@
+from r6.sdc.pdf import render_questionnaire_response_pdf, _format_answer, _footer_text
+
+
+def _small_qr():
+    return {
+        "resourceType": "QuestionnaireResponse",
+        "status": "completed",
+        "item": [
+            {
+                "linkId": "demographics",
+                "item": [
+                    {"linkId": "demographics.given-name", "text": "First name",
+                     "answer": [{"valueString": "Jane"}]},
+                    {"linkId": "demographics.family-name", "text": "Last name",
+                     "answer": [{"valueString": "Doe"}]},
+                ],
+            },
+        ],
+    }
+
+
+def _qr_with_medications(n_repeats=2):
+    qr = _small_qr()
+    meds = {
+        "linkId": "medications",
+        "text": "Current medications",
+        "item": [
+            {"linkId": "medications.no-current-medications",
+             "text": "Patient confirms no current medications",
+             "answer": [{"valueBoolean": False}]},
+        ],
+    }
+    for i in range(n_repeats):
+        meds["item"].append({
+            "linkId": "medications.item",
+            "text": "Medication",
+            "item": [
+                {"linkId": "medications.item.name", "text": "Medication name",
+                 "answer": [{"valueString": f"Med {i + 1}"}]},
+                {"linkId": "medications.item.dose", "text": "Dose",
+                 "answer": [{"valueString": f"{i + 1}0mg daily"}]},
+            ],
+        })
+    qr["item"].append(meds)
+    return qr
+
+
+def _qr_with_unanswered_allergy():
+    qr = _small_qr()
+    qr["item"].append({
+        "linkId": "allergies",
+        "text": "Allergies",
+        "item": [
+            # Unanswered — must render blank, not a default "Yes"/"No".
+            {"linkId": "allergies.no-known-allergies",
+             "text": "No known allergies (patient confirmed)"},
+        ],
+    })
+    return qr
+
+
+def test_render_small_qr_returns_pdf_bytes():
+    pdf = render_questionnaire_response_pdf(_small_qr())
+    assert isinstance(pdf, (bytes, bytearray))
+    assert len(pdf) > 0
+    assert pdf[:4] == b"%PDF"
+
+
+def test_repeating_medications_group_renders_and_scales_output():
+    empty_pdf = render_questionnaire_response_pdf(_small_qr())
+    meds_pdf = render_questionnaire_response_pdf(_qr_with_medications())
+    assert meds_pdf[:4] == b"%PDF"
+    assert len(meds_pdf) > len(empty_pdf)
+
+
+def test_repeating_medications_more_repeats_yields_more_content():
+    two_pdf = render_questionnaire_response_pdf(_qr_with_medications(2))
+    four_pdf = render_questionnaire_response_pdf(_qr_with_medications(4))
+    assert len(four_pdf) > len(two_pdf)
+
+
+def test_unanswered_allergy_renders_without_crash():
+    pdf = render_questionnaire_response_pdf(_qr_with_unanswered_allergy())
+    assert pdf[:4] == b"%PDF"
+    assert len(pdf) > 0
+
+
+def test_unanswered_boolean_item_does_not_format_as_yes():
+    qr = _qr_with_unanswered_allergy()
+    unanswered = qr["item"][-1]["item"][0]
+    assert "answer" not in unanswered
+    formatted = _format_answer(unanswered)
+    assert formatted != "Yes"
+    assert formatted != "No"
+
+
+def test_format_answer_blank_marker_for_unanswered_item():
+    assert _format_answer({"linkId": "x"}) == "—"
+
+
+def test_format_answer_value_string():
+    assert _format_answer({"linkId": "x", "answer": [{"valueString": "Jane"}]}) == "Jane"
+
+
+def test_format_answer_value_boolean_true():
+    assert _format_answer({"linkId": "x", "answer": [{"valueBoolean": True}]}) == "Yes"
+
+
+def test_format_answer_value_boolean_false():
+    assert _format_answer({"linkId": "x", "answer": [{"valueBoolean": False}]}) == "No"
+
+
+def test_format_answer_value_date():
+    assert _format_answer(
+        {"linkId": "x", "answer": [{"valueDate": "1990-01-02"}]}) == "1990-01-02"
+
+
+def test_format_answer_value_integer():
+    assert _format_answer({"linkId": "x", "answer": [{"valueInteger": 42}]}) == "42"
+
+
+def test_format_answer_value_quantity():
+    formatted = _format_answer({"linkId": "x", "answer": [
+        {"valueQuantity": {"value": 130, "unit": "mmHg"}}]})
+    assert formatted == "130 mmHg"
+
+
+def test_format_answer_value_coding_uses_display():
+    formatted = _format_answer({"linkId": "x", "answer": [
+        {"valueCoding": {"system": "http://hl7.org/fhir/administrative-gender",
+                          "code": "female", "display": "Female"}}]})
+    assert formatted == "Female"
+
+
+def test_footer_text_includes_reviewed_on_when_provided():
+    footer = _footer_text("2026-07-10")
+    assert "2026-07-10" in footer
+    assert "Reviewed by patient on 2026-07-10" in footer
+    assert "not a medical record" in footer
+
+
+def test_footer_text_shows_not_yet_reviewed_when_absent():
+    footer = _footer_text(None)
+    assert "(not yet reviewed)" in footer
+
+
+def test_render_with_reviewed_on_does_not_raise():
+    pdf = render_questionnaire_response_pdf(_small_qr(), reviewed_on="2026-07-10")
+    assert pdf[:4] == b"%PDF"
+
+
+def test_render_uses_questionnaire_title_and_falls_back_to_linkid_labels():
+    questionnaire = {
+        "title": "HealthClaw Standard Intake",
+        "item": [
+            {
+                "linkId": "demographics",
+                "text": "Demographics",
+                "item": [
+                    {"linkId": "demographics.given-name", "text": "First name"},
+                ],
+            },
+        ],
+    }
+    # QR item omits `text` entirely — label must fall back to the Questionnaire's item text.
+    qr = {
+        "resourceType": "QuestionnaireResponse",
+        "item": [
+            {
+                "linkId": "demographics",
+                "item": [
+                    {"linkId": "demographics.given-name",
+                     "answer": [{"valueString": "Jane"}]},
+                ],
+            },
+        ],
+    }
+    pdf = render_questionnaire_response_pdf(qr, questionnaire=questionnaire,
+                                            subject_label="Jane Doe")
+    assert pdf[:4] == b"%PDF"
+
+
+def test_render_empty_qr_does_not_crash():
+    pdf = render_questionnaire_response_pdf(
+        {"resourceType": "QuestionnaireResponse", "item": []})
+    assert pdf[:4] == b"%PDF"


### PR DESCRIPTION
## Summary
- Adds `r6/sdc/pdf.py::render_questionnaire_response_pdf(questionnaire_response, questionnaire=None, *, reviewed_on=None, subject_label=None) -> bytes`, walking the QR item tree (sections → repeating groups → leaf answers) into a PDF via reportlab, reusing the `SimpleDocTemplate`/`Paragraph`/`Spacer` pattern from `r6/smbp/report.py`.
- **Unanswered leaf items render as a blank field (em dash), never omitted or defaulted.** This matters most for `allergies.no-known-allergies` (see `r6/sdc/intake.py` invariant): a blank must never be mistaken for an affirmative "Yes" — the PDF's `_format_answer` helper is unit-tested directly for this.
- **Provenance footer (required, safety):** every rendered PDF states "Populated from the patient's health records by an automated system. Reviewed by patient on {reviewed_on or '(not yet reviewed)'}. This is a draft intake form, not a medical record."
- Answer formatting covers `valueString`/`valueBoolean` ("Yes"/"No")/`valueDate`/`valueInteger`/`valueDecimal`/`valueQuantity` ("value unit")/`valueCoding` (display) etc.
- Title comes from the Questionnaire's `title` + optional `subject_label`; item labels prefer the QR item's own `text`, fall back to the Questionnaire's item text (matched by linkId), then linkId.

## Test plan
- [x] `uv run python -m pytest` — 1201 passed (baseline 1183 + 18 new tests in `tests/test_sdc_pdf.py`)
- [x] `uvx ruff check r6/ tests/ scripts/ main.py app.py` — clean
- reportlab compresses PDF content streams by default, so plain-text assertions against PDF bytes aren't reliable. Per the task guidance, tests instead: (a) assert PDF bytes are non-empty and start with `%PDF` for structural sanity (single QR, repeating medications x2/x4 scaling by size), and (b) unit-test the internal `_format_answer`/`_footer_text` helpers directly for the blank-vs-"Yes" and reviewed_on/"(not yet reviewed)" behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)