### PR TITLE
Forms rail (6/9): structured per-item review page (server-side allergy-attestation gate)

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,6 +167,11 @@ from r6.actions.routes import actions_blueprint
 from r6.actions.registry import all_kinds as _action_kinds
 import r6.actions.rails
 r6.actions.rails.register_all()
+# Import for side effect: registers the /<id>/review GET+POST routes on
+# actions_blueprint (Task 6 structured per-item review page). MUST precede
+# register_blueprint — routes can't be added to a blueprint after it is
+# registered on the app.
+import r6.actions.review  # noqa: F401
 app.register_blueprint(actions_blueprint)
 logger.info("Actions Blueprint registered at /r6/actions (rails: %s)",
             ', '.join(_action_kinds()))

--- a/r6/actions/confirmations.py
+++ b/r6/actions/confirmations.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from models import db
 from r6.actions.models import _utcnow
 
-APPROVED_VIA_VALUES = ('telegram', 'dashboard')
+APPROVED_VIA_VALUES = ('telegram', 'dashboard', 'review-page')
 
 
 class ActionConfirmation(db.Model):

--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -1,0 +1,401 @@
+"""Structured per-item review page (Task 6) — the CORE SAFETY UI.
+
+Two routes on the actions blueprint:
+
+  GET  /r6/actions/<id>/review  — render a per-item confirmation page for a
+       form-fill action: Demographics read-only; each populated medication a
+       row with a required Still-taking? decision; each populated allergy a
+       row with a confirm/remove decision PLUS the explicit, UNCHECKED
+       "No known allergies (patient confirmed)" checkbox; each condition
+       confirmable. Provenance ("from your records") on populated items.
+
+  POST /r6/actions/<id>/review  — the SERVER-SIDE SAFETY GATE. It RE-POPULATES
+       the questionnaire from the tenant's FHIR (never trusting the client
+       about how many rows exist), then requires: every med row acted on, every
+       allergy row acted on, AND (the NKA box affirmed OR >=1 allergy
+       confirmed). A crafted POST that skips the allergy attestation is
+       rejected 422 — silence about allergies is never consent, and NKA is
+       never inferred from the absence of allergy data. On success it builds
+       the reviewed QuestionnaireResponse (status completed, author = reviewing
+       Device, source = Patient), persists it tenant-scoped, issues an
+       ActionConfirmation (approved_via='review-page'), and stores the reviewed
+       QR id on the action for Task 8's execute().
+
+Auth mirrors /confirm: X-Tenant-Id + a tenant-bound X-Step-Up-Token. The token
+is validated multi-use (not nonce-consumed) so the page can be re-opened and
+submitted with the same credential; the load-bearing gate here is the
+per-item + allergy-attestation check, not single-use.
+"""
+import json
+import logging
+
+from flask import render_template, request
+
+from models import db
+from r6.actions.confirmations import issue_confirmation
+from r6.actions.models import ProposedAction
+from r6.actions.routes import _error, _tenant_or_none, actions_blueprint
+from r6.audit import record_audit_event
+from r6.models import R6Resource
+from r6.sdc.intake import intake_questionnaire
+from r6.sdc.populate import populate_questionnaire
+from r6.stepup import validate_step_up_token
+
+logger = logging.getLogger(__name__)
+
+_MED_ACTIONS = ('yes', 'no', 'remove')
+_ITEM_ACTIONS = ('confirm', 'remove')
+
+# Where each list resource references its patient (R4 is inconsistent —
+# AllergyIntolerance uses `patient`, everything else `subject`).
+_CONTENT_TYPES = (
+    ('Observation', 'subject'),
+    ('MedicationRequest', 'subject'),
+    ('AllergyIntolerance', 'patient'),
+    ('Condition', 'subject'),
+)
+
+
+def _require_step_up(tenant_id):
+    """Return None if a valid tenant-bound step-up token is present, else an
+    (response, status) error tuple. Multi-use validation (no nonce consume) so
+    GET-then-POST with one token works."""
+    token = request.headers.get('X-Step-Up-Token')
+    if not token:
+        return _error(401, 'Review requires X-Step-Up-Token header')
+    valid, err = validate_step_up_token(token, tenant_id)
+    if not valid:
+        return _error(401, 'Step-up token rejected: %s' % err)
+    return None
+
+
+def _load_form_fill_action(action_id, tenant_id):
+    """Load a form-fill action that is tenant-scoped and awaiting_confirmation.
+    Returns the action or None (caller maps None -> 404). A wrong tenant, wrong
+    kind, or wrong status all collapse to 'not found' — no information leak."""
+    action = ProposedAction.query.filter_by(
+        id=action_id, tenant_id=tenant_id).first()
+    if action is None:
+        return None
+    if action.kind != 'form-fill':
+        return None
+    if action.status != 'awaiting_confirmation':
+        return None
+    return action
+
+
+def _resolve_questionnaire(action, tenant_id):
+    """Resolve the action's questionnaire. A stored Questionnaire wins; the
+    canonical intake form is the built-in fallback for 'healthclaw-intake'."""
+    qref = (action.payload.get('questionnaire') or '').strip()
+    ident = qref.split('/')[-1].split('|')[0]
+    row = R6Resource.query.filter_by(
+        resource_type='Questionnaire', id=ident, tenant_id=tenant_id).first()
+    if row is not None:
+        return row.to_fhir_json()
+    if ident == 'healthclaw-intake' or not ident:
+        return intake_questionnaire()
+    return intake_questionnaire()
+
+
+def _load_patient(tenant_id, subject_ref=None):
+    if subject_ref:
+        ident = subject_ref.split('/')[-1]
+        row = R6Resource.query.filter_by(
+            resource_type='Patient', id=ident, tenant_id=tenant_id).first()
+        return row.to_fhir_json() if row else None
+    row = R6Resource.query.filter_by(
+        resource_type='Patient', tenant_id=tenant_id).first()
+    return row.to_fhir_json() if row else None
+
+
+def _gather_content(tenant_id, patient):
+    content = []
+    if patient:
+        content.append(patient)
+    if not (patient and patient.get('id')):
+        return content
+    ref = 'Patient/%s' % patient['id']
+    for resource_type, subject_field in _CONTENT_TYPES:
+        for row in R6Resource.query.filter_by(
+                resource_type=resource_type, tenant_id=tenant_id).all():
+            resource = row.to_fhir_json()
+            if (resource.get(subject_field) or {}).get('reference') == ref:
+                content.append(resource)
+    return content
+
+
+def _draft_qr(action, tenant_id):
+    """Populate the action's questionnaire from the tenant's FHIR -> draft QR.
+    Deterministic: population order fixes the med/allergy/condition row indices
+    used by both the rendered page and the POST gate."""
+    questionnaire = _resolve_questionnaire(action, tenant_id)
+    subject_ref = (action.payload.get('subject') or {}).get('reference') \
+        if isinstance(action.payload.get('subject'), dict) else None
+    patient = _load_patient(tenant_id, subject_ref)
+    content = _gather_content(tenant_id, patient)
+    qr, _issues = populate_questionnaire(questionnaire, patient, content)
+    return questionnaire, patient, qr
+
+
+def _section_repeats(draft_qr, section_link_id, item_link_id):
+    """Ordered list of populated repeat items for a repeating section group."""
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') == section_link_id:
+            return [child for child in group.get('item', [])
+                    if child.get('linkId') == item_link_id]
+    return []
+
+
+def _leaf_value(repeat_item, leaf_link_id):
+    for child in repeat_item.get('item', []):
+        if child.get('linkId') == leaf_link_id:
+            for ans in child.get('answer', []):
+                if 'valueString' in ans:
+                    return ans['valueString']
+    return None
+
+
+def _demographics(draft_qr):
+    """Ordered (label, value) pairs from the populated demographics group."""
+    labels = {
+        'demographics.given-name': 'First name',
+        'demographics.family-name': 'Last name',
+        'demographics.birth-date': 'Date of birth',
+        'demographics.gender': 'Gender',
+        'demographics.phone': 'Phone',
+        'demographics.address-line': 'Street address',
+        'demographics.address-city': 'City',
+        'demographics.address-state': 'State',
+        'demographics.address-postal-code': 'Postal code',
+    }
+    out = []
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') != 'demographics':
+            continue
+        for child in group.get('item', []):
+            value = None
+            for ans in child.get('answer', []):
+                for key in ('valueString', 'valueDate', 'valueBoolean'):
+                    if key in ans:
+                        value = ans[key]
+                if isinstance(ans.get('valueCoding'), dict):
+                    value = ans['valueCoding'].get('display') \
+                        or ans['valueCoding'].get('code')
+            if value is not None:
+                out.append((labels.get(child.get('linkId'),
+                                       child.get('linkId')), value))
+    return out
+
+
+def _view_rows(draft_qr):
+    """Build the template's per-item view model from the draft QR."""
+    meds = []
+    for row in _section_repeats(draft_qr, 'medications', 'medications.item'):
+        meds.append({
+            'name': _leaf_value(row, 'medications.item.name') or 'Medication',
+            'dose': _leaf_value(row, 'medications.item.dose'),
+        })
+    allergies = []
+    for row in _section_repeats(draft_qr, 'allergies', 'allergies.item'):
+        allergies.append({
+            'allergen': _leaf_value(row, 'allergies.item.allergen')
+            or 'Allergy',
+            'reaction': _leaf_value(row, 'allergies.item.reaction'),
+        })
+    conditions = []
+    for row in _section_repeats(draft_qr, 'conditions', 'conditions.item'):
+        conditions.append({
+            'name': _leaf_value(row, 'conditions.item.name') or 'Condition',
+        })
+    return meds, allergies, conditions
+
+
+@actions_blueprint.route('/<action_id>/review', methods=['GET'])
+def review_form(action_id):
+    tenant_id = _tenant_or_none()
+    if not tenant_id:
+        return _error(400, 'X-Tenant-Id header is required')
+    auth_err = _require_step_up(tenant_id)
+    if auth_err is not None:
+        return auth_err
+
+    action = _load_form_fill_action(action_id, tenant_id)
+    if action is None:
+        return _error(404, 'Unknown action')
+
+    _questionnaire, _patient, draft_qr = _draft_qr(action, tenant_id)
+    demographics = _demographics(draft_qr)
+    meds, allergies, conditions = _view_rows(draft_qr)
+
+    record_audit_event(
+        'read', resource_type='ProposedAction', resource_id=action.id,
+        agent_id=request.headers.get('X-Agent-Id'), tenant_id=tenant_id,
+        detail='review page rendered',
+    )
+    html = render_template(
+        'action_review.html', action_id=action_id, demographics=demographics,
+        meds=meds, allergies=allergies, conditions=conditions,
+        step_up_token=request.headers.get('X-Step-Up-Token', ''),
+        tenant_id=tenant_id)
+    return html, 200
+
+
+def _submitted(action_id):
+    """Read the submitted decisions from JSON or form-encoded body."""
+    body = request.get_json(silent=True)
+    if isinstance(body, dict):
+        return {k: ('' if v is None else str(v)) for k, v in body.items()}
+    return {k: v for k, v in request.form.items()}
+
+
+def _truthy(value):
+    return str(value).strip().lower() in ('1', 'true', 'on', 'yes', 'checked')
+
+
+@actions_blueprint.route('/<action_id>/review', methods=['POST'])
+def review_submit(action_id):
+    tenant_id = _tenant_or_none()
+    if not tenant_id:
+        return _error(400, 'X-Tenant-Id header is required')
+    auth_err = _require_step_up(tenant_id)
+    if auth_err is not None:
+        return auth_err
+
+    action = _load_form_fill_action(action_id, tenant_id)
+    if action is None:
+        return _error(404, 'Unknown action')
+
+    # RE-POPULATE from FHIR: the server, not the client, decides which rows
+    # exist and must be acted on. This is what makes the gate un-craftable.
+    _questionnaire, patient, draft_qr = _draft_qr(action, tenant_id)
+    med_rows = _section_repeats(draft_qr, 'medications', 'medications.item')
+    allergy_rows = _section_repeats(draft_qr, 'allergies', 'allergies.item')
+    condition_rows = _section_repeats(draft_qr, 'conditions',
+                                      'conditions.item')
+    submitted = _submitted(action_id)
+
+    # (1) Every medication row must be acted on with a valid decision.
+    med_decisions = []
+    for i in range(len(med_rows)):
+        decision = submitted.get('med-%d' % i, '').strip().lower()
+        if decision not in _MED_ACTIONS:
+            return _error(422, 'Every medication must be reviewed '
+                               '(Still taking? Yes/No/Remove). Medication '
+                               'row %d was not acted on.' % (i + 1))
+        med_decisions.append(decision)
+
+    # (2) Every allergy row must be acted on with a valid decision.
+    allergy_decisions = []
+    for i in range(len(allergy_rows)):
+        decision = submitted.get('allergy-%d' % i, '').strip().lower()
+        if decision not in _ITEM_ACTIONS:
+            return _error(422, 'Every allergy must be reviewed '
+                               '(Confirm/Remove). Allergy row %d was not '
+                               'acted on.' % (i + 1))
+        allergy_decisions.append(decision)
+
+    # (3) THE ATTESTATION GATE (load-bearing): the patient must either confirm
+    # at least one allergy OR explicitly affirm "no known allergies". Removing
+    # every allergy row without checking NKA does NOT satisfy this — an absence
+    # of allergies is never inferred, it must be affirmatively attested.
+    nka_affirmed = _truthy(submitted.get('nka', ''))
+    confirmed_allergy = any(d == 'confirm' for d in allergy_decisions)
+    if not (nka_affirmed or confirmed_allergy):
+        return _error(422, 'You must confirm at least one allergy OR check '
+                           '"No known allergies (patient confirmed)". No '
+                           'known allergies is never assumed.')
+
+    # (4) Conditions are confirmable but not gating.
+    condition_decisions = [
+        submitted.get('condition-%d' % i, 'confirm').strip().lower()
+        for i in range(len(condition_rows))]
+
+    # (5) Build the reviewed QuestionnaireResponse from the human's decisions.
+    reviewed_qr = _build_reviewed_qr(
+        draft_qr, patient, med_rows, med_decisions, allergy_rows,
+        allergy_decisions, nka_affirmed, condition_rows, condition_decisions)
+
+    qr_row = R6Resource(resource_type='QuestionnaireResponse',
+                        resource_json=json.dumps(reviewed_qr),
+                        tenant_id=tenant_id)
+    db.session.add(qr_row)
+    db.session.flush()          # assign qr_row.id
+
+    # (6) Consent record for the review approval + hand-off marker for Task 8.
+    issue_confirmation(action_id, approved_via='review-page', ttl_minutes=15)
+    payload = action.payload
+    payload['reviewed_qr_id'] = qr_row.id
+    action.payload_json = json.dumps(payload)
+    db.session.commit()
+
+    record_audit_event(
+        'update', resource_type='ProposedAction', resource_id=action.id,
+        agent_id=request.headers.get('X-Agent-Id'), tenant_id=tenant_id,
+        detail='reviewed via review-page; qr=%s' % qr_row.id,
+    )
+
+    from flask import jsonify
+    return jsonify({
+        'id': action.id,
+        'status': action.status,
+        'reviewed_qr_id': qr_row.id,
+        'approved_via': 'review-page',
+        'next_step': ('Review recorded and approval issued. Form generation '
+                      '(PDF/DocumentReference) is Task 8; the form-fill '
+                      'executor currently returns an honest needs_review '
+                      'placeholder.'),
+    }), 200
+
+
+def _build_reviewed_qr(draft_qr, patient, med_rows, med_decisions,
+                       allergy_rows, allergy_decisions, nka_affirmed,
+                       condition_rows, condition_decisions):
+    """Assemble the completed QuestionnaireResponse: demographics carried
+    through, only kept meds/allergies/conditions included, and the NKA boolean
+    set ONLY from the explicit attestation."""
+    from r6.actions.models import _utcnow
+
+    items = []
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') == 'demographics':
+            items.append(group)
+
+    kept_meds = [row for row, decision in zip(med_rows, med_decisions)
+                 if decision != 'remove']
+    meds_group = {'linkId': 'medications', 'item': list(kept_meds)}
+    items.append(meds_group)
+
+    kept_allergies = [row for row, decision in zip(allergy_rows,
+                                                   allergy_decisions)
+                      if decision == 'confirm']
+    allergy_children = [{
+        'linkId': 'allergies.no-known-allergies',
+        'answer': [{'valueBoolean': bool(nka_affirmed)}],
+    }]
+    allergy_children.extend(kept_allergies)
+    items.append({'linkId': 'allergies', 'item': allergy_children})
+
+    kept_conditions = [row for row, decision in zip(condition_rows,
+                                                    condition_decisions)
+                       if decision != 'remove']
+    if kept_conditions:
+        items.append({'linkId': 'conditions', 'item': list(kept_conditions)})
+
+    qr = {
+        'resourceType': 'QuestionnaireResponse',
+        'status': 'completed',
+        'questionnaire': draft_qr.get('questionnaire'),
+        'authored': _utcnow().isoformat() + 'Z',
+        # Reviewing Device authored the structured response; the patient is the
+        # information source.
+        'author': {'reference': 'Device/healthclaw-review',
+                   'display': 'HealthClaw review page'},
+        'source': {'reference': 'Patient'},
+        'item': items,
+    }
+    subject = (patient or {})
+    if subject.get('resourceType') and subject.get('id'):
+        qr['subject'] = {'reference': 'Patient/%s' % subject['id']}
+        qr['source'] = {'reference': 'Patient/%s' % subject['id']}
+    return qr

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -1,0 +1,233 @@
+{% extends "base.html" %}
+{% block title %}Review your intake form — HealthClaw Guardrails{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-9">
+
+    <div class="d-flex align-items-center mb-3">
+      <i class="fas fa-clipboard-check me-2" style="color:var(--r6-primary);font-size:1.6rem"></i>
+      <div>
+        <h2 class="mb-0">Review each item before we generate your form</h2>
+        <p class="text-muted mb-0">
+          Nothing is submitted until you confirm every medication and allergy
+          below. "No known allergies" is never assumed on your behalf.
+        </p>
+      </div>
+    </div>
+
+    <form id="review-form" method="post"
+          action="/r6/actions/{{ action_id }}/review">
+
+      <!-- Demographics: read-only, straight from your records -->
+      <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span><i class="fas fa-id-card me-2"></i>Demographics</span>
+          <span class="badge bg-secondary">read-only · from your records</span>
+        </div>
+        <div class="card-body">
+          {% if demographics %}
+          <dl class="row mb-0">
+            {% for label, value in demographics %}
+            <dt class="col-sm-4 text-muted">{{ label }}</dt>
+            <dd class="col-sm-8">{{ value }}</dd>
+            {% endfor %}
+          </dl>
+          {% else %}
+          <p class="text-muted mb-0">No demographic details found in your records.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Medications: confirm each one individually -->
+      <div class="card mb-4">
+        <div class="card-header"><i class="fas fa-pills me-2"></i>Current medications</div>
+        <div class="card-body">
+          {% if meds %}
+          <p class="text-muted small">Each medication below is <strong>from your records</strong>. Tell us whether you are still taking it.</p>
+          {% for med in meds %}
+          <div class="med-row border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center"
+               data-row-index="{{ loop.index0 }}">
+            <div class="me-3">
+              <div class="fw-bold">{{ med.name }}</div>
+              {% if med.dose %}<div class="text-muted small">{{ med.dose }}</div>{% endif %}
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group" aria-label="Still taking {{ med.name }}?">
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-yes" value="yes" required>
+              <label class="btn btn-outline-success btn-sm" for="med-{{ loop.index0 }}-yes">Still taking</label>
+
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-no" value="no">
+              <label class="btn btn-outline-warning btn-sm" for="med-{{ loop.index0 }}-no">Not anymore</label>
+
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="med-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+          {% else %}
+          <p class="text-muted mb-0">No medications found in your records.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Allergies: confirm each, and the explicit NKA attestation -->
+      <div class="card mb-4 border-warning">
+        <div class="card-header"><i class="fas fa-triangle-exclamation me-2"></i>Allergies</div>
+        <div class="card-body">
+          {% if allergies %}
+          <p class="text-muted small">Each allergy below is <strong>from your records</strong>. Confirm or remove each one.</p>
+          {% for allergy in allergies %}
+          <div class="allergy-row border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center"
+               data-row-index="{{ loop.index0 }}">
+            <div class="me-3">
+              <div class="fw-bold">{{ allergy.allergen }}</div>
+              {% if allergy.reaction %}<div class="text-muted small">Reaction: {{ allergy.reaction }}</div>{% endif %}
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group" aria-label="Confirm {{ allergy.allergen }}?">
+              <input type="radio" class="btn-check allergy-choice" name="allergy-{{ loop.index0 }}"
+                     id="allergy-{{ loop.index0 }}-confirm" value="confirm">
+              <label class="btn btn-outline-success btn-sm" for="allergy-{{ loop.index0 }}-confirm">Confirm</label>
+
+              <input type="radio" class="btn-check allergy-choice" name="allergy-{{ loop.index0 }}"
+                     id="allergy-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="allergy-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+          {% else %}
+          <div class="alert alert-warning mb-3" role="alert">
+            <i class="fas fa-circle-info me-1"></i>
+            No allergies found in your records — add them or affirmatively confirm none below.
+          </div>
+          {% endif %}
+
+          <div class="form-check mt-2 p-3 bg-body-secondary rounded">
+            <!-- CRITICAL: never pre-checked. NKA is an explicit attestation,
+                 never inferred from the absence of allergy data. -->
+            <input class="form-check-input" type="checkbox" name="nka" id="nka" value="true">
+            <label class="form-check-label fw-bold" for="nka">
+              No known allergies (patient confirmed)
+            </label>
+            <div class="text-muted small">
+              Only check this if the patient has affirmatively stated they have no known allergies.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Conditions: confirmable -->
+      {% if conditions %}
+      <div class="card mb-4">
+        <div class="card-header"><i class="fas fa-notes-medical me-2"></i>Problems / conditions</div>
+        <div class="card-body">
+          <p class="text-muted small">Each condition below is <strong>from your records</strong>.</p>
+          {% for condition in conditions %}
+          <div class="border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fw-bold">{{ condition.name }}</div>
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group">
+              <input type="radio" class="btn-check" name="condition-{{ loop.index0 }}"
+                     id="condition-{{ loop.index0 }}-confirm" value="confirm" checked>
+              <label class="btn btn-outline-success btn-sm" for="condition-{{ loop.index0 }}-confirm">Confirm</label>
+
+              <input type="radio" class="btn-check" name="condition-{{ loop.index0 }}"
+                     id="condition-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="condition-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+
+      <div id="review-gate-msg" class="alert alert-secondary" role="alert">
+        Review every medication and allergy, then confirm an allergy or check
+        "No known allergies" to continue.
+      </div>
+
+      <button type="submit" id="approve-btn" class="btn btn-primary btn-lg" disabled>
+        <i class="fas fa-check me-1"></i>Approve &amp; generate
+      </button>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // Client-side UX only. The SERVER POST re-populates from FHIR and is the
+  // real, un-craftable gate (see r6/actions/review.py).
+  (function () {
+    var TENANT = {{ tenant_id | tojson }};
+    var TOKEN = {{ step_up_token | tojson }};
+    var form = document.getElementById('review-form');
+    var btn = document.getElementById('approve-btn');
+    var gateMsg = document.getElementById('review-gate-msg');
+
+    function medRows() {
+      var names = {};
+      form.querySelectorAll('.med-choice').forEach(function (el) { names[el.name] = true; });
+      return Object.keys(names);
+    }
+    function allergyRows() {
+      var names = {};
+      form.querySelectorAll('.allergy-choice').forEach(function (el) { names[el.name] = true; });
+      return Object.keys(names);
+    }
+    function selected(name) {
+      var el = form.querySelector('input[name="' + name + '"]:checked');
+      return el ? el.value : null;
+    }
+    function evaluate() {
+      var allMeds = medRows().every(function (n) { return selected(n) !== null; });
+      var allAllergies = allergyRows().every(function (n) { return selected(n) !== null; });
+      var confirmedAllergy = allergyRows().some(function (n) { return selected(n) === 'confirm'; });
+      var nka = form.querySelector('#nka').checked;
+      var ok = allMeds && allAllergies && (confirmedAllergy || nka);
+      btn.disabled = !ok;
+      gateMsg.className = ok ? 'alert alert-success' : 'alert alert-secondary';
+      gateMsg.textContent = ok
+        ? 'Ready to generate. The server will re-verify every item on submit.'
+        : 'Review every medication and allergy, then confirm an allergy or check "No known allergies" to continue.';
+      return ok;
+    }
+    form.addEventListener('change', evaluate);
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      if (!evaluate()) { return; }
+      var payload = {};
+      new FormData(form).forEach(function (v, k) { payload[k] = v; });
+      if (form.querySelector('#nka').checked) { payload['nka'] = 'true'; }
+      fetch(form.action, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tenant-Id': TENANT,
+          'X-Step-Up-Token': TOKEN
+        },
+        body: JSON.stringify(payload)
+      }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
+        .then(function (res) {
+          if (res.r.ok) {
+            gateMsg.className = 'alert alert-success';
+            gateMsg.textContent = 'Review recorded. ' + (res.b.next_step || '');
+            btn.disabled = true;
+          } else {
+            gateMsg.className = 'alert alert-danger';
+            gateMsg.textContent = res.b.error || 'Submission rejected.';
+          }
+        });
+    });
+
+    evaluate();
+  })();
+</script>
+{% endblock %}

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -1,0 +1,332 @@
+"""Structured per-item review page (Task 6) — the core safety UI.
+
+A human confirms each populated medication and allergy individually, and must
+EXPLICITLY affirm "no known allergies" — it is never inferred from the absence
+of allergy data. The server-side POST is the load-bearing gate: a crafted POST
+that skips the allergy attestation MUST be rejected (422), leaving the action
+untouched and issuing NO ActionConfirmation.
+
+Field contract for POST /r6/actions/<id>/review (JSON or form):
+  med-<i>       one of 'yes' | 'no' | 'remove'   (i = 0..N-1 populated meds)
+  allergy-<i>   one of 'confirm' | 'remove'      (i = 0..M-1 populated allergies)
+  condition-<i> one of 'confirm' | 'remove'      (optional; confirmable)
+  nka           truthy => the explicit "no known allergies" attestation
+The server RE-POPULATES from the tenant's FHIR to decide which med/allergy
+rows must be acted on — it never trusts the client about how many rows exist.
+"""
+import json
+
+from models import db
+from r6.actions.confirmations import ActionConfirmation
+from r6.actions.models import ProposedAction
+
+PATIENT = {
+    'resourceType': 'Patient', 'id': 'test-patient-1',
+    'name': [{'family': 'Smith', 'given': ['John']}],
+    'gender': 'male', 'birthDate': '1990-01-15',
+}
+MED_A = {
+    'resourceType': 'MedicationRequest', 'id': 'med-a', 'status': 'active',
+    'intent': 'order',
+    'medicationCodeableConcept': {'text': 'Metformin 500 mg tablet'},
+    'dosageInstruction': [{'text': 'Take 1 tablet twice daily'}],
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+MED_B = {
+    'resourceType': 'MedicationRequest', 'id': 'med-b', 'status': 'active',
+    'intent': 'order',
+    'medicationCodeableConcept': {'text': 'Lisinopril 10 mg tablet'},
+    'dosageInstruction': [{'text': 'Take 1 tablet daily'}],
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+ALLERGY_A = {
+    'resourceType': 'AllergyIntolerance', 'id': 'allergy-a',
+    'code': {'text': 'Penicillin'},
+    'reaction': [{'manifestation': [{'text': 'Hives'}]}],
+    'patient': {'reference': 'Patient/test-patient-1'},
+}
+CONDITION_A = {
+    'resourceType': 'Condition', 'id': 'cond-a',
+    'code': {'text': 'Type 2 diabetes mellitus'},
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+
+FORM_FILL_BODY = {
+    'kind': 'form-fill',
+    'payload': {'to': 'Intake portal', 'questionnaire': 'healthclaw-intake',
+                'body': 'new patient intake form'},
+}
+
+
+def _seed(app, tenant, resources):
+    with app.app_context():
+        for r in resources:
+            db.session.add(R6(r, tenant))
+        db.session.commit()
+
+
+def R6(resource, tenant):
+    from r6.models import R6Resource
+    return R6Resource(resource_type=resource['resourceType'],
+                      resource_json=json.dumps(resource),
+                      resource_id=resource['id'], tenant_id=tenant)
+
+
+def _staged_form_fill(client, tenant_headers, auth_headers):
+    """propose + commit a form-fill action -> awaiting_confirmation."""
+    r = client.post('/r6/actions/propose', json=FORM_FILL_BODY,
+                    headers=tenant_headers)
+    assert r.status_code == 201, r.get_data(as_text=True)
+    action_id = r.get_json()['id']
+    c = client.post('/r6/actions/%s/commit' % action_id, headers=auth_headers)
+    assert c.status_code == 202, c.get_data(as_text=True)
+    return action_id
+
+
+def _get(client, headers, action_id):
+    return client.get('/r6/actions/%s/review' % action_id, headers=headers)
+
+
+def _post(client, headers, action_id, body):
+    return client.post('/r6/actions/%s/review' % action_id,
+                       headers=headers, json=body)
+
+
+# ---------------------------------------------------------------------------
+# GET renders the review page
+# ---------------------------------------------------------------------------
+
+def test_get_review_renders_populated_items_nka_not_prechecked(
+        client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'],
+          [PATIENT, MED_A, MED_B, ALLERGY_A, CONDITION_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    # Populated clinical content is shown with provenance.
+    assert 'Metformin 500 mg tablet' in html
+    assert 'Lisinopril 10 mg tablet' in html
+    assert 'Penicillin' in html
+    assert 'from your records' in html
+    # The NKA checkbox exists and is NOT pre-checked.
+    assert 'no known allergies' in html.lower()
+    nka_idx = html.lower().find('no known allergies')
+    # find the input element for NKA (name="nka") and assert it is unchecked
+    assert 'name="nka"' in html
+    input_idx = html.find('name="nka"')
+    # slice the input tag and ensure 'checked' is not inside it
+    tag = html[html.rfind('<input', 0, input_idx):
+               html.find('>', input_idx) + 1]
+    assert 'checked' not in tag.lower()
+    assert nka_idx > 0
+
+
+def test_get_review_no_allergies_never_prechecks_nka(
+        client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'No allergies found in your records' in html
+    input_idx = html.find('name="nka"')
+    tag = html[html.rfind('<input', 0, input_idx):
+               html.find('>', input_idx) + 1]
+    assert 'checked' not in tag.lower()
+
+
+def test_get_review_requires_step_up(client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _get(client, tenant_headers, action_id)   # no step-up token
+    assert resp.status_code == 401
+
+
+def test_get_review_non_form_fill_404(client, app, tenant_headers, auth_headers):
+    r = client.post('/r6/actions/propose', json={
+        'kind': 'sms',
+        'payload': {'to': 'Dr. Smith', 'phone': '617-555-0100',
+                    'body': 'reminder'}}, headers=tenant_headers)
+    action_id = r.get_json()['id']
+    client.post('/r6/actions/%s/commit' % action_id, headers=auth_headers)
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 404
+
+
+def test_get_review_wrong_tenant_404(client, app, tenant_headers, auth_headers,
+                                     other_tenant_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _get(client, other_tenant_headers, action_id)
+    assert resp.status_code == 404
+
+
+def test_get_review_requires_awaiting_confirmation(client, app, tenant_headers,
+                                                   auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    r = client.post('/r6/actions/propose', json=FORM_FILL_BODY,
+                    headers=tenant_headers)
+    action_id = r.get_json()['id']          # proposed, NOT committed
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# LOAD-BEARING server-side allergy-attestation gate
+# ---------------------------------------------------------------------------
+
+def test_post_omitting_allergy_attestation_is_rejected(
+        client, app, tenant_headers, auth_headers):
+    """A crafted POST that acts on every row but neither confirms an allergy
+    nor affirms NKA MUST be rejected — silence is never consent."""
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    # Every med acted on; the one allergy is REMOVED (not confirmed); no NKA.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'med-1': 'no', 'allergy-0': 'remove'})
+    assert resp.status_code == 422, resp.get_data(as_text=True)
+    assert 'allergy' in resp.get_json()['error'].lower()
+
+    with app.app_context():
+        # Action untouched, NO consent record issued.
+        assert db.session.get(ProposedAction,
+                              action_id).status == 'awaiting_confirmation'
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+def test_post_no_allergies_still_requires_nka_attestation(
+        client, app, tenant_headers, auth_headers):
+    """Zero allergies in the records does NOT let the form proceed silently —
+    the patient must affirmatively check NKA."""
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _post(client, auth_headers, action_id, {'med-0': 'yes'})
+    assert resp.status_code == 422
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+def test_post_missing_med_action_is_rejected(client, app, tenant_headers,
+                                             auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    # med-1 omitted -> a medication row was not acted on.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'nka': 'true'})
+    assert resp.status_code == 422
+    assert 'medication' in resp.get_json()['error'].lower()
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# POST happy paths
+# ---------------------------------------------------------------------------
+
+def test_post_with_nka_affirmed_succeeds(client, app, tenant_headers,
+                                         auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'med-1': 'no', 'nka': 'true'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    with app.app_context():
+        rows = ActionConfirmation.query.filter_by(action_id=action_id).all()
+        assert len(rows) == 1
+        assert rows[0].approved_via == 'review-page'
+        # Reviewed QR persisted, tenant-scoped, status completed.
+        action = db.session.get(ProposedAction, action_id)
+        qr_id = action.payload.get('reviewed_qr_id')
+        assert qr_id
+        from r6.models import R6Resource
+        row = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', id=qr_id,
+            tenant_id=tenant).first()
+        assert row is not None
+        qr = row.to_fhir_json()
+        assert qr['status'] == 'completed'
+        # NKA attestation captured as an explicit boolean true.
+        assert _nka_answer(qr) is True
+
+
+def test_post_confirming_real_allergy_succeeds(client, app, tenant_headers,
+                                               auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    # Confirm the real allergy; NO NKA. This satisfies the attestation gate.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'allergy-0': 'confirm'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id, approved_via='review-page').count() == 1
+        action = db.session.get(ProposedAction, action_id)
+        qr_id = action.payload.get('reviewed_qr_id')
+        from r6.models import R6Resource
+        qr = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', id=qr_id,
+            tenant_id=tenant).first().to_fhir_json()
+        assert qr['status'] == 'completed'
+        assert _nka_answer(qr) is not True   # NKA never inferred
+
+
+def test_post_requires_step_up(client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = client.post('/r6/actions/%s/review' % action_id,
+                       headers=tenant_headers, json={'med-0': 'yes',
+                                                     'nka': 'true'})
+    assert resp.status_code == 401
+
+
+def test_post_wrong_tenant_404(client, app, tenant_headers, auth_headers,
+                               other_tenant_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _post(client, other_tenant_headers, action_id,
+                 {'med-0': 'yes', 'nka': 'true'})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# confirmations.py accepts the new channel
+# ---------------------------------------------------------------------------
+
+def test_issue_confirmation_accepts_review_page(app):
+    from r6.actions.confirmations import (APPROVED_VIA_VALUES,
+                                          issue_confirmation)
+    assert 'review-page' in APPROVED_VIA_VALUES
+    with app.app_context():
+        c = issue_confirmation('some-action', 'review-page', ttl_minutes=15)
+        db.session.add(c)
+        db.session.commit()
+        assert c.approved_via == 'review-page'
+
+
+def _nka_answer(qr):
+    """Extract the boolean answer for allergies.no-known-allergies, or None."""
+    for group in qr.get('item', []):
+        if group.get('linkId') == 'allergies':
+            for child in group.get('item', []):
+                if child.get('linkId') == 'allergies.no-known-allergies':
+                    for ans in child.get('answer', []):
+                        if 'valueBoolean' in ans:
+                            return ans['valueBoolean']
+    return None


### PR DESCRIPTION
## Forms rail (6/9) — the core safety UI

A structured per-item review page where a human confirms **each** populated medication and allergy individually, and must **explicitly** affirm "no known allergies" — it is never inferred.

### Routes (auth: `X-Tenant-Id` + tenant-bound `X-Step-Up-Token`, same as `/confirm`)
- **GET `/r6/actions/<id>/review`** — loads the form-fill `ProposedAction` (404 unless tenant-scoped, kind `form-fill`, and `awaiting_confirmation`), populates its questionnaire from the tenant's FHIR into a draft QR, and renders `templates/action_review.html`: Demographics read-only; each medication a required *Still taking? Yes/No/Remove* row; each allergy a *Confirm/Remove* row **plus** the explicit **"No known allergies (patient confirmed)"** checkbox, rendered **UNCHECKED**; conditions confirmable; `"from your records"` provenance on populated items. When no allergies are found it shows *"No allergies found in your records — add them or affirmatively confirm none"* and still never pre-checks NKA.
- **POST `/r6/actions/<id>/review`** — the load-bearing gate.

### How the server gate works (the load-bearing safety property)
The POST does **not** trust the client about how many rows exist. It **re-populates** the questionnaire from the tenant's FHIR data server-side, then enforces:
1. Every medication row acted on with a valid decision (`yes`/`no`/`remove`).
2. Every allergy row acted on with a valid decision (`confirm`/`remove`).
3. **The attestation gate:** at least one allergy `confirm`, **OR** the NKA box explicitly checked.

A crafted POST that acts on every row but removes all allergies without checking NKA (or one with zero allergies and no NKA) is rejected **422**, the action stays `awaiting_confirmation`, and **no `ActionConfirmation` is issued**. Silence about allergies is never consent; NKA is never inferred from absent allergy data. The client-side JS only gates the button for UX — the server is the real gate.

On success: builds the reviewed `QuestionnaireResponse` (status `completed`, author = reviewing `Device`, source = `Patient`, NKA boolean set **only** from the explicit attestation), persists it tenant-scoped as an `R6Resource`, issues `issue_confirmation(approved_via='review-page', ttl_minutes=15)`, and stores the reviewed QR id on the action payload for Task 8's `execute()`.

### Scope / not in this PR
PDF / `DocumentReference` generation is **Task 8**. The form-fill executor still returns an honest `needs_review` placeholder — no fabricated completed form here.

### Also
- Added `'review-page'` to `APPROVED_VIA_VALUES` in `r6/actions/confirmations.py`.

### Tests — `tests/actions/test_review_flow.py` (14 new)
- GET renders populated meds/allergies with NKA **not** pre-checked (asserted against the HTML), incl. the no-allergies branch.
- **Load-bearing:** POST omitting the allergy attestation → 422, action untouched, no confirmation issued.
- POST with NKA affirmed → 200, confirmation issued (`review-page`), reviewed QR stored `status=completed`.
- POST confirming a real allergy (no NKA) → 200; NKA never inferred.
- Missing med action → 422; non-form-fill / wrong tenant / not-awaiting / missing step-up → 404/401.
- `issue_confirmation` accepts `'review-page'`.

Full suite: **1237 passed** (1223 baseline + 14). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)