### PR TITLE
Forms rail (5/9): DocumentReference persistence with embedded PDF bytes

### DIFF
--- a/r6/sdc/documents.py
+++ b/r6/sdc/documents.py
@@ -1,0 +1,93 @@
+"""Persist a completed intake PDF as a FHIR DocumentReference.
+
+persist_intake_document() embeds the actual PDF bytes (base64, per FHIR's
+Attachment.data) in content[0].attachment.data — not just a byte count —
+so the rendered PDF (r6/sdc/pdf.py::render_questionnaire_response_pdf) can
+be retrieved later for delivery (Task 7) without re-rendering.
+
+Mirrors r6/smbp/routes.py::_persist_document_reference's DocumentReference
+shape, generalized to carry the bytes and to optionally link back to the
+QuestionnaireResponse the PDF was rendered from.
+"""
+
+import base64
+import json
+from datetime import datetime, timezone
+
+from models import db
+from r6.models import R6Resource
+from r6.audit import record_audit_event
+
+# LOINC "Summarization of episode note" — a generic document-summary type
+# code commonly used for rendered clinical/administrative documents (CCD-style
+# summaries) when no more specific LOINC code applies. Mirrors the smbp
+# report's use of a LOINC coding for its DocumentReference.type.
+_INTAKE_DOCUMENT_TYPE = {
+    "coding": [{"system": "http://loinc.org", "code": "34133-9",
+                "display": "Summarization of episode note"}]
+}
+
+
+def persist_intake_document(tenant_id, subject_ref, pdf_bytes, *, title=None,
+                             questionnaire_response_id=None):
+    """Persist `pdf_bytes` as a FHIR DocumentReference under `tenant_id`.
+
+    subject_ref: e.g. "Patient/123" — stored as DocumentReference.subject.
+    title: attachment title; defaults to "Intake form".
+    questionnaire_response_id: if provided, links the DocumentReference back
+        to the QuestionnaireResponse the PDF was rendered from via both
+        context.related and relatesTo, so the structured QR and the rendered
+        PDF can be traced to each other.
+
+    Returns the stored DocumentReference resource dict (with id/meta).
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    doc = {
+        "resourceType": "DocumentReference",
+        "status": "current",
+        "type": _INTAKE_DOCUMENT_TYPE,
+        "subject": {"reference": subject_ref},
+        "date": now,
+        "content": [{
+            "attachment": {
+                "contentType": "application/pdf",
+                "title": title or "Intake form",
+                "size": len(pdf_bytes),
+                "data": base64.b64encode(pdf_bytes).decode("ascii"),
+            }
+        }],
+    }
+    if questionnaire_response_id:
+        qr_reference = f"QuestionnaireResponse/{questionnaire_response_id}"
+        doc["context"] = {"related": [{"reference": qr_reference}]}
+        doc["relatesTo"] = [{"code": "transforms",
+                             "target": {"reference": qr_reference}}]
+
+    row = R6Resource(resource_type="DocumentReference",
+                     resource_json=json.dumps(doc), tenant_id=tenant_id)
+    db.session.add(row)
+    db.session.commit()
+    record_audit_event("create", "DocumentReference", row.id,
+                       tenant_id=tenant_id, detail="intake pdf persisted")
+    return row.to_fhir_json()
+
+
+def get_document_pdf_bytes(tenant_id, docref_id):
+    """Load the DocumentReference `docref_id` under `tenant_id` and decode
+    its embedded PDF bytes back out of content[0].attachment.data.
+
+    Returns None if the DocumentReference doesn't exist for that tenant, or
+    has no embedded attachment data.
+    """
+    row = R6Resource.query.filter_by(resource_type="DocumentReference",
+                                     id=docref_id, tenant_id=tenant_id).first()
+    if row is None:
+        return None
+    resource = row.to_fhir_json()
+    content = resource.get("content") or []
+    if not content:
+        return None
+    data = (content[0].get("attachment") or {}).get("data")
+    if not data:
+        return None
+    return base64.b64decode(data)

--- a/tests/test_sdc_documents.py
+++ b/tests/test_sdc_documents.py
@@ -1,0 +1,143 @@
+"""Tests for r6/sdc/documents.py — DocumentReference persistence with
+embedded PDF bytes (base64 Attachment.data) and the round-trip getter used
+by the delivery route (Task 7)."""
+
+import base64
+
+from r6.sdc.documents import persist_intake_document, get_document_pdf_bytes
+
+PDF_BYTES = b"%PDF-1.4 test bytes"
+OTHER_TENANT = "other-tenant"
+
+
+def test_persist_stores_documentreference_retrievable_by_id(app):
+    with app.app_context():
+        from r6.models import R6Resource
+
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES, title="My Intake")
+
+        assert resource["resourceType"] == "DocumentReference"
+        assert resource["status"] == "current"
+        assert resource["subject"]["reference"] == "Patient/123"
+
+        row = R6Resource.query.filter_by(
+            resource_type="DocumentReference", id=resource["id"],
+            tenant_id="test-tenant").first()
+        assert row is not None
+
+
+def test_attachment_content_type_and_size(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        attachment = resource["content"][0]["attachment"]
+        assert attachment["contentType"] == "application/pdf"
+        assert attachment["size"] == len(PDF_BYTES)
+
+
+def test_attachment_data_is_base64_and_decodes_to_exact_bytes(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        attachment = resource["content"][0]["attachment"]
+        data = attachment["data"]
+        # Valid base64 — round-trips without raising, and matches the input.
+        decoded = base64.b64decode(data, validate=True)
+        assert decoded == PDF_BYTES
+
+
+def test_title_defaults_when_not_provided(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        assert resource["content"][0]["attachment"]["title"] == "Intake form"
+
+
+def test_title_uses_provided_value(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES, title="Custom Title")
+        assert resource["content"][0]["attachment"]["title"] == "Custom Title"
+
+
+def test_get_document_pdf_bytes_round_trips_exact_bytes(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        fetched = get_document_pdf_bytes("test-tenant", resource["id"])
+        assert fetched == PDF_BYTES
+
+
+def test_get_document_pdf_bytes_returns_none_for_missing_docref(app):
+    with app.app_context():
+        assert get_document_pdf_bytes("test-tenant", "does-not-exist") is None
+
+
+def test_tenant_isolation_docref_not_visible_to_other_tenant(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        # Same docref id, wrong tenant — must not resolve.
+        assert get_document_pdf_bytes(OTHER_TENANT, resource["id"]) is None
+
+
+def test_tenant_isolation_query_scoped(app):
+    with app.app_context():
+        from r6.models import R6Resource
+
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+
+        other_tenant_rows = R6Resource.query.filter_by(
+            resource_type="DocumentReference", tenant_id=OTHER_TENANT).all()
+        assert other_tenant_rows == []
+
+        same_id_other_tenant = R6Resource.query.filter_by(
+            resource_type="DocumentReference", id=resource["id"],
+            tenant_id=OTHER_TENANT).first()
+        assert same_id_other_tenant is None
+
+
+def test_questionnaire_response_id_links_context_related(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES,
+            questionnaire_response_id="qr-42")
+
+        related_refs = [r["reference"]
+                        for r in resource["context"]["related"]]
+        assert "QuestionnaireResponse/qr-42" in related_refs
+
+
+def test_questionnaire_response_id_links_relates_to(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES,
+            questionnaire_response_id="qr-42")
+
+        assert resource["relatesTo"][0]["target"]["reference"] == \
+            "QuestionnaireResponse/qr-42"
+        assert resource["relatesTo"][0]["code"] == "transforms"
+
+
+def test_no_questionnaire_response_id_omits_context_and_relates_to(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        assert "context" not in resource
+        assert "relatesTo" not in resource
+
+
+def test_persisted_document_visible_via_get_after_second_document(app):
+    """A second DocumentReference for a different subject doesn't shadow
+    the first — bytes fetched by id must match what was stored for that id."""
+    with app.app_context():
+        first = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        second_bytes = b"%PDF-1.4 a different document entirely"
+        second = persist_intake_document(
+            "test-tenant", "Patient/456", second_bytes)
+
+        assert get_document_pdf_bytes("test-tenant", first["id"]) == PDF_BYTES
+        assert get_document_pdf_bytes("test-tenant", second["id"]) == second_bytes


### PR DESCRIPTION
## Summary
- Adds `r6/sdc/documents.py::persist_intake_document(tenant_id, subject_ref, pdf_bytes, *, title=None, questionnaire_response_id=None)`: builds a FHIR R4 `DocumentReference` (`status: current`, LOINC 34133-9 "Summarization of episode note" as the document type, `subject`, `date`) whose `content[0].attachment` carries `contentType: application/pdf`, `title`, `size`, and — the point of this task — `data`: the **base64-encoded PDF bytes** (FHIR `Attachment.data` is base64), not just a byte count. Persists tenant-scoped as an `R6Resource`, mirroring `r6/smbp/routes.py::_persist_document_reference`, and emits an audit event.
- When `questionnaire_response_id` is passed, links the DocumentReference back to the source `QuestionnaireResponse` via both `context.related` and `relatesTo` (code `transforms`), so the structured QR and the rendered PDF can be traced to each other.
- Adds `get_document_pdf_bytes(tenant_id, docref_id) -> bytes | None`: loads the DocumentReference (tenant-scoped) and decodes `content[0].attachment.data` back to the exact bytes — this is the round-trip getter Task 7's delivery route will use. Returns `None` if the DocumentReference doesn't exist for that tenant or has no embedded data.

## Test plan
- [x] `tests/test_sdc_documents.py` (13 new tests): retrievable by id under tenant, `contentType`/`size` correctness, `data` is valid base64 that decodes to the exact input bytes, `get_document_pdf_bytes` round-trips exact bytes, missing-docref returns `None`, tenant isolation (same docref id under a different tenant resolves to nothing, both via the getter and via a direct scoped query), `context.related`/`relatesTo` present and correct when `questionnaire_response_id` is given, both omitted when it isn't, and multi-document non-shadowing.
- [x] `uv run python -m pytest tests/ -q` — 1236 passed.
- [x] `uvx ruff check r6/ tests/ scripts/ main.py app.py` — clean.
- [x] `uv.lock` churn reverted before commit (not included in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)