### PR TITLE
Forms rail (T5–T9): populate → per-item review → provenance PDF → signed link, end to end

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,7 @@ The contract floor for real actions is on `main`:
 - **The action rail + public extension point.** Real-world capabilities are `ActionExecutor`s registered in a plugin registry. Adding a capability behind the full guardrail rail (validation → human gate → audit → observability) is ~50 lines and touches no core code. See [Extending the action rail](#extending-the-action-rail).
 - **Durable execution.** Attempt ledger, provider reconciliation, an external-tick reaper, and an append-only action-event log — a crashed worker can't strand or double-fire a real-world action.
 - **Reliability floor.** Config preflight (`GET /r6/ops/preflight`), a Postgres CI lane (kills the SQLite-masks-varchar bug class), MCP fetch timeouts, poller storm-detection, source-aware resource identity `(tenant, type, id)`, and a mandatory red-flag emergency screen on action text.
+- **The forms rail — first end-to-end real action.** `$populate` fills the canonical intake questionnaire from the patient's own record → a **structured per-item review** (every medication and allergy confirmed individually; "no known allergies" is rejected server-side unless explicitly attested, and the item list is re-derived from FHIR so a crafted request can't skip a row) → a reviewed `QuestionnaireResponse` → a provenance-stamped PDF persisted as a FHIR `DocumentReference` → a **signed, expiring download link**. The `form-fill` executor fails loud (`needs_review` / `provider_not_configured` / `stale_source_data`) and only reports `completed` on a fully rendered, persisted, linked PDF. See [the demo run-of-show](docs/demos/forms-rail-run-of-show.md).
 
 ## 🔜 Now — the comms rail
 
