### PR TITLE
Forms rail (3/9): form-fill ActionExecutor skeleton (registered, fail-loud, honest needs_review placeholder)

### DIFF
--- a/r6/actions/rails/__init__.py
+++ b/r6/actions/rails/__init__.py
@@ -18,8 +18,10 @@ to reach a known-good registry state rather than relying on import order.
 Scope note: 'insurance-call' registers here too (Task 10) — a tiny subclass
 of PhoneCallExecutor in phone.py that only overrides kind (same Bland.ai
 transport; the insurance script source lives with the proposer). 'form-fill'
-stays unregistered on purpose: proposable, but Approve fails loud at the
-confirm route instead of pretending to execute.
+(Task 3) is also registered now, but its execute() is a skeleton: it fails
+loud without PUBLIC_BASE_URL and otherwise returns an honest needs_review
+placeholder — the full populate/review/render/DocumentReference orchestration
+lands in Task 8.
 """
 
 import logging
@@ -102,14 +104,14 @@ def reconcile_needs_review():
     return ExecutionResult(status='needs_review', outcome={'reason': 'reconcile_unreachable'})
 
 
-from r6.actions.rails import phone, sms  # noqa: E402  (registration side effect)
+from r6.actions.rails import form_fill, phone, sms  # noqa: E402  (registration side effect)
 
 
 def register_all():
     """(Re-)register every rail executor. Idempotent: safe to call after
     registry._clear(), and safe to call repeatedly — duplicate-kind
     registrations are swallowed."""
-    for module in (phone, sms):
+    for module in (phone, sms, form_fill):
         try:
             module.register()
         except ValueError:

--- a/r6/actions/rails/form_fill.py
+++ b/r6/actions/rails/form_fill.py
@@ -1,0 +1,67 @@
+"""form-fill rail — the ActionExecutor skeleton for kind 'form-fill'
+(Task 3). Registered so form-fill joins the action rail like phone-call and
+sms: it validates its payload shape and fails loud
+(ExecutionResult(status='failed', error=PROVIDER_NOT_CONFIGURED)) when
+PUBLIC_BASE_URL isn't configured, same fail-loud posture as the other
+rails.
+
+execute() is deliberately NOT the full orchestration yet. The real
+form-fill flow is populate -> human review -> render -> DocumentReference ->
+deliver a link built from PUBLIC_BASE_URL; that lands in Task 8. Until then,
+execute() returns an honest ExecutionResult(status='needs_review') — never
+a fabricated 'completed' — so a form-fill Approve is visibly incomplete
+rather than silently wrong.
+"""
+
+import os
+
+from r6.actions import errors
+from r6.actions.registry import ExecutionResult, register_executor
+
+
+class FormFillExecutor:
+    kind = 'form-fill'
+    # PUBLIC_BASE_URL is genuinely required: the delivery link handed to the
+    # patient/staff (and the render step in Task 8) is built from it, the
+    # same way the phone/sms webhook callback URLs are (see
+    # r6.actions.rails._webhook_url).
+    required_env = ('PUBLIC_BASE_URL',)
+
+    def validate(self, payload):
+        questionnaire = payload.get('questionnaire')
+        body = payload.get('body')
+        if (not isinstance(questionnaire, str) or not questionnaire
+                or not isinstance(body, str) or not body):
+            return [errors.PAYLOAD_INVALID]
+        return []
+
+    def execute(self, action):
+        # Env check comes before any payload-specific logic: a dark rail
+        # fails loud regardless of what the caller sent.
+        if not os.environ.get('PUBLIC_BASE_URL'):
+            return ExecutionResult(status='failed',
+                                   error=errors.PROVIDER_NOT_CONFIGURED)
+        # TODO(Task 8): populate -> human review -> render -> FHIR
+        # DocumentReference -> deliver a shareable link built from
+        # PUBLIC_BASE_URL. Until that lands, this is an honest placeholder:
+        # fail safe (needs_review), never a fake 'completed' PDF/link.
+        return ExecutionResult(
+            status='needs_review',
+            outcome={'reason': 'form-fill orchestration lands in Task 8'},
+        )
+
+    def reconcile(self, action):
+        # form-fill has no async provider webhook (unlike Bland.ai/Twilio),
+        # so there is no external status to poll. Keep it honest: report
+        # needs_review rather than inventing a verdict.
+        return ExecutionResult(
+            status='needs_review',
+            outcome={'reason': 'form-fill orchestration lands in Task 8'},
+        )
+
+
+def register():
+    register_executor(FormFillExecutor())
+
+
+register()

--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -78,9 +78,10 @@ def _emergency_refusal_or_none(tenant_id, text):
 
 
 def _rail_validation_or_none(kind, payload):
-    """Executor validation when a rail is registered for this kind. Kinds
-    with no rail (e.g. form-fill) skip this — VALID_KINDS remains the
-    propose gate; they fail loud at confirm instead."""
+    """Executor validation when a rail is registered for this kind. A
+    VALID_KINDS entry with no registered rail (none today; possible for a
+    future kind) skips this — VALID_KINDS remains the propose gate, and
+    such a kind fails loud at confirm instead."""
     ex = get_executor(kind)
     if ex is None:
         return None
@@ -523,9 +524,11 @@ def confirm_action(action_id):
                                         json.dumps(action.summary())),
     )
 
-    # (e) A kind with no registered rail fails loud — never a fake success
-    # (form-fill is proposable but not yet executable). Checked before the
-    # provider_request_at stamp: no provider call is even possible here.
+    # (e) A kind with no registered rail fails loud — never a fake success.
+    # Every VALID_KINDS entry has a rail today (form-fill's is a Task-3
+    # skeleton), so this is defensive for a future kind added to
+    # VALID_KINDS ahead of its rail. Checked before the provider_request_at
+    # stamp: no provider call is even possible here.
     ex = get_executor(action.kind)
     if ex is None:
         summary = 'No executor for kind: %s' % action.kind

--- a/tests/actions/test_confirm_is_commit.py
+++ b/tests/actions/test_confirm_is_commit.py
@@ -312,15 +312,18 @@ def test_commit_does_not_consume_token_only_confirm_does(
 # executor result mapping at confirm
 # ---------------------------------------------------------------------------
 
-def test_unregistered_kind_fails_loud_at_confirm(client, tenant_headers,
-                                                 auth_headers, app,
-                                                 action_registry,
-                                                 fake_providers):
-    """form-fill is a VALID_KIND with no rail — proposable, but Approve
-    fails loud instead of pretending."""
+def test_form_fill_without_public_base_url_fails_loud_at_confirm(
+        client, tenant_headers, auth_headers, app, action_registry,
+        fake_providers, monkeypatch):
+    """form-fill has a registered rail (Task 3), but it's a skeleton:
+    execute() fails loud instead of pretending when PUBLIC_BASE_URL isn't
+    configured — same fail-loud contract as an unregistered kind, now
+    routed through the executor itself rather than the no-executor path."""
+    monkeypatch.delenv('PUBLIC_BASE_URL', raising=False)
     action_id = _propose(client, tenant_headers, body={
         'kind': 'form-fill',
-        'payload': {'to': 'Intake portal', 'body': 'demographics form'},
+        'payload': {'to': 'Intake portal', 'questionnaire': 'healthclaw-intake',
+                    'body': 'demographics form'},
     })
     _commit(client, auth_headers, action_id)
     resp = _confirm(client, auth_headers, action_id)
@@ -330,7 +333,7 @@ def test_unregistered_kind_fails_loud_at_confirm(client, tenant_headers,
     with app.app_context():
         row = db.session.get(ProposedAction, action_id)
         assert row.status == 'failed'
-        assert 'form-fill' in row.outcome_summary
+        assert row.outcome_summary == errors.PROVIDER_NOT_CONFIGURED
 
 
 def test_needs_review_result_maps_to_needs_review(client, tenant_headers,

--- a/tests/actions/test_form_fill_executor.py
+++ b/tests/actions/test_form_fill_executor.py
@@ -1,0 +1,75 @@
+"""form-fill rail (Task 3) — registered ActionExecutor skeleton.
+
+execute() is intentionally NOT the full populate->review->render->
+DocumentReference->link orchestration (that's Task 8). This is the
+fail-loud/fail-safe shell: missing PUBLIC_BASE_URL is a loud failure, and
+even with it present the honest answer today is 'needs_review', never a
+fabricated 'completed'.
+"""
+from r6.actions import errors
+from r6.actions.registry import all_kinds, get_executor
+
+
+def test_form_fill_is_registered(action_registry):
+    assert 'form-fill' in all_kinds()
+
+
+def test_required_env_is_public_base_url(action_registry):
+    ex = get_executor('form-fill')
+    assert ex.required_env == ('PUBLIC_BASE_URL',)
+
+
+def test_validate_rejects_empty_payload(action_registry):
+    ex = get_executor('form-fill')
+    errs = ex.validate({})
+    assert isinstance(errs, list) and errs
+
+
+def test_validate_accepts_questionnaire_and_body(action_registry):
+    ex = get_executor('form-fill')
+    assert ex.validate({'questionnaire': 'healthclaw-intake', 'body': 'x'}) == []
+
+
+def test_validate_rejects_missing_questionnaire(action_registry):
+    ex = get_executor('form-fill')
+    errs = ex.validate({'body': 'x'})
+    assert isinstance(errs, list) and errs
+
+
+def test_validate_rejects_missing_body(action_registry):
+    ex = get_executor('form-fill')
+    errs = ex.validate({'questionnaire': 'healthclaw-intake'})
+    assert isinstance(errs, list) and errs
+
+
+class _Action:
+    def __init__(self, payload):
+        self.payload = payload
+        self.external_ref = None
+        self.id = 'test-action'
+        self.tenant_id = 'test-tenant'
+
+
+def test_execute_without_public_base_url_fails_loud(action_registry, monkeypatch):
+    monkeypatch.delenv('PUBLIC_BASE_URL', raising=False)
+    ex = get_executor('form-fill')
+    result = ex.execute(_Action({'questionnaire': 'healthclaw-intake', 'body': 'x'}))
+    assert result.status == 'failed'
+    assert result.error == errors.PROVIDER_NOT_CONFIGURED
+
+
+def test_execute_with_public_base_url_is_honest_needs_review(action_registry,
+                                                              monkeypatch):
+    """Orchestration lands in Task 8 — until then, execute() must never fake
+    a completed form. needs_review is the honest placeholder."""
+    monkeypatch.setenv('PUBLIC_BASE_URL', 'https://app.example.org')
+    ex = get_executor('form-fill')
+    result = ex.execute(_Action({'questionnaire': 'healthclaw-intake', 'body': 'x'}))
+    assert result.status == 'needs_review'
+    assert result.status != 'completed'
+
+
+def test_reconcile_is_honest_needs_review(action_registry):
+    ex = get_executor('form-fill')
+    result = ex.reconcile(_Action({'questionnaire': 'healthclaw-intake', 'body': 'x'}))
+    assert result.status in ('needs_review', 'completed', 'failed')


### PR DESCRIPTION
## Summary
- Adds `r6/actions/rails/form_fill.py` — `FormFillExecutor` (`kind = 'form-fill'`, `required_env = ('PUBLIC_BASE_URL',)`) and registers it in `register_all()`, so form-fill joins phone-call/sms/insurance-call in the action registry and now passes the generic `ActionExecutor` contract suite (`tests/actions/test_contract_generic.py`).
- `validate(payload)` requires `payload['questionnaire']` (string) and `payload['body']` (non-empty string); returns `errors.PAYLOAD_INVALID` otherwise.
- **`execute()` is a skeleton, not the real orchestration.** It checks `PUBLIC_BASE_URL` first (fails loud with `errors.PROVIDER_NOT_CONFIGURED` if unset, regardless of payload shape — same fail-loud posture as phone/sms) and otherwise returns an honest `ExecutionResult(status='needs_review', outcome={'reason': 'form-fill orchestration lands in Task 8'})`. It never fabricates a `completed` result. The full populate → human review → render → FHIR `DocumentReference` → deliver-link flow is Task 8 (tracked via a `TODO(Task 8)` comment in the file).
- `reconcile()` similarly returns an honest `needs_review` — form-fill has no async provider webhook to poll (unlike Bland.ai/Twilio).
- Updates the previously-accurate-but-now-stale comments/test that assumed form-fill had *no* rail: `r6/actions/routes.py` (`_rail_validation_or_none` docstring + the confirm-route "no registered rail" comment) and `tests/actions/test_confirm_is_commit.py` (renamed the test to `test_form_fill_without_public_base_url_fails_loud_at_confirm`, now proposes a valid form-fill payload and asserts the *same* 502/`PROVIDER_NOT_CONFIGURED` outcome, now reached via the registered executor's fail-loud path instead of the no-executor path).
- New `tests/actions/test_form_fill_executor.py`: registration, `validate` accept/reject cases, `required_env` shape, execute-without-`PUBLIC_BASE_URL` fails loud, execute-with-`PUBLIC_BASE_URL` is `needs_review` (never `completed`), reconcile is honest.

## Test plan
- [x] TDD: wrote failing tests first (`AttributeError: 'NoneType' object has no attribute 'execute'`), then implemented `FormFillExecutor` to green.
- [x] `uv run python -m pytest -q` → 1196 passed (baseline was 1183; +13 from the new form-fill test file and the generic contract suite now parametrizing over the `form-fill` kind).
- [x] `tests/actions/test_contract_generic.py` passes for `form-fill` (validate-rejects-empty, required_env-declared, reconcile-implemented, execute-without-credentials-fails-loud — including with a phone-shaped `{phone, body}` payload, confirming the env check runs before payload-specific logic).
- [x] `uvx ruff check r6/ tests/ scripts/ main.py app.py` → All checks passed.
- [x] `uv.lock` churn reverted before commit (no lockfile diff in the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)