### PR TITLE
Forms rail (2/9): populate meds/allergies/conditions from FHIR lists (NKA never inferred)

### DIFF
--- a/r6/sdc/intake.py
+++ b/r6/sdc/intake.py
@@ -12,9 +12,11 @@ Sections:
   - medications / allergies / conditions: repeating `<section>.item` groups
     structured with `definition` pointing at the relevant resource type
     (MedicationRequest / AllergyIntolerance / Condition). They intentionally
-    carry NO initialExpression yet — populate.py only matches Observations
-    by item.code and Patient-rooted FHIRPath today. Wiring these groups to
-    fill one repeat per matching list resource is Task 2.
+    carry NO initialExpression — populate.py (Task 2) fills them by matching
+    `definition` against list resources in the supplied content directly,
+    emitting one repeat per matching resource (see
+    r6/sdc/populate.py:_populate_list_group and
+    tests/test_populate_lists.py).
 
 NKA (no-known-allergies) invariant — READ THIS BEFORE TOUCHING
 `allergies.no-known-allergies`:
@@ -24,10 +26,14 @@ NKA (no-known-allergies) invariant — READ THIS BEFORE TOUCHING
     initialExpression, because silence about allergies is not consent —
     a default here would let the form-fill rail present "no known
     allergies" for a patient who was simply never asked, which is a
-    patient-safety hazard. Task 2's list-resource population must not
-    touch this item; it stays operator/patient-entered only.
+    patient-safety hazard. List-resource population (Task 2) never touches
+    this item — it only fills the repeating `allergies.item` group, and
+    zero AllergyIntolerance resources simply means zero repeats, never an
+    inferred answer here. It stays operator/patient-entered only.
     Enforced by tests/test_intake_questionnaire.py::
-    test_no_known_allergies_invariant_never_defaulted.
+    test_no_known_allergies_invariant_never_defaulted and
+    tests/test_populate_lists.py::
+    test_zero_allergies_never_infers_no_known_allergies.
 """
 
 import copy
@@ -43,8 +49,11 @@ INITIAL_EXPRESSION_URL = (
 # to Patient because demographics is the only section that both populates
 # and extracts correctly today. The `definition` values on the medications /
 # allergies / conditions items point at their real target resource types
-# (MedicationRequest / AllergyIntolerance / Condition) for Task 2 to wire up;
-# until then those items simply won't have answers for extract to touch.
+# (MedicationRequest / AllergyIntolerance / Condition) and populate.py (Task
+# 2) does fill answers for them from list resources — but extract.py's
+# single-target-type limitation means writing those answers back out to
+# MedicationRequest/AllergyIntolerance/Condition resources is still future
+# work, not this task.
 DEFINITION_EXTRACT_URL = (
     "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
     "sdc-questionnaire-definitionExtract"

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -1,11 +1,27 @@
 """SDC $populate engine — Questionnaire + subject + content -> QuestionnaireResponse.
 
-Pure function (no DB, no Flask). Supports two SDC population mechanisms:
+Pure function (no DB, no Flask). Supports three SDC population mechanisms:
   - Expression-based: items carrying an initialExpression (FHIRPath).
   - Observation-based: items with an item.code (LOINC) matched against
     Observations in the supplied content.
+  - List-resource-based: a `repeats: true` group whose leaves carry a
+    `definition` naming a supported resource type (MedicationRequest /
+    AllergyIntolerance / Condition) emits one repeat of the group per
+    matching resource for the subject (see _populate_list_group).
 
 Out of scope (v1): StructureMap-based and CQL populate.