@@ -25,9 +26,9 @@ Making the first two actions *real*:
 - Two-phase call scripts (verify you've reached a human before disclosing anything; AI + recording disclosure), contact-by-reference (the model never handles a raw phone number), and RxNorm→DEA schedule awareness for prescription-related calls.
 - Action observability: a dashboard panel + daily digest so a 2am failure is known by breakfast.
 
-## 🟡 Next — forms + standards
+## 🟡 Next — standards + delivery hardening
 
-- **Form completion.** SDC `$populate` fills a standard intake questionnaire from the patient's own record → a **structured per-item review** (meds and allergies confirmed individually; "no known allergies" is never inferred) → a completed PDF delivered via encrypted SMART Health Link.
+- **Encrypted SMART Health Link delivery.** The forms rail ships a signed, expiring download link today; the next step wraps it in a full SHL envelope (encrypted manifest + one-time flag), reusing the Node server's SHL builder, so the PDF can be shared through the standard SHL viewer ecosystem.
 - **FHIR Implementation Guide.** A continuous-build IG so the guardrails are reviewable in the community's own terms: a two-agent AuditEvent profile (AI agent + human verifier), a Provenance-per-action profile, SDC-conformant questionnaires, and the six guardrail properties as testable requirements. Standards-native expression of what the code already does.
 - **Granular SMART v2 scopes** per tool; regulatory-posture doc (patient-directed access under 45 CFR 164.524; FTC Health Breach Notification Rule).
 

--- a/docs/demos/forms-rail-run-of-show.md
+++ b/docs/demos/forms-rail-run-of-show.md
@@ -1,0 +1,73 @@
+# Forms rail — demo run-of-show
+
+**The story in one line:** *An AI agent fills your intake form from your real
+health records → you review each medication and allergy individually (the
+software can never claim "no known allergies" for you) → you get a shareable,
+provenance-stamped PDF.*
+
+This is the Aug-18 webinar centerpiece. It runs entirely on **synthetic data**
+and needs no phone/SMS provider — every step is real, server-side, and
+guardrailed. Total runtime ~6 minutes.
+
+## Why it lands
+
+The audience has seen "AI fills a form" demos. What they have *not* seen is a
+form-filling agent that **structurally cannot fabricate a clinical assertion**.
+The load-bearing beat is the allergy review: removing every allergy without
+explicitly attesting "no known allergies" is rejected *server-side* (HTTP 422),
+and a crafted request can't dodge it because the server re-derives the item list
+from FHIR rather than trusting the client. Silence about allergies is never
+consent. That is the whole pitch — safety you can watch fail closed.
+
+## Pre-flight (before you present)
+
+1. Stack up locally or point at a demo deployment:
+   ```bash
+   STEP_UP_SECRET=dev-secret PUBLIC_BASE_URL=http://localhost:5000 python main.py
+   ```
+   `PUBLIC_BASE_URL` **must** be set — the rail fails loud (`provider_not_configured`)
+   without it, by design. That's a feature you can show, but for the happy-path
+   demo, set it.
+2. Seed synthetic records for the demo tenant: `POST /r6/fhir/internal/seed`.
+   Confirm the patient has at least one medication and one real allergy
+   (Penicillin) so the review page has something to confirm.
+3. Mint a step-up token: `POST /r6/fhir/internal/step-up-token {"tenant_id": "desktop-demo"}`.
+4. Open the guardrail scorecard in a browser tab you can flip to:
+   `GET /r6/fhir/$conformance?format=text` — Grade A. (Credibility anchor.)
+
+## Run of show
+
+| Beat | You do | You say |
+|------|--------|---------|
+| **1. The ask** | In the agent (Claude Desktop / any MCP client), ask it to *"fill out my new-patient intake form from my records."* The agent calls `action_propose` (kind `form-fill`). | "I'm not uploading anything. The agent is reading my *own* FHIR records through the guardrail layer." |
+| **2. Propose ≠ do** | Show the action is `awaiting_confirmation`, not done. | "It proposed. It did **not** submit. Nothing an agent's own tools can do will approve its own action — that's the out-of-band gate." |
+| **3. The review page** | Open `GET /r6/actions/<id>/review`. Each medication and each allergy is its own row, populated *from the record* with provenance. The **"No known allergies (patient confirmed)"** box is **unchecked**. | "It filled the form, but every clinical line waits for me. Notice the allergy box is empty — the software did not decide that for me." |
+| **4. The safety beat** *(the money shot)* | Try to submit having **removed** the Penicillin allergy but **without** checking the NKA box. It's rejected — **422**, no approval issued, form not finalized. | "Watch. I remove my allergy and try to submit without attesting. The server refuses. It re-checked my records — I can't quietly drop a real allergy, and it will never *assume* I have none." |
+| **5. Honest submit** | Confirm the Penicillin allergy (or check NKA if that were true), confirm meds, submit. The review page issues the confirmation. | "Now I attest, item by item. This is the human-in-the-loop, and it's recorded." |
+| **6. Execute** | The out-of-band confirm (`POST /r6/actions/<id>/confirm`) runs `execute()`: reviewed answers → PDF → FHIR `DocumentReference` → signed link. Show the action now `completed` with a `delivery_link`. | "Only *after* I approved does it render anything. No approval, no PDF — it fails closed." |
+| **7. The artifact** | Open the `delivery_link` in a fresh browser (no login, no headers — the signature in the URL is the credential). The PDF opens with the provenance footer: *populated from records by an automated system, reviewed by the patient on <date>.* | "Here's the shareable form. It's stamped with exactly how it was made and that a human reviewed it. That footer is the difference between a document a clinic can trust and one it can't." |
+| **8. Prove it** | Flip to the `$conformance` tab: Grade A. | "None of this is 'trust me.' The guardrails grade themselves A–F in CI. This deployment is A." |
+
+## Fallbacks if something misbehaves
+
+- **Link 404s:** the DocumentReference is tenant-scoped — make sure the browser
+  link's `t=` matches the demo tenant. Re-run from beat 6.
+- **422 on the honest submit too:** you left a medication row un-actioned. Every
+  med and allergy row must have a decision; that's intentional.
+- **`provider_not_configured`:** `PUBLIC_BASE_URL` isn't set on the server. Set
+  it and restart. (Or lean in: "this is the rail refusing to run half-configured.")
+- **No allergy to confirm:** the seed didn't include one. Re-seed, or fall back
+  to the NKA path — but the allergy-confirm path is the stronger story.
+
+## The two live polls (audience engagement)
+
+1. *"Would you trust an AI agent to fill a medical form for you?"* — ask **before**
+   beat 4. (Most say no.)
+2. *"Now that you've seen it fail closed on the allergy — would you?"* — ask
+   **after** beat 8. The shift is the talk.
+
+## One-line takeaway to close on
+
+"Agents are going to touch medical records whether the industry is ready or not.
+The question isn't *if* — it's whether the guardrails are open, inspectable, and
+provable. This is. Come build the next rail with us."

--- a/main.py
+++ b/main.py
@@ -167,6 +167,11 @@ from r6.actions.routes import actions_blueprint
 from r6.actions.registry import all_kinds as _action_kinds
 import r6.actions.rails
 r6.actions.rails.register_all()
+# Import for side effect: registers the /<id>/review GET+POST routes on
+# actions_blueprint (Task 6 structured per-item review page). MUST precede
+# register_blueprint — routes can't be added to a blueprint after it is
+# registered on the app.
+import r6.actions.review  # noqa: F401
 app.register_blueprint(actions_blueprint)
 logger.info("Actions Blueprint registered at /r6/actions (rails: %s)",
             ', '.join(_action_kinds()))

--- a/main.py
+++ b/main.py
@@ -189,6 +189,13 @@ from r6.smbp.routes import smbp_blueprint
 app.register_blueprint(smbp_blueprint)
 logger.info("SMBP Blueprint registered at /r6/smbp")
 
+# Register SDC delivery Blueprint — public signed download route for intake
+# PDFs. On its OWN blueprint (not r6_blueprint) so it is reachable without
+# X-Tenant-Id / X-Step-Up-Token headers: the signed URL is the credential.
+from r6.sdc.delivery import sdc_delivery_blueprint
+app.register_blueprint(sdc_delivery_blueprint)
+logger.info("SDC delivery Blueprint registered at /r6/sdc")
+
 # Register Wearables Blueprint (opt-in via OPEN_WEARABLES_URL)
 from r6.wearables.routes import wearables_blueprint
 app.register_blueprint(wearables_blueprint)

--- a/r6/actions/confirmations.py
+++ b/r6/actions/confirmations.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from models import db
 from r6.actions.models import _utcnow
 
-APPROVED_VIA_VALUES = ('telegram', 'dashboard')
+APPROVED_VIA_VALUES = ('telegram', 'dashboard', 'review-page')
 
 
 class ActionConfirmation(db.Model):

--- a/r6/actions/rails/form_fill.py
+++ b/r6/actions/rails/form_fill.py
@@ -1,22 +1,24 @@
-"""form-fill rail — the ActionExecutor skeleton for kind 'form-fill'
-(Task 3). Registered so form-fill joins the action rail like phone-call and
-sms: it validates its payload shape and fails loud
-(ExecutionResult(status='failed', error=PROVIDER_NOT_CONFIGURED)) when
-PUBLIC_BASE_URL isn't configured, same fail-loud posture as the other
-rails.
+"""form-fill rail — the ActionExecutor for kind 'form-fill' (Task 8).
 
-execute() is deliberately NOT the full orchestration yet. The real
-form-fill flow is populate -> human review -> render -> DocumentReference ->
-deliver a link built from PUBLIC_BASE_URL; that lands in Task 8. Until then,
-execute() returns an honest ExecutionResult(status='needs_review') — never
-a fabricated 'completed' — so a form-fill Approve is visibly incomplete
-rather than silently wrong.
+execute() is now the real end-to-end orchestration: it takes the human-
+reviewed QuestionnaireResponse handed over by the review page (Task 6),
+renders it to a PDF (Task 4), persists that PDF as a FHIR DocumentReference
+(Task 5), and returns a signed, expiring download link (Task 7).
+
+Safety posture is unchanged and load-bearing: this rail fails loud, never
+fabricates a completed form.
+  - PUBLIC_BASE_URL unset               -> failed / PROVIDER_NOT_CONFIGURED
+  - no reviewed QR on the action        -> needs_review (never 'completed')
+  - reviewed QR vanished (deleted/stale)-> failed / STALE_SOURCE_DATA
+  - any render/persist/link exception   -> failed / PROVIDER_ERROR
+Only on a fully rendered+persisted+linked PDF does it return 'completed'.
 """
 
 import os
 
 from r6.actions import errors
 from r6.actions.registry import ExecutionResult, register_executor
+from r6.models import R6Resource
 
 
 class FormFillExecutor:
@@ -36,27 +38,140 @@ class FormFillExecutor:
         return []
 
     def execute(self, action):
-        # Env check comes before any payload-specific logic: a dark rail
+        # (1) Env check comes before any payload-specific logic: a dark rail
         # fails loud regardless of what the caller sent.
         if not os.environ.get('PUBLIC_BASE_URL'):
             return ExecutionResult(status='failed',
                                    error=errors.PROVIDER_NOT_CONFIGURED)
-        # TODO(Task 8): populate -> human review -> render -> FHIR
-        # DocumentReference -> deliver a shareable link built from
-        # PUBLIC_BASE_URL. Until that lands, this is an honest placeholder:
-        # fail safe (needs_review), never a fake 'completed' PDF/link.
+
+        # (2) Require a human-reviewed QuestionnaireResponse. Its id is stamped
+        # onto the action by the review page (Task 6). No reviewed QR means the
+        # form was never reviewed — we DO NOT fabricate one and DO NOT emit a
+        # 'completed' form; we fall back to needs_review (the honest state).
+        reviewed_qr_id = action.payload.get('reviewed_qr_id')
+        if not reviewed_qr_id:
+            return ExecutionResult(
+                status='needs_review',
+                outcome={'reason': 'form not reviewed — open the review page '
+                                   'and confirm each item first'},
+            )
+
+        # (3) Load the reviewed QR, tenant-scoped. If it vanished (deleted or
+        # stale), the reviewed answers are gone: fail loud, never render a
+        # blank/guessed form.
+        row = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', id=reviewed_qr_id,
+            tenant_id=action.tenant_id).first()
+        if row is None:
+            return ExecutionResult(status='failed',
+                                   error=errors.STALE_SOURCE_DATA)
+        reviewed_qr = row.to_fhir_json()
+
+        # (4)-(7) Render -> persist -> link. Any failure here maps to a loud
+        # PROVIDER_ERROR — an exception must never escape as a fake success.
+        try:
+            from r6.sdc.pdf import render_questionnaire_response_pdf
+            from r6.sdc.documents import persist_intake_document
+            from r6.sdc.delivery import build_document_link
+
+            # (4) Resolve the questionnaire for nicer labels — non-fatal.
+            questionnaire = self._resolve_questionnaire(
+                reviewed_qr.get('questionnaire'), action.tenant_id)
+
+            # (5) Render the reviewed answers to a PDF.
+            subject_ref = (reviewed_qr.get('subject') or {}).get('reference')
+            subject_label = self._subject_label(subject_ref, action.tenant_id)
+            reviewed_on = reviewed_qr.get('authored')
+            pdf_bytes = render_questionnaire_response_pdf(
+                reviewed_qr, questionnaire=questionnaire,
+                reviewed_on=reviewed_on, subject_label=subject_label)
+
+            # (6) Persist the PDF as a FHIR DocumentReference.
+            docref = persist_intake_document(
+                action.tenant_id, subject_ref, pdf_bytes,
+                title='Completed intake form',
+                questionnaire_response_id=reviewed_qr_id)
+            docref_id = docref['id']
+
+            # (7) Build a signed, expiring download link.
+            link = build_document_link(action.tenant_id, docref_id)
+        except Exception as exc:  # noqa: BLE001 — fail loud, never fake success
+            # Truncate to keep the taxonomy detail PHI-free-ish; do not log PHI.
+            return ExecutionResult(status='failed', error=errors.PROVIDER_ERROR,
+                                   outcome={'detail': str(exc)[:200]})
+
+        # (8) Success: the docref id is the provider_ref; the link + ids ride
+        # in the outcome so the confirm route can surface them.
         return ExecutionResult(
-            status='needs_review',
-            outcome={'reason': 'form-fill orchestration lands in Task 8'},
-        )
+            status='completed', provider_ref=docref_id,
+            outcome={'document_reference_id': docref_id,
+                     'delivery_link': link,
+                     'questionnaire_response_id': reviewed_qr_id})
+
+    @staticmethod
+    def _resolve_questionnaire(questionnaire_ref, tenant_id):
+        """Best-effort load of the stored Questionnaire for nicer labels.
+
+        Falls back to the canonical intake Questionnaire. Never raises — label
+        resolution is a nicety, not a gate on delivering the reviewed answers.
+        """
+        from r6.sdc.intake import intake_questionnaire
+        try:
+            if questionnaire_ref:
+                q_id = str(questionnaire_ref).split('|')[0]
+                if q_id.startswith('Questionnaire/'):
+                    q_id = q_id.split('/', 1)[1]
+                q_id = q_id.rstrip('/').split('/')[-1]
+                row = R6Resource.query.filter_by(
+                    resource_type='Questionnaire', id=q_id,
+                    tenant_id=tenant_id).first()
+                if row is not None:
+                    return row.to_fhir_json()
+        except Exception:  # noqa: BLE001 — non-fatal; fall through to canonical
+            pass
+        try:
+            return intake_questionnaire()
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _subject_label(subject_ref, tenant_id):
+        """Best-effort human name for the PDF title from the subject Patient.
+
+        Returns None when nothing is easily available — the renderer treats a
+        missing label as "no name", never a hard error.
+        """
+        if not subject_ref or not str(subject_ref).startswith('Patient/'):
+            return None
+        try:
+            patient_id = str(subject_ref).split('/', 1)[1]
+            row = R6Resource.query.filter_by(
+                resource_type='Patient', id=patient_id,
+                tenant_id=tenant_id).first()
+            if row is None:
+                return None
+            names = (row.to_fhir_json().get('name') or [])
+            if not names:
+                return None
+            name = names[0]
+            if name.get('text'):
+                return name['text']
+            given = ' '.join(name.get('given') or [])
+            label = ('%s %s' % (given, name.get('family') or '')).strip()
+            return label or None
+        except Exception:  # noqa: BLE001 — label is a nicety, never a gate
+            return None
 
     def reconcile(self, action):
-        # form-fill has no async provider webhook (unlike Bland.ai/Twilio),
-        # so there is no external status to poll. Keep it honest: report
-        # needs_review rather than inventing a verdict.
+        # form-fill has no async provider webhook (unlike Bland.ai/Twilio) and
+        # execute() is now synchronous and terminal — it either completes the
+        # render/persist/link in one shot or fails loud. There is no external
+        # status to poll, so keep this honest: needs_review, never an invented
+        # verdict.
         return ExecutionResult(
             status='needs_review',
-            outcome={'reason': 'form-fill orchestration lands in Task 8'},
+            outcome={'reason': 'form-fill execute() is synchronous and '
+                               'terminal — nothing to reconcile'},
         )
 
 

--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -1,0 +1,401 @@
+"""Structured per-item review page (Task 6) — the CORE SAFETY UI.
+
+Two routes on the actions blueprint:
+
+  GET  /r6/actions/<id>/review  — render a per-item confirmation page for a
+       form-fill action: Demographics read-only; each populated medication a
+       row with a required Still-taking? decision; each populated allergy a
+       row with a confirm/remove decision PLUS the explicit, UNCHECKED
+       "No known allergies (patient confirmed)" checkbox; each condition
+       confirmable. Provenance ("from your records") on populated items.
+
+  POST /r6/actions/<id>/review  — the SERVER-SIDE SAFETY GATE. It RE-POPULATES
+       the questionnaire from the tenant's FHIR (never trusting the client
+       about how many rows exist), then requires: every med row acted on, every
+       allergy row acted on, AND (the NKA box affirmed OR >=1 allergy
+       confirmed). A crafted POST that skips the allergy attestation is
+       rejected 422 — silence about allergies is never consent, and NKA is
+       never inferred from the absence of allergy data. On success it builds
+       the reviewed QuestionnaireResponse (status completed, author = reviewing
+       Device, source = Patient), persists it tenant-scoped, issues an
+       ActionConfirmation (approved_via='review-page'), and stores the reviewed
+       QR id on the action for Task 8's execute().
+
+Auth mirrors /confirm: X-Tenant-Id + a tenant-bound X-Step-Up-Token. The token
+is validated multi-use (not nonce-consumed) so the page can be re-opened and
+submitted with the same credential; the load-bearing gate here is the
+per-item + allergy-attestation check, not single-use.
+"""
+import json
+import logging
+
+from flask import render_template, request
+
+from models import db
+from r6.actions.confirmations import issue_confirmation
+from r6.actions.models import ProposedAction
+from r6.actions.routes import _error, _tenant_or_none, actions_blueprint
+from r6.audit import record_audit_event
+from r6.models import R6Resource
+from r6.sdc.intake import intake_questionnaire
+from r6.sdc.populate import populate_questionnaire
+from r6.stepup import validate_step_up_token
+
+logger = logging.getLogger(__name__)
+
+_MED_ACTIONS = ('yes', 'no', 'remove')
+_ITEM_ACTIONS = ('confirm', 'remove')
+
+# Where each list resource references its patient (R4 is inconsistent —
+# AllergyIntolerance uses `patient`, everything else `subject`).
+_CONTENT_TYPES = (
+    ('Observation', 'subject'),
+    ('MedicationRequest', 'subject'),
+    ('AllergyIntolerance', 'patient'),
+    ('Condition', 'subject'),
+)
+
+
+def _require_step_up(tenant_id):
+    """Return None if a valid tenant-bound step-up token is present, else an
+    (response, status) error tuple. Multi-use validation (no nonce consume) so
+    GET-then-POST with one token works."""
+    token = request.headers.get('X-Step-Up-Token')
+    if not token:
+        return _error(401, 'Review requires X-Step-Up-Token header')
+    valid, err = validate_step_up_token(token, tenant_id)
+    if not valid:
+        return _error(401, 'Step-up token rejected: %s' % err)
+    return None
+
+
+def _load_form_fill_action(action_id, tenant_id):
+    """Load a form-fill action that is tenant-scoped and awaiting_confirmation.
+    Returns the action or None (caller maps None -> 404). A wrong tenant, wrong
+    kind, or wrong status all collapse to 'not found' — no information leak."""
+    action = ProposedAction.query.filter_by(
+        id=action_id, tenant_id=tenant_id).first()
+    if action is None:
+        return None
+    if action.kind != 'form-fill':
+        return None
+    if action.status != 'awaiting_confirmation':
+        return None
+    return action
+
+
+def _resolve_questionnaire(action, tenant_id):
+    """Resolve the action's questionnaire. A stored Questionnaire wins; the
+    canonical intake form is the built-in fallback for 'healthclaw-intake'."""
+    qref = (action.payload.get('questionnaire') or '').strip()
+    ident = qref.split('/')[-1].split('|')[0]
+    row = R6Resource.query.filter_by(
+        resource_type='Questionnaire', id=ident, tenant_id=tenant_id).first()
+    if row is not None:
+        return row.to_fhir_json()
+    if ident == 'healthclaw-intake' or not ident:
+        return intake_questionnaire()
+    return intake_questionnaire()
+
+
+def _load_patient(tenant_id, subject_ref=None):
+    if subject_ref:
+        ident = subject_ref.split('/')[-1]
+        row = R6Resource.query.filter_by(
+            resource_type='Patient', id=ident, tenant_id=tenant_id).first()
+        return row.to_fhir_json() if row else None
+    row = R6Resource.query.filter_by(
+        resource_type='Patient', tenant_id=tenant_id).first()
+    return row.to_fhir_json() if row else None
+
+
+def _gather_content(tenant_id, patient):
+    content = []
+    if patient:
+        content.append(patient)
+    if not (patient and patient.get('id')):
+        return content
+    ref = 'Patient/%s' % patient['id']
+    for resource_type, subject_field in _CONTENT_TYPES:
+        for row in R6Resource.query.filter_by(
+                resource_type=resource_type, tenant_id=tenant_id).all():
+            resource = row.to_fhir_json()
+            if (resource.get(subject_field) or {}).get('reference') == ref:
+                content.append(resource)
+    return content
+
+
+def _draft_qr(action, tenant_id):
+    """Populate the action's questionnaire from the tenant's FHIR -> draft QR.
+    Deterministic: population order fixes the med/allergy/condition row indices
+    used by both the rendered page and the POST gate."""
+    questionnaire = _resolve_questionnaire(action, tenant_id)
+    subject_ref = (action.payload.get('subject') or {}).get('reference') \
+        if isinstance(action.payload.get('subject'), dict) else None
+    patient = _load_patient(tenant_id, subject_ref)
+    content = _gather_content(tenant_id, patient)
+    qr, _issues = populate_questionnaire(questionnaire, patient, content)
+    return questionnaire, patient, qr
+
+
+def _section_repeats(draft_qr, section_link_id, item_link_id):
+    """Ordered list of populated repeat items for a repeating section group."""
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') == section_link_id:
+            return [child for child in group.get('item', [])
+                    if child.get('linkId') == item_link_id]
+    return []
+
+
+def _leaf_value(repeat_item, leaf_link_id):
+    for child in repeat_item.get('item', []):
+        if child.get('linkId') == leaf_link_id:
+            for ans in child.get('answer', []):
+                if 'valueString' in ans:
+                    return ans['valueString']
+    return None
+
+
+def _demographics(draft_qr):
+    """Ordered (label, value) pairs from the populated demographics group."""
+    labels = {
+        'demographics.given-name': 'First name',
+        'demographics.family-name': 'Last name',
+        'demographics.birth-date': 'Date of birth',
+        'demographics.gender': 'Gender',
+        'demographics.phone': 'Phone',
+        'demographics.address-line': 'Street address',
+        'demographics.address-city': 'City',
+        'demographics.address-state': 'State',
+        'demographics.address-postal-code': 'Postal code',
+    }
+    out = []
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') != 'demographics':
+            continue
+        for child in group.get('item', []):
+            value = None
+            for ans in child.get('answer', []):
+                for key in ('valueString', 'valueDate', 'valueBoolean'):
+                    if key in ans:
+                        value = ans[key]
+                if isinstance(ans.get('valueCoding'), dict):
+                    value = ans['valueCoding'].get('display') \
+                        or ans['valueCoding'].get('code')
+            if value is not None:
+                out.append((labels.get(child.get('linkId'),
+                                       child.get('linkId')), value))
+    return out
+
+
+def _view_rows(draft_qr):
+    """Build the template's per-item view model from the draft QR."""
+    meds = []
+    for row in _section_repeats(draft_qr, 'medications', 'medications.item'):
+        meds.append({
+            'name': _leaf_value(row, 'medications.item.name') or 'Medication',
+            'dose': _leaf_value(row, 'medications.item.dose'),
+        })
+    allergies = []
+    for row in _section_repeats(draft_qr, 'allergies', 'allergies.item'):
+        allergies.append({
+            'allergen': _leaf_value(row, 'allergies.item.allergen')
+            or 'Allergy',
+            'reaction': _leaf_value(row, 'allergies.item.reaction'),
+        })
+    conditions = []
+    for row in _section_repeats(draft_qr, 'conditions', 'conditions.item'):
+        conditions.append({
+            'name': _leaf_value(row, 'conditions.item.name') or 'Condition',
+        })
+    return meds, allergies, conditions
+
+
+@actions_blueprint.route('/<action_id>/review', methods=['GET'])
+def review_form(action_id):
+    tenant_id = _tenant_or_none()
+    if not tenant_id:
+        return _error(400, 'X-Tenant-Id header is required')
+    auth_err = _require_step_up(tenant_id)
+    if auth_err is not None:
+        return auth_err
+
+    action = _load_form_fill_action(action_id, tenant_id)
+    if action is None:
+        return _error(404, 'Unknown action')
+
+    _questionnaire, _patient, draft_qr = _draft_qr(action, tenant_id)
+    demographics = _demographics(draft_qr)
+    meds, allergies, conditions = _view_rows(draft_qr)
+
+    record_audit_event(
+        'read', resource_type='ProposedAction', resource_id=action.id,
+        agent_id=request.headers.get('X-Agent-Id'), tenant_id=tenant_id,
+        detail='review page rendered',
+    )
+    html = render_template(
+        'action_review.html', action_id=action_id, demographics=demographics,
+        meds=meds, allergies=allergies, conditions=conditions,
+        step_up_token=request.headers.get('X-Step-Up-Token', ''),
+        tenant_id=tenant_id)
+    return html, 200
+
+
+def _submitted(action_id):
+    """Read the submitted decisions from JSON or form-encoded body."""
+    body = request.get_json(silent=True)
+    if isinstance(body, dict):
+        return {k: ('' if v is None else str(v)) for k, v in body.items()}
+    return {k: v for k, v in request.form.items()}
+
+
+def _truthy(value):
+    return str(value).strip().lower() in ('1', 'true', 'on', 'yes', 'checked')
+
+
+@actions_blueprint.route('/<action_id>/review', methods=['POST'])
+def review_submit(action_id):
+    tenant_id = _tenant_or_none()
+    if not tenant_id:
+        return _error(400, 'X-Tenant-Id header is required')
+    auth_err = _require_step_up(tenant_id)
+    if auth_err is not None:
+        return auth_err
+
+    action = _load_form_fill_action(action_id, tenant_id)
+    if action is None:
+        return _error(404, 'Unknown action')
+
+    # RE-POPULATE from FHIR: the server, not the client, decides which rows
+    # exist and must be acted on. This is what makes the gate un-craftable.
+    _questionnaire, patient, draft_qr = _draft_qr(action, tenant_id)
+    med_rows = _section_repeats(draft_qr, 'medications', 'medications.item')
+    allergy_rows = _section_repeats(draft_qr, 'allergies', 'allergies.item')
+    condition_rows = _section_repeats(draft_qr, 'conditions',
+                                      'conditions.item')
+    submitted = _submitted(action_id)
+
+    # (1) Every medication row must be acted on with a valid decision.
+    med_decisions = []
+    for i in range(len(med_rows)):
+        decision = submitted.get('med-%d' % i, '').strip().lower()
+        if decision not in _MED_ACTIONS:
+            return _error(422, 'Every medication must be reviewed '
+                               '(Still taking? Yes/No/Remove). Medication '
+                               'row %d was not acted on.' % (i + 1))
+        med_decisions.append(decision)
+
+    # (2) Every allergy row must be acted on with a valid decision.
+    allergy_decisions = []
+    for i in range(len(allergy_rows)):
+        decision = submitted.get('allergy-%d' % i, '').strip().lower()
+        if decision not in _ITEM_ACTIONS:
+            return _error(422, 'Every allergy must be reviewed '
+                               '(Confirm/Remove). Allergy row %d was not '
+                               'acted on.' % (i + 1))
+        allergy_decisions.append(decision)
+
+    # (3) THE ATTESTATION GATE (load-bearing): the patient must either confirm
+    # at least one allergy OR explicitly affirm "no known allergies". Removing
+    # every allergy row without checking NKA does NOT satisfy this — an absence
+    # of allergies is never inferred, it must be affirmatively attested.
+    nka_affirmed = _truthy(submitted.get('nka', ''))
+    confirmed_allergy = any(d == 'confirm' for d in allergy_decisions)
+    if not (nka_affirmed or confirmed_allergy):
+        return _error(422, 'You must confirm at least one allergy OR check '
+                           '"No known allergies (patient confirmed)". No '
+                           'known allergies is never assumed.')
+
+    # (4) Conditions are confirmable but not gating.
+    condition_decisions = [
+        submitted.get('condition-%d' % i, 'confirm').strip().lower()
+        for i in range(len(condition_rows))]
+
+    # (5) Build the reviewed QuestionnaireResponse from the human's decisions.
+    reviewed_qr = _build_reviewed_qr(
+        draft_qr, patient, med_rows, med_decisions, allergy_rows,
+        allergy_decisions, nka_affirmed, condition_rows, condition_decisions)
+
+    qr_row = R6Resource(resource_type='QuestionnaireResponse',
+                        resource_json=json.dumps(reviewed_qr),
+                        tenant_id=tenant_id)
+    db.session.add(qr_row)
+    db.session.flush()          # assign qr_row.id
+
+    # (6) Consent record for the review approval + hand-off marker for Task 8.
+    issue_confirmation(action_id, approved_via='review-page', ttl_minutes=15)
+    payload = action.payload
+    payload['reviewed_qr_id'] = qr_row.id
+    action.payload_json = json.dumps(payload)
+    db.session.commit()
+
+    record_audit_event(
+        'update', resource_type='ProposedAction', resource_id=action.id,
+        agent_id=request.headers.get('X-Agent-Id'), tenant_id=tenant_id,
+        detail='reviewed via review-page; qr=%s' % qr_row.id,
+    )
+
+    from flask import jsonify
+    return jsonify({
+        'id': action.id,
+        'status': action.status,
+        'reviewed_qr_id': qr_row.id,
+        'approved_via': 'review-page',
+        'next_step': ('Review recorded and approval issued. Form generation '
+                      '(PDF/DocumentReference) is Task 8; the form-fill '
+                      'executor currently returns an honest needs_review '
+                      'placeholder.'),
+    }), 200
+
+
+def _build_reviewed_qr(draft_qr, patient, med_rows, med_decisions,
+                       allergy_rows, allergy_decisions, nka_affirmed,
+                       condition_rows, condition_decisions):
+    """Assemble the completed QuestionnaireResponse: demographics carried
+    through, only kept meds/allergies/conditions included, and the NKA boolean
+    set ONLY from the explicit attestation."""
+    from r6.actions.models import _utcnow
+
+    items = []
+    for group in draft_qr.get('item', []):
+        if group.get('linkId') == 'demographics':
+            items.append(group)
+
+    kept_meds = [row for row, decision in zip(med_rows, med_decisions)
+                 if decision != 'remove']
+    meds_group = {'linkId': 'medications', 'item': list(kept_meds)}
+    items.append(meds_group)
+
+    kept_allergies = [row for row, decision in zip(allergy_rows,
+                                                   allergy_decisions)
+                      if decision == 'confirm']
+    allergy_children = [{
+        'linkId': 'allergies.no-known-allergies',
+        'answer': [{'valueBoolean': bool(nka_affirmed)}],
+    }]
+    allergy_children.extend(kept_allergies)
+    items.append({'linkId': 'allergies', 'item': allergy_children})
+
+    kept_conditions = [row for row, decision in zip(condition_rows,
+                                                    condition_decisions)
+                       if decision != 'remove']
+    if kept_conditions:
+        items.append({'linkId': 'conditions', 'item': list(kept_conditions)})
+
+    qr = {
+        'resourceType': 'QuestionnaireResponse',
+        'status': 'completed',
+        'questionnaire': draft_qr.get('questionnaire'),
+        'authored': _utcnow().isoformat() + 'Z',
+        # Reviewing Device authored the structured response; the patient is the
+        # information source.
+        'author': {'reference': 'Device/healthclaw-review',
+                   'display': 'HealthClaw review page'},
+        'source': {'reference': 'Patient'},
+        'item': items,
+    }
+    subject = (patient or {})
+    if subject.get('resourceType') and subject.get('id'):
+        qr['subject'] = {'reference': 'Patient/%s' % subject['id']}
+        qr['source'] = {'reference': 'Patient/%s' % subject['id']}
+    return qr

--- a/r6/sdc/delivery.py
+++ b/r6/sdc/delivery.py
@@ -1,0 +1,123 @@
+"""Signed, expiring download links for a persisted intake-PDF DocumentReference.
+
+A patient (or a clinic) opens the link and downloads the PDF with no login and
+no headers: the HMAC signature embedded in the URL *is* the authorization. The
+signing reuses the same HMAC-SHA256 / STEP_UP_SECRET pattern as r6/stepup.py —
+no new crypto is invented here.
+
+The public download route lives on its OWN blueprint (sdc_delivery_blueprint),
+NOT on r6_blueprint, precisely because r6_blueprint's before_request hook
+enforces X-Tenant-Id / X-Step-Up-Token. This route must be reachable without
+those headers.
+
+Future enhancement: wrap the link in a full SMART Health Link (SHL) envelope —
+encrypted manifest + one-time flag — which lives in the Node server. That is
+out of scope for this signed-download-route implementation.
+"""
+
+import hashlib
+import hmac
+import os
+import time
+from urllib.parse import quote
+
+from flask import Blueprint, Response, request
+
+from r6.sdc.documents import get_document_pdf_bytes
+from r6.audit import record_audit_event
+
+# One week — a patient/clinic link that is emailed and opened days later.
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600  # 604800
+
+
+def _link_secret():
+    """Shared HMAC secret — same source as the step-up tokens."""
+    return os.environ.get('STEP_UP_SECRET', '')
+
+
+def _sign(tenant_id, docref_id, exp):
+    """Hex HMAC-SHA256 over the exact message ``tenant_id\\ndocref_id\\nexp``.
+
+    Raises ValueError (fail loud) when STEP_UP_SECRET is unset — an unsigned or
+    empty-key signature must never be handed out.
+    """
+    secret = _link_secret()
+    if not secret:
+        raise ValueError('STEP_UP_SECRET is required to sign a document link')
+    msg = f"{tenant_id}\n{docref_id}\n{exp}"
+    return hmac.new(secret.encode(), msg.encode(), hashlib.sha256).hexdigest()
+
+
+def build_document_link(tenant_id, docref_id, *, ttl_seconds=DEFAULT_TTL_SECONDS,
+                        now=None):
+    """Build an ABSOLUTE, signed, expiring download URL for a DocumentReference.
+
+    base comes from PUBLIC_BASE_URL. Raises ValueError (fail loud, mirroring
+    r6/actions/rails/form_fill.py) when PUBLIC_BASE_URL is unset — a delivery
+    link with no host is useless and must never be silently produced.
+
+    ``now`` is injectable for deterministic tests; defaults to time.time().
+    """
+    base = os.environ.get('PUBLIC_BASE_URL', '').rstrip('/')
+    if not base:
+        raise ValueError('PUBLIC_BASE_URL is required to build a delivery link')
+    exp = int(now or time.time()) + ttl_seconds
+    sig = _sign(tenant_id, docref_id, exp)
+    return (f"{base}/r6/sdc/documents/{docref_id}"
+            f"?t={quote(tenant_id)}&exp={exp}&sig={sig}")
+
+
+def verify_document_link(tenant_id, docref_id, exp, sig, *, now=None):
+    """Verify a signed download link. Returns ``(ok, reason)``.
+
+    Order matters: the signature is checked BEFORE expiry, so a tampered exp is
+    reported as 'bad-signature' (not 'expired'). reason is one of
+    'malformed', 'bad-signature', 'expired', or 'ok'.
+    """
+    try:
+        exp_int = int(exp)
+    except (TypeError, ValueError):
+        return False, 'malformed'
+    expected = _sign(tenant_id, docref_id, exp_int)
+    if not hmac.compare_digest(expected, sig):
+        return False, 'bad-signature'
+    if int(now or time.time()) > exp_int:
+        return False, 'expired'
+    return True, 'ok'
+
+
+# ---------------------------------------------------------------------------
+# Public download route — deliberately NOT on r6_blueprint (whose
+# before_request hook enforces tenant headers). The signature is the credential.
+# ---------------------------------------------------------------------------
+sdc_delivery_blueprint = Blueprint('sdc_delivery', __name__, url_prefix='/r6/sdc')
+
+
+@sdc_delivery_blueprint.route('/documents/<docref_id>', methods=['GET'])
+def download_document(docref_id):
+    """Serve the intake PDF for ``docref_id`` when the signed link verifies."""
+    tenant_id = request.args.get('t')
+    exp = request.args.get('exp')
+    sig = request.args.get('sig')
+    if not tenant_id or not exp or not sig:
+        return Response('missing link parameters', status=400,
+                        mimetype='text/plain')
+
+    ok, reason = verify_document_link(tenant_id, docref_id, exp, sig)
+    if not ok:
+        if reason == 'expired':
+            return Response('link expired', status=410, mimetype='text/plain')
+        # bad-signature / malformed
+        return Response('invalid link', status=403, mimetype='text/plain')
+
+    pdf = get_document_pdf_bytes(tenant_id, docref_id)
+    if pdf is None:
+        return Response('document not found', status=404, mimetype='text/plain')
+
+    record_audit_event('read', resource_type='DocumentReference',
+                       resource_id=docref_id, tenant_id=tenant_id,
+                       detail='intake pdf downloaded via signed link')
+
+    resp = Response(pdf, mimetype='application/pdf')
+    resp.headers['Content-Disposition'] = 'attachment; filename="intake.pdf"'
+    return resp