+
+SAFETY INVARIANT — read before touching list-resource population:
+`allergies.no-known-allergies` (and `medications.no-current-medications`)
+must NEVER be auto-answered here. They carry no `code` and no
+initialExpression (see r6/sdc/intake.py), so the ordinary leaf-resolution
+path already leaves them unanswered — and list-group population (this
+module) only ever touches the *repeating* `<section>.item` groups, never
+those sibling booleans. Zero matching resources means the repeating group
+simply contributes zero repeats; it never flips a boolean to make up for
+the absence. Enforced by tests/test_populate_lists.py::
+test_zero_allergies_never_infers_no_known_allergies (the load-bearing one)
+and test_zero_medications_never_infers_no_current_medications.
 """
 
 from r6.sdc.expressions import build_context, evaluate
@@ -30,6 +46,111 @@ _ANSWER_KEY_BY_TYPE = {
 }
 
 
+def _codeable_concept_text(concept):
+    """Best-effort human text for a CodeableConcept: .text, else first coding.display."""
+    if not concept:
+        return None
+    text = concept.get("text")
+    if text:
+        return text
+    for coding in concept.get("coding", []):
+        display = coding.get("display")
+        if display:
+            return display
+    return None
+
+
+def _medication_name(resource):
+    return _codeable_concept_text(resource.get("medicationCodeableConcept"))
+
+
+def _medication_dose(resource):
+    instructions = resource.get("dosageInstruction") or []
+    if not instructions:
+        return None
+    return instructions[0].get("text")
+
+
+def _allergy_allergen(resource):
+    return _codeable_concept_text(resource.get("code"))
+
+
+def _allergy_reaction(resource):
+    for reaction in resource.get("reaction") or []:
+        for manifestation in reaction.get("manifestation") or []:
+            text = _codeable_concept_text(manifestation)
+            if text:
+                return text
+    return None
+
+
+def _condition_name(resource):
+    return _codeable_concept_text(resource.get("code"))
+
+
+_ACTIVE_MEDICATION_STATUSES = {"active", "on-hold"}
+_EXCLUDED_VERIFICATION_STATUSES = {"entered-in-error", "refuted"}
+_ACTIVE_CONDITION_CLINICAL_STATUSES = {"active", "recurrence", "relapse"}
+_CONFIRMED_CONDITION_VERIFICATION_STATUSES = {"confirmed", "provisional", "differential"}
+
+
+def _status_codes(resource, field):
+    return {c.get("code") for c in (resource.get(field) or {}).get("coding", [])}
+
+
+def _medication_request_included(resource):
+    return resource.get("status") in _ACTIVE_MEDICATION_STATUSES
+
+
+def _allergy_intolerance_included(resource):
+    verification = _status_codes(resource, "verificationStatus")
+    return not (verification & _EXCLUDED_VERIFICATION_STATUSES)
+
+
+def _condition_included(resource):
+    clinical = _status_codes(resource, "clinicalStatus")
+    verification = _status_codes(resource, "verificationStatus")
+    if clinical and not (clinical & _ACTIVE_CONDITION_CLINICAL_STATUSES):
+        return False
+    if verification and not (verification & _CONFIRMED_CONDITION_VERIFICATION_STATUSES):
+        return False
+    return True
+
+
+# Per-resource-type: which element (definition path) resolves to which value,
+# which field on the resource holds the subject reference (R4 is
+# inconsistent here — AllergyIntolerance uses `patient`, not `subject`), and
+# a status/verification filter deciding whether a resource is "current"
+# enough to surface on the intake form. These map the *concrete* element
+# paths used by r6/sdc/intake.py — this is intentionally not a general
+# FHIRPath engine (see module docstring).
+_LIST_RESOURCE_CONFIG = {
+    "MedicationRequest": {
+        "subject_field": "subject",
+        "included": _medication_request_included,
+        "resolvers": {
+            "medicationCodeableConcept.text": _medication_name,
+            "dosageInstruction.text": _medication_dose,
+        },
+    },
+    "AllergyIntolerance": {
+        "subject_field": "patient",
+        "included": _allergy_intolerance_included,
+        "resolvers": {
+            "code.text": _allergy_allergen,
+            "reaction.manifestation.text": _allergy_reaction,
+        },
+    },
+    "Condition": {
+        "subject_field": "subject",
+        "included": _condition_included,
+        "resolvers": {
+            "code.text": _condition_name,
+        },
+    },
+}
+
+
 def populate_questionnaire(questionnaire, subject, content_resources):
     """Return (questionnaire_response, issues).
 
@@ -47,9 +168,8 @@ def populate_questionnaire(questionnaire, subject, content_resources):
 
     answer_items = []
     for item in questionnaire.get("item", []):