--- a/r6/sdc/documents.py
+++ b/r6/sdc/documents.py
@@ -1,0 +1,93 @@
+"""Persist a completed intake PDF as a FHIR DocumentReference.
+
+persist_intake_document() embeds the actual PDF bytes (base64, per FHIR's
+Attachment.data) in content[0].attachment.data — not just a byte count —
+so the rendered PDF (r6/sdc/pdf.py::render_questionnaire_response_pdf) can
+be retrieved later for delivery (Task 7) without re-rendering.
+
+Mirrors r6/smbp/routes.py::_persist_document_reference's DocumentReference
+shape, generalized to carry the bytes and to optionally link back to the
+QuestionnaireResponse the PDF was rendered from.
+"""
+
+import base64
+import json
+from datetime import datetime, timezone
+
+from models import db
+from r6.models import R6Resource
+from r6.audit import record_audit_event
+
+# LOINC "Summarization of episode note" — a generic document-summary type
+# code commonly used for rendered clinical/administrative documents (CCD-style
+# summaries) when no more specific LOINC code applies. Mirrors the smbp
+# report's use of a LOINC coding for its DocumentReference.type.
+_INTAKE_DOCUMENT_TYPE = {
+    "coding": [{"system": "http://loinc.org", "code": "34133-9",
+                "display": "Summarization of episode note"}]
+}
+
+
+def persist_intake_document(tenant_id, subject_ref, pdf_bytes, *, title=None,
+                             questionnaire_response_id=None):
+    """Persist `pdf_bytes` as a FHIR DocumentReference under `tenant_id`.
+
+    subject_ref: e.g. "Patient/123" — stored as DocumentReference.subject.
+    title: attachment title; defaults to "Intake form".
+    questionnaire_response_id: if provided, links the DocumentReference back
+        to the QuestionnaireResponse the PDF was rendered from via both
+        context.related and relatesTo, so the structured QR and the rendered
+        PDF can be traced to each other.
+
+    Returns the stored DocumentReference resource dict (with id/meta).
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    doc = {
+        "resourceType": "DocumentReference",
+        "status": "current",
+        "type": _INTAKE_DOCUMENT_TYPE,
+        "subject": {"reference": subject_ref},
+        "date": now,
+        "content": [{
+            "attachment": {
+                "contentType": "application/pdf",
+                "title": title or "Intake form",
+                "size": len(pdf_bytes),
+                "data": base64.b64encode(pdf_bytes).decode("ascii"),
+            }
+        }],
+    }
+    if questionnaire_response_id:
+        qr_reference = f"QuestionnaireResponse/{questionnaire_response_id}"
+        doc["context"] = {"related": [{"reference": qr_reference}]}
+        doc["relatesTo"] = [{"code": "transforms",
+                             "target": {"reference": qr_reference}}]
+
+    row = R6Resource(resource_type="DocumentReference",
+                     resource_json=json.dumps(doc), tenant_id=tenant_id)
+    db.session.add(row)
+    db.session.commit()
+    record_audit_event("create", "DocumentReference", row.id,
+                       tenant_id=tenant_id, detail="intake pdf persisted")
+    return row.to_fhir_json()
+
+
+def get_document_pdf_bytes(tenant_id, docref_id):
+    """Load the DocumentReference `docref_id` under `tenant_id` and decode
+    its embedded PDF bytes back out of content[0].attachment.data.
+
+    Returns None if the DocumentReference doesn't exist for that tenant, or
+    has no embedded attachment data.
+    """
+    row = R6Resource.query.filter_by(resource_type="DocumentReference",
+                                     id=docref_id, tenant_id=tenant_id).first()
+    if row is None:
+        return None
+    resource = row.to_fhir_json()
+    content = resource.get("content") or []
+    if not content:
+        return None
+    data = (content[0].get("attachment") or {}).get("data")
+    if not data:
+        return None
+    return base64.b64decode(data)

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -1,0 +1,233 @@
+{% extends "base.html" %}
+{% block title %}Review your intake form — HealthClaw Guardrails{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-9">
+
+    <div class="d-flex align-items-center mb-3">
+      <i class="fas fa-clipboard-check me-2" style="color:var(--r6-primary);font-size:1.6rem"></i>
+      <div>
+        <h2 class="mb-0">Review each item before we generate your form</h2>
+        <p class="text-muted mb-0">
+          Nothing is submitted until you confirm every medication and allergy
+          below. "No known allergies" is never assumed on your behalf.
+        </p>
+      </div>
+    </div>
+
+    <form id="review-form" method="post"
+          action="/r6/actions/{{ action_id }}/review">
+
+      <!-- Demographics: read-only, straight from your records -->
+      <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span><i class="fas fa-id-card me-2"></i>Demographics</span>
+          <span class="badge bg-secondary">read-only · from your records</span>
+        </div>
+        <div class="card-body">
+          {% if demographics %}
+          <dl class="row mb-0">
+            {% for label, value in demographics %}
+            <dt class="col-sm-4 text-muted">{{ label }}</dt>
+            <dd class="col-sm-8">{{ value }}</dd>
+            {% endfor %}
+          </dl>
+          {% else %}
+          <p class="text-muted mb-0">No demographic details found in your records.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Medications: confirm each one individually -->
+      <div class="card mb-4">
+        <div class="card-header"><i class="fas fa-pills me-2"></i>Current medications</div>
+        <div class="card-body">
+          {% if meds %}
+          <p class="text-muted small">Each medication below is <strong>from your records</strong>. Tell us whether you are still taking it.</p>
+          {% for med in meds %}
+          <div class="med-row border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center"
+               data-row-index="{{ loop.index0 }}">
+            <div class="me-3">
+              <div class="fw-bold">{{ med.name }}</div>
+              {% if med.dose %}<div class="text-muted small">{{ med.dose }}</div>{% endif %}
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group" aria-label="Still taking {{ med.name }}?">
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-yes" value="yes" required>
+              <label class="btn btn-outline-success btn-sm" for="med-{{ loop.index0 }}-yes">Still taking</label>
+
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-no" value="no">
+              <label class="btn btn-outline-warning btn-sm" for="med-{{ loop.index0 }}-no">Not anymore</label>
+
+              <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
+                     id="med-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="med-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+          {% else %}
+          <p class="text-muted mb-0">No medications found in your records.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Allergies: confirm each, and the explicit NKA attestation -->
+      <div class="card mb-4 border-warning">
+        <div class="card-header"><i class="fas fa-triangle-exclamation me-2"></i>Allergies</div>
+        <div class="card-body">
+          {% if allergies %}
+          <p class="text-muted small">Each allergy below is <strong>from your records</strong>. Confirm or remove each one.</p>
+          {% for allergy in allergies %}
+          <div class="allergy-row border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center"
+               data-row-index="{{ loop.index0 }}">
+            <div class="me-3">
+              <div class="fw-bold">{{ allergy.allergen }}</div>
+              {% if allergy.reaction %}<div class="text-muted small">Reaction: {{ allergy.reaction }}</div>{% endif %}
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group" aria-label="Confirm {{ allergy.allergen }}?">
+              <input type="radio" class="btn-check allergy-choice" name="allergy-{{ loop.index0 }}"
+                     id="allergy-{{ loop.index0 }}-confirm" value="confirm">
+              <label class="btn btn-outline-success btn-sm" for="allergy-{{ loop.index0 }}-confirm">Confirm</label>
+
+              <input type="radio" class="btn-check allergy-choice" name="allergy-{{ loop.index0 }}"
+                     id="allergy-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="allergy-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+          {% else %}
+          <div class="alert alert-warning mb-3" role="alert">
+            <i class="fas fa-circle-info me-1"></i>
+            No allergies found in your records — add them or affirmatively confirm none below.
+          </div>
+          {% endif %}
+
+          <div class="form-check mt-2 p-3 bg-body-secondary rounded">
+            <!-- CRITICAL: never pre-checked. NKA is an explicit attestation,
+                 never inferred from the absence of allergy data. -->
+            <input class="form-check-input" type="checkbox" name="nka" id="nka" value="true">
+            <label class="form-check-label fw-bold" for="nka">
+              No known allergies (patient confirmed)
+            </label>
+            <div class="text-muted small">
+              Only check this if the patient has affirmatively stated they have no known allergies.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Conditions: confirmable -->
+      {% if conditions %}
+      <div class="card mb-4">
+        <div class="card-header"><i class="fas fa-notes-medical me-2"></i>Problems / conditions</div>
+        <div class="card-body">
+          <p class="text-muted small">Each condition below is <strong>from your records</strong>.</p>
+          {% for condition in conditions %}
+          <div class="border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fw-bold">{{ condition.name }}</div>
+              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+            </div>
+            <div class="btn-group" role="group">
+              <input type="radio" class="btn-check" name="condition-{{ loop.index0 }}"
+                     id="condition-{{ loop.index0 }}-confirm" value="confirm" checked>
+              <label class="btn btn-outline-success btn-sm" for="condition-{{ loop.index0 }}-confirm">Confirm</label>
+
+              <input type="radio" class="btn-check" name="condition-{{ loop.index0 }}"
+                     id="condition-{{ loop.index0 }}-remove" value="remove">
+              <label class="btn btn-outline-danger btn-sm" for="condition-{{ loop.index0 }}-remove">Remove</label>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+
+      <div id="review-gate-msg" class="alert alert-secondary" role="alert">
+        Review every medication and allergy, then confirm an allergy or check
+        "No known allergies" to continue.
+      </div>
+
+      <button type="submit" id="approve-btn" class="btn btn-primary btn-lg" disabled>
+        <i class="fas fa-check me-1"></i>Approve &amp; generate
+      </button>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // Client-side UX only. The SERVER POST re-populates from FHIR and is the
+  // real, un-craftable gate (see r6/actions/review.py).
+  (function () {
+    var TENANT = {{ tenant_id | tojson }};
+    var TOKEN = {{ step_up_token | tojson }};
+    var form = document.getElementById('review-form');
+    var btn = document.getElementById('approve-btn');
+    var gateMsg = document.getElementById('review-gate-msg');
+
+    function medRows() {
+      var names = {};
+      form.querySelectorAll('.med-choice').forEach(function (el) { names[el.name] = true; });
+      return Object.keys(names);
+    }
+    function allergyRows() {
+      var names = {};
+      form.querySelectorAll('.allergy-choice').forEach(function (el) { names[el.name] = true; });
+      return Object.keys(names);
+    }
+    function selected(name) {
+      var el = form.querySelector('input[name="' + name + '"]:checked');
+      return el ? el.value : null;
+    }
+    function evaluate() {
+      var allMeds = medRows().every(function (n) { return selected(n) !== null; });
+      var allAllergies = allergyRows().every(function (n) { return selected(n) !== null; });
+      var confirmedAllergy = allergyRows().some(function (n) { return selected(n) === 'confirm'; });
+      var nka = form.querySelector('#nka').checked;
+      var ok = allMeds && allAllergies && (confirmedAllergy || nka);
+      btn.disabled = !ok;
+      gateMsg.className = ok ? 'alert alert-success' : 'alert alert-secondary';
+      gateMsg.textContent = ok
+        ? 'Ready to generate. The server will re-verify every item on submit.'
+        : 'Review every medication and allergy, then confirm an allergy or check "No known allergies" to continue.';
+      return ok;
+    }
+    form.addEventListener('change', evaluate);
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      if (!evaluate()) { return; }
+      var payload = {};
+      new FormData(form).forEach(function (v, k) { payload[k] = v; });
+      if (form.querySelector('#nka').checked) { payload['nka'] = 'true'; }
+      fetch(form.action, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tenant-Id': TENANT,
+          'X-Step-Up-Token': TOKEN
+        },
+        body: JSON.stringify(payload)
+      }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
+        .then(function (res) {
+          if (res.r.ok) {
+            gateMsg.className = 'alert alert-success';
+            gateMsg.textContent = 'Review recorded. ' + (res.b.next_step || '');
+            btn.disabled = true;
+          } else {
+            gateMsg.className = 'alert alert-danger';
+            gateMsg.textContent = res.b.error || 'Submission rejected.';
+          }
+        });
+    });
+
+    evaluate();
+  })();
+</script>
+{% endblock %}

--- a/tests/actions/test_form_fill_execute.py
+++ b/tests/actions/test_form_fill_execute.py
@@ -1,0 +1,166 @@
+"""form-fill execute() end-to-end (Task 8).
+
+execute() is now the real orchestration: reviewed QuestionnaireResponse ->
+rendered PDF -> FHIR DocumentReference -> signed download link. These tests
+pin the safety contract branch-by-branch (fail loud, never fabricate a
+completed form) plus one full propose -> review -> confirm -> download
+integration path on synthetic data with the allergy attestation satisfied.
+"""
+import json
+
+from models import db
+from r6.actions.models import ProposedAction
+from r6.actions.rails.form_fill import FormFillExecutor
+from r6.actions import errors
+from r6.models import R6Resource
+from r6.sdc.documents import get_document_pdf_bytes
+
+# Reuse the review-flow fixtures/helpers/constants verbatim.
+from tests.actions.test_review_flow import (
+    PATIENT, MED_A, ALLERGY_A, _seed, _staged_form_fill,
+)
+
+BASE_URL = 'https://example.test'
+
+
+def _reviewed_qr(subject_id='test-patient-1', nka=True):
+    """A completed QuestionnaireResponse of the shape the review page persists:
+    a subject, one medication, and the explicit NKA attestation boolean."""
+    qr = {
+        'resourceType': 'QuestionnaireResponse',
+        'status': 'completed',
+        'questionnaire': 'healthclaw-intake',
+        'authored': '2026-07-11T12:00:00Z',
+        'subject': {'reference': 'Patient/%s' % subject_id},
+        'item': [
+            {'linkId': 'medications', 'item': [
+                {'linkId': 'medications.med', 'text': 'Metformin 500 mg tablet',
+                 'answer': [{'valueString': 'Metformin 500 mg tablet'}]},
+            ]},
+            {'linkId': 'allergies', 'item': [
+                {'linkId': 'allergies.no-known-allergies',
+                 'answer': [{'valueBoolean': nka}]},
+            ]},
+        ],
+    }
+    return qr
+
+
+def _persist_qr(tenant, qr):
+    row = R6Resource(resource_type='QuestionnaireResponse',
+                     resource_json=json.dumps(qr), tenant_id=tenant)
+    db.session.add(row)
+    db.session.commit()
+    return row.id
+
+
+def _action(tenant, payload):
+    return ProposedAction(tenant_id=tenant, kind='form-fill', payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: the four safety branches of execute()
+# ---------------------------------------------------------------------------
+
+def test_execute_without_public_base_url_fails_loud(app, tenant_id, monkeypatch):
+    monkeypatch.delenv('PUBLIC_BASE_URL', raising=False)
+    with app.app_context():
+        action = _action(tenant_id, {'questionnaire': 'healthclaw-intake',
+                                     'body': 'x', 'reviewed_qr_id': 'whatever'})
+        result = FormFillExecutor().execute(action)
+    assert result.status == 'failed'
+    assert result.error == errors.PROVIDER_NOT_CONFIGURED
+
+
+def test_execute_without_reviewed_qr_is_needs_review(app, tenant_id, monkeypatch):
+    """No reviewed QR -> the form was never human-reviewed. Never 'completed'."""
+    monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)
+    with app.app_context():
+        action = _action(tenant_id, {'questionnaire': 'healthclaw-intake',
+                                     'body': 'x'})
+        result = FormFillExecutor().execute(action)
+    assert result.status == 'needs_review'
+    assert result.status != 'completed'
+
+
+def test_execute_missing_qr_row_is_stale_source_data(app, tenant_id, monkeypatch):
+    monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)
+    with app.app_context():
+        action = _action(tenant_id, {'questionnaire': 'healthclaw-intake',
+                                     'body': 'x',
+                                     'reviewed_qr_id': 'does-not-exist'})
+        result = FormFillExecutor().execute(action)
+    assert result.status == 'failed'
+    assert result.error == errors.STALE_SOURCE_DATA
+
+
+def test_execute_happy_path_renders_persists_and_links(app, tenant_id,
+                                                       monkeypatch):
+    monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)
+    with app.app_context():
+        qr_id = _persist_qr(tenant_id, _reviewed_qr())
+        action = _action(tenant_id, {'questionnaire': 'healthclaw-intake',
+                                     'body': 'x', 'reviewed_qr_id': qr_id})
+        result = FormFillExecutor().execute(action)
+
+        assert result.status == 'completed', result.outcome
+        docref_id = result.provider_ref
+        assert docref_id
+        assert result.outcome['document_reference_id'] == docref_id
+        assert result.outcome['questionnaire_response_id'] == qr_id
+        link = result.outcome['delivery_link']
+        assert '/r6/sdc/documents/%s' % docref_id in link
+        assert link.startswith(BASE_URL)
+
+        # The DocumentReference exists for the tenant and carries real PDF bytes.
+        pdf = get_document_pdf_bytes(tenant_id, docref_id)
+        assert pdf and pdf.startswith(b'%PDF')
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: propose -> review (confirm the allergy) -> confirm -> download
+# ---------------------------------------------------------------------------
+
+def test_end_to_end_propose_review_confirm_download(client, app, tenant_headers,
+                                                    auth_headers, action_registry,
+                                                    monkeypatch):
+    monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)
+    tenant = tenant_headers['X-Tenant-Id']
+    # Real allergy (Penicillin) so the attestation is satisfied by CONFIRMING it
+    # (not by NKA) — the human affirmatively confirms the allergy row.
+    _seed(app, tenant, [PATIENT, MED_A, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    # Review: act on the med and CONFIRM the real allergy (no NKA needed).
+    review = client.post('/r6/actions/%s/review' % action_id,
+                         headers=auth_headers,
+                         json={'med-0': 'yes', 'allergy-0': 'confirm'})
+    assert review.status_code == 200, review.get_data(as_text=True)
+    assert review.get_json()['reviewed_qr_id']
+
+    # Out-of-band confirm — mirrors tests/actions/test_confirm_is_commit.py::
+    # _confirm (auth_headers carry a valid step-up token; commit/review are
+    # multi-use, confirm consumes the nonce).
+    confirm = client.post('/r6/actions/%s/confirm' % action_id,
+                         headers=auth_headers, json={})
+    assert confirm.status_code == 200, confirm.get_data(as_text=True)
+    assert confirm.get_json()['status'] == 'completed'
+
+    # Pull the delivery link out of the persisted outcome.
+    with app.app_context():
+        row = db.session.get(ProposedAction, action_id)
+        assert row.status == 'completed'
+        outcome = json.loads(row.outcome_summary)
+        link = outcome['delivery_link']
+        docref_id = outcome['document_reference_id']
+        assert row.external_ref == docref_id
+
+    # GET the signed link (path + query) — the signature IS the credential, so
+    # no tenant/step-up headers are supplied.
+    from urllib.parse import urlparse, parse_qs
+    parsed = urlparse(link)
+    query = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+    resp = client.get(parsed.path, query_string=query)
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/pdf'
+    assert resp.data.startswith(b'%PDF')

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -1,0 +1,332 @@
+"""Structured per-item review page (Task 6) — the core safety UI.
+
+A human confirms each populated medication and allergy individually, and must
+EXPLICITLY affirm "no known allergies" — it is never inferred from the absence
+of allergy data. The server-side POST is the load-bearing gate: a crafted POST
+that skips the allergy attestation MUST be rejected (422), leaving the action
+untouched and issuing NO ActionConfirmation.
+
+Field contract for POST /r6/actions/<id>/review (JSON or form):
+  med-<i>       one of 'yes' | 'no' | 'remove'   (i = 0..N-1 populated meds)
+  allergy-<i>   one of 'confirm' | 'remove'      (i = 0..M-1 populated allergies)
+  condition-<i> one of 'confirm' | 'remove'      (optional; confirmable)
+  nka           truthy => the explicit "no known allergies" attestation
+The server RE-POPULATES from the tenant's FHIR to decide which med/allergy
+rows must be acted on — it never trusts the client about how many rows exist.
+"""
+import json
+
+from models import db
+from r6.actions.confirmations import ActionConfirmation
+from r6.actions.models import ProposedAction
+
+PATIENT = {
+    'resourceType': 'Patient', 'id': 'test-patient-1',
+    'name': [{'family': 'Smith', 'given': ['John']}],
+    'gender': 'male', 'birthDate': '1990-01-15',
+}
+MED_A = {
+    'resourceType': 'MedicationRequest', 'id': 'med-a', 'status': 'active',
+    'intent': 'order',
+    'medicationCodeableConcept': {'text': 'Metformin 500 mg tablet'},
+    'dosageInstruction': [{'text': 'Take 1 tablet twice daily'}],
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+MED_B = {
+    'resourceType': 'MedicationRequest', 'id': 'med-b', 'status': 'active',
+    'intent': 'order',
+    'medicationCodeableConcept': {'text': 'Lisinopril 10 mg tablet'},
+    'dosageInstruction': [{'text': 'Take 1 tablet daily'}],
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+ALLERGY_A = {
+    'resourceType': 'AllergyIntolerance', 'id': 'allergy-a',
+    'code': {'text': 'Penicillin'},
+    'reaction': [{'manifestation': [{'text': 'Hives'}]}],
+    'patient': {'reference': 'Patient/test-patient-1'},
+}
+CONDITION_A = {
+    'resourceType': 'Condition', 'id': 'cond-a',
+    'code': {'text': 'Type 2 diabetes mellitus'},
+    'subject': {'reference': 'Patient/test-patient-1'},
+}
+
+FORM_FILL_BODY = {
+    'kind': 'form-fill',
+    'payload': {'to': 'Intake portal', 'questionnaire': 'healthclaw-intake',
+                'body': 'new patient intake form'},
+}
+
+
+def _seed(app, tenant, resources):
+    with app.app_context():
+        for r in resources:
+            db.session.add(R6(r, tenant))
+        db.session.commit()
+
+
+def R6(resource, tenant):
+    from r6.models import R6Resource
+    return R6Resource(resource_type=resource['resourceType'],
+                      resource_json=json.dumps(resource),
+                      resource_id=resource['id'], tenant_id=tenant)
+
+
+def _staged_form_fill(client, tenant_headers, auth_headers):
+    """propose + commit a form-fill action -> awaiting_confirmation."""
+    r = client.post('/r6/actions/propose', json=FORM_FILL_BODY,
+                    headers=tenant_headers)
+    assert r.status_code == 201, r.get_data(as_text=True)
+    action_id = r.get_json()['id']
+    c = client.post('/r6/actions/%s/commit' % action_id, headers=auth_headers)
+    assert c.status_code == 202, c.get_data(as_text=True)
+    return action_id
+
+
+def _get(client, headers, action_id):
+    return client.get('/r6/actions/%s/review' % action_id, headers=headers)
+
+
+def _post(client, headers, action_id, body):
+    return client.post('/r6/actions/%s/review' % action_id,
+                       headers=headers, json=body)
+
+
+# ---------------------------------------------------------------------------
+# GET renders the review page
+# ---------------------------------------------------------------------------
+
+def test_get_review_renders_populated_items_nka_not_prechecked(
+        client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'],
+          [PATIENT, MED_A, MED_B, ALLERGY_A, CONDITION_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    # Populated clinical content is shown with provenance.
+    assert 'Metformin 500 mg tablet' in html
+    assert 'Lisinopril 10 mg tablet' in html
+    assert 'Penicillin' in html
+    assert 'from your records' in html
+    # The NKA checkbox exists and is NOT pre-checked.
+    assert 'no known allergies' in html.lower()
+    nka_idx = html.lower().find('no known allergies')
+    # find the input element for NKA (name="nka") and assert it is unchecked
+    assert 'name="nka"' in html
+    input_idx = html.find('name="nka"')
+    # slice the input tag and ensure 'checked' is not inside it
+    tag = html[html.rfind('<input', 0, input_idx):
+               html.find('>', input_idx) + 1]
+    assert 'checked' not in tag.lower()
+    assert nka_idx > 0
+
+
+def test_get_review_no_allergies_never_prechecks_nka(
+        client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'No allergies found in your records' in html
+    input_idx = html.find('name="nka"')
+    tag = html[html.rfind('<input', 0, input_idx):
+               html.find('>', input_idx) + 1]
+    assert 'checked' not in tag.lower()
+
+
+def test_get_review_requires_step_up(client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _get(client, tenant_headers, action_id)   # no step-up token
+    assert resp.status_code == 401
+
+
+def test_get_review_non_form_fill_404(client, app, tenant_headers, auth_headers):
+    r = client.post('/r6/actions/propose', json={
+        'kind': 'sms',
+        'payload': {'to': 'Dr. Smith', 'phone': '617-555-0100',
+                    'body': 'reminder'}}, headers=tenant_headers)
+    action_id = r.get_json()['id']
+    client.post('/r6/actions/%s/commit' % action_id, headers=auth_headers)
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 404
+
+
+def test_get_review_wrong_tenant_404(client, app, tenant_headers, auth_headers,
+                                     other_tenant_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _get(client, other_tenant_headers, action_id)
+    assert resp.status_code == 404
+
+
+def test_get_review_requires_awaiting_confirmation(client, app, tenant_headers,
+                                                   auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    r = client.post('/r6/actions/propose', json=FORM_FILL_BODY,
+                    headers=tenant_headers)
+    action_id = r.get_json()['id']          # proposed, NOT committed
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# LOAD-BEARING server-side allergy-attestation gate
+# ---------------------------------------------------------------------------
+
+def test_post_omitting_allergy_attestation_is_rejected(
+        client, app, tenant_headers, auth_headers):
+    """A crafted POST that acts on every row but neither confirms an allergy
+    nor affirms NKA MUST be rejected — silence is never consent."""
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    # Every med acted on; the one allergy is REMOVED (not confirmed); no NKA.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'med-1': 'no', 'allergy-0': 'remove'})
+    assert resp.status_code == 422, resp.get_data(as_text=True)
+    assert 'allergy' in resp.get_json()['error'].lower()
+
+    with app.app_context():
+        # Action untouched, NO consent record issued.
+        assert db.session.get(ProposedAction,
+                              action_id).status == 'awaiting_confirmation'
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+def test_post_no_allergies_still_requires_nka_attestation(
+        client, app, tenant_headers, auth_headers):
+    """Zero allergies in the records does NOT let the form proceed silently —
+    the patient must affirmatively check NKA."""
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _post(client, auth_headers, action_id, {'med-0': 'yes'})
+    assert resp.status_code == 422
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+def test_post_missing_med_action_is_rejected(client, app, tenant_headers,
+                                             auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    # med-1 omitted -> a medication row was not acted on.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'nka': 'true'})
+    assert resp.status_code == 422
+    assert 'medication' in resp.get_json()['error'].lower()
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# POST happy paths
+# ---------------------------------------------------------------------------
+
+def test_post_with_nka_affirmed_succeeds(client, app, tenant_headers,
+                                         auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'med-1': 'no', 'nka': 'true'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    with app.app_context():
+        rows = ActionConfirmation.query.filter_by(action_id=action_id).all()
+        assert len(rows) == 1
+        assert rows[0].approved_via == 'review-page'
+        # Reviewed QR persisted, tenant-scoped, status completed.
+        action = db.session.get(ProposedAction, action_id)
+        qr_id = action.payload.get('reviewed_qr_id')
+        assert qr_id
+        from r6.models import R6Resource
+        row = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', id=qr_id,
+            tenant_id=tenant).first()
+        assert row is not None
+        qr = row.to_fhir_json()
+        assert qr['status'] == 'completed'
+        # NKA attestation captured as an explicit boolean true.
+        assert _nka_answer(qr) is True
+
+
+def test_post_confirming_real_allergy_succeeds(client, app, tenant_headers,
+                                               auth_headers):
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    # Confirm the real allergy; NO NKA. This satisfies the attestation gate.
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'allergy-0': 'confirm'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id, approved_via='review-page').count() == 1
+        action = db.session.get(ProposedAction, action_id)
+        qr_id = action.payload.get('reviewed_qr_id')
+        from r6.models import R6Resource
+        qr = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', id=qr_id,
+            tenant_id=tenant).first().to_fhir_json()
+        assert qr['status'] == 'completed'
+        assert _nka_answer(qr) is not True   # NKA never inferred
+
+
+def test_post_requires_step_up(client, app, tenant_headers, auth_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = client.post('/r6/actions/%s/review' % action_id,
+                       headers=tenant_headers, json={'med-0': 'yes',
+                                                     'nka': 'true'})
+    assert resp.status_code == 401
+
+
+def test_post_wrong_tenant_404(client, app, tenant_headers, auth_headers,
+                               other_tenant_headers):
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    resp = _post(client, other_tenant_headers, action_id,
+                 {'med-0': 'yes', 'nka': 'true'})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# confirmations.py accepts the new channel
+# ---------------------------------------------------------------------------
+
+def test_issue_confirmation_accepts_review_page(app):
+    from r6.actions.confirmations import (APPROVED_VIA_VALUES,
+                                          issue_confirmation)
+    assert 'review-page' in APPROVED_VIA_VALUES
+    with app.app_context():
+        c = issue_confirmation('some-action', 'review-page', ttl_minutes=15)
+        db.session.add(c)
+        db.session.commit()
+        assert c.approved_via == 'review-page'
+
+
+def _nka_answer(qr):
+    """Extract the boolean answer for allergies.no-known-allergies, or None."""
+    for group in qr.get('item', []):
+        if group.get('linkId') == 'allergies':
+            for child in group.get('item', []):
+                if child.get('linkId') == 'allergies.no-known-allergies':
+                    for ans in child.get('answer', []):
+                        if 'valueBoolean' in ans:
+                            return ans['valueBoolean']
+    return None

--- a/tests/actions/test_review_gate_adversarial.py
+++ b/tests/actions/test_review_gate_adversarial.py
@@ -6,8 +6,6 @@ that silently drops a real allergy or asserts "no known allergies" without an
 explicit human attestation. Mirrors the hands-on verification done for the SDC
 populate NKA invariant.
 """
-import json
-
 from models import db
 from r6.actions.confirmations import ActionConfirmation
 from r6.actions.models import ProposedAction

--- a/tests/actions/test_review_gate_adversarial.py
+++ b/tests/actions/test_review_gate_adversarial.py
@@ -1,0 +1,68 @@
+"""Adversarial probes for the review-page allergy-attestation gate (Task 6).
+
+Written by the coordinator (not the implementer) to independently attack the
+load-bearing safety property: the software must NEVER let a form be finalized
+that silently drops a real allergy or asserts "no known allergies" without an
+explicit human attestation. Mirrors the hands-on verification done for the SDC
+populate NKA invariant.
+"""
+import json
+
+from models import db
+from r6.actions.confirmations import ActionConfirmation
+from r6.actions.models import ProposedAction
+
+from tests.actions.test_review_flow import (
+    ALLERGY_A, PATIENT, R6, _post, _staged_form_fill,
+)
+
+
+def _no_confirmation(app, action_id):
+    with app.app_context():
+        return ActionConfirmation.query.filter_by(action_id=action_id).count() == 0
+
+
+def _action(app, action_id):
+    with app.app_context():
+        a = ProposedAction.query.filter_by(id=action_id).first()
+        return a.status, (a.payload or {}).get('reviewed_qr_id')
+
+
+def test_fake_extra_allergy_confirm_cannot_bypass_nka_gate(
+        client, app, tenant_headers, auth_headers, tenant_id):
+    """Patient HAS a real Penicillin allergy. Attacker removes the real row and
+    submits a fabricated allergy-1=confirm (no such server row) plus no NKA.
+    The gate reads decisions only over server-derived rows, so the fake confirm
+    is ignored -> 422, no ActionConfirmation, action untouched."""
+    with app.app_context():
+        db.session.add(R6(PATIENT, tenant_id))
+        db.session.add(R6(ALLERGY_A, tenant_id))
+        db.session.commit()
+
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    body = {'allergy-0': 'remove', 'allergy-1': 'confirm'}  # no 'nka'
+    r = _post(client, {**tenant_headers, **auth_headers}, action_id, body)
+
+    assert r.status_code == 422, r.get_data(as_text=True)
+    assert _no_confirmation(app, action_id), 'a rejected review must issue NO confirmation'
+    status, reviewed_qr_id = _action(app, action_id)
+    assert status == 'awaiting_confirmation', 'rejected review must not advance the action'
+    assert reviewed_qr_id is None, 'no reviewed QR should be persisted on rejection'
+
+
+def test_removing_real_allergy_without_nka_is_rejected(
+        client, app, tenant_headers, auth_headers, tenant_id):
+    """The canonical dangerous case: a real allergy exists, the human removes it
+    and does NOT attest NKA. Silence is not consent -> 422, no confirmation."""
+    with app.app_context():
+        db.session.add(R6(PATIENT, tenant_id))
+        db.session.add(R6(ALLERGY_A, tenant_id))
+        db.session.commit()
+
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+    r = _post(client, {**tenant_headers, **auth_headers}, action_id,
+              {'allergy-0': 'remove'})
+
+    assert r.status_code == 422, r.get_data(as_text=True)
+    assert _no_confirmation(app, action_id)