-        populated = _populate_item(item, subject, context, observations, issues)
-        if populated is not None:
-            answer_items.append(populated)
+        answer_items.extend(_populate_item(
+            item, subject, context, observations, issues, content_resources))
 
     qr = {
         "resourceType": "QuestionnaireResponse",
@@ -63,21 +183,29 @@ def populate_questionnaire(questionnaire, subject, content_resources):
     return qr, issues
 
 
-def _populate_item(item, subject, context, observations, issues):
+def _populate_item(item, subject, context, observations, issues, content_resources):
+    """Populate one questionnaire item. Always returns a list of zero or more
+    QuestionnaireResponse items (zero or one for ordinary items; zero or many
+    for a repeating list-resource group — one per matching resource).
+    """
     link_id = item.get("linkId")
     item_type = item.get("type")
 
-    # Group: recurse, keep the group only if it produced child answers.
     if item_type == "group":
+        list_resource_type = _list_group_resource_type(item)
+        if item.get("repeats") and list_resource_type:
+            return _populate_list_group(item, list_resource_type, subject,
+                                        content_resources)
+        # Ordinary group: recurse, keep the group only if it produced
+        # child answers.
         children = []
         for child in item.get("item", []):
-            populated = _populate_item(child, subject, context,
-                                       observations, issues)
-            if populated is not None:
-                children.append(populated)
+            children.extend(_populate_item(
+                child, subject, context, observations, issues,
+                content_resources))
         if not children:
-            return None
-        return {"linkId": link_id, "item": children}
+            return []
+        return [{"linkId": link_id, "item": children}]
 
     answer_value, value_key = _resolve_answer(
         item, item_type, context, observations, issues, link_id)
@@ -86,7 +214,78 @@ def _populate_item(item, subject, context, observations, issues):
     answer_item = {"linkId": link_id}
     if answer_value is not None:
         answer_item["answer"] = [{value_key: answer_value}]
-    return answer_item
+    return [answer_item]
+
+
+def _list_group_resource_type(item):
+    """Return the resource type this group's leaves are `definition`-linked
+    to, if it's a recognized list-resource group (see _LIST_RESOURCE_CONFIG);
+    None otherwise.
+    """
+    for child in item.get("item", []):
+        resource_type, _element_path = _parse_definition(child.get("definition"))
+        if resource_type in _LIST_RESOURCE_CONFIG:
+            return resource_type
+    return None
+
+
+def _parse_definition(definition):
+    """Split a `<StructureDefinition url>#<Type>.<element.path>` definition
+    into (resource_type, element_path). Returns (None, None) if not parseable.
+    """
+    if not definition or "#" not in definition:
+        return None, None
+    path = definition.split("#", 1)[1]
+    parts = path.split(".", 1)
+    if len(parts) != 2:
+        return None, None
+    return parts[0], parts[1]
+
+
+def _populate_list_group(item, resource_type, subject, content_resources):
+    """Emit one repeat of `item` per matching, currently-relevant resource of
+    `resource_type` for `subject`. Returns [] when there are none — an empty
+    repeating group, never a default answer for a sibling item (see module
+    docstring's safety invariant).
+    """
+    config = _LIST_RESOURCE_CONFIG[resource_type]
+    subject_ref = _reference(subject)
+    resources = [
+        r for r in (content_resources or [])
+        if r.get("resourceType") == resource_type
+        and _references_subject(r, config["subject_field"], subject_ref)
+        and config["included"](r)
+    ]
+
+    repeats = []
+    for resource in resources:
+        children = []
+        for child in item.get("item", []):
+            child_resource_type, element_path = _parse_definition(
+                child.get("definition"))
+            resolver = None
+            if child_resource_type == resource_type:
+                resolver = config["resolvers"].get(element_path)
+            value = resolver(resource) if resolver else None
+            child_item = {"linkId": child.get("linkId")}
+            if value is not None:
+                value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
+                child_item["answer"] = [{value_key: value}]
+            children.append(child_item)
+        repeats.append({"linkId": item.get("linkId"), "item": children})
+    return repeats
+
+
+def _references_subject(resource, subject_field, subject_ref):
+    """True if `resource[subject_field].reference` matches subject_ref, or if
+    there's no subject_ref to check against (permissive, matching the
+    existing Observation-matching behavior which doesn't filter by subject
+    either — content_resources is the caller's scoping responsibility).
+    """
+    if not subject_ref:
+        return True
+    ref = (resource.get(subject_field) or {}).get("reference")
+    return ref == subject_ref.get("reference")
 
 
 def _resolve_answer(item, item_type, context, observations, issues, link_id):

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -174,7 +174,9 @@ def register_sdc_routes(blueprint, deps):
         if subject:
             content.append(subject)
         if subject and subject.get("id"):
-            content.extend(_load_observations(subject["id"], tenant_id))
+            for resource_type, subject_field in _AUTO_LOADED_RESOURCE_TYPES:
+                content.extend(_load_resources_for_patient(
+                    resource_type, subject_field, subject["id"], tenant_id))
         bundle = _param_resource(params, "content")
         if bundle and bundle.get("resourceType") == "Bundle":
             content.extend(e["resource"] for e in bundle.get("entry", [])
@@ -212,15 +214,29 @@ def _load_stored(resource_type, resource_id, tenant_id):
     return row.to_fhir_json() if row else None
 
 
-def _load_observations(patient_id, tenant_id):
+# Resource types $populate auto-loads for the subject, alongside the field
+# each one uses to reference its patient (R4 is inconsistent here —
+# AllergyIntolerance uses `patient`, everything else here uses `subject`).
+# MedicationRequest/AllergyIntolerance/Condition feed r6/sdc/populate.py's
+# list-resource population (medications/allergies/conditions repeating
+# groups on the intake Questionnaire); Observation feeds item.code matching.
+_AUTO_LOADED_RESOURCE_TYPES = [
+    ("Observation", "subject"),
+    ("MedicationRequest", "subject"),
+    ("AllergyIntolerance", "patient"),
+    ("Condition", "subject"),
+]
+
+
+def _load_resources_for_patient(resource_type, subject_field, patient_id, tenant_id):
     rows = R6Resource.query.filter_by(
-        resource_type="Observation", tenant_id=tenant_id).all()
+        resource_type=resource_type, tenant_id=tenant_id).all()
     out = []
     ref = f"Patient/{patient_id}"
     for row in rows:
-        obs = row.to_fhir_json()
-        if obs.get("subject", {}).get("reference") == ref:
-            out.append(obs)
+        resource = row.to_fhir_json()
+        if resource.get(subject_field, {}).get("reference") == ref:
+            out.append(resource)
     return out
 
 

--- a/tests/test_intake_questionnaire.py
+++ b/tests/test_intake_questionnaire.py
@@ -8,8 +8,11 @@ Covers:
   - The NKA (no-known-allergies) invariant: it is a distinct affirmative
     attestation, never defaulted and never inferrable from absent data.
   - $populate still runs end-to-end against the new Questionnaire and mirrors
-    its structure in the QuestionnaireResponse, even though meds/allergies/
-    conditions won't actually fill until Task 2 wires list-resource matching.
+    its structure in the QuestionnaireResponse. List-resource population
+    itself (filling medications/allergies/conditions from FHIR resources) is
+    covered in tests/test_populate_lists.py (Task 2); this file only checks
+    that, absent any list resources, those groups populate to zero repeats
+    rather than fabricating anything.
 """
 
 from r6.sdc.intake import intake_questionnaire
@@ -191,17 +194,20 @@ def test_populate_mirrors_new_structure():
                   if i["linkId"] == "demographics.family-name")
     assert family["answer"][0]["valueString"] == "Lovelace"
 
-    # Meds/allergies/conditions groups don't populate yet (Task 2), but the
-    # leaf items still mirror the questionnaire's structure with no answer.
+    # No MedicationRequest/AllergyIntolerance/Condition resources were
+    # supplied, so the repeating medications.item/allergies.item groups
+    # populate to zero repeats (Task 2: list-resource population never
+    # fabricates a repeat, and absence of data never flips a sibling
+    # boolean — see test_populate_lists.py for the full Task 2 coverage).
     meds_group = next(i for i in qr["item"] if i["linkId"] == "medications")
-    meds_repeat = next(i for i in meds_group["item"]
-                        if i["linkId"] == "medications.item")
-    meds_name = next(i for i in meds_repeat["item"]
-                      if i["linkId"] == "medications.item.name")
-    assert "answer" not in meds_name
+    assert all(i["linkId"] != "medications.item" for i in meds_group["item"])
+    no_current_meds = next(i for i in meds_group["item"]
+                            if i["linkId"] == "medications.no-current-medications")
+    assert "answer" not in no_current_meds
 
     allergies_group = next(i for i in qr["item"]
                             if i["linkId"] == "allergies")
+    assert all(i["linkId"] != "allergies.item" for i in allergies_group["item"])
     nka = next(i for i in allergies_group["item"]
                if i["linkId"] == "allergies.no-known-allergies")
     assert "answer" not in nka

--- a/tests/test_populate_lists.py
+++ b/tests/test_populate_lists.py
@@ -1,0 +1,272 @@
+"""Tests for populate.py's list-resource population (forms rail Task 2).
+
+Covers filling the intake Questionnaire's repeating medications / allergies /
+conditions groups from a subject's MedicationRequest / AllergyIntolerance /
+Condition resources.
+
+THE LOAD-BEARING SAFETY INVARIANT: `allergies.no-known-allergies` (and
+similarly `medications.no-current-medications`) must NEVER be auto-answered
+by populate — not `true`, not `false`, no `answer` key at all — regardless
+of whether the patient has any allergies/medications on file. Absent data is
+not consent to a "no known allergies" attestation; only a human can make
+that call (Task 6). See test_zero_allergies_never_infers_no_known_allergies
+below, which is the point of this whole file.
+"""
+
+from r6.sdc.intake import intake_questionnaire
+from r6.sdc.populate import populate_questionnaire
+
+
+PATIENT = {
+    "resourceType": "Patient",
+    "id": "p1",
+    "name": [{"given": ["Ada"], "family": "Lovelace"}],
+    "birthDate": "1815-12-10",
+    "gender": "female",
+}
+
+
+def _walk(items):
+    for item in items:
+        yield item
+        if "item" in item:
+            yield from _walk(item["item"])
+
+
+def _by_link_id(qr, link_id):
+    """Return the first item with this linkId (groups may repeat)."""
+    for item in _walk(qr.get("item", [])):
+        if item.get("linkId") == link_id:
+            return item
+    return None
+
+
+def _all_by_link_id(qr, link_id):
+    return [item for item in _walk(qr.get("item", [])) if item.get("linkId") == link_id]
+
+
+def _med_request(rid, display, status="active", dose=None):
+    resource = {
+        "resourceType": "MedicationRequest",
+        "id": rid,
+        "status": status,
+        "intent": "order",
+        "subject": {"reference": "Patient/p1"},
+        "medicationCodeableConcept": {
+            "coding": [{"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                        "code": "0000", "display": display}],
+        },
+    }
+    if dose:
+        resource["dosageInstruction"] = [{"text": dose}]
+    return resource
+
+
+def _allergy(rid, allergen, reaction=None):
+    resource = {
+        "resourceType": "AllergyIntolerance",
+        "id": rid,
+        "patient": {"reference": "Patient/p1"},
+        "code": {"text": allergen},
+    }
+    if reaction:
+        resource["reaction"] = [{"manifestation": [{"text": reaction}]}]
+    return resource
+
+
+def _condition(rid, name):
+    return {
+        "resourceType": "Condition",
+        "id": rid,
+        "subject": {"reference": "Patient/p1"},
+        "clinicalStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            "code": "active"}]},
+        "verificationStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "code": "confirmed"}]},
+        "code": {"text": name},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Medications populate from active MedicationRequests
+# ---------------------------------------------------------------------------
+
+def test_two_active_medications_populate_two_repeats():
+    q = intake_questionnaire()
+    meds = [
+        _med_request("m1", "Metformin 500 MG Oral Tablet", dose="Twice daily"),
+        _med_request("m2", "Lisinopril 10 MG Oral Tablet"),
+    ]
+    content = [PATIENT] + meds
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    repeats = _all_by_link_id(qr, "medications.item")
+    assert len(repeats) == 2
+    names = {
+        next(c["answer"][0]["valueString"] for c in r["item"]
+             if c["linkId"] == "medications.item.name")
+        for r in repeats
+    }
+    assert names == {"Metformin 500 MG Oral Tablet", "Lisinopril 10 MG Oral Tablet"}
+
+    dosed = next(r for r in repeats
+                 if any(c["linkId"] == "medications.item.name"
+                        and c["answer"][0]["valueString"] == "Metformin 500 MG Oral Tablet"
+                        for c in r["item"]))
+    dose_item = next(c for c in dosed["item"] if c["linkId"] == "medications.item.dose")
+    assert dose_item["answer"][0]["valueString"] == "Twice daily"
+    assert issues == []
+
+
+def test_inactive_medications_excluded():
+    q = intake_questionnaire()
+    meds = [
+        _med_request("m1", "Metformin 500 MG Oral Tablet", status="active"),
+        _med_request("m2", "Old Stopped Drug", status="stopped"),
+        _med_request("m3", "Cancelled Drug", status="cancelled"),
+    ]
+    content = [PATIENT] + meds
+
+    qr, _issues = populate_questionnaire(q, PATIENT, content)
+
+    repeats = _all_by_link_id(qr, "medications.item")
+    assert len(repeats) == 1
+    name_item = next(c for c in repeats[0]["item"] if c["linkId"] == "medications.item.name")
+    assert name_item["answer"][0]["valueString"] == "Metformin 500 MG Oral Tablet"
+
+
+# ---------------------------------------------------------------------------
+# 2 & 3. Allergies populate + the load-bearing NKA invariant
+# ---------------------------------------------------------------------------
+
+def test_one_allergy_populates_and_nka_stays_unanswered():
+    q = intake_questionnaire()
+    content = [PATIENT, _allergy("a1", "Penicillin", reaction="Hives")]
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    repeats = _all_by_link_id(qr, "allergies.item")
+    assert len(repeats) == 1
+    allergen = next(c for c in repeats[0]["item"] if c["linkId"] == "allergies.item.allergen")
+    assert allergen["answer"][0]["valueString"] == "Penicillin"
+    reaction = next(c for c in repeats[0]["item"] if c["linkId"] == "allergies.item.reaction")
+    assert reaction["answer"][0]["valueString"] == "Hives"
+
+    nka = _by_link_id(qr, "allergies.no-known-allergies")
+    assert "answer" not in nka
+    assert issues == []
+
+
+def test_zero_allergies_never_infers_no_known_allergies():
+    """THE LOAD-BEARING TEST.
+
+    Zero AllergyIntolerance resources must NOT cause the engine to answer
+    `allergies.no-known-allergies` with true, false, or anything at all.
+    Absent data is not an attestation. A human must affirm NKA explicitly
+    (Task 6's review step) — populate must never do it on their behalf.
+    """
+    q = intake_questionnaire()
+    content = [PATIENT]  # no AllergyIntolerance resources whatsoever
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    nka = _by_link_id(qr, "allergies.no-known-allergies")
+    assert nka is not None
+    assert "answer" not in nka, (
+        "allergies.no-known-allergies must never be auto-answered — absent "
+        "allergy data is not consent to a no-known-allergies attestation"
+    )
+
+    # The allergies repeating group produced zero repeats — it's empty, not
+    # defaulted to anything.
+    assert _all_by_link_id(qr, "allergies.item") == []
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Medications: same absent-data-is-not-inference principle
+# ---------------------------------------------------------------------------
+
+def test_zero_medications_never_infers_no_current_medications():
+    q = intake_questionnaire()
+    content = [PATIENT]  # no MedicationRequest resources whatsoever
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    no_current = _by_link_id(qr, "medications.no-current-medications")
+    assert no_current is not None
+    assert "answer" not in no_current
+
+    assert _all_by_link_id(qr, "medications.item") == []
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Conditions populate
+# ---------------------------------------------------------------------------
+
+def test_three_conditions_populate_three_repeats():
+    q = intake_questionnaire()
+    conditions = [
+        _condition("c1", "Type 2 diabetes mellitus"),
+        _condition("c2", "Essential hypertension"),
+        _condition("c3", "Hyperlipidemia"),
+    ]
+    content = [PATIENT] + conditions
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    repeats = _all_by_link_id(qr, "conditions.item")
+    assert len(repeats) == 3
+    names = {
+        next(c["answer"][0]["valueString"] for c in r["item"]
+             if c["linkId"] == "conditions.item.name")
+        for r in repeats
+    }
+    assert names == {"Type 2 diabetes mellitus", "Essential hypertension",
+                      "Hyperlipidemia"}
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Regression: existing Observation/demographics population still works
+# ---------------------------------------------------------------------------
+
+def test_demographics_and_observations_regression():
+    q = intake_questionnaire()
+    patient = dict(PATIENT, telecom=[{"system": "phone", "value": "617-555-0198"}],
+                   address=[{"line": ["123 Clinical Ave"], "city": "Boston",
+                             "state": "MA", "postalCode": "02101"}])
+    content = [patient]
+
+    qr, issues = populate_questionnaire(q, patient, content)
+
+    given = _by_link_id(qr, "demographics.given-name")
+    assert given["answer"][0]["valueString"] == "Ada"
+    family = _by_link_id(qr, "demographics.family-name")
+    assert family["answer"][0]["valueString"] == "Lovelace"
+    dob = _by_link_id(qr, "demographics.birth-date")
+    assert dob["answer"][0]["valueDate"] == "1815-12-10"
+    assert issues == []
+
+
+def test_all_three_lists_populate_together_and_nka_still_unanswered():
+    q = intake_questionnaire()
+    content = [
+        PATIENT,
+        _med_request("m1", "Metformin 500 MG Oral Tablet"),
+        _allergy("a1", "Penicillin"),
+        _condition("c1", "Type 2 diabetes mellitus"),
+    ]
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    assert len(_all_by_link_id(qr, "medications.item")) == 1
+    assert len(_all_by_link_id(qr, "allergies.item")) == 1
+    assert len(_all_by_link_id(qr, "conditions.item")) == 1
+    nka = _by_link_id(qr, "allergies.no-known-allergies")
+    assert "answer" not in nka
+    assert issues == []

--- a/tests/test_sdc_routes.py
+++ b/tests/test_sdc_routes.py
@@ -47,6 +47,95 @@ def test_populate_by_id(client, app, tenant_id, tenant_headers):
     assert qr["item"][0]["answer"][0]["valueString"] == "Ada"
 
 
+def test_populate_auto_loads_medications_allergies_conditions(
+        client, app, tenant_id, tenant_headers):
+    """$populate over the API (not just the pure populate_questionnaire
+    function) should auto-load a patient's MedicationRequest/
+    AllergyIntolerance/Condition resources from the tenant store, the same
+    way it already auto-loads Observations — the forms rail isn't complete
+    if a caller has to hand-assemble a content Bundle just to see a
+    patient's med list.
+    """
+    _store(app, {"resourceType": "Patient", "id": "p1",
+                 "name": [{"given": ["Ada"]}]}, tenant_id)
+    _store(app, {"resourceType": "MedicationRequest", "id": "m1",
+                 "status": "active", "intent": "order",
+                 "subject": {"reference": "Patient/p1"},
+                 "medicationCodeableConcept": {"text": "Metformin"}},
+           tenant_id)
+    _store(app, {"resourceType": "AllergyIntolerance", "id": "a1",
+                 "patient": {"reference": "Patient/p1"},
+                 "code": {"text": "Penicillin"}}, tenant_id)
+    _store(app, {"resourceType": "Condition", "id": "c1",
+                 "subject": {"reference": "Patient/p1"},
+                 "clinicalStatus": {"coding": [{"code": "active"}]},
+                 "verificationStatus": {"coding": [{"code": "confirmed"}]},
+                 "code": {"text": "Type 2 diabetes"}}, tenant_id)
+    _store(app, {"resourceType": "Questionnaire", "id": "healthclaw-intake",
+                 "status": "active",
+                 "item": [
+                     {"linkId": "medications", "type": "group", "item": [
+                         {"linkId": "medications.item", "type": "group",
+                          "repeats": True, "item": [
+                              {"linkId": "medications.item.name",
+                               "type": "string",
+                               "definition":
+                                   "http://hl7.org/fhir/StructureDefinition/"
+                                   "MedicationRequest#MedicationRequest."
+                                   "medicationCodeableConcept.text"}]}]},
+                     {"linkId": "allergies", "type": "group", "item": [
+                         {"linkId": "allergies.no-known-allergies",
+                          "type": "boolean"},
+                         {"linkId": "allergies.item", "type": "group",
+                          "repeats": True, "item": [
+                              {"linkId": "allergies.item.allergen",
+                               "type": "string",
+                               "definition":
+                                   "http://hl7.org/fhir/StructureDefinition/"
+                                   "AllergyIntolerance#AllergyIntolerance."
+                                   "code.text"}]}]},
+                     {"linkId": "conditions", "type": "group", "item": [
+                         {"linkId": "conditions.item", "type": "group",
+                          "repeats": True, "item": [
+                              {"linkId": "conditions.item.name",
+                               "type": "string",
+                               "definition":
+                                   "http://hl7.org/fhir/StructureDefinition/"
+                                   "Condition#Condition.code.text"}]}]},
+                 ]},
+           tenant_id)
+
+    resp = client.post(
+        "/r6/fhir/Questionnaire/healthclaw-intake/$populate",
+        headers=tenant_headers,
+        json={"resourceType": "Parameters",
+              "parameter": [{"name": "subject",
+                             "valueReference": {"reference": "Patient/p1"}}]},
+    )
+
+    assert resp.status_code == 200
+    qr = _param(resp.get_json(), "response")
+
+    def by_link_id(items, link_id):
+        for item in items:
+            if item["linkId"] == link_id:
+                return item
+            if "item" in item:
+                found = by_link_id(item["item"], link_id)
+                if found:
+                    return found
+        return None
+
+    med_name = by_link_id(qr["item"], "medications.item.name")
+    assert med_name["answer"][0]["valueString"] == "Metformin"
+    allergen = by_link_id(qr["item"], "allergies.item.allergen")
+    assert allergen["answer"][0]["valueString"] == "Penicillin"
+    nka = by_link_id(qr["item"], "allergies.no-known-allergies")
+    assert "answer" not in nka
+    condition_name = by_link_id(qr["item"], "conditions.item.name")
+    assert condition_name["answer"][0]["valueString"] == "Type 2 diabetes"
+
+
 def test_extract_requires_step_up(client, tenant_headers):
     resp = client.post(
         "/r6/fhir/QuestionnaireResponse/$extract",


### PR DESCRIPTION
## Summary

Task 2 of the forms rail: extends `populate_questionnaire` (`r6/sdc/populate.py`) so the intake Questionnaire's repeating `medications.item` / `allergies.item` / `conditions.item` groups fill from a patient's `MedicationRequest` / `AllergyIntolerance` / `Condition` resources — one repeat per matching resource, resolved via each leaf's `definition` element path (a small concrete resolver table per resource type, not a general FHIRPath engine, per the task's scope). Also generalizes `r6/sdc/routes.py`'s content auto-load (previously Observation-only) to the same three resource types, so `$populate` over the API delivers this without a caller hand-assembling a `content` Bundle.

- **Medications**: one repeat per `MedicationRequest` with status `active`/`on-hold` (stopped/cancelled/entered-in-error excluded); fills `medications.item.name` (medication text or coding display) and `medications.item.dose` (first `dosageInstruction.text`).
- **Allergies**: one repeat per `AllergyIntolerance` (excludes `verificationStatus` `entered-in-error`/`refuted`); fills allergen + first reaction manifestation text.
- **Conditions**: one repeat per `Condition` with active-ish `clinicalStatus` and confirmed-ish `verificationStatus` (lenient when either is absent).

## THE SAFETY INVARIANT — the point of this PR

`allergies.no-known-allergies` (and `medications.no-current-medications`) is **never** touched by list-resource population:

- Patient has allergies on file → the group populates; NKA stays unanswered.
- Patient has **zero** `AllergyIntolerance` resources → the repeating group emits **zero repeats** — it does not flip NKA to `true`, does not flip it to `false`, does not add any `answer` at all. Absent data ≠ consent to a "no known allergies" attestation. A human affirms it explicitly later (Task 6's review step).

This works because the population logic for a repeating group only ever produces repeats of `<section>.item` — it structurally cannot touch the sibling boolean leaf, which has no `code` and no `initialExpression` (unchanged from Task 1) and so is never auto-answered by the ordinary leaf path either. Both invariants are enforced by explicit tests:

- `tests/test_populate_lists.py::test_zero_allergies_never_infers_no_known_allergies` — **the load-bearing test**, asserts no `answer` key at all on `allergies.no-known-allergies` when there are zero `AllergyIntolerance` resources.
- `tests/test_populate_lists.py::test_zero_medications_never_infers_no_current_medications` — same principle for meds.

## Test plan

- [x] TDD: wrote `tests/test_populate_lists.py` first, confirmed all 6 new scenarios fail against the old engine, then implemented.
- [x] `tests/test_intake_questionnaire.py::test_populate_mirrors_new_structure` updated — a zero-resource populate now correctly produces zero repeats for `medications.item`/`allergies.item` (previously it asserted a stale Task-1-era unfilled-template shape).
- [x] `tests/test_sdc_routes.py` — new `test_populate_auto_loads_medications_allergies_conditions` covers the route-level auto-load end-to-end.
- [x] Full suite: `uv run python -m pytest tests/ -q` → **1192 passed** (baseline 1183 + 9 new).
- [x] `uvx ruff check r6/ tests/ scripts/ main.py app.py` → clean.
- [x] `uv.lock` churn (version bump from `uv run`) left out of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)