--- a/tests/test_sdc_delivery.py
+++ b/tests/test_sdc_delivery.py
@@ -1,0 +1,225 @@
+"""Tests for r6/sdc/delivery.py — signed, expiring download links for a
+persisted intake-PDF DocumentReference (Task 7).
+
+The signed URL IS the authorization: the public download route is reachable
+without X-Tenant-Id / X-Step-Up-Token headers, so these tests exercise the
+route with a bare test client and rely on the signature in the query string.
+"""
+
+import time
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+from r6.sdc.delivery import (
+    build_document_link,
+    verify_document_link,
+    _sign,
+)
+from r6.sdc.documents import persist_intake_document
+
+PDF_BYTES = b"%PDF-1.4 hello"
+
+
+@pytest.fixture(autouse=True)
+def _delivery_env(monkeypatch):
+    """Every delivery test needs a signing secret and a base URL."""
+    monkeypatch.setenv('STEP_UP_SECRET', 'test-secret')
+    monkeypatch.setenv('PUBLIC_BASE_URL', 'https://example.test')
+
+
+def _persist(app, tenant='test-tenant', pdf=PDF_BYTES):
+    with app.app_context():
+        resource = persist_intake_document(tenant, "Patient/123", pdf)
+        return resource["id"]
+
+
+def _route_path_and_query(link):
+    """Split an absolute link into (path, query-dict) for the test client."""
+    parsed = urlparse(link)
+    query = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+    return parsed.path, query
+
+
+# --- build_document_link / verify_document_link unit behaviour ---
+
+def test_build_link_contains_route_and_params():
+    link = build_document_link('test-tenant', 'docref-1')
+    assert '/r6/sdc/documents/docref-1' in link
+    _, query = _route_path_and_query(link)
+    assert query['t'] == 'test-tenant'
+    assert 'exp' in query
+    assert 'sig' in query
+
+
+def test_verify_accepts_freshly_built_link():
+    link = build_document_link('test-tenant', 'docref-1', now=1000)
+    _, query = _route_path_and_query(link)
+    ok, reason = verify_document_link(
+        'test-tenant', 'docref-1', query['exp'], query['sig'], now=1000)
+    assert ok is True
+    assert reason == 'ok'
+
+
+def test_link_is_absolute_and_uses_base_url():
+    link = build_document_link('test-tenant', 'docref-1')
+    assert link.startswith('https://example.test/r6/sdc/documents/docref-1')
+
+
+def test_tenant_id_is_url_quoted():
+    # urllib.parse.quote (default safe='/') percent-encodes the space.
+    link = build_document_link('tenant with space', 'docref-1')
+    assert 't=tenant%20with%20space' in link
+
+
+def test_verify_tenant_bound_signature_rejects_other_tenant():
+    link = build_document_link('tenant-A', 'docref-1', now=1000)
+    _, query = _route_path_and_query(link)
+    ok, reason = verify_document_link(
+        'tenant-B', 'docref-1', query['exp'], query['sig'], now=1000)
+    assert ok is False
+    assert reason == 'bad-signature'
+
+
+def test_verify_tampered_signature_is_bad_signature():
+    link = build_document_link('test-tenant', 'docref-1', now=1000)
+    _, query = _route_path_and_query(link)
+    bad_sig = ('0' if query['sig'][0] != '0' else '1') + query['sig'][1:]
+    ok, reason = verify_document_link(
+        'test-tenant', 'docref-1', query['exp'], bad_sig, now=1000)
+    assert ok is False
+    assert reason == 'bad-signature'
+
+
+def test_verify_tampered_exp_caught_as_bad_signature_before_expiry():
+    # Keep the original signature but move exp far into the future. Because
+    # signature is checked before expiry, this is bad-signature, not a pass.
+    link = build_document_link('test-tenant', 'docref-1', now=1000)
+    _, query = _route_path_and_query(link)
+    forged_exp = str(int(query['exp']) + 999999)
+    ok, reason = verify_document_link(
+        'test-tenant', 'docref-1', forged_exp, query['sig'], now=1000)
+    assert ok is False
+    assert reason == 'bad-signature'
+
+
+def test_verify_expired_link():
+    link = build_document_link('test-tenant', 'docref-1',
+                               ttl_seconds=100, now=1000)
+    _, query = _route_path_and_query(link)
+    # now is past exp (1100)
+    ok, reason = verify_document_link(
+        'test-tenant', 'docref-1', query['exp'], query['sig'], now=5000)
+    assert ok is False
+    assert reason == 'expired'
+
+
+def test_verify_malformed_exp():
+    ok, reason = verify_document_link(
+        'test-tenant', 'docref-1', 'not-a-number', 'deadbeef', now=1000)
+    assert ok is False
+    assert reason == 'malformed'
+
+
+def test_build_link_raises_without_public_base_url(monkeypatch):
+    monkeypatch.delenv('PUBLIC_BASE_URL', raising=False)
+    with pytest.raises(ValueError, match='PUBLIC_BASE_URL is required'):
+        build_document_link('test-tenant', 'docref-1')
+
+
+def test_sign_raises_without_secret(monkeypatch):
+    monkeypatch.delenv('STEP_UP_SECRET', raising=False)
+    with pytest.raises(ValueError, match='STEP_UP_SECRET is required'):
+        _sign('test-tenant', 'docref-1', 1234567890)
+
+
+# --- Full round-trip through the public route ---
+
+def test_route_round_trip_returns_pdf_bytes(app, client):
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id)
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)
+
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/pdf'
+    assert resp.data == PDF_BYTES
+
+
+def test_route_sets_attachment_disposition(app, client):
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id)
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)
+    assert 'attachment' in resp.headers.get('Content-Disposition', '')
+    assert 'intake.pdf' in resp.headers.get('Content-Disposition', '')
+
+
+def test_route_tampered_signature_is_403(app, client):
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id)
+    path, query = _route_path_and_query(link)
+    query['sig'] = ('0' if query['sig'][0] != '0' else '1') + query['sig'][1:]
+
+    resp = client.get(path, query_string=query)
+    assert resp.status_code == 403
+
+
+def test_route_tampered_exp_is_403(app, client):
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id)
+    path, query = _route_path_and_query(link)
+    query['exp'] = str(int(query['exp']) + 999999)
+
+    resp = client.get(path, query_string=query)
+    assert resp.status_code == 403
+
+
+def test_route_expired_link_is_410(app, client):
+    docref_id = _persist(app)
+    # Build a link that already expired well before "now".
+    link = build_document_link('test-tenant', docref_id,
+                               ttl_seconds=1, now=1000)
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)
+    assert resp.status_code == 410
+
+
+def test_route_unknown_docref_is_404(app, client):
+    # Valid signature for a docref that does not exist.
+    link = build_document_link('test-tenant', 'does-not-exist')
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)
+    assert resp.status_code == 404
+
+
+def test_route_missing_query_params_is_400(app, client):
+    resp = client.get('/r6/sdc/documents/docref-1')
+    assert resp.status_code == 400
+
+
+def test_route_reachable_without_tenant_headers(app, client):
+    """The signed URL is the credential — no X-Tenant-Id header supplied."""
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id)
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)  # no headers at all
+    assert resp.status_code == 200
+    assert resp.data == PDF_BYTES
+
+
+def test_route_current_time_expiry(app, client):
+    """A link built with a real (short) TTL still works right now, proving
+    the default now=time.time() path (not just injected now=) is wired."""
+    docref_id = _persist(app)
+    link = build_document_link('test-tenant', docref_id,
+                               ttl_seconds=3600, now=int(time.time()))
+    path, query = _route_path_and_query(link)
+
+    resp = client.get(path, query_string=query)
+    assert resp.status_code == 200

--- a/tests/test_sdc_documents.py
+++ b/tests/test_sdc_documents.py
@@ -1,0 +1,143 @@
+"""Tests for r6/sdc/documents.py — DocumentReference persistence with
+embedded PDF bytes (base64 Attachment.data) and the round-trip getter used
+by the delivery route (Task 7)."""
+
+import base64
+
+from r6.sdc.documents import persist_intake_document, get_document_pdf_bytes
+
+PDF_BYTES = b"%PDF-1.4 test bytes"
+OTHER_TENANT = "other-tenant"
+
+
+def test_persist_stores_documentreference_retrievable_by_id(app):
+    with app.app_context():
+        from r6.models import R6Resource
+
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES, title="My Intake")
+
+        assert resource["resourceType"] == "DocumentReference"
+        assert resource["status"] == "current"
+        assert resource["subject"]["reference"] == "Patient/123"
+
+        row = R6Resource.query.filter_by(
+            resource_type="DocumentReference", id=resource["id"],
+            tenant_id="test-tenant").first()
+        assert row is not None
+
+
+def test_attachment_content_type_and_size(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        attachment = resource["content"][0]["attachment"]
+        assert attachment["contentType"] == "application/pdf"
+        assert attachment["size"] == len(PDF_BYTES)
+
+
+def test_attachment_data_is_base64_and_decodes_to_exact_bytes(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        attachment = resource["content"][0]["attachment"]
+        data = attachment["data"]
+        # Valid base64 — round-trips without raising, and matches the input.
+        decoded = base64.b64decode(data, validate=True)
+        assert decoded == PDF_BYTES
+
+
+def test_title_defaults_when_not_provided(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        assert resource["content"][0]["attachment"]["title"] == "Intake form"
+
+
+def test_title_uses_provided_value(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES, title="Custom Title")
+        assert resource["content"][0]["attachment"]["title"] == "Custom Title"
+
+
+def test_get_document_pdf_bytes_round_trips_exact_bytes(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        fetched = get_document_pdf_bytes("test-tenant", resource["id"])
+        assert fetched == PDF_BYTES
+
+
+def test_get_document_pdf_bytes_returns_none_for_missing_docref(app):
+    with app.app_context():
+        assert get_document_pdf_bytes("test-tenant", "does-not-exist") is None
+
+
+def test_tenant_isolation_docref_not_visible_to_other_tenant(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        # Same docref id, wrong tenant — must not resolve.
+        assert get_document_pdf_bytes(OTHER_TENANT, resource["id"]) is None
+
+
+def test_tenant_isolation_query_scoped(app):
+    with app.app_context():
+        from r6.models import R6Resource
+
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+
+        other_tenant_rows = R6Resource.query.filter_by(
+            resource_type="DocumentReference", tenant_id=OTHER_TENANT).all()
+        assert other_tenant_rows == []
+
+        same_id_other_tenant = R6Resource.query.filter_by(
+            resource_type="DocumentReference", id=resource["id"],
+            tenant_id=OTHER_TENANT).first()
+        assert same_id_other_tenant is None
+
+
+def test_questionnaire_response_id_links_context_related(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES,
+            questionnaire_response_id="qr-42")
+
+        related_refs = [r["reference"]
+                        for r in resource["context"]["related"]]
+        assert "QuestionnaireResponse/qr-42" in related_refs
+
+
+def test_questionnaire_response_id_links_relates_to(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES,
+            questionnaire_response_id="qr-42")
+
+        assert resource["relatesTo"][0]["target"]["reference"] == \
+            "QuestionnaireResponse/qr-42"
+        assert resource["relatesTo"][0]["code"] == "transforms"
+
+
+def test_no_questionnaire_response_id_omits_context_and_relates_to(app):
+    with app.app_context():
+        resource = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        assert "context" not in resource
+        assert "relatesTo" not in resource
+
+
+def test_persisted_document_visible_via_get_after_second_document(app):
+    """A second DocumentReference for a different subject doesn't shadow
+    the first — bytes fetched by id must match what was stored for that id."""
+    with app.app_context():
+        first = persist_intake_document(
+            "test-tenant", "Patient/123", PDF_BYTES)
+        second_bytes = b"%PDF-1.4 a different document entirely"
+        second = persist_intake_document(
+            "test-tenant", "Patient/456", second_bytes)
+
+        assert get_document_pdf_bytes("test-tenant", first["id"]) == PDF_BYTES
+        assert get_document_pdf_bytes("test-tenant", second["id"]) == second_bytes


### PR DESCRIPTION
## The forms rail — first fully-real, guardrailed action, end to end

An AI agent fills a patient's intake questionnaire from their **own FHIR records** → the patient **reviews each medication and allergy individually** (the software can never assert "no known allergies" for them) → a **provenance-stamped PDF** is persisted as a FHIR `DocumentReference` and delivered via a **signed, expiring link**. Everything is server-side, fail-loud, and behind the out-of-band human gate. This is the Aug-18 webinar centerpiece.

This is **one combined PR** for the whole rail (Tasks 5–9 of the [forms-rail plan](docs/superpowers/plans/2026-07-12-forms-rail-plan.md); Tasks 1–4 already merged). It supersedes and closes the per-task PRs #100 and #101 — their commits are included here.

### What's in it
- **T5 — DocumentReference persistence** (`r6/sdc/documents.py`): stores the rendered PDF as `content[0].attachment.data` (real base64 bytes, not just a size), tenant-scoped, links back to the source `QuestionnaireResponse`; round-trip getter for delivery.
- **T6 — Structured per-item review page** (`r6/actions/review.py`, `templates/action_review.html`): the core safety UI. The POST handler **re-populates the item list from FHIR server-side** and requires every med/allergy row to be acted on, plus the load-bearing attestation gate — *confirm ≥1 allergy OR explicitly check "no known allergies."* Removing every allergy without attesting NKA → **422, no `ActionConfirmation` issued**. NKA is set only from the explicit checkbox, never inferred.
- **T7 — Signed, expiring download link** (`r6/sdc/delivery.py`): a public download route whose HMAC signature (same primitive as step-up tokens) *is* the credential — no headers needed. Signature checked before expiry; tenant bound into the signature; fails loud without `STEP_UP_SECRET`/`PUBLIC_BASE_URL`.
- **T8 — `execute()` orchestration** (`r6/actions/rails/form_fill.py`): reviewed QR → PDF → DocumentReference → signed link. Fails loud on every unhappy path (`needs_review` when unreviewed, `stale_source_data` when the reviewed QR vanished, `provider_not_configured`, `provider_error`); returns `completed` **only** on a fully rendered+persisted+linked PDF.
- **T9 — e2e + demo**: a full HTTP integration test drives propose → commit → review (confirming a real Penicillin allergy) → out-of-band confirm → downloads the signed link and asserts real PDF bytes. Plus a presenter [demo run-of-show](docs/demos/forms-rail-run-of-show.md) and roadmap update.

### Safety verification (done hands-on, not just asserted)
The coordinator independently attacked the allergy-attestation gate (`tests/actions/test_review_gate_adversarial.py`), confirming:
- A **fabricated extra `allergy-confirm`** for a row that doesn't exist server-side **cannot** bypass the NKA gate (decisions are read only over server-re-derived rows) → 422, no confirmation.
- **Removing a real allergy without attesting NKA** → 422, no confirmation, action left `awaiting_confirmation`.

### Checks
- `uvx ruff check r6/ tests/ scripts/ main.py app.py` → clean
- `uv run python -m pytest tests/ -q` → **1277 passed** (baseline 1252 + 25 new)
- Grade-A guardrail conformance suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
