### PR TITLE
$conformance: grade error fidelity as property seven

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ properties pass while local search still accepts unsupported filters. The same
 harness runs against the Flask test client as a **CI baseline**
 (`tests/test_guardrail_conformance.py`), so grade movement is explicit rather
 than hidden. `--json` emits a machine-readable report; `--mcp-url` also probes
-MCP `tools/call` error signaling. Library API:
+MCP `tools/call` error signaling. For an authenticated MCP deployment, set
+`MCP_AUTH_TOKEN` or pass `--mcp-auth-token`. Library API:
 `from r6.conformance import LiveProbeClient, ProbeContext, run_conformance`.
 
 ## Install as a Claude Plugin

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ AI Agent ──▶ MCP Server ──▶ Guardrail Proxy ──▶ Any FHIR Serve
 ## Prove it: guardrail conformance
 
 The guardrails are **verifiable, not marketing.** A runnable harness probes any
-deployment with synthetic data and emits a scorecard across all six properties —
+deployment with synthetic data and emits a scorecard across all seven properties —
 run it against your own instance (or ours):
 
 ```bash
@@ -123,10 +123,11 @@ python scripts/guardrail_conformance.py \
 
 ```text
 HealthClaw Guardrail Conformance — https://app.healthclaw.io [tenant=desktop-demo]
-  Grade: A   (6/6 properties)
+  Grade: B   (6/7 properties)
   [PASS] PHI Redaction            [PASS] Human-in-the-Loop
   [PASS] Immutable Audit Trail    [PASS] Tenant Isolation
   [PASS] Step-Up Authorization    [PASS] Medical Disclaimers
+  [FAIL] Error Fidelity — F (local-fhir-only)
 ```
 
 Or hit the **one-URL self-test** on any running deployment — no token needed, it
@@ -136,9 +137,13 @@ self-tenants internally and returns 200 at Grade A (503 otherwise):
 curl "https://app.healthclaw.io/r6/fhir/\$conformance?format=text"
 ```
 
-The same harness runs against the Flask test client as a **CI gate** (`tests/test_guardrail_conformance.py`),
-so a guardrail regression fails the build. `--json` emits a machine-readable
-report. Library API: `from r6.conformance import LiveProbeClient, ProbeContext, run_conformance`.
+The initial error-fidelity baseline is intentionally B: the original six
+properties pass while local search still accepts unsupported filters. The same
+harness runs against the Flask test client as a **CI baseline**
+(`tests/test_guardrail_conformance.py`), so grade movement is explicit rather
+than hidden. `--json` emits a machine-readable report; `--mcp-url` also probes
+MCP `tools/call` error signaling. Library API:
+`from r6.conformance import LiveProbeClient, ProbeContext, run_conformance`.
 
 ## Install as a Claude Plugin
 
@@ -215,7 +220,7 @@ Tool names use underscores (not dots) for Claude Desktop / MCP client compatibil
 | `fhir_lastn` | Most recent N observations per code |
 | `fhir_interpret_labs` | Lab reference-range interpretation (`$interpret`) — decision support, not diagnosis |
 | `care_gaps` | Preventive-care gaps (`$care-gaps`) — screenings/immunizations that may be due, from the patient's own records |
-| `guardrail_conformance` | Run the guardrail conformance self-test — graded A–F scorecard across all six properties |
+| `guardrail_conformance` | Run the guardrail conformance self-test — graded A–F scorecard across all seven properties |
 | `fhir_permission_evaluate` | R6 Permission access control evaluation |
 | `fhir_subscription_topics` | List available SubscriptionTopics |
 | `questionnaire_populate` | SDC `$populate` — pre-fill a Questionnaire for a subject |

--- a/docs/demos/forms-rail-run-of-show.md
+++ b/docs/demos/forms-rail-run-of-show.md
@@ -33,7 +33,8 @@ consent. That is the whole pitch — safety you can watch fail closed.
    (Penicillin) so the review page has something to confirm.
 3. Mint a step-up token: `POST /r6/fhir/internal/step-up-token {"tenant_id": "desktop-demo"}`.
 4. Open the guardrail scorecard in a browser tab you can flip to:
-   `GET /r6/fhir/$conformance?format=text` — Grade A. (Credibility anchor.)
+   `GET /r6/fhir/$conformance?format=text` — the intentional Grade B baseline:
+   six established properties pass and Error Fidelity is visibly F.
 
 ## Run of show
 
@@ -46,7 +47,7 @@ consent. That is the whole pitch — safety you can watch fail closed.
 | **5. Honest submit** | Confirm the Penicillin allergy (or check NKA if that were true), confirm meds, submit. The review page issues the confirmation. | "Now I attest, item by item. This is the human-in-the-loop, and it's recorded." |
 | **6. Execute** | The out-of-band confirm (`POST /r6/actions/<id>/confirm`) runs `execute()`: reviewed answers → PDF → FHIR `DocumentReference` → signed link. Show the action now `completed` with a `delivery_link`. | "Only *after* I approved does it render anything. No approval, no PDF — it fails closed." |
 | **7. The artifact** | Open the `delivery_link` in a fresh browser (no login, no headers — the signature in the URL is the credential). The PDF opens with the provenance footer: *populated from records by an automated system, reviewed by the patient on <date>.* | "Here's the shareable form. It's stamped with exactly how it was made and that a human reviewed it. That footer is the difference between a document a clinic can trust and one it can't." |
-| **8. Prove it** | Flip to the `$conformance` tab: Grade A. | "None of this is 'trust me.' The guardrails grade themselves A–F in CI. This deployment is A." |
+| **8. Prove it** | Flip to the `$conformance` tab: Grade B (6/7), with Error Fidelity F. | "None of this is 'trust me.' The guardrails grade themselves A–F in CI, including the failure paths that still need work. The scorecard does not award itself an A for adding a probe." |
 
 ## Fallbacks if something misbehaves
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,8 +93,9 @@ Flask/DB), report builders, and a `register_*_routes` function wired in
 - The whole set is enforced by the **conformance harness**:
   `tests/test_guardrail_conformance.py` pins the measured CI baseline, and
   `GET /r6/fhir/$conformance` grades any live deployment. The current baseline
-  is intentionally Grade B (6/7): error fidelity remains F until the local
-  search and MCP transport follow-ups land.
+  is intentionally Grade B (6/7): the in-process error-fidelity profile remains
+  F until the local-search follow-up lands. The optional CLI MCP profile remains
+  C until its separate transport follow-up lands.
 
 ## Deploy notes (maintainers)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,8 +91,10 @@ Flask/DB), report builders, and a `register_*_routes` function wired in
 - Redaction imports: `from r6.redaction import apply_redaction` (Safe Harbor)
   or `apply_patient_controlled_redaction(resource, patient_id)`.
 - The whole set is enforced by the **conformance harness**:
-  `tests/test_guardrail_conformance.py` is a CI gate (must stay Grade A), and
-  `GET /r6/fhir/$conformance` grades any live deployment.
+  `tests/test_guardrail_conformance.py` pins the measured CI baseline, and
+  `GET /r6/fhir/$conformance` grades any live deployment. The current baseline
+  is intentionally Grade B (6/7): error fidelity remains F until the local
+  search and MCP transport follow-ups land.
 
 ## Deploy notes (maintainers)
 

--- a/docs/recipes/healthclaw-in-front-of-aidbox.md
+++ b/docs/recipes/healthclaw-in-front-of-aidbox.md
@@ -65,9 +65,9 @@ or a pre-issued bearer.)
 ## Prove the guardrails hold
 
 Run the conformance harness against the HealthClaw instance sitting in front of
-Aidbox — it grades all seven properties A–F, so you can *show* (not assert) that
-the original six protections and truthful failure behavior are enforced on the
-path to your box:
+Aidbox — it grades all seven properties A–F, so you can *show* (not assert)
+which protections hold and which failure paths still need work on the path to
+your box:
 
 ```bash
 curl "$BASE/r6/fhir/\$conformance?format=text"

--- a/docs/recipes/healthclaw-in-front-of-aidbox.md
+++ b/docs/recipes/healthclaw-in-front-of-aidbox.md
@@ -65,9 +65,9 @@ or a pre-issued bearer.)
 ## Prove the guardrails hold
 
 Run the conformance harness against the HealthClaw instance sitting in front of
-Aidbox — it grades all six properties A–F, so you can *show* (not assert) that
-redaction, audit, step-up, human-in-the-loop, tenant isolation, and disclaimers
-are enforced on the path to your box:
+Aidbox — it grades all seven properties A–F, so you can *show* (not assert) that
+the original six protections and truthful failure behavior are enforced on the
+path to your box:
 
 ```bash
 curl "$BASE/r6/fhir/\$conformance?format=text"

--- a/docs/recipes/healthclaw-in-front-of-healthbankone.md
+++ b/docs/recipes/healthclaw-in-front-of-healthbankone.md
@@ -56,7 +56,7 @@ at the HBO-backed deployment:
 ```bash
 python scripts/guardrail_conformance.py --base-url https://<deployment> \
   --tenant <hbo-tenant> --step-up-token <token>
-# → Grade A (6/6): PHI Redaction · Audit · Step-Up · Human-in-the-Loop · Tenant Isolation · Disclaimers
+# → Current baseline Grade B (6/7): the original six pass; Error Fidelity is F
 ```
 
 A partner (or a regulator) can run it and see, on synthetic data, that every

--- a/docs/recipes/healthclaw-in-front-of-healthbankone.md
+++ b/docs/recipes/healthclaw-in-front-of-healthbankone.md
@@ -59,8 +59,8 @@ python scripts/guardrail_conformance.py --base-url https://<deployment> \
 # → Current baseline Grade B (6/7): the original six pass; Error Fidelity is F
 ```
 
-A partner (or a regulator) can run it and see, on synthetic data, that every
-guardrail fires regardless of the backend.
+A partner (or a regulator) can run it on synthetic data and see exactly which
+guardrails hold and which still fail, regardless of the backend.
 
 ## Identity: OAuth/OIDC scope authorization (roadmap)
 

--- a/r6/conformance/__init__.py
+++ b/r6/conformance/__init__.py
@@ -1,6 +1,6 @@
 """HealthClaw guardrail conformance harness.
 
-Verify the six guardrail properties against any deployment:
+Verify the seven guardrail properties against any deployment:
     from r6.conformance import LiveProbeClient, ProbeContext, run_conformance
     report = run_conformance(LiveProbeClient(base_url), ProbeContext(tenant, token))
     print(report.render())
@@ -10,10 +10,12 @@ from r6.conformance.probes import (  # noqa: F401
     Check,
     ConformanceReport,
     FlaskProbeClient,
+    LiveMCPProbeClient,
     LiveProbeClient,
     PROPERTIES,
     ProbeContext,
     ProbeResult,
+    _error_fidelity_grade,
     _grade,
     run_conformance,
 )

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -39,6 +39,10 @@ PROPERTIES = (
 _ERROR_FIDELITY_GRADE_ORDER = {"F": 0, "C": 1, "A": 2}
 _MCP_INVALID_RESOURCE = "WidgetQuintaviousZzyzxbarton"
 _MCP_HOSTILE_URL = "https://db.internal.example/patient/secret"
+_HOSTILE_VALUE_TOKENS = (
+    _GIVEN.lower(), _FAMILY.lower(), "db.internal.example",
+)
+_URL_SCHEME_TOKENS = ("http://", "https://")
 _REQUEST_ERROR_CODES = {"invalid", "structure", "value", "not-supported"}
 _LOCAL_SUPPORTED_PARAMETER_EVIDENCE = {
     "patient", "code", "status", "_lastupdated",
@@ -516,9 +520,13 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
             for token in re.findall(
                 r"[A-Za-z_][A-Za-z0-9_-]*", match.group(1))
         }
-        supported = declared & _LOCAL_SUPPORTED_PARAMETER_EVIDENCE
         parameter_lower = parameter.lower()
         remaining = text[:match.start()] + text[match.end():]
+        # `_lastUpdated` is record modification time, not clinical datetime.
+        # Any mention outside the factual supported-set list is an ambiguous or
+        # unsafe correction, so it cannot earn A.
+        if "_lastupdated" in remaining.lower():
+            continue
         parameter_token = re.escape(parameter_lower)
         rejection = re.search(
             rf"(?:^|[.!?]\s*)(?:"
@@ -532,9 +540,42 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
         )
         if (parameter_lower not in declared
                 and rejection is not None
-                and len(supported) >= 2):
+                and declared == _LOCAL_SUPPORTED_PARAMETER_EVIDENCE):
             return True
     return False
+
+
+def _outcome_names_unsupported_modifier(body, modifier: str) -> bool:
+    """Require a corrective rejection to identify the unsupported modifier."""
+    if not _is_operation_outcome(body):
+        return False
+    token = re.escape(modifier.lower())
+    rejection = re.compile(
+        rf"(?:^|[.!?]\s*)(?:"
+        rf"(?:unsupported|invalid|rejected)\s+modifier\s*:?\s*{token}"
+        rf"|modifier\s*:?\s*{token}\s+(?:(?:is|was)\s+)?"
+        rf"(?:unsupported|not\s+supported|rejected|invalid|not\s+implemented)"
+        rf"|{token}\s+modifier\s+(?:(?:is|was)\s+)?"
+        rf"(?:unsupported|not\s+supported|rejected|invalid|not\s+implemented)"
+        rf")\s*(?=[.!?]|$)",
+        re.IGNORECASE,
+    )
+    for issue in body.get("issue", []):
+        if not isinstance(issue, dict):
+            continue
+        details = issue.get("details")
+        text = details.get("text", "") if isinstance(details, dict) else ""
+        if isinstance(text, str) and rejection.search(text):
+            return True
+    return False
+
+
+def _modifier_rejection_grade(status, body, modifier: str) -> str:
+    grade = _rejection_grade(status, body)
+    if (grade == "A"
+            and not _outcome_names_unsupported_modifier(body, modifier)):
+        return "C"
+    return grade
 
 
 def _safe_warning_outcome(outcome) -> bool:
@@ -555,7 +596,8 @@ def _safe_warning_outcome(outcome) -> bool:
         and isinstance(issue["details"]["text"], str)
         and bool(issue["details"]["text"].strip())
         for issue in issues
-    ) and _outcome_omits_hostile_values(outcome))
+    ) and _values_omit_hostile_tokens(
+        outcome, extra_tokens=_URL_SCHEME_TOKENS))
 
 
 def _has_outcome_warning(bundle, parameter: str) -> bool:
@@ -663,6 +705,16 @@ def _new_audit_outcome_grade(before, after) -> str:
     return "A" if new_codes[0] == "8" else ("F" if new_codes[0] == "0" else "C")
 
 
+def _new_audit_failures_grade(before, after, expected_count: int) -> str:
+    """Grade a bounded batch of rejected requests from their new audit codes."""
+    new_codes = _new_audit_outcome_codes(before, after)
+    if len(new_codes) != expected_count:
+        return "C"
+    if all(code == "8" for code in new_codes):
+        return "A"
+    return "F" if "0" in new_codes else "C"
+
+
 def _new_audit_outcome_codes(before, after) -> list[str]:
     before_ids = set(_audit_events(before))
     return [
@@ -729,32 +781,29 @@ def _corrective_outcome(body, expected_codes: set[str]) -> bool:
                 or not text.strip()):
             return False
         saw_expected = True
-    return saw_expected and _outcome_omits_hostile_values(body)
+    return saw_expected and _values_omit_hostile_tokens(
+        body, extra_tokens=_URL_SCHEME_TOKENS)
 
 
-def _outcome_omits_hostile_values(value) -> bool:
-    blob = json.dumps(value).lower()
-    unsafe_tokens = (
-        _GIVEN.lower(), _FAMILY.lower(),
-        "quintavious zzyzxbarton",
-        _MCP_INVALID_RESOURCE.lower(),
-        "http://", "https://",
-    )
+def _values_omit_hostile_tokens(*values, extra_tokens=()) -> bool:
+    """Fail closed if any serialized evidence contains a synthetic leak token."""
+    try:
+        blob = "\n".join(
+            value if isinstance(value, str) else json.dumps(value)
+            for value in values
+        ).lower()
+    except (TypeError, ValueError):
+        return False
+    unsafe_tokens = (*_HOSTILE_VALUE_TOKENS, *extra_tokens)
     return not any(token in blob for token in unsafe_tokens)
 
 
 def _response_omits_hostile_values(body, text) -> bool:
-    blob = (text or json.dumps(body or {})).lower()
-    return not any(token in blob for token in (
-        _GIVEN.lower(), _FAMILY.lower(),
-        "quintavious zzyzxbarton", "http://", "https://",
-    ))
+    return _values_omit_hostile_tokens(
+        body, text, extra_tokens=_URL_SCHEME_TOKENS)
 
 
 def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
-    hostile_name = "Quintavious Zzyzxbarton"
-    hostile_url = "https://db.internal.example/patient/secret"
-
     _, audit_before, _ = proxy_client.request(
         "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
 
@@ -798,8 +847,7 @@ def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
     _, audit_after, _ = proxy_client.request(
         "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     audit_codes = _new_audit_outcome_codes(audit_before, audit_after)
-    audit_blob = json.dumps(audit_after or {})
-    audit_safe = hostile_name not in audit_blob and hostile_url not in audit_blob
+    audit_safe = _values_omit_hostile_tokens(audit_after)
     audit_ok = (len(audit_codes) == 3
                 and all(code == "8" for code in audit_codes)
                 and audit_safe)
@@ -872,7 +920,8 @@ def _mcp_profile_grade(mcp_client) -> str:
             and has_outcome
             and not malformed_content
             and len(payloads) == len(outcomes)
-            and _mcp_result_omits_hostile_values(result)
+            and _values_omit_hostile_tokens(
+                result, extra_tokens=_URL_SCHEME_TOKENS)
             and all(_safe_corrective_mcp_outcome(outcome) for outcome in outcomes)):
         return "A"
     if has_failure or result.get("isError") is True:
@@ -905,19 +954,42 @@ def _safe_corrective_mcp_outcome(outcome) -> bool:
         text = details["text"]
         if not isinstance(text, str) or not text.strip():
             return False
-    return saw_expected_category and _mcp_result_omits_hostile_values(outcome)
+    return saw_expected_category and _values_omit_hostile_tokens(
+        outcome, extra_tokens=_URL_SCHEME_TOKENS)
 
 
-def _mcp_result_omits_hostile_values(value) -> bool:
-    blob = json.dumps(value).lower()
-    unsafe_tokens = (
-        _MCP_INVALID_RESOURCE.lower(),
-        "quintavious",
-        "zzyzxbarton",
-        "http://",
-        "https://",
-    )
-    return not any(token in blob for token in unsafe_tokens)
+def _run_optional_error_fidelity_profiles(
+        result: ProbeResult, ctx: ProbeContext, *, mcp_client=None,
+        proxy_client=None) -> ProbeResult:
+    """Run each configured optional profile even if another profile failed."""
+    executed_grades = [result.grade or "F"]
+    if mcp_client is not None:
+        mcp_grade = _mcp_profile_grade(mcp_client)
+        mcp_check_name = "MCP tool failure is corrective and flagged"
+        result.profiles["mcp"] = _profile(
+            "run", grade=mcp_grade, checks=[mcp_check_name])
+        executed_grades.append(mcp_grade)
+        result.coverage = "local+mcp"
+        result.checks.append(Check(
+            mcp_check_name, mcp_grade == "A", f"grade {mcp_grade}"))
+
+    if proxy_client is not None:
+        try:
+            proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
+        except Exception as exc:
+            proxy_grade = "F"
+            proxy_checks = [
+                Check("proxy profile executed", False, type(exc).__name__)
+            ]
+        result.profiles["proxy"] = _profile(
+            "run", grade=proxy_grade,
+            checks=[check.name for check in proxy_checks])
+        executed_grades.append(proxy_grade)
+        result.checks.extend(proxy_checks)
+        result.coverage = "full" if mcp_client is not None else "local+proxy"
+
+    result.grade = _error_fidelity_grade(executed_grades)
+    return result
 
 
 def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> ProbeResult:
@@ -958,26 +1030,36 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
     lenient_audit_grade = _new_audit_warning_grade(
         lenient_audit_before, lenient_audit_after, "datetime")
 
+    _, modifier_audit_before, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     modifier_status, modifier_body, _ = client.request(
         "GET", f"/Observation?{modifier_query}", ctx.read_headers())
-    modifier_grade = _rejection_grade(modifier_status, modifier_body)
+    modifier_grade = _modifier_rejection_grade(
+        modifier_status, modifier_body, "code:exact")
     modifier_strict_status, modifier_strict_body, _ = client.request(
         "GET", f"/Observation?{modifier_query}", strict_headers)
-    modifier_strict_grade = _rejection_grade(
-        modifier_strict_status, modifier_strict_body)
+    modifier_strict_grade = _modifier_rejection_grade(
+        modifier_strict_status, modifier_strict_body, "code:exact")
     lenient_headers = ctx.read_headers()
     lenient_headers["Prefer"] = "handling=lenient"
     modifier_lenient_status, modifier_lenient_body, _ = client.request(
         "GET", f"/Observation?{modifier_query}", lenient_headers)
-    modifier_lenient_grade = _rejection_grade(
-        modifier_lenient_status, modifier_lenient_body)
+    modifier_lenient_grade = _modifier_rejection_grade(
+        modifier_lenient_status, modifier_lenient_body, "code:exact")
     modifier_grade = _error_fidelity_grade([
         modifier_grade, modifier_strict_grade, modifier_lenient_grade,
     ])
+    _, modifier_audit_after, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
+    modifier_audit_grade = _new_audit_failures_grade(
+        modifier_audit_before, modifier_audit_after, 3)
+    if 200 in (
+            modifier_status, modifier_strict_status, modifier_lenient_status):
+        modifier_audit_grade = "F"
 
     local_grade = _error_fidelity_grade([
         strict_grade, audit_grade, lenient_grade, lenient_audit_grade,
-        modifier_grade,
+        modifier_grade, modifier_audit_grade,
     ])
     checks = [
         Check("strict unknown parameter is rejected", strict_grade == "A",
@@ -994,6 +1076,9 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
               f"grade {modifier_grade}; statuses "
               f"{modifier_status},{modifier_strict_status},"
               f"{modifier_lenient_status}"),
+        Check("unsupported modifier rejections are audited as failures",
+              modifier_audit_grade == "A",
+              f"grade {modifier_audit_grade}"),
     ]
     local_check_names = [check.name for check in checks]
     profiles = {
@@ -1001,40 +1086,14 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
         "mcp": _profile("not_run"),
         "proxy": _profile("not_run"),
     }
-    executed_grades = [local_grade]
-    coverage = "local-fhir-only"
-    if mcp_client is not None:
-        mcp_grade = _mcp_profile_grade(mcp_client)
-        mcp_check_name = "MCP tool failure is corrective and flagged"
-        profiles["mcp"] = _profile(
-            "run", grade=mcp_grade, checks=[mcp_check_name])
-        executed_grades.append(mcp_grade)
-        coverage = "local+mcp"
-        checks.append(Check(
-            mcp_check_name, mcp_grade == "A",
-            f"grade {mcp_grade}"))
-
-    if proxy_client is not None:
-        try:
-            proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
-        except Exception as exc:
-            proxy_grade = "F"
-            proxy_checks = [
-                Check("proxy profile executed", False, type(exc).__name__)
-            ]
-        profiles["proxy"] = _profile(
-            "run", grade=proxy_grade,
-            checks=[check.name for check in proxy_checks])
-        executed_grades.append(proxy_grade)
-        checks.extend(proxy_checks)
-        coverage = "full" if mcp_client is not None else "local+proxy"
-
-    return ProbeResult(
+    result = ProbeResult(
         "error_fidelity", "Error Fidelity", checks,
-        grade=_error_fidelity_grade(executed_grades),
-        coverage=coverage,
+        grade=local_grade,
+        coverage="local-fhir-only",
         profiles=profiles,
     )
+    return _run_optional_error_fidelity_profiles(
+        result, ctx, mcp_client=mcp_client, proxy_client=proxy_client)
 
 
 _PROBES = (
@@ -1062,7 +1121,7 @@ def run_conformance(client, ctx: ProbeContext, *, mcp_client=None,
         results.append(probe_error_fidelity(
             client, ctx, mcp_client=mcp_client, proxy_client=proxy_client))
     except Exception as exc:  # a probe crash is a FAIL, never a harness crash
-        results.append(ProbeResult(
+        failure = ProbeResult(
             "error_fidelity", "Error Fidelity",
             [Check("probe executed", False, type(exc).__name__)],
             grade="F", coverage="local-fhir-only",
@@ -1070,6 +1129,8 @@ def run_conformance(client, ctx: ProbeContext, *, mcp_client=None,
                 "local": _profile("run", grade="F", checks=["probe executed"]),
                 "mcp": _profile("not_run"),
                 "proxy": _profile("not_run"),
-            }))
+            })
+        results.append(_run_optional_error_fidelity_profiles(
+            failure, ctx, mcp_client=mcp_client, proxy_client=proxy_client))
     return ConformanceReport(results, base=getattr(client, "base", ""),
                              tenant=ctx.tenant)

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -1,10 +1,10 @@
 """Guardrail conformance probes.
 
-Runs the six HealthClaw guardrail properties against a live endpoint (or the
+Runs the seven HealthClaw guardrail properties against a live endpoint (or the
 Flask test client) and emits a scorecard. The point: the guardrail claims are
 *verifiable*, not marketing — a partner can run this against any deployment and
-prove PHI redaction, audit, step-up, human-in-the-loop, tenant isolation, and
-medical disclaimers actually hold.
+prove PHI redaction, audit, step-up, human-in-the-loop, tenant isolation,
+medical disclaimers, and truthful failure behavior actually hold.
 
 The probes create SYNTHETIC data (obviously-fake PHI tokens) so a live run
 against a real deployment never touches patient data.
@@ -30,7 +30,20 @@ PROPERTIES = (
     "human_in_the_loop",
     "tenant_isolation",
     "medical_disclaimer",
+    "error_fidelity",
 )
+
+_ERROR_FIDELITY_GRADE_ORDER = {"F": 0, "C": 1, "A": 2}
+
+
+def _error_fidelity_grade(grades: list[str]) -> str:
+    """Return the weakest executed error-fidelity profile grade."""
+    if not grades:
+        return "F"
+    unknown = set(grades) - set(_ERROR_FIDELITY_GRADE_ORDER)
+    if unknown:
+        raise ValueError(f"Unknown error-fidelity grade: {sorted(unknown)}")
+    return min(grades, key=_ERROR_FIDELITY_GRADE_ORDER.__getitem__)
 
 
 def _synthetic_patient():
@@ -70,10 +83,21 @@ class ProbeResult:
     property: str
     checks: list[Check] = field(default_factory=list)
     note: str = ""
+    grade: Optional[str] = None
+    coverage: str = "full"
+    profiles: dict = field(default_factory=dict)
 
     @property
     def passed(self) -> bool:
+        if self.grade is not None:
+            return self.grade == "A"
         return bool(self.checks) and all(c.passed for c in self.checks)
+
+    @property
+    def effective_grade(self) -> str:
+        if self.grade is not None:
+            return self.grade
+        return "A" if self.passed else "F"
 
 
 def _grade(passed: int, total: int) -> str:
@@ -118,7 +142,8 @@ class ConformanceReport:
             "score": {"passed": p, "total": t},
             "properties": [
                 {"key": r.key, "property": r.property, "passed": r.passed,
-                 "note": r.note,
+                 "grade": r.effective_grade, "coverage": r.coverage,
+                 "profiles": r.profiles, "note": r.note,
                  "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail}
                             for c in r.checks]}
                 for r in self.results
@@ -131,7 +156,10 @@ class ConformanceReport:
                  f"[tenant={self.tenant}]",
                  f"  Grade: {self.grade}   ({p}/{t} properties)", ""]
         for r in self.results:
-            lines.append(f"  [{'PASS' if r.passed else 'FAIL'}] {r.property}")
+            label = r.property
+            if r.grade is not None:
+                label += f" — {r.effective_grade} ({r.coverage})"
+            lines.append(f"  [{'PASS' if r.passed else 'FAIL'}] {label}")
             for c in r.checks:
                 mark = "✓" if c.passed else "✗"
                 suffix = f" — {c.detail}" if c.detail and not c.passed else ""
@@ -201,7 +229,86 @@ class LiveProbeClient:
         return r.status_code, body, r.text
 
 
-# --- The six probes ------------------------------------------------------------
+class LiveMCPProbeClient:
+    """Small Streamable HTTP MCP client used only by optional conformance probes."""
+
+    def __init__(self, mcp_url, session=None):
+        import requests
+        self._url = mcp_url.rstrip("/")
+        self._s = session or requests.Session()
+        self._session_id = None
+        self._protocol_version = "2025-06-18"
+
+    def _headers(self):
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": self._protocol_version,
+        }
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        return headers
+
+    def _initialize(self):
+        response = self._s.post(
+            self._url,
+            headers=self._headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": self._protocol_version,
+                    "capabilities": {},
+                    "clientInfo": {"name": "healthclaw-conformance", "version": "1"},
+                },
+            },
+            timeout=15,
+        )
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict) or "error" in body:
+            raise RuntimeError("MCP initialize failed")
+        self._session_id = response.headers.get("Mcp-Session-Id")
+        if not self._session_id:
+            raise RuntimeError("MCP initialize returned no session id")
+        result = body.get("result", {})
+        if isinstance(result, dict) and isinstance(result.get("protocolVersion"), str):
+            self._protocol_version = result["protocolVersion"]
+
+        initialized = self._s.post(
+            self._url,
+            headers=self._headers(),
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            timeout=15,
+        )
+        initialized.raise_for_status()
+
+    def call_tool(self, name, arguments):
+        if self._session_id is None:
+            self._initialize()
+        response = self._s.post(
+            self._url,
+            headers=self._headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+            timeout=25,
+        )
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict) or "error" in body:
+            raise RuntimeError("MCP tools/call failed")
+        result = body.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError("MCP tools/call returned no result")
+        return result
+
+
+# --- Guardrail probes ----------------------------------------------------------
 
 def _create_synthetic(client, ctx) -> tuple[Optional[str], object]:
     status, body, _ = client.request(
@@ -318,6 +425,258 @@ def probe_medical_disclaimer(client, ctx) -> ProbeResult:
     return r
 
 
+def _is_operation_outcome(body) -> bool:
+    return isinstance(body, dict) and body.get("resourceType") == "OperationOutcome"
+
+
+def _rejection_grade(status, body, expected_status=400) -> str:
+    if status == 200:
+        return "F"
+    if status == expected_status and _is_operation_outcome(body):
+        return "A"
+    return "C"
+
+
+def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
+    """A local rejection is corrective only if it identifies the bad key and
+    tells the caller which search parameters are supported."""
+    if not _is_operation_outcome(body):
+        return False
+    for issue in body.get("issue", []):
+        if not isinstance(issue, dict):
+            continue
+        details = issue.get("details", {})
+        text = details.get("text", "") if isinstance(details, dict) else ""
+        if parameter in text and "supported" in text.lower():
+            return True
+    return False
+
+
+def _has_outcome_warning(bundle) -> bool:
+    if not isinstance(bundle, dict) or bundle.get("resourceType") != "Bundle":
+        return False
+    for entry in bundle.get("entry", []):
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("search", {}).get("mode") != "outcome":
+            continue
+        outcome = entry.get("resource")
+        if not _is_operation_outcome(outcome):
+            continue
+        issues = outcome.get("issue", [])
+        severities = {i.get("severity") for i in issues if isinstance(i, dict)}
+        if issues and not severities.intersection({"fatal", "error"}):
+            return True
+    return False
+
+
+def _self_link_omits(bundle, parameter: str) -> bool:
+    if not isinstance(bundle, dict):
+        return False
+    links = bundle.get("link", [])
+    self_urls = [link.get("url", "") for link in links
+                 if isinstance(link, dict) and link.get("relation") == "self"]
+    return bool(self_urls) and all(f"{parameter}=" not in url for url in self_urls)
+
+
+def _latest_audit_outcome_code(bundle):
+    if not isinstance(bundle, dict):
+        return None
+    entries = bundle.get("entry", [])
+    if not entries or not isinstance(entries[0], dict):
+        return None
+    resource = entries[0].get("resource", {})
+    return resource.get("outcome", {}).get("code", {}).get("code")
+
+
+def _audit_outcome_codes(bundle) -> list[str]:
+    if not isinstance(bundle, dict):
+        return []
+    codes = []
+    for entry in bundle.get("entry", []):
+        if not isinstance(entry, dict):
+            continue
+        resource = entry.get("resource", {})
+        code = resource.get("outcome", {}).get("code", {}).get("code")
+        if isinstance(code, str):
+            codes.append(code)
+    return codes
+
+
+def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
+    hostile_name = "Quintavious Zzyzxbarton"
+    hostile_url = "https://db.internal.example/patient/secret"
+
+    rejected_status, rejected_body, rejected_text = proxy_client.request(
+        "GET", "/Observation?__conformance_case=rejection", ctx.read_headers())
+    rejected_blob = rejected_text or json.dumps(rejected_body or {})
+    rejection_safe = hostile_name not in rejected_blob and hostile_url not in rejected_blob
+    rejection_ok = (rejected_status == 400
+                    and _is_operation_outcome(rejected_body)
+                    and rejection_safe)
+    rejection_grade = ("A" if rejection_ok else
+                       ("F" if rejected_status == 200 or not rejection_safe else "C"))
+
+    auth_status, auth_body, _ = proxy_client.request(
+        "GET", "/Patient/conformance-auth", ctx.read_headers())
+    auth_issue = (auth_body.get("issue", [{}])[0]
+                  if _is_operation_outcome(auth_body) else {})
+    auth_ok = (auth_status in (401, 403, 502)
+               and _is_operation_outcome(auth_body)
+               and auth_issue.get("code") == "security")
+    auth_grade = "A" if auth_ok else ("F" if auth_status in (200, 404) else "C")
+
+    server_status, server_body, _ = proxy_client.request(
+        "GET", "/Observation?__conformance_case=server", ctx.read_headers())
+    server_ok = server_status >= 500 and _is_operation_outcome(server_body)
+    server_grade = "A" if server_ok else ("F" if server_status == 200 else "C")
+
+    timeout_status, timeout_body, _ = proxy_client.request(
+        "GET", "/Observation?__conformance_case=timeout", ctx.read_headers())
+    timeout_ok = timeout_status >= 500 and _is_operation_outcome(timeout_body)
+    timeout_grade = "A" if timeout_ok else ("F" if timeout_status == 200 else "C")
+
+    _, audit_body, _ = proxy_client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=3", ctx.read_headers())
+    audit_codes = _audit_outcome_codes(audit_body)
+    audit_blob = json.dumps(audit_body or {})
+    audit_safe = hostile_name not in audit_blob and hostile_url not in audit_blob
+    audit_ok = (len(audit_codes) >= 3
+                and all(code == "8" for code in audit_codes[:3])
+                and audit_safe)
+    audit_grade = "A" if audit_ok else ("F" if "0" in audit_codes[:2] else "C")
+
+    grade = _error_fidelity_grade([
+        rejection_grade, auth_grade, server_grade, timeout_grade, audit_grade,
+    ])
+    return grade, [
+        Check("proxy rejection preserves sanitized outcome", rejection_grade == "A",
+              f"grade {rejection_grade}; status {rejected_status}"),
+        Check("proxy auth failure is not not-found", auth_grade == "A",
+              f"grade {auth_grade}; status {auth_status}"),
+        Check("proxy server failure is truthful", server_grade == "A",
+              f"grade {server_grade}; status {server_status}"),
+        Check("proxy timeout is truthful", timeout_grade == "A",
+              f"grade {timeout_grade}; status {timeout_status}"),
+        Check("proxy failure audit is truthful", audit_grade == "A",
+              f"grade {audit_grade}; outcomes {','.join(audit_codes) or 'missing'}"),
+    ]
+
+
+def _mcp_profile_grade(mcp_client) -> str:
+    try:
+        result = mcp_client.call_tool(
+            "fhir_search", {"resource_type": "Widget", "_count": 1})
+    except Exception:  # transport probe executed but did not return a tool result
+        return "C"
+    if not isinstance(result, dict):
+        return "F"
+
+    payloads = []
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        payloads.append(structured)
+    for item in result.get("content", []):
+        if not isinstance(item, dict) or not isinstance(item.get("text"), str):
+            continue
+        try:
+            payloads.append(json.loads(item["text"]))
+        except (TypeError, ValueError):
+            payloads.append({"text": item["text"]})
+
+    has_outcome = any(_is_operation_outcome(payload) for payload in payloads)
+    has_failure = has_outcome or any(
+        isinstance(payload, dict)
+        and ("error" in payload or "failed" in str(payload.get("text", "")).lower())
+        for payload in payloads
+    )
+    if result.get("isError") is True and has_outcome:
+        return "A"
+    if has_failure or result.get("isError") is True:
+        return "C"
+    return "F"
+
+
+def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> ProbeResult:
+    """Grade failure-path truthfulness without fixing the known gaps."""
+    strict_headers = ctx.read_headers()
+    strict_headers["Prefer"] = "handling=strict"
+    strict_status, strict_body, _ = client.request(
+        "GET", "/Observation?datetime=x", strict_headers)
+    strict_grade = _rejection_grade(strict_status, strict_body)
+    if strict_grade == "A" and not _outcome_names_parameter_and_supported_set(
+            strict_body, "datetime"):
+        strict_grade = "C"
+
+    _, audit_body, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=1", ctx.read_headers())
+    audit_code = _latest_audit_outcome_code(audit_body)
+    audit_grade = "A" if audit_code == "8" else ("F" if audit_code == "0" else "C")
+
+    lenient_status, lenient_body, _ = client.request(
+        "GET", "/Observation?datetime=x", ctx.read_headers())
+    lenient_ok = (lenient_status == 200
+                  and _has_outcome_warning(lenient_body)
+                  and _self_link_omits(lenient_body, "datetime"))
+    lenient_grade = "A" if lenient_ok else ("F" if lenient_status == 200 else "C")
+
+    modifier_status, modifier_body, _ = client.request(
+        "GET", "/Observation?code:exact=x", ctx.read_headers())
+    modifier_grade = _rejection_grade(modifier_status, modifier_body)
+    modifier_strict_status, modifier_strict_body, _ = client.request(
+        "GET", "/Observation?code:exact=x", strict_headers)
+    modifier_strict_grade = _rejection_grade(
+        modifier_strict_status, modifier_strict_body)
+    modifier_grade = _error_fidelity_grade([
+        modifier_grade, modifier_strict_grade,
+    ])
+
+    local_grade = _error_fidelity_grade([
+        strict_grade, audit_grade, lenient_grade, modifier_grade,
+    ])
+    checks = [
+        Check("strict unknown parameter is rejected", strict_grade == "A",
+              f"grade {strict_grade}; status {strict_status}"),
+        Check("strict rejection is audited as a failure", audit_grade == "A",
+              f"grade {audit_grade}; outcome {audit_code or 'missing'}"),
+        Check("lenient unknown parameter carries an outcome warning",
+              lenient_grade == "A",
+              f"grade {lenient_grade}; status {lenient_status}"),
+        Check("unsupported modifier is rejected", modifier_grade == "A",
+              f"grade {modifier_grade}; statuses "
+              f"{modifier_status},{modifier_strict_status}"),
+    ]
+    profiles = {
+        "local": {"status": "run", "grade": local_grade},
+        "mcp": {"status": "not_run"},
+        "proxy": {"status": "not_run"},
+    }
+    executed_grades = [local_grade]
+    coverage = "local-fhir-only"
+    if mcp_client is not None:
+        mcp_grade = _mcp_profile_grade(mcp_client)
+        profiles["mcp"] = {"status": "run", "grade": mcp_grade}
+        executed_grades.append(mcp_grade)
+        coverage = "local+mcp"
+        checks.append(Check(
+            "MCP tool failure is corrective and flagged", mcp_grade == "A",
+            f"grade {mcp_grade}"))
+
+    if proxy_client is not None:
+        proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
+        profiles["proxy"] = {"status": "run", "grade": proxy_grade}
+        executed_grades.append(proxy_grade)
+        checks.extend(proxy_checks)
+        coverage = "full" if mcp_client is not None else "local+proxy"
+
+    return ProbeResult(
+        "error_fidelity", "Error Fidelity", checks,
+        grade=_error_fidelity_grade(executed_grades),
+        coverage=coverage,
+        profiles=profiles,
+    )
+
+
 _PROBES = (
     probe_phi_redaction,
     probe_audit_trail,
@@ -328,7 +687,8 @@ _PROBES = (
 )
 
 
-def run_conformance(client, ctx: ProbeContext) -> ConformanceReport:
+def run_conformance(client, ctx: ProbeContext, *, mcp_client=None,
+                    proxy_client=None) -> ConformanceReport:
     results = []
     for probe in _PROBES:
         try:
@@ -338,5 +698,20 @@ def run_conformance(client, ctx: ProbeContext) -> ConformanceReport:
             results.append(ProbeResult(
                 key, key.replace("_", " ").title(),
                 [Check("probe executed", False, type(exc).__name__)]))
+    try:
+        results.append(probe_error_fidelity(
+            client, ctx, mcp_client=mcp_client, proxy_client=proxy_client))
+    except Exception as exc:  # a probe crash is a FAIL, never a harness crash
+        results.append(ProbeResult(
+            "error_fidelity", "Error Fidelity",
+            [Check("probe executed", False, type(exc).__name__)],
+            grade="F", coverage="local-fhir-only",
+            profiles={
+                "local": {"status": "run", "grade": "F"},
+                "mcp": ({"status": "run", "grade": "F"}
+                        if mcp_client is not None else {"status": "not_run"}),
+                "proxy": ({"status": "run", "grade": "F"}
+                          if proxy_client is not None else {"status": "not_run"}),
+            }))
     return ConformanceReport(results, base=getattr(client, "base", ""),
                              tenant=ctx.tenant)

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -174,6 +174,16 @@ class ConformanceReport:
             if r.grade is not None:
                 label += f" — {r.effective_grade} ({r.coverage})"
             lines.append(f"  [{'PASS' if r.passed else 'FAIL'}] {label}")
+            for profile_name, profile in r.profiles.items():
+                status = profile.get("status", "unknown")
+                profile_grade = profile.get("grade")
+                grade_suffix = f" — {profile_grade}" if profile_grade else ""
+                lines.append(
+                    f"        {profile_name}: {status}{grade_suffix}")
+                profile_checks = profile.get("checks", [])
+                if profile_checks:
+                    lines.append(
+                        f"          checks: {', '.join(profile_checks)}")
             for c in r.checks:
                 mark = "✓" if c.passed else "✗"
                 suffix = f" — {c.detail}" if c.detail and not c.passed else ""
@@ -274,7 +284,8 @@ def _mcp_response_json(response, expected_id=None) -> dict:
 class LiveMCPProbeClient:
     """Small Streamable HTTP MCP client used only by optional conformance probes."""
 
-    def __init__(self, mcp_url, session=None, tenant=None, step_up_token=None):
+    def __init__(self, mcp_url, session=None, tenant=None, step_up_token=None,
+                 mcp_auth_token=None):
         import requests
         self._url = mcp_url.rstrip("/")
         self._s = session or requests.Session()
@@ -282,6 +293,7 @@ class LiveMCPProbeClient:
         self._protocol_version = "2025-06-18"
         self._tenant = tenant
         self._step_up_token = step_up_token
+        self._mcp_auth_token = mcp_auth_token
 
     def _headers(self):
         headers = {
@@ -295,6 +307,8 @@ class LiveMCPProbeClient:
             headers["X-Tenant-Id"] = self._tenant
         if self._step_up_token:
             headers["X-Step-Up-Token"] = self._step_up_token
+        if self._mcp_auth_token:
+            headers["Authorization"] = f"Bearer {self._mcp_auth_token}"
         return headers
 
     def _initialize(self):
@@ -951,8 +965,14 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
         "GET", f"/Observation?{modifier_query}", strict_headers)
     modifier_strict_grade = _rejection_grade(
         modifier_strict_status, modifier_strict_body)
+    lenient_headers = ctx.read_headers()
+    lenient_headers["Prefer"] = "handling=lenient"
+    modifier_lenient_status, modifier_lenient_body, _ = client.request(
+        "GET", f"/Observation?{modifier_query}", lenient_headers)
+    modifier_lenient_grade = _rejection_grade(
+        modifier_lenient_status, modifier_lenient_body)
     modifier_grade = _error_fidelity_grade([
-        modifier_grade, modifier_strict_grade,
+        modifier_grade, modifier_strict_grade, modifier_lenient_grade,
     ])
 
     local_grade = _error_fidelity_grade([
@@ -972,7 +992,8 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
               f"grade {lenient_audit_grade}"),
         Check("unsupported modifier is rejected", modifier_grade == "A",
               f"grade {modifier_grade}; statuses "
-              f"{modifier_status},{modifier_strict_status}"),
+              f"{modifier_status},{modifier_strict_status},"
+              f"{modifier_lenient_status}"),
     ]
     local_check_names = [check.name for check in checks]
     profiles = {

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -34,6 +34,8 @@ PROPERTIES = (
 )
 
 _ERROR_FIDELITY_GRADE_ORDER = {"F": 0, "C": 1, "A": 2}
+_MCP_INVALID_RESOURCE = "WidgetQuintaviousZzyzxbarton"
+_MCP_HOSTILE_URL = "https://db.internal.example/patient/secret"
 
 
 def _error_fidelity_grade(grades: list[str]) -> str:
@@ -479,16 +481,6 @@ def _self_link_omits(bundle, parameter: str) -> bool:
     return bool(self_urls) and all(f"{parameter}=" not in url for url in self_urls)
 
 
-def _latest_audit_outcome_code(bundle):
-    if not isinstance(bundle, dict):
-        return None
-    entries = bundle.get("entry", [])
-    if not entries or not isinstance(entries[0], dict):
-        return None
-    resource = entries[0].get("resource", {})
-    return resource.get("outcome", {}).get("code", {}).get("code")
-
-
 def _audit_outcome_codes(bundle) -> list[str]:
     if not isinstance(bundle, dict):
         return []
@@ -501,6 +493,41 @@ def _audit_outcome_codes(bundle) -> list[str]:
         if isinstance(code, str):
             codes.append(code)
     return codes
+
+
+def _audit_events(bundle) -> dict[str, str]:
+    if not isinstance(bundle, dict):
+        return {}
+    events = {}
+    for entry in bundle.get("entry", []):
+        if not isinstance(entry, dict):
+            continue
+        resource = entry.get("resource", {})
+        event_id = resource.get("id")
+        code = resource.get("outcome", {}).get("code", {}).get("code")
+        if isinstance(event_id, str) and isinstance(code, str):
+            events[event_id] = code
+    return events
+
+
+def _new_audit_outcome_grade(before, after) -> str:
+    """Grade only a uniquely correlated audit event; ambiguity is opaque."""
+    before_ids = set(_audit_events(before))
+    new_codes = [
+        code for event_id, code in _audit_events(after).items()
+        if event_id not in before_ids
+    ]
+    if len(new_codes) != 1:
+        return "C"
+    return "A" if new_codes[0] == "8" else ("F" if new_codes[0] == "0" else "C")
+
+
+def _profile(status: str, *, grade: Optional[str] = None,
+             checks=()) -> dict:
+    result = {"status": status, "checks": list(checks)}
+    if grade is not None:
+        result["grade"] = grade
+    return result
 
 
 def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
@@ -566,7 +593,11 @@ def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
 def _mcp_profile_grade(mcp_client) -> str:
     try:
         result = mcp_client.call_tool(
-            "fhir_search", {"resource_type": "Widget", "_count": 1})
+            "fhir_search", {
+                "resource_type": _MCP_INVALID_RESOURCE,
+                "patient": _MCP_HOSTILE_URL,
+                "_count": 1,
+            })
     except Exception:  # transport probe executed but did not return a tool result
         return "C"
     if not isinstance(result, dict):
@@ -584,23 +615,70 @@ def _mcp_profile_grade(mcp_client) -> str:
         except (TypeError, ValueError):
             payloads.append({"text": item["text"]})
 
-    has_outcome = any(_is_operation_outcome(payload) for payload in payloads)
+    outcomes = [payload for payload in payloads if _is_operation_outcome(payload)]
+    has_outcome = bool(outcomes)
     has_failure = has_outcome or any(
         isinstance(payload, dict)
         and ("error" in payload or "failed" in str(payload.get("text", "")).lower())
         for payload in payloads
     )
-    if result.get("isError") is True and has_outcome:
+    if (result.get("isError") is True
+            and has_outcome
+            and len(payloads) == len(outcomes)
+            and _mcp_result_omits_hostile_values(result)
+            and all(_safe_corrective_mcp_outcome(outcome) for outcome in outcomes)):
         return "A"
     if has_failure or result.get("isError") is True:
         return "C"
     return "F"
 
 
+def _safe_corrective_mcp_outcome(outcome) -> bool:
+    """Accept only the narrow, synthesized outcome contract for this probe."""
+    issues = outcome.get("issue", []) if isinstance(outcome, dict) else []
+    if not issues:
+        return False
+    saw_expected_category = False
+    for issue in issues:
+        if not isinstance(issue, dict):
+            return False
+        if set(issue) - {"severity", "code", "details"}:
+            return False
+        if issue.get("severity") not in {"fatal", "error"}:
+            return False
+        code = issue.get("code")
+        if (not isinstance(code, str)
+                or code != code.lower()
+                or not code.replace("-", "").isalnum()):
+            return False
+        saw_expected_category = saw_expected_category or code == "not-supported"
+        details = issue.get("details")
+        if not isinstance(details, dict) or set(details) != {"text"}:
+            return False
+        text = details["text"]
+        if not isinstance(text, str) or not text.strip():
+            return False
+    return saw_expected_category and _mcp_result_omits_hostile_values(outcome)
+
+
+def _mcp_result_omits_hostile_values(value) -> bool:
+    blob = json.dumps(value).lower()
+    unsafe_tokens = (
+        _MCP_INVALID_RESOURCE.lower(),
+        "quintavious",
+        "zzyzxbarton",
+        "http://",
+        "https://",
+    )
+    return not any(token in blob for token in unsafe_tokens)
+
+
 def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> ProbeResult:
     """Grade failure-path truthfulness without fixing the known gaps."""
     strict_headers = ctx.read_headers()
     strict_headers["Prefer"] = "handling=strict"
+    _, audit_before, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     strict_status, strict_body, _ = client.request(
         "GET", "/Observation?datetime=x", strict_headers)
     strict_grade = _rejection_grade(strict_status, strict_body)
@@ -608,10 +686,11 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
             strict_body, "datetime"):
         strict_grade = "C"
 
-    _, audit_body, _ = client.request(
-        "GET", "/AuditEvent?entity-type=Observation&_count=1", ctx.read_headers())
-    audit_code = _latest_audit_outcome_code(audit_body)
-    audit_grade = "A" if audit_code == "8" else ("F" if audit_code == "0" else "C")
+    _, audit_after, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
+    audit_grade = _new_audit_outcome_grade(audit_before, audit_after)
+    if strict_status == 200:
+        audit_grade = "F"
 
     lenient_status, lenient_body, _ = client.request(
         "GET", "/Observation?datetime=x", ctx.read_headers())
@@ -638,7 +717,7 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
         Check("strict unknown parameter is rejected", strict_grade == "A",
               f"grade {strict_grade}; status {strict_status}"),
         Check("strict rejection is audited as a failure", audit_grade == "A",
-              f"grade {audit_grade}; outcome {audit_code or 'missing'}"),
+              f"grade {audit_grade}"),
         Check("lenient unknown parameter carries an outcome warning",
               lenient_grade == "A",
               f"grade {lenient_grade}; status {lenient_status}"),
@@ -646,25 +725,30 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
               f"grade {modifier_grade}; statuses "
               f"{modifier_status},{modifier_strict_status}"),
     ]
+    local_check_names = [check.name for check in checks]
     profiles = {
-        "local": {"status": "run", "grade": local_grade},
-        "mcp": {"status": "not_run"},
-        "proxy": {"status": "not_run"},
+        "local": _profile("run", grade=local_grade, checks=local_check_names),
+        "mcp": _profile("not_run"),
+        "proxy": _profile("not_run"),
     }
     executed_grades = [local_grade]
     coverage = "local-fhir-only"
     if mcp_client is not None:
         mcp_grade = _mcp_profile_grade(mcp_client)
-        profiles["mcp"] = {"status": "run", "grade": mcp_grade}
+        mcp_check_name = "MCP tool failure is corrective and flagged"
+        profiles["mcp"] = _profile(
+            "run", grade=mcp_grade, checks=[mcp_check_name])
         executed_grades.append(mcp_grade)
         coverage = "local+mcp"
         checks.append(Check(
-            "MCP tool failure is corrective and flagged", mcp_grade == "A",
+            mcp_check_name, mcp_grade == "A",
             f"grade {mcp_grade}"))
 
     if proxy_client is not None:
         proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
-        profiles["proxy"] = {"status": "run", "grade": proxy_grade}
+        profiles["proxy"] = _profile(
+            "run", grade=proxy_grade,
+            checks=[check.name for check in proxy_checks])
         executed_grades.append(proxy_grade)
         checks.extend(proxy_checks)
         coverage = "full" if mcp_client is not None else "local+proxy"
@@ -707,11 +791,11 @@ def run_conformance(client, ctx: ProbeContext, *, mcp_client=None,
             [Check("probe executed", False, type(exc).__name__)],
             grade="F", coverage="local-fhir-only",
             profiles={
-                "local": {"status": "run", "grade": "F"},
-                "mcp": ({"status": "run", "grade": "F"}
-                        if mcp_client is not None else {"status": "not_run"}),
-                "proxy": ({"status": "run", "grade": "F"}
-                          if proxy_client is not None else {"status": "not_run"}),
+                "local": _profile("run", grade="F", checks=["probe executed"]),
+                "mcp": (_profile("run", grade="F", checks=["probe executed"])
+                        if mcp_client is not None else _profile("not_run")),
+                "proxy": (_profile("run", grade="F", checks=["probe executed"])
+                          if proxy_client is not None else _profile("not_run")),
             }))
     return ConformanceReport(results, base=getattr(client, "base", ""),
                              tenant=ctx.tenant)

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -13,8 +13,11 @@ against a real deployment never touches patient data.
 from __future__ import annotations
 
 import json
+import re
+import uuid
 from dataclasses import dataclass, field
 from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit
 
 # Distinctive synthetic tokens — if any survive a redacted read, redaction failed.
 _SSN = "000-00-9999"
@@ -36,6 +39,15 @@ PROPERTIES = (
 _ERROR_FIDELITY_GRADE_ORDER = {"F": 0, "C": 1, "A": 2}
 _MCP_INVALID_RESOURCE = "WidgetQuintaviousZzyzxbarton"
 _MCP_HOSTILE_URL = "https://db.internal.example/patient/secret"
+_REQUEST_ERROR_CODES = {"invalid", "structure", "value", "not-supported"}
+_LOCAL_SUPPORTED_PARAMETER_EVIDENCE = {
+    "patient", "code", "status", "_lastupdated",
+    "_count", "_sort", "_summary", "context-id",
+}
+_SUPPORTED_SET_RE = re.compile(
+    r"(?:^|[.!?]\s+)supported parameters?\s*:\s*([^.!?]+)",
+    re.IGNORECASE,
+)
 
 
 def _error_fidelity_grade(grades: list[str]) -> str:
@@ -144,7 +156,7 @@ class ConformanceReport:
             "score": {"passed": p, "total": t},
             "properties": [
                 {"key": r.key, "property": r.property, "passed": r.passed,
-                 "grade": r.effective_grade, "coverage": r.coverage,
+                 "grade": r.grade, "coverage": r.coverage,
                  "profiles": r.profiles, "note": r.note,
                  "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail}
                             for c in r.checks]}
@@ -231,15 +243,45 @@ class LiveProbeClient:
         return r.status_code, body, r.text
 
 
+def _mcp_response_json(response, expected_id=None) -> dict:
+    """Decode either JSON or an SSE message from Streamable HTTP."""
+    content_type = response.headers.get("Content-Type", "").lower()
+    if "text/event-stream" not in content_type:
+        body = response.json()
+        if (isinstance(body, dict)
+                and (expected_id is None or body.get("id") == expected_id)):
+            return body
+        raise RuntimeError("MCP response was not a JSON object")
+
+    for event in response.text.replace("\r\n", "\n").split("\n\n"):
+        data = "\n".join(
+            line[5:].lstrip() for line in event.splitlines()
+            if line.startswith("data:")
+        )
+        if not data:
+            continue
+        try:
+            body = json.loads(data)
+        except (TypeError, ValueError):
+            continue
+        if (isinstance(body, dict)
+                and (expected_id is None or body.get("id") == expected_id)
+                and ("result" in body or "error" in body)):
+            return body
+    raise RuntimeError("MCP SSE response contained no JSON message")
+
+
 class LiveMCPProbeClient:
     """Small Streamable HTTP MCP client used only by optional conformance probes."""
 
-    def __init__(self, mcp_url, session=None):
+    def __init__(self, mcp_url, session=None, tenant=None, step_up_token=None):
         import requests
         self._url = mcp_url.rstrip("/")
         self._s = session or requests.Session()
         self._session_id = None
         self._protocol_version = "2025-06-18"
+        self._tenant = tenant
+        self._step_up_token = step_up_token
 
     def _headers(self):
         headers = {
@@ -249,6 +291,10 @@ class LiveMCPProbeClient:
         }
         if self._session_id:
             headers["Mcp-Session-Id"] = self._session_id
+        if self._tenant:
+            headers["X-Tenant-Id"] = self._tenant
+        if self._step_up_token:
+            headers["X-Step-Up-Token"] = self._step_up_token
         return headers
 
     def _initialize(self):
@@ -268,12 +314,10 @@ class LiveMCPProbeClient:
             timeout=15,
         )
         response.raise_for_status()
-        body = response.json()
+        body = _mcp_response_json(response, expected_id=1)
         if not isinstance(body, dict) or "error" in body:
             raise RuntimeError("MCP initialize failed")
         self._session_id = response.headers.get("Mcp-Session-Id")
-        if not self._session_id:
-            raise RuntimeError("MCP initialize returned no session id")
         result = body.get("result", {})
         if isinstance(result, dict) and isinstance(result.get("protocolVersion"), str):
             self._protocol_version = result["protocolVersion"]
@@ -301,7 +345,7 @@ class LiveMCPProbeClient:
             timeout=25,
         )
         response.raise_for_status()
-        body = response.json()
+        body = _mcp_response_json(response, expected_id=2)
         if not isinstance(body, dict) or "error" in body:
             raise RuntimeError("MCP tools/call failed")
         result = body.get("result")
@@ -434,7 +478,8 @@ def _is_operation_outcome(body) -> bool:
 def _rejection_grade(status, body, expected_status=400) -> str:
     if status == 200:
         return "F"
-    if status == expected_status and _is_operation_outcome(body):
+    if status == expected_status and _corrective_outcome(
+            body, _REQUEST_ERROR_CODES):
         return "A"
     return "C"
 
@@ -449,27 +494,77 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
             continue
         details = issue.get("details", {})
         text = details.get("text", "") if isinstance(details, dict) else ""
-        if parameter in text and "supported" in text.lower():
+        match = _SUPPORTED_SET_RE.search(text)
+        if match is None:
+            continue
+        declared = {
+            token.lower()
+            for token in re.findall(
+                r"[A-Za-z_][A-Za-z0-9_-]*", match.group(1))
+        }
+        supported = declared & _LOCAL_SUPPORTED_PARAMETER_EVIDENCE
+        parameter_lower = parameter.lower()
+        remaining = text[:match.start()] + text[match.end():]
+        parameter_token = re.escape(parameter_lower)
+        rejection = re.search(
+            rf"(?:^|[.!?]\s*)(?:"
+            rf"(?:unsupported|unknown|invalid)\s+(?:search\s+)?"
+            rf"parameter\s*:?\s*{parameter_token}"
+            rf"|{parameter_token}\s+(?:(?:is|was)\s+)?"
+            rf"(?:ignored|unsupported|rejected|invalid|unknown)"
+            rf"|{parameter_token}\s+is\s+not\s+implemented"
+            rf")\s*(?=[.!?]|$)",
+            remaining.lower(),
+        )
+        if (parameter_lower not in declared
+                and rejection is not None
+                and len(supported) >= 2):
             return True
     return False
 
 
-def _has_outcome_warning(bundle) -> bool:
+def _safe_warning_outcome(outcome) -> bool:
+    if not _is_operation_outcome(outcome):
+        return False
+    if set(outcome) != {"resourceType", "issue"}:
+        return False
+    issues = outcome.get("issue", [])
+    if not isinstance(issues, list) or not issues:
+        return False
+    return (all(
+        isinstance(issue, dict)
+        and not set(issue) - {"severity", "code", "details"}
+        and issue.get("severity") in {"warning", "information"}
+        and issue.get("code") in _REQUEST_ERROR_CODES
+        and isinstance(issue.get("details"), dict)
+        and set(issue["details"]) == {"text"}
+        and isinstance(issue["details"]["text"], str)
+        and bool(issue["details"]["text"].strip())
+        for issue in issues
+    ) and _outcome_omits_hostile_values(outcome))
+
+
+def _has_outcome_warning(bundle, parameter: str) -> bool:
     if not isinstance(bundle, dict) or bundle.get("resourceType") != "Bundle":
         return False
-    for entry in bundle.get("entry", []):
+    entries = bundle.get("entry", [])
+    if not isinstance(entries, list):
+        return False
+    saw_corrective_warning = False
+    for entry in entries:
         if not isinstance(entry, dict):
-            continue
-        if entry.get("search", {}).get("mode") != "outcome":
+            return False
+        search = entry.get("search")
+        if not isinstance(search, dict) or search.get("mode") != "outcome":
             continue
         outcome = entry.get("resource")
-        if not _is_operation_outcome(outcome):
-            continue
-        issues = outcome.get("issue", [])
-        severities = {i.get("severity") for i in issues if isinstance(i, dict)}
-        if issues and not severities.intersection({"fatal", "error"}):
-            return True
-    return False
+        if not _safe_warning_outcome(outcome):
+            return False
+        saw_corrective_warning = (
+            saw_corrective_warning
+            or _outcome_names_parameter_and_supported_set(outcome, parameter)
+        )
+    return saw_corrective_warning
 
 
 def _self_link_omits(bundle, parameter: str) -> bool:
@@ -477,35 +572,71 @@ def _self_link_omits(bundle, parameter: str) -> bool:
         return False
     links = bundle.get("link", [])
     self_urls = [link.get("url", "") for link in links
-                 if isinstance(link, dict) and link.get("relation") == "self"]
-    return bool(self_urls) and all(f"{parameter}=" not in url for url in self_urls)
+                 if isinstance(link, dict) and link.get("relation") == "self"
+                 and isinstance(link.get("url"), str)]
+    return bool(self_urls) and all(
+        parameter not in {key for key, _ in parse_qsl(
+            urlsplit(url).query, keep_blank_values=True)}
+        for url in self_urls
+    )
 
 
-def _audit_outcome_codes(bundle) -> list[str]:
+def _self_link_includes(bundle, parameter: str, value: str) -> bool:
     if not isinstance(bundle, dict):
-        return []
-    codes = []
+        return False
+    self_urls = [link.get("url", "") for link in bundle.get("link", [])
+                 if isinstance(link, dict) and link.get("relation") == "self"
+                 and isinstance(link.get("url"), str)]
+    return bool(self_urls) and all(
+        (parameter, value) in parse_qsl(
+            urlsplit(url).query, keep_blank_values=True)
+        for url in self_urls
+    )
+
+
+def _bundle_matches_subject(bundle, subject_ref: str) -> bool:
+    """A supposedly bounded search may return only the synthetic subject."""
+    if not isinstance(bundle, dict) or bundle.get("resourceType") != "Bundle":
+        return False
+    entries = bundle.get("entry", [])
+    if not isinstance(entries, list):
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            return False
+        resource = entry.get("resource")
+        search = entry.get("search")
+        mode = search.get("mode") if isinstance(search, dict) else None
+        if _is_operation_outcome(resource) and mode == "outcome":
+            continue
+        if not isinstance(resource, dict):
+            return False
+        subject = resource.get("subject")
+        if (not isinstance(subject, dict)
+                or subject.get("reference") != subject_ref):
+            return False
+    return True
+
+
+def _audit_resources(bundle) -> dict[str, dict]:
+    if not isinstance(bundle, dict):
+        return {}
+    resources = {}
     for entry in bundle.get("entry", []):
         if not isinstance(entry, dict):
             continue
-        resource = entry.get("resource", {})
-        code = resource.get("outcome", {}).get("code", {}).get("code")
-        if isinstance(code, str):
-            codes.append(code)
-    return codes
+        resource = entry.get("resource")
+        if (isinstance(resource, dict)
+                and isinstance(resource.get("id"), str)):
+            resources[resource["id"]] = resource
+    return resources
 
 
 def _audit_events(bundle) -> dict[str, str]:
-    if not isinstance(bundle, dict):
-        return {}
     events = {}
-    for entry in bundle.get("entry", []):
-        if not isinstance(entry, dict):
-            continue
-        resource = entry.get("resource", {})
-        event_id = resource.get("id")
+    for event_id, resource in _audit_resources(bundle).items():
         code = resource.get("outcome", {}).get("code", {}).get("code")
-        if isinstance(event_id, str) and isinstance(code, str):
+        if isinstance(code, str):
             events[event_id] = code
     return events
 
@@ -526,11 +657,31 @@ def _new_audit_outcome_codes(before, after) -> list[str]:
     ]
 
 
-def _new_audit_expected_grade(before, after, expected_code: str) -> str:
-    new_codes = _new_audit_outcome_codes(before, after)
-    if len(new_codes) != 1:
+def _new_audit_warning_grade(before, after, parameter: str) -> str:
+    before_ids = set(_audit_resources(before))
+    new_resources = [
+        resource for event_id, resource in _audit_resources(after).items()
+        if event_id not in before_ids
+    ]
+    if len(new_resources) != 1:
         return "C"
-    return "A" if new_codes[0] == expected_code else "F"
+    outcome = new_resources[0].get("outcome", {})
+    if outcome.get("code", {}).get("code") != "0":
+        return "F"
+    details = outcome.get("detail", [])
+    if not isinstance(details, list):
+        return "C"
+    texts = [detail.get("text", "") for detail in details
+             if isinstance(detail, dict)
+             and isinstance(detail.get("text"), str)]
+    lowered = " ".join(texts).lower()
+    if f"{parameter.lower()}=" in lowered or "http://" in lowered or "https://" in lowered:
+        return "F"
+    if "applied" in lowered and parameter.lower() in lowered:
+        return "C"
+    if "ignored" in lowered and parameter.lower() in lowered:
+        return "A"
+    return "C"
 
 
 def _profile(status: str, *, grade: Optional[str] = None,
@@ -547,17 +698,43 @@ def _corrective_outcome(body, expected_codes: set[str]) -> bool:
     issues = body.get("issue", [])
     if not isinstance(issues, list) or not issues:
         return False
+    if set(body) - {"resourceType", "issue"}:
+        return False
+    saw_expected = False
     for issue in issues:
-        if not isinstance(issue, dict):
-            continue
+        if (not isinstance(issue, dict)
+                or set(issue) - {"severity", "code", "details"}):
+            return False
         details = issue.get("details")
         text = details.get("text") if isinstance(details, dict) else None
-        if (issue.get("severity") in {"fatal", "error"}
-                and issue.get("code") in expected_codes
-                and isinstance(text, str)
-                and text.strip()):
-            return True
-    return False
+        if (issue.get("severity") not in {"fatal", "error"}
+                or issue.get("code") not in expected_codes
+                or not isinstance(details, dict)
+                or set(details) != {"text"}
+                or not isinstance(text, str)
+                or not text.strip()):
+            return False
+        saw_expected = True
+    return saw_expected and _outcome_omits_hostile_values(body)
+
+
+def _outcome_omits_hostile_values(value) -> bool:
+    blob = json.dumps(value).lower()
+    unsafe_tokens = (
+        _GIVEN.lower(), _FAMILY.lower(),
+        "quintavious zzyzxbarton",
+        _MCP_INVALID_RESOURCE.lower(),
+        "http://", "https://",
+    )
+    return not any(token in blob for token in unsafe_tokens)
+
+
+def _response_omits_hostile_values(body, text) -> bool:
+    blob = (text or json.dumps(body or {})).lower()
+    return not any(token in blob for token in (
+        _GIVEN.lower(), _FAMILY.lower(),
+        "quintavious zzyzxbarton", "http://", "https://",
+    ))
 
 
 def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
@@ -569,8 +746,8 @@ def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
 
     rejected_status, rejected_body, rejected_text = proxy_client.request(
         "GET", "/Observation?__conformance_case=rejection", ctx.read_headers())
-    rejected_blob = rejected_text or json.dumps(rejected_body or {})
-    rejection_safe = hostile_name not in rejected_blob and hostile_url not in rejected_blob
+    rejection_safe = _response_omits_hostile_values(
+        rejected_body, rejected_text)
     rejection_ok = (rejected_status == 400
                     and _corrective_outcome(
                         rejected_body,
@@ -579,23 +756,29 @@ def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
     rejection_grade = ("A" if rejection_ok else
                        ("F" if rejected_status == 200 or not rejection_safe else "C"))
 
-    auth_status, auth_body, _ = proxy_client.request(
+    auth_status, auth_body, auth_text = proxy_client.request(
         "GET", "/Patient/conformance-auth", ctx.read_headers())
+    # In server-credential proxy mode an upstream 401/403 is deliberately
+    # mapped to 502: the caller cannot repair the proxy's credential. In
+    # caller-auth mode the original 401/403 remains truthful.
     auth_ok = (auth_status in (401, 403, 502)
-               and _corrective_outcome(auth_body, {"security"}))
+               and _corrective_outcome(auth_body, {"security"})
+               and _response_omits_hostile_values(auth_body, auth_text))
     auth_grade = "A" if auth_ok else ("F" if auth_status in (200, 404) else "C")
 
-    server_status, server_body, _ = proxy_client.request(
+    server_status, server_body, server_text = proxy_client.request(
         "GET", "/Observation?__conformance_case=server", ctx.read_headers())
     server_ok = (server_status >= 500
                  and _corrective_outcome(
-                     server_body, {"exception", "transient", "processing"}))
+                     server_body, {"exception", "transient", "processing"})
+                 and _response_omits_hostile_values(server_body, server_text))
     server_grade = "A" if server_ok else ("F" if server_status == 200 else "C")
 
-    timeout_status, timeout_body, _ = proxy_client.request(
+    timeout_status, timeout_body, timeout_text = proxy_client.request(
         "GET", "/Observation?__conformance_case=timeout", ctx.read_headers())
     timeout_ok = (timeout_status >= 500
-                  and _corrective_outcome(timeout_body, {"timeout", "transient"}))
+                  and _corrective_outcome(timeout_body, {"timeout", "transient"})
+                  and _response_omits_hostile_values(timeout_body, timeout_text))
     timeout_grade = "A" if timeout_ok else ("F" if timeout_status == 200 else "C")
 
     _, audit_after, _ = proxy_client.request(
@@ -621,7 +804,7 @@ def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
         Check("proxy timeout is truthful", timeout_grade == "A",
               f"grade {timeout_grade}; status {timeout_status}"),
         Check("proxy failure audit is truthful", audit_grade == "A",
-              f"grade {audit_grade}; outcomes {','.join(audit_codes) or 'missing'}"),
+              f"grade {audit_grade}; observed {len(audit_codes)} outcomes"),
     ]
 
 
@@ -640,15 +823,29 @@ def _mcp_profile_grade(mcp_client) -> str:
 
     payloads = []
     structured = result.get("structuredContent")
+    malformed_content = ("structuredContent" in result
+                         and not isinstance(structured, dict))
     if isinstance(structured, dict):
         payloads.append(structured)
-    for item in result.get("content", []):
-        if not isinstance(item, dict) or not isinstance(item.get("text"), str):
+    content = result.get("content", [])
+    malformed_content = malformed_content or not isinstance(content, list)
+    if malformed_content:
+        content = []
+    for item in content:
+        if (not isinstance(item, dict)
+                or set(item) != {"type", "text"}
+                or item.get("type") != "text"
+                or not isinstance(item.get("text"), str)):
+            malformed_content = True
             continue
         try:
-            payloads.append(json.loads(item["text"]))
+            payload = json.loads(item["text"])
         except (TypeError, ValueError):
-            payloads.append({"text": item["text"]})
+            malformed_content = True
+            payload = {"text": item["text"]}
+        if not isinstance(payload, dict):
+            malformed_content = True
+        payloads.append(payload)
 
     outcomes = [payload for payload in payloads if _is_operation_outcome(payload)]
     has_outcome = bool(outcomes)
@@ -659,6 +856,7 @@ def _mcp_profile_grade(mcp_client) -> str:
     )
     if (result.get("isError") is True
             and has_outcome
+            and not malformed_content
             and len(payloads) == len(outcomes)
             and _mcp_result_omits_hostile_values(result)
             and all(_safe_corrective_mcp_outcome(outcome) for outcome in outcomes)):
@@ -712,10 +910,13 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
     """Grade failure-path truthfulness without fixing the known gaps."""
     strict_headers = ctx.read_headers()
     strict_headers["Prefer"] = "handling=strict"
+    subject_ref = f"Patient/conformance-error-fidelity-{uuid.uuid4().hex}"
+    strict_query = urlencode({"patient": subject_ref, "datetime": "x"})
+    modifier_query = urlencode({"patient": subject_ref, "code:exact": "x"})
     _, audit_before, _ = client.request(
         "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     strict_status, strict_body, _ = client.request(
-        "GET", "/Observation?datetime=x", strict_headers)
+        "GET", f"/Observation?{strict_query}", strict_headers)
     strict_grade = _rejection_grade(strict_status, strict_body)
     if strict_grade == "A" and not _outcome_names_parameter_and_supported_set(
             strict_body, "datetime"):
@@ -730,21 +931,24 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
     _, lenient_audit_before, _ = client.request(
         "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     lenient_status, lenient_body, _ = client.request(
-        "GET", "/Observation?datetime=x", ctx.read_headers())
+        "GET", f"/Observation?{strict_query}", ctx.read_headers())
     _, lenient_audit_after, _ = client.request(
         "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     lenient_ok = (lenient_status == 200
-                  and _has_outcome_warning(lenient_body)
-                  and _self_link_omits(lenient_body, "datetime"))
+                  and _has_outcome_warning(lenient_body, "datetime")
+                  and _self_link_omits(lenient_body, "datetime")
+                  and _self_link_includes(
+                      lenient_body, "patient", subject_ref)
+                  and _bundle_matches_subject(lenient_body, subject_ref))
     lenient_grade = "A" if lenient_ok else ("F" if lenient_status == 200 else "C")
-    lenient_audit_grade = _new_audit_expected_grade(
-        lenient_audit_before, lenient_audit_after, "0")
+    lenient_audit_grade = _new_audit_warning_grade(
+        lenient_audit_before, lenient_audit_after, "datetime")
 
     modifier_status, modifier_body, _ = client.request(
-        "GET", "/Observation?code:exact=x", ctx.read_headers())
+        "GET", f"/Observation?{modifier_query}", ctx.read_headers())
     modifier_grade = _rejection_grade(modifier_status, modifier_body)
     modifier_strict_status, modifier_strict_body, _ = client.request(
-        "GET", "/Observation?code:exact=x", strict_headers)
+        "GET", f"/Observation?{modifier_query}", strict_headers)
     modifier_strict_grade = _rejection_grade(
         modifier_strict_status, modifier_strict_body)
     modifier_grade = _error_fidelity_grade([

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -510,13 +510,25 @@ def _outcome_has_unsafe_last_updated_suggestion(body) -> bool:
     """
     if not _is_operation_outcome(body):
         return False
+
+    def strip_exact_supported_set(match: re.Match) -> str:
+        declared = {
+            token.lower()
+            for token in re.findall(
+                r"[A-Za-z_][A-Za-z0-9_-]*", match.group(1))
+        }
+        if declared == _LOCAL_SUPPORTED_PARAMETER_EVIDENCE:
+            return ""
+        return match.group(0)
+
     for issue in body.get("issue", []):
         if not isinstance(issue, dict):
             continue
         details = issue.get("details")
         text = details.get("text", "") if isinstance(details, dict) else ""
         if (isinstance(text, str)
-                and "_lastupdated" in _SUPPORTED_SET_RE.sub("", text).lower()):
+                and "_lastupdated" in _SUPPORTED_SET_RE.sub(
+                    strip_exact_supported_set, text).lower()):
             return True
     return False
 

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -502,10 +502,31 @@ def _rejection_grade(status, body, expected_status=400) -> str:
     return "C"
 
 
+def _outcome_has_unsafe_last_updated_suggestion(body) -> bool:
+    """Reject `_lastUpdated` as a proposed substitute for clinical datetime.
+
+    A supported-parameter list may name `_lastUpdated` factually. Any mention
+    elsewhere in any issue is ambiguous or unsafe correction evidence.
+    """
+    if not _is_operation_outcome(body):
+        return False
+    for issue in body.get("issue", []):
+        if not isinstance(issue, dict):
+            continue
+        details = issue.get("details")
+        text = details.get("text", "") if isinstance(details, dict) else ""
+        if (isinstance(text, str)
+                and "_lastupdated" in _SUPPORTED_SET_RE.sub("", text).lower()):
+            return True
+    return False
+
+
 def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
     """A local rejection is corrective only if it identifies the bad key and
     tells the caller which search parameters are supported."""
     if not _is_operation_outcome(body):
+        return False
+    if _outcome_has_unsafe_last_updated_suggestion(body):
         return False
     for issue in body.get("issue", []):
         if not isinstance(issue, dict):
@@ -522,11 +543,6 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
         }
         parameter_lower = parameter.lower()
         remaining = text[:match.start()] + text[match.end():]
-        # `_lastUpdated` is record modification time, not clinical datetime.
-        # Any mention outside the factual supported-set list is an ambiguous or
-        # unsafe correction, so it cannot earn A.
-        if "_lastupdated" in remaining.lower():
-            continue
         parameter_token = re.escape(parameter_lower)
         rejection = re.search(
             rf"(?:^|[.!?]\s*)(?:"
@@ -615,6 +631,8 @@ def _has_outcome_warning(bundle, parameter: str) -> bool:
             continue
         outcome = entry.get("resource")
         if not _safe_warning_outcome(outcome):
+            return False
+        if _outcome_has_unsafe_last_updated_suggestion(outcome):
             return False
         saw_corrective_warning = (
             saw_corrective_warning

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -512,14 +512,25 @@ def _audit_events(bundle) -> dict[str, str]:
 
 def _new_audit_outcome_grade(before, after) -> str:
     """Grade only a uniquely correlated audit event; ambiguity is opaque."""
-    before_ids = set(_audit_events(before))
-    new_codes = [
-        code for event_id, code in _audit_events(after).items()
-        if event_id not in before_ids
-    ]
+    new_codes = _new_audit_outcome_codes(before, after)
     if len(new_codes) != 1:
         return "C"
     return "A" if new_codes[0] == "8" else ("F" if new_codes[0] == "0" else "C")
+
+
+def _new_audit_outcome_codes(before, after) -> list[str]:
+    before_ids = set(_audit_events(before))
+    return [
+        code for event_id, code in _audit_events(after).items()
+        if event_id not in before_ids
+    ]
+
+
+def _new_audit_expected_grade(before, after, expected_code: str) -> str:
+    new_codes = _new_audit_outcome_codes(before, after)
+    if len(new_codes) != 1:
+        return "C"
+    return "A" if new_codes[0] == expected_code else "F"
 
 
 def _profile(status: str, *, grade: Optional[str] = None,
@@ -530,48 +541,72 @@ def _profile(status: str, *, grade: Optional[str] = None,
     return result
 
 
+def _corrective_outcome(body, expected_codes: set[str]) -> bool:
+    if not _is_operation_outcome(body):
+        return False
+    issues = body.get("issue", [])
+    if not isinstance(issues, list) or not issues:
+        return False
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        details = issue.get("details")
+        text = details.get("text") if isinstance(details, dict) else None
+        if (issue.get("severity") in {"fatal", "error"}
+                and issue.get("code") in expected_codes
+                and isinstance(text, str)
+                and text.strip()):
+            return True
+    return False
+
+
 def _proxy_profile(proxy_client, ctx) -> tuple[str, list[Check]]:
     hostile_name = "Quintavious Zzyzxbarton"
     hostile_url = "https://db.internal.example/patient/secret"
+
+    _, audit_before, _ = proxy_client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
 
     rejected_status, rejected_body, rejected_text = proxy_client.request(
         "GET", "/Observation?__conformance_case=rejection", ctx.read_headers())
     rejected_blob = rejected_text or json.dumps(rejected_body or {})
     rejection_safe = hostile_name not in rejected_blob and hostile_url not in rejected_blob
     rejection_ok = (rejected_status == 400
-                    and _is_operation_outcome(rejected_body)
+                    and _corrective_outcome(
+                        rejected_body,
+                        {"invalid", "structure", "value", "not-supported"})
                     and rejection_safe)
     rejection_grade = ("A" if rejection_ok else
                        ("F" if rejected_status == 200 or not rejection_safe else "C"))
 
     auth_status, auth_body, _ = proxy_client.request(
         "GET", "/Patient/conformance-auth", ctx.read_headers())
-    auth_issue = (auth_body.get("issue", [{}])[0]
-                  if _is_operation_outcome(auth_body) else {})
     auth_ok = (auth_status in (401, 403, 502)
-               and _is_operation_outcome(auth_body)
-               and auth_issue.get("code") == "security")
+               and _corrective_outcome(auth_body, {"security"}))
     auth_grade = "A" if auth_ok else ("F" if auth_status in (200, 404) else "C")
 
     server_status, server_body, _ = proxy_client.request(
         "GET", "/Observation?__conformance_case=server", ctx.read_headers())
-    server_ok = server_status >= 500 and _is_operation_outcome(server_body)
+    server_ok = (server_status >= 500
+                 and _corrective_outcome(
+                     server_body, {"exception", "transient", "processing"}))
     server_grade = "A" if server_ok else ("F" if server_status == 200 else "C")
 
     timeout_status, timeout_body, _ = proxy_client.request(
         "GET", "/Observation?__conformance_case=timeout", ctx.read_headers())
-    timeout_ok = timeout_status >= 500 and _is_operation_outcome(timeout_body)
+    timeout_ok = (timeout_status >= 500
+                  and _corrective_outcome(timeout_body, {"timeout", "transient"}))
     timeout_grade = "A" if timeout_ok else ("F" if timeout_status == 200 else "C")
 
-    _, audit_body, _ = proxy_client.request(
-        "GET", "/AuditEvent?entity-type=Observation&_count=3", ctx.read_headers())
-    audit_codes = _audit_outcome_codes(audit_body)
-    audit_blob = json.dumps(audit_body or {})
+    _, audit_after, _ = proxy_client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
+    audit_codes = _new_audit_outcome_codes(audit_before, audit_after)
+    audit_blob = json.dumps(audit_after or {})
     audit_safe = hostile_name not in audit_blob and hostile_url not in audit_blob
-    audit_ok = (len(audit_codes) >= 3
-                and all(code == "8" for code in audit_codes[:3])
+    audit_ok = (len(audit_codes) == 3
+                and all(code == "8" for code in audit_codes)
                 and audit_safe)
-    audit_grade = "A" if audit_ok else ("F" if "0" in audit_codes[:2] else "C")
+    audit_grade = "A" if audit_ok else ("F" if "0" in audit_codes else "C")
 
     grade = _error_fidelity_grade([
         rejection_grade, auth_grade, server_grade, timeout_grade, audit_grade,
@@ -692,12 +727,18 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
     if strict_status == 200:
         audit_grade = "F"
 
+    _, lenient_audit_before, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     lenient_status, lenient_body, _ = client.request(
         "GET", "/Observation?datetime=x", ctx.read_headers())
+    _, lenient_audit_after, _ = client.request(
+        "GET", "/AuditEvent?entity-type=Observation&_count=200", ctx.read_headers())
     lenient_ok = (lenient_status == 200
                   and _has_outcome_warning(lenient_body)
                   and _self_link_omits(lenient_body, "datetime"))
     lenient_grade = "A" if lenient_ok else ("F" if lenient_status == 200 else "C")
+    lenient_audit_grade = _new_audit_expected_grade(
+        lenient_audit_before, lenient_audit_after, "0")
 
     modifier_status, modifier_body, _ = client.request(
         "GET", "/Observation?code:exact=x", ctx.read_headers())
@@ -711,7 +752,8 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
     ])
 
     local_grade = _error_fidelity_grade([
-        strict_grade, audit_grade, lenient_grade, modifier_grade,
+        strict_grade, audit_grade, lenient_grade, lenient_audit_grade,
+        modifier_grade,
     ])
     checks = [
         Check("strict unknown parameter is rejected", strict_grade == "A",
@@ -721,6 +763,9 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
         Check("lenient unknown parameter carries an outcome warning",
               lenient_grade == "A",
               f"grade {lenient_grade}; status {lenient_status}"),
+        Check("lenient warning is audited truthfully",
+              lenient_audit_grade == "A",
+              f"grade {lenient_audit_grade}"),
         Check("unsupported modifier is rejected", modifier_grade == "A",
               f"grade {modifier_grade}; statuses "
               f"{modifier_status},{modifier_strict_status}"),
@@ -745,7 +790,13 @@ def probe_error_fidelity(client, ctx, mcp_client=None, proxy_client=None) -> Pro
             f"grade {mcp_grade}"))
 
     if proxy_client is not None:
-        proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
+        try:
+            proxy_grade, proxy_checks = _proxy_profile(proxy_client, ctx)
+        except Exception as exc:
+            proxy_grade = "F"
+            proxy_checks = [
+                Check("proxy profile executed", False, type(exc).__name__)
+            ]
         profiles["proxy"] = _profile(
             "run", grade=proxy_grade,
             checks=[check.name for check in proxy_checks])
@@ -792,10 +843,8 @@ def run_conformance(client, ctx: ProbeContext, *, mcp_client=None,
             grade="F", coverage="local-fhir-only",
             profiles={
                 "local": _profile("run", grade="F", checks=["probe executed"]),
-                "mcp": (_profile("run", grade="F", checks=["probe executed"])
-                        if mcp_client is not None else _profile("not_run")),
-                "proxy": (_profile("run", grade="F", checks=["probe executed"])
-                          if proxy_client is not None else _profile("not_run")),
+                "mcp": _profile("not_run"),
+                "proxy": _profile("not_run"),
             }))
     return ConformanceReport(results, base=getattr(client, "base", ""),
                              tenant=ctx.tenant)

--- a/r6/conformance/routes.py
+++ b/r6/conformance/routes.py
@@ -28,10 +28,21 @@ def _shields(report_dict):
     p = report_dict["score"]["passed"]
     t = report_dict["score"]["total"]
     grade = report_dict["grade"]
+    error_fidelity = next(
+        (p for p in report_dict["properties"]
+         if p["key"] == "error_fidelity"),
+        None,
+    )
+    fidelity_suffix = ""
+    if error_fidelity is not None:
+        fidelity_suffix = (
+            f"; error fidelity {error_fidelity['grade']}, "
+            f"{error_fidelity['coverage']}"
+        )
     return {
         "schemaVersion": 1,
         "label": "guardrail conformance",
-        "message": f"{grade} ({p}/{t})",
+        "message": f"{grade} ({p}/{t}{fidelity_suffix})",
         "color": "brightgreen" if report_dict["passed"] else
                  ("yellow" if grade in ("B", "C") else "red"),
     }
@@ -77,7 +88,11 @@ def register_conformance_routes(blueprint, deps):
                 ProbeResult(
                     p["key"], p["property"],
                     [Check(c["name"], c["passed"], c["detail"]) for c in p["checks"]],
-                    p.get("note", ""))
+                    note=p.get("note", ""),
+                    grade=p.get("grade"),
+                    coverage=p.get("coverage", "full"),
+                    profiles=p.get("profiles", {}),
+                )
                 for p in body["properties"]
             ]
             rep = ConformanceReport(results, base=body.get("target", ""),

--- a/scripts/guardrail_conformance.py
+++ b/scripts/guardrail_conformance.py
@@ -1,10 +1,9 @@
 """Guardrail conformance scorecard for any HealthClaw deployment.
 
-Proves the six guardrail properties actually hold — PHI redaction, immutable
-audit, step-up authorization, human-in-the-loop, tenant isolation, and medical
-disclaimers — by probing a live endpoint with synthetic data. Partners can run
-this against their own deployment (or ours) to verify the guardrails are real,
-not marketing.
+Proves the seven guardrail properties actually hold — including error fidelity
+on rejected requests — by probing a live endpoint with synthetic data. Partners
+can run this against their own deployment (or ours) to verify the guardrails are
+real, not marketing.
 
 Usage:
     python scripts/guardrail_conformance.py \
@@ -23,7 +22,12 @@ import sys
 
 sys.path.insert(0, __file__.rsplit("/scripts/", 1)[0])
 
-from r6.conformance import LiveProbeClient, ProbeContext, run_conformance  # noqa: E402
+from r6.conformance import (  # noqa: E402
+    LiveMCPProbeClient,
+    LiveProbeClient,
+    ProbeContext,
+    run_conformance,
+)
 
 
 def main():
@@ -35,12 +39,16 @@ def main():
                     help="write-capable step-up token for --tenant")
     ap.add_argument("--second-tenant", default="conformance-tenant-b",
                     help="a different tenant id, for the isolation probe")
+    ap.add_argument("--mcp-url",
+                    help="optional Streamable HTTP MCP endpoint for tools/call coverage")
     ap.add_argument("--json", action="store_true", help="emit JSON instead of a scorecard")
     args = ap.parse_args()
 
     ctx = ProbeContext(tenant=args.tenant, step_up_token=args.step_up_token,
                        second_tenant=args.second_tenant)
-    report = run_conformance(LiveProbeClient(args.base_url), ctx)
+    mcp_client = LiveMCPProbeClient(args.mcp_url) if args.mcp_url else None
+    report = run_conformance(
+        LiveProbeClient(args.base_url), ctx, mcp_client=mcp_client)
 
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))

--- a/scripts/guardrail_conformance.py
+++ b/scripts/guardrail_conformance.py
@@ -10,6 +10,7 @@ Usage:
         --base-url https://app.healthclaw.io \
         --tenant desktop-demo \
         --step-up-token <token>          # mint via POST /r6/fhir/internal/step-up-token
+    # For protected MCP coverage, also set MCP_AUTH_TOKEN and pass --mcp-url.
     # add --json for machine-readable output; exits non-zero if grade < A.
 
 The probes create SYNTHETIC data (obviously-fake PHI); a live run never touches
@@ -18,6 +19,7 @@ real patient records.
 
 import argparse
 import json
+import os
 import sys
 
 sys.path.insert(0, __file__.rsplit("/scripts/", 1)[0])
@@ -41,6 +43,12 @@ def main():
                     help="a different tenant id, for the isolation probe")
     ap.add_argument("--mcp-url",
                     help="optional Streamable HTTP MCP endpoint for tools/call coverage")
+    ap.add_argument(
+        "--mcp-auth-token",
+        default=os.environ.get("MCP_AUTH_TOKEN"),
+        help=("optional MCP transport bearer token; defaults to the "
+              "MCP_AUTH_TOKEN environment variable"),
+    )
     ap.add_argument("--json", action="store_true", help="emit JSON instead of a scorecard")
     args = ap.parse_args()
 
@@ -50,6 +58,7 @@ def main():
         args.mcp_url,
         tenant=args.tenant,
         step_up_token=args.step_up_token,
+        mcp_auth_token=args.mcp_auth_token,
     ) if args.mcp_url else None)
     report = run_conformance(
         LiveProbeClient(args.base_url), ctx, mcp_client=mcp_client)

--- a/scripts/guardrail_conformance.py
+++ b/scripts/guardrail_conformance.py
@@ -46,7 +46,11 @@ def main():
 
     ctx = ProbeContext(tenant=args.tenant, step_up_token=args.step_up_token,
                        second_tenant=args.second_tenant)
-    mcp_client = LiveMCPProbeClient(args.mcp_url) if args.mcp_url else None
+    mcp_client = (LiveMCPProbeClient(
+        args.mcp_url,
+        tenant=args.tenant,
+        step_up_token=args.step_up_token,
+    ) if args.mcp_url else None)
     report = run_conformance(
         LiveProbeClient(args.base_url), ctx, mcp_client=mcp_client)
 

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -167,6 +167,13 @@ describe("Tool Schema Tests", () => {
     expect(schemas).toHaveLength(29);
   });
 
+  it("describes error fidelity as the seventh conformance property", () => {
+    const schema = schemas.find((tool) => tool.name === "guardrail_conformance");
+
+    expect(schema?.description).toContain("seven guardrail properties");
+    expect(schema?.description).toContain("error fidelity");
+  });
+
   it("defaults to a registry without token-mint and seed tools", () => {
     const restrictedTools = new FHIRTools("http://localhost:5000/r6/fhir");
     const names = restrictedTools.getMCPToolSchemas().map((tool) => tool.name);

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -592,7 +592,7 @@ export class FHIRTools {
         name: "guardrail_conformance",
         title: "Guardrail Conformance Scorecard",
         description:
-          "Run the guardrail conformance self-test on the connected HealthClaw deployment and return the graded scorecard (A-F across PHI redaction, immutable audit, step-up auth, human-in-the-loop, tenant isolation, medical disclaimers). Uses synthetic data only. Set fresh=true to force a new run instead of the cached result.",
+          "Run the guardrail conformance self-test on the connected HealthClaw deployment and return the graded scorecard across seven guardrail properties: PHI redaction, immutable audit, step-up auth, human-in-the-loop, tenant isolation, medical disclaimers, and error fidelity. Uses synthetic data only. Set fresh=true to force a new run instead of the cached result.",
         tier: "read",
         handler: ({ input, headers }) =>
           this.guardrailConformance(input.fresh === true, headers),

--- a/tests/test_conformance_endpoint.py
+++ b/tests/test_conformance_endpoint.py
@@ -21,7 +21,8 @@ def test_conformance_endpoint_grades_the_live_app(client):
         p for p in body["properties"] if p["key"] == "error_fidelity")
     assert error_fidelity["grade"] == "F"
     assert error_fidelity["coverage"] == "local-fhir-only"
-    assert error_fidelity["profiles"]["proxy"] == {"status": "not_run"}
+    assert error_fidelity["profiles"]["proxy"] == {
+        "status": "not_run", "checks": []}
 
 
 def test_conformance_endpoint_text_format(client):

--- a/tests/test_conformance_endpoint.py
+++ b/tests/test_conformance_endpoint.py
@@ -8,21 +8,28 @@ the scorecard — a one-URL "prove the guardrails hold" for partners and demos.
 
 def test_conformance_endpoint_grades_the_live_app(client):
     r = client.get("/r6/fhir/$conformance")
-    assert r.status_code == 200
+    assert r.status_code == 503
     body = r.get_json()
-    assert body["passed"] is True
-    assert body["grade"] == "A"
-    assert body["score"]["passed"] == body["score"]["total"] == 6
+    assert body["passed"] is False
+    assert body["grade"] == "B"
+    assert body["score"] == {"passed": 6, "total": 7}
     keys = {p["key"] for p in body["properties"]}
     assert keys == {"phi_redaction", "audit_trail", "step_up_enforcement",
-                    "human_in_the_loop", "tenant_isolation", "medical_disclaimer"}
+                    "human_in_the_loop", "tenant_isolation", "medical_disclaimer",
+                    "error_fidelity"}
+    error_fidelity = next(
+        p for p in body["properties"] if p["key"] == "error_fidelity")
+    assert error_fidelity["grade"] == "F"
+    assert error_fidelity["coverage"] == "local-fhir-only"
+    assert error_fidelity["profiles"]["proxy"] == {"status": "not_run"}
 
 
 def test_conformance_endpoint_text_format(client):
     r = client.get("/r6/fhir/$conformance?format=text")
-    assert r.status_code == 200
+    assert r.status_code == 503
     text = r.get_data(as_text=True)
-    assert "Grade: A" in text and "PHI Redaction" in text
+    assert "Grade: B" in text and "PHI Redaction" in text
+    assert "Error Fidelity — F (local-fhir-only)" in text
 
 
 def test_conformance_uses_isolated_selftest_tenant(client):
@@ -37,8 +44,8 @@ def test_conformance_shields_badge_format(client):
     b = r.get_json()
     assert b["schemaVersion"] == 1
     assert b["label"] == "guardrail conformance"
-    assert b["message"].startswith("A")           # e.g. "A (6/6)"
-    assert b["color"] in ("brightgreen", "green")
+    assert b["message"] == "B (6/7; error fidelity F, local-fhir-only)"
+    assert b["color"] == "yellow"
 
 
 def test_conformance_is_cached_between_calls(client):

--- a/tests/test_conformance_endpoint.py
+++ b/tests/test_conformance_endpoint.py
@@ -31,6 +31,7 @@ def test_conformance_endpoint_text_format(client):
     text = r.get_data(as_text=True)
     assert "Grade: B" in text and "PHI Redaction" in text
     assert "Error Fidelity — F (local-fhir-only)" in text
+    assert "PHI Redaction — A (full)" not in text
 
 
 def test_conformance_uses_isolated_selftest_tenant(client):

--- a/tests/test_conformance_endpoint.py
+++ b/tests/test_conformance_endpoint.py
@@ -31,6 +31,9 @@ def test_conformance_endpoint_text_format(client):
     text = r.get_data(as_text=True)
     assert "Grade: B" in text and "PHI Redaction" in text
     assert "Error Fidelity — F (local-fhir-only)" in text
+    assert "local: run — F" in text
+    assert "mcp: not_run" in text
+    assert "proxy: not_run" in text
     assert "PHI Redaction — A (full)" not in text
 
 
@@ -48,6 +51,7 @@ def test_conformance_shields_badge_format(client):
     assert b["label"] == "guardrail conformance"
     assert b["message"] == "B (6/7; error fidelity F, local-fhir-only)"
     assert b["color"] == "yellow"
+    assert set(b) == {"schemaVersion", "label", "message", "color"}
 
 
 def test_conformance_is_cached_between_calls(client):

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -106,6 +106,7 @@ def test_local_contract_rejects_false_a_evidence():
         _corrective_outcome,
         _has_outcome_warning,
         _outcome_names_parameter_and_supported_set,
+        _outcome_names_unsupported_modifier,
         _self_link_omits,
     )
 
@@ -131,6 +132,10 @@ def test_local_contract_rejects_false_a_evidence():
         "datetime was not rejected. Supported parameters: patient, code, status.",
         "There are no unknown problems with datetime. Supported parameters: "
         "patient, code, status.",
+        "datetime is unsupported. Use _lastUpdated instead. Supported parameters: "
+        "patient, code, status, _lastUpdated, _count, _sort, _summary, context-id.",
+        "datetime is unsupported. Supported parameters: patient, code, status, "
+        "_lastUpdated, _count, _sort, _summary, context-id, invented-filter.",
     ):
         body = {
             "resourceType": "OperationOutcome",
@@ -185,6 +190,31 @@ def test_local_contract_rejects_false_a_evidence():
             }],
         },
     }
+    assert not _has_outcome_warning({
+        "resourceType": "Bundle",
+        "entry": [safe_warning],
+    }, "datetime")
+
+    generic_modifier = {
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "not-supported",
+            "details": {"text": "The requested modifier is not supported."},
+        }],
+    }
+    named_modifier = {
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "not-supported",
+            "details": {"text": "Modifier code:exact is not supported."},
+        }],
+    }
+    assert not _outcome_names_unsupported_modifier(
+        generic_modifier, "code:exact")
+    assert _outcome_names_unsupported_modifier(named_modifier, "code:exact")
+
     hostile_extra_warning = {
         "search": {"mode": "outcome"},
         "resource": {
@@ -287,9 +317,10 @@ def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
             "checks": [
                 "strict unknown parameter is rejected",
                 "strict rejection is audited as a failure",
-                "lenient unknown parameter carries an outcome warning",
-                "lenient warning is audited truthfully",
-                "unsupported modifier is rejected",
+                    "lenient unknown parameter carries an outcome warning",
+                    "lenient warning is audited truthfully",
+                    "unsupported modifier is rejected",
+                    "unsupported modifier rejections are audited as failures",
             ],
         },
         "mcp": {"status": "not_run", "checks": []},
@@ -301,6 +332,7 @@ def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
         "lenient unknown parameter carries an outcome warning",
         "lenient warning is audited truthfully",
         "unsupported modifier is rejected",
+        "unsupported modifier rejections are audited as failures",
     }
     assert report.score == (6, 7)
     assert report.grade == "B"
@@ -514,6 +546,15 @@ def test_proxy_a_requires_a_corrective_operation_outcome():
     }, {"invalid"})
 
 
+def test_hostile_value_check_considers_parsed_body_and_raw_text():
+    from r6.conformance.probes import _response_omits_hostile_values
+
+    assert not _response_omits_hostile_values(
+        {"detail": "Quintavious"}, '{"detail":"safe"}')
+    assert not _response_omits_hostile_values(
+        {"detail": "safe"}, '{"detail":"ZzYzXbArToN"}')
+
+
 def test_proxy_profile_does_not_echo_malformed_audit_codes():
     import json
 
@@ -558,7 +599,7 @@ def test_proxy_profile_does_not_echo_malformed_audit_codes():
     assert hostile not in json.dumps([check.detail for check in checks])
 
 
-def test_error_fidelity_crash_does_not_claim_optional_profiles_ran():
+def test_error_fidelity_crash_still_runs_configured_optional_profiles():
     class BrokenLocalClient:
         base = "broken"
 
@@ -570,9 +611,15 @@ def test_error_fidelity_crash_does_not_claim_optional_profiles_ran():
         mcp_client=object(), proxy_client=object())
 
     result = next(r for r in report.results if r.key == "error_fidelity")
-    assert result.coverage == "local-fhir-only"
-    assert result.profiles["mcp"] == {"status": "not_run", "checks": []}
-    assert result.profiles["proxy"] == {"status": "not_run", "checks": []}
+    assert result.coverage == "full"
+    assert result.profiles["mcp"] == {
+        "status": "run", "grade": "C",
+        "checks": ["MCP tool failure is corrective and flagged"],
+    }
+    assert result.profiles["proxy"] == {
+        "status": "run", "grade": "F",
+        "checks": ["proxy profile executed"],
+    }
 
 
 def test_live_mcp_probe_client_initializes_then_calls_tool():
@@ -716,7 +763,8 @@ def test_scripted_local_contract_can_reach_a_without_reading_real_data():
     from r6.conformance.probes import probe_error_fidelity
 
     corrective_text = (
-        "datetime is not implemented. Supported parameters: patient, code, status."
+        "datetime is not implemented. Supported parameters: patient, code, status, "
+        "_lastUpdated, _count, _sort, _summary, context-id."
     )
 
     def audit_event(event_id, code, detail=None):
@@ -747,17 +795,20 @@ def test_scripted_local_contract_can_reach_a_without_reading_real_data():
                 self.audit_call += 1
                 old = audit_event("old", "0")
                 strict = audit_event("strict", "8")
+                lenient = audit_event(
+                    "lenient", "0", "ignored parameter: datetime")
                 if self.audit_call == 1:
                     body = audit_bundle(old)
                 elif self.audit_call in (2, 3):
                     body = audit_bundle(strict, old)
+                elif self.audit_call in (4, 5):
+                    body = audit_bundle(lenient, strict, old)
                 else:
                     body = audit_bundle(
-                        audit_event(
-                            "lenient", "0", "ignored parameter: datetime"),
-                        strict,
-                        old,
-                    )
+                        audit_event("modifier-default", "8"),
+                        audit_event("modifier-strict", "8"),
+                        audit_event("modifier-lenient", "8"),
+                        lenient, strict, old)
                 return 200, body, ""
 
             self.observation_call += 1
@@ -796,7 +847,7 @@ def test_scripted_local_contract_can_reach_a_without_reading_real_data():
                 "issue": [{
                     "severity": "error",
                     "code": "not-supported",
-                    "details": {"text": "The requested modifier is not supported."},
+                    "details": {"text": "Modifier code:exact is not supported."},
                 }],
             }
             return 400, body, ""
@@ -805,6 +856,11 @@ def test_scripted_local_contract_can_reach_a_without_reading_real_data():
         LocalAClient(), ProbeContext("tenant", "token"))
     assert result.grade == "A"
     assert result.passed is True
+    assert any(
+        check.name == "unsupported modifier rejections are audited as failures"
+        and check.passed
+        for check in result.checks
+    )
 
 
 def test_injected_mock_proxy_profile_passes_the_full_error_contract(

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -97,9 +97,18 @@ def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
     assert result.grade == "F"
     assert result.coverage == "local-fhir-only"
     assert result.profiles == {
-        "local": {"status": "run", "grade": "F"},
-        "mcp": {"status": "not_run"},
-        "proxy": {"status": "not_run"},
+        "local": {
+            "status": "run",
+            "grade": "F",
+            "checks": [
+                "strict unknown parameter is rejected",
+                "strict rejection is audited as a failure",
+                "lenient unknown parameter carries an outcome warning",
+                "unsupported modifier is rejected",
+            ],
+        },
+        "mcp": {"status": "not_run", "checks": []},
+        "proxy": {"status": "not_run", "checks": []},
     }
     assert {check.name for check in result.checks} == {
         "strict unknown parameter is rejected",
@@ -117,7 +126,7 @@ def test_optional_mcp_profile_records_status_only_errors_as_c(client, tenant_id,
     class StatusOnlyMCPClient:
         def call_tool(self, name, arguments):
             assert name == "fhir_search"
-            assert arguments["resource_type"] == "Widget"
+            assert arguments["resource_type"] == "WidgetQuintaviousZzyzxbarton"
             return {
                 "content": [{
                     "type": "text",
@@ -132,7 +141,10 @@ def test_optional_mcp_profile_records_status_only_errors_as_c(client, tenant_id,
     result = next(r for r in report.results if r.key == "error_fidelity")
     assert result.grade == "F"  # local F is weaker than MCP C
     assert result.coverage == "local+mcp"
-    assert result.profiles["mcp"] == {"status": "run", "grade": "C"}
+    assert result.profiles["mcp"] == {
+        "status": "run", "grade": "C",
+        "checks": ["MCP tool failure is corrective and flagged"],
+    }
     assert any(c.name == "MCP tool failure is corrective and flagged"
                for c in result.checks)
 
@@ -163,7 +175,64 @@ def test_optional_mcp_profile_accepts_flagged_operation_outcome(
         mcp_client=CorrectiveMCPClient())
 
     result = next(r for r in report.results if r.key == "error_fidelity")
-    assert result.profiles["mcp"] == {"status": "run", "grade": "A"}
+    assert result.profiles["mcp"] == {
+        "status": "run", "grade": "A",
+        "checks": ["MCP tool failure is corrective and flagged"],
+    }
+
+
+def test_optional_mcp_profile_rejects_unsanitized_operation_outcome(
+        client, tenant_id, step_up_token):
+    class UnsafeMCPClient:
+        def call_tool(self, name, arguments):
+            return {
+                "isError": True,
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({
+                        "resourceType": "OperationOutcome",
+                        "issue": [{
+                            "severity": "error",
+                            "code": "not-supported",
+                            "details": {"text": "Patient Quintavious Zzyzxbarton"},
+                            "diagnostics": "https://db.internal.example/secret",
+                        }],
+                    }),
+                }],
+            }
+
+    import json
+
+    report = run_conformance(
+        FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token),
+        mcp_client=UnsafeMCPClient())
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.profiles["mcp"]["grade"] != "A"
+
+
+def test_audit_correlation_uses_new_event_ids_not_only_latest_entry():
+    from r6.conformance.probes import _new_audit_outcome_grade
+
+    def bundle(*events):
+        return {
+            "resourceType": "Bundle",
+            "entry": [
+                {"resource": {
+                    "resourceType": "AuditEvent",
+                    "id": event_id,
+                    "outcome": {"code": {"code": outcome}},
+                }}
+                for event_id, outcome in events
+            ],
+        }
+
+    before = bundle(("old", "0"))
+    after = bundle(("probe", "8"), ("old", "0"))
+    ambiguous = bundle(("concurrent", "0"), ("probe", "8"), ("old", "0"))
+
+    assert _new_audit_outcome_grade(before, after) == "A"
+    assert _new_audit_outcome_grade(before, ambiguous) == "C"
 
 
 def test_live_mcp_probe_client_initializes_then_calls_tool():
@@ -270,10 +339,26 @@ def test_injected_mock_proxy_profile_passes_the_full_error_contract(
     result = next(r for r in report.results if r.key == "error_fidelity")
     assert result.grade == "F"  # local F remains the weakest profile
     assert result.coverage == "local+proxy"
-    assert result.profiles["proxy"] == {"status": "run", "grade": "A"}
+    assert result.profiles["proxy"] == {
+        "status": "run", "grade": "A",
+        "checks": [
+            "proxy rejection preserves sanitized outcome",
+            "proxy auth failure is not not-found",
+            "proxy server failure is truthful",
+            "proxy timeout is truthful",
+            "proxy failure audit is truthful",
+        ],
+    }
     proxy_checks = [c for c in result.checks if c.name.startswith("proxy ")]
     assert proxy_checks and all(c.passed for c in proxy_checks)
     assert hostile_name not in json.dumps(result.profiles)
     assert hostile_url not in report.render()
     assert hostile_name not in caplog.text
     assert hostile_url not in caplog.text
+    from r6.models import AuditEventRecord
+    details = [
+        event.detail or ""
+        for event in AuditEventRecord.query.filter_by(tenant_id=tenant_id).all()
+    ]
+    assert all(hostile_name not in detail for detail in details)
+    assert all(hostile_url not in detail for detail in details)

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -104,6 +104,7 @@ def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
                 "strict unknown parameter is rejected",
                 "strict rejection is audited as a failure",
                 "lenient unknown parameter carries an outcome warning",
+                "lenient warning is audited truthfully",
                 "unsupported modifier is rejected",
             ],
         },
@@ -114,6 +115,7 @@ def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
         "strict unknown parameter is rejected",
         "strict rejection is audited as a failure",
         "lenient unknown parameter carries an outcome warning",
+        "lenient warning is audited truthfully",
         "unsupported modifier is rejected",
     }
     assert report.score == (6, 7)
@@ -212,7 +214,10 @@ def test_optional_mcp_profile_rejects_unsanitized_operation_outcome(
 
 
 def test_audit_correlation_uses_new_event_ids_not_only_latest_entry():
-    from r6.conformance.probes import _new_audit_outcome_grade
+    from r6.conformance.probes import (
+        _new_audit_outcome_codes,
+        _new_audit_outcome_grade,
+    )
 
     def bundle(*events):
         return {
@@ -233,6 +238,43 @@ def test_audit_correlation_uses_new_event_ids_not_only_latest_entry():
 
     assert _new_audit_outcome_grade(before, after) == "A"
     assert _new_audit_outcome_grade(before, ambiguous) == "C"
+    assert _new_audit_outcome_codes(before, ambiguous) == ["0", "8"]
+
+
+def test_proxy_a_requires_a_corrective_operation_outcome():
+    from r6.conformance.probes import _corrective_outcome
+
+    assert not _corrective_outcome(
+        {"resourceType": "OperationOutcome"}, {"invalid"})
+    assert not _corrective_outcome({
+        "resourceType": "OperationOutcome",
+        "issue": [{"severity": "error", "code": "security"}],
+    }, {"invalid"})
+    assert _corrective_outcome({
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "invalid",
+            "details": {"text": "The request was invalid."},
+        }],
+    }, {"invalid"})
+
+
+def test_error_fidelity_crash_does_not_claim_optional_profiles_ran():
+    class BrokenLocalClient:
+        base = "broken"
+
+        def request(self, *args, **kwargs):
+            raise RuntimeError("synthetic failure")
+
+    report = run_conformance(
+        BrokenLocalClient(), ProbeContext("tenant", "token"),
+        mcp_client=object(), proxy_client=object())
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.coverage == "local-fhir-only"
+    assert result.profiles["mcp"] == {"status": "not_run", "checks": []}
+    assert result.profiles["proxy"] == {"status": "not_run", "checks": []}
 
 
 def test_live_mcp_probe_client_initializes_then_calls_tool():

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -1,8 +1,8 @@
-"""The guardrail conformance harness must certify our OWN deployment.
+"""The guardrail conformance harness must grade our OWN deployment honestly.
 
-This is both the unit test for r6/conformance and a standing CI gate: if any of
-the six guardrail properties regresses, this suite fails. The same harness runs
-against a live partner deployment via scripts/guardrail_conformance.py.
+This is both the unit test for r6/conformance and a standing CI baseline.  The
+same harness runs against a live partner deployment via
+scripts/guardrail_conformance.py.
 """
 
 from r6.conformance import (
@@ -14,22 +14,22 @@ def _ctx(app, tenant_id, step_up_token):
     return ProbeContext(tenant=tenant_id, step_up_token=step_up_token)
 
 
-def test_our_deployment_passes_every_guardrail_property(client, tenant_id, step_up_token):
+def test_our_deployment_records_the_known_error_fidelity_baseline(
+        client, tenant_id, step_up_token):
     report = run_conformance(FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token))
-    failed = [r.property for r in report.results if not r.passed]
-    assert report.passed, (
-        f"Guardrail conformance FAILED for: {failed}\n" + report.render())
-    # all six properties were actually exercised
+
     assert {r.key for r in report.results} == set(PROPERTIES)
-    assert report.score == (len(PROPERTIES), len(PROPERTIES))
-    assert report.grade == "A"
+    assert report.score == (6, 7)
+    assert report.grade == "B"
+    assert report.passed is False
+    assert [r.key for r in report.results if not r.passed] == ["error_fidelity"]
 
 
 def test_report_is_json_serializable(client, tenant_id, step_up_token):
     report = run_conformance(FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token))
     d = report.to_dict()
-    assert d["passed"] is True
-    assert d["grade"] == "A"
+    assert d["passed"] is False
+    assert d["grade"] == "B"
     assert len(d["properties"]) == len(PROPERTIES)
     for prop in d["properties"]:
         assert "checks" in prop and prop["checks"]
@@ -44,3 +44,236 @@ def test_grade_scales_with_failures():
     assert _grade(3, 6) == "D"
     assert _grade(2, 6) == "F"
     assert _grade(0, 6) == "F"
+
+
+def test_report_exposes_property_grade_and_profile_coverage():
+    """A graded property remains a normal report property, but it passes only
+    at A and tells callers exactly which probe profiles were exercised."""
+    from r6.conformance import Check, ConformanceReport, ProbeResult
+
+    result = ProbeResult(
+        "error_fidelity",
+        "Error Fidelity",
+        [Check("tool error is corrective", False, "status-only error")],
+        grade="C",
+        coverage="local+mcp",
+        profiles={
+            "local": {"status": "run", "grade": "A"},
+            "mcp": {"status": "run", "grade": "C"},
+            "proxy": {"status": "not_run"},
+        },
+    )
+    report = ConformanceReport([result], base="local", tenant="t1")
+
+    body = report.to_dict()
+    prop = body["properties"][0]
+    assert prop["grade"] == "C"
+    assert prop["coverage"] == "local+mcp"
+    assert prop["profiles"]["proxy"] == {"status": "not_run"}
+    assert prop["passed"] is False
+    assert report.passed is False
+    assert "Error Fidelity — C (local+mcp)" in report.render()
+
+
+def test_error_fidelity_grade_uses_the_worst_executed_profile():
+    from r6.conformance import _error_fidelity_grade
+    from r6.conformance.probes import _rejection_grade
+
+    assert _error_fidelity_grade(["A"]) == "A"
+    assert _error_fidelity_grade(["A", "C"]) == "C"
+    assert _error_fidelity_grade(["C", "F", "A"]) == "F"
+    assert _error_fidelity_grade([]) == "F"
+    assert _rejection_grade(200, {}) == "F"
+    assert _rejection_grade(502, {"resourceType": "OperationOutcome"}) == "C"
+    assert _rejection_grade(400, {"resourceType": "OperationOutcome"}) == "A"
+
+
+def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
+                                                            step_up_token):
+    report = run_conformance(
+        FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token))
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.grade == "F"
+    assert result.coverage == "local-fhir-only"
+    assert result.profiles == {
+        "local": {"status": "run", "grade": "F"},
+        "mcp": {"status": "not_run"},
+        "proxy": {"status": "not_run"},
+    }
+    assert {check.name for check in result.checks} == {
+        "strict unknown parameter is rejected",
+        "strict rejection is audited as a failure",
+        "lenient unknown parameter carries an outcome warning",
+        "unsupported modifier is rejected",
+    }
+    assert report.score == (6, 7)
+    assert report.grade == "B"
+    assert report.passed is False
+
+
+def test_optional_mcp_profile_records_status_only_errors_as_c(client, tenant_id,
+                                                              step_up_token):
+    class StatusOnlyMCPClient:
+        def call_tool(self, name, arguments):
+            assert name == "fhir_search"
+            assert arguments["resource_type"] == "Widget"
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": '{"error":"Search failed with status 400"}',
+                }],
+            }
+
+    report = run_conformance(
+        FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token),
+        mcp_client=StatusOnlyMCPClient())
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.grade == "F"  # local F is weaker than MCP C
+    assert result.coverage == "local+mcp"
+    assert result.profiles["mcp"] == {"status": "run", "grade": "C"}
+    assert any(c.name == "MCP tool failure is corrective and flagged"
+               for c in result.checks)
+
+
+def test_optional_mcp_profile_accepts_flagged_operation_outcome(
+        client, tenant_id, step_up_token):
+    class CorrectiveMCPClient:
+        def call_tool(self, name, arguments):
+            return {
+                "isError": True,
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({
+                        "resourceType": "OperationOutcome",
+                        "issue": [{
+                            "severity": "error",
+                            "code": "not-supported",
+                            "details": {"text": "Resource type is not supported."},
+                        }],
+                    }),
+                }],
+            }
+
+    import json
+
+    report = run_conformance(
+        FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token),
+        mcp_client=CorrectiveMCPClient())
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.profiles["mcp"] == {"status": "run", "grade": "A"}
+
+
+def test_live_mcp_probe_client_initializes_then_calls_tool():
+    from r6.conformance import LiveMCPProbeClient
+
+    class Response:
+        def __init__(self, body, headers=None):
+            self._body = body
+            self.headers = headers or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+            self.responses = [
+                Response({"result": {"protocolVersion": "2025-06-18"}},
+                         {"Mcp-Session-Id": "session-1"}),
+                Response({}),
+                Response({"result": {
+                    "content": [{"type": "text", "text": "{}"}],
+                    "isError": True,
+                }}),
+            ]
+
+        def post(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            return self.responses.pop(0)
+
+    session = Session()
+    client = LiveMCPProbeClient("https://mcp.example.test/mcp", session=session)
+    result = client.call_tool("fhir_search", {"resource_type": "Widget"})
+
+    assert result["isError"] is True
+    assert len(session.calls) == 3
+    assert session.calls[1][1]["json"]["method"] == "notifications/initialized"
+    assert session.calls[2][1]["headers"]["Mcp-Session-Id"] == "session-1"
+    assert session.calls[2][1]["json"]["method"] == "tools/call"
+
+
+def test_injected_mock_proxy_profile_passes_the_full_error_contract(
+        client, tenant_id, step_up_token, caplog):
+    import httpx
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from r6.fhir_proxy import FHIRUpstreamProxy
+
+    hostile_name = "Quintavious Zzyzxbarton"
+    hostile_url = "https://db.internal.example/patient/secret"
+
+    def response(status, body):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.content = json.dumps(body).encode()
+        resp.json.return_value = body
+        return resp
+
+    rejected = response(400, {
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error", "code": "invalid",
+            "details": {"text": f"Patient {hostile_name} rejected"},
+            "diagnostics": hostile_url,
+        }],
+    })
+    unauthorized = response(401, {
+        "resourceType": "OperationOutcome",
+        "issue": [{"severity": "error", "code": "login",
+                   "diagnostics": "expired proxy credential"}],
+    })
+    server_error = response(500, {
+        "resourceType": "OperationOutcome",
+        "issue": [{"severity": "error", "code": "exception",
+                   "diagnostics": hostile_url}],
+    })
+
+    proxy = FHIRUpstreamProxy("https://mock-fhir.example")
+    proxy._client.get = MagicMock(
+        side_effect=[
+            rejected,
+            unauthorized,
+            server_error,
+            httpx.ReadTimeout(hostile_url),
+        ])
+    local_client = FlaskProbeClient(client)
+
+    class InjectedProxyClient:
+        def request(self, *args, **kwargs):
+            with patch("r6.routes.get_proxy_for_request", return_value=proxy):
+                return local_client.request(*args, **kwargs)
+
+    try:
+        report = run_conformance(
+            local_client, _ctx(None, tenant_id, step_up_token),
+            proxy_client=InjectedProxyClient())
+    finally:
+        proxy.close()
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.grade == "F"  # local F remains the weakest profile
+    assert result.coverage == "local+proxy"
+    assert result.profiles["proxy"] == {"status": "run", "grade": "A"}
+    proxy_checks = [c for c in result.checks if c.name.startswith("proxy ")]
+    assert proxy_checks and all(c.passed for c in proxy_checks)
+    assert hostile_name not in json.dumps(result.profiles)
+    assert hostile_url not in report.render()
+    assert hostile_name not in caplog.text
+    assert hostile_url not in caplog.text

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -75,6 +75,18 @@ def test_report_exposes_property_grade_and_profile_coverage():
     assert "Error Fidelity — C (local+mcp)" in report.render()
 
 
+def test_report_serialization_preserves_legacy_implicit_grade():
+    from r6.conformance import Check, ConformanceReport, ProbeResult
+
+    report = ConformanceReport([
+        ProbeResult("legacy", "Legacy Property", [Check("passes", True)])
+    ])
+
+    prop = report.to_dict()["properties"][0]
+    assert prop["grade"] is None
+    assert "Legacy Property — A (full)" not in report.render()
+
+
 def test_error_fidelity_grade_uses_the_worst_executed_profile():
     from r6.conformance import _error_fidelity_grade
     from r6.conformance.probes import _rejection_grade
@@ -85,7 +97,179 @@ def test_error_fidelity_grade_uses_the_worst_executed_profile():
     assert _error_fidelity_grade([]) == "F"
     assert _rejection_grade(200, {}) == "F"
     assert _rejection_grade(502, {"resourceType": "OperationOutcome"}) == "C"
-    assert _rejection_grade(400, {"resourceType": "OperationOutcome"}) == "A"
+    assert _rejection_grade(400, {"resourceType": "OperationOutcome"}) == "C"
+
+
+def test_local_contract_rejects_false_a_evidence():
+    from r6.conformance.probes import (
+        _bundle_matches_subject,
+        _corrective_outcome,
+        _has_outcome_warning,
+        _outcome_names_parameter_and_supported_set,
+        _self_link_omits,
+    )
+
+    unsupported_only = {
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "invalid",
+            "details": {"text": "datetime is unsupported."},
+        }],
+    }
+    assert not _outcome_names_parameter_and_supported_set(
+        unsupported_only, "datetime")
+    for negated in (
+        "Unsupported parameters: datetime, patient, code.",
+        "The unsupported parameter datetime conflicts with patient and code.",
+        "datetime is not a supported parameter; patient and code are examples.",
+        "datetime rejected. Supported parameters: patiently, barcode.",
+        "datetime rejected. Supported parameters: status-code, patientish.",
+        "Supported parameters: patient, datetime, code.",
+        "datetime is not invalid. Supported parameters: patient, code, status.",
+        "datetime is not unsupported. Supported parameters: patient, code, status.",
+        "datetime was not rejected. Supported parameters: patient, code, status.",
+        "There are no unknown problems with datetime. Supported parameters: "
+        "patient, code, status.",
+    ):
+        body = {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": negated},
+            }],
+        }
+        assert not _outcome_names_parameter_and_supported_set(body, "datetime")
+
+    unrelated_warning = {
+        "resourceType": "Bundle",
+        "entry": [{
+            "search": {"mode": "outcome"},
+            "resource": {
+                "resourceType": "OperationOutcome",
+                "issue": [{"severity": "banana", "code": "invalid"}],
+            },
+        }],
+    }
+    assert not _has_outcome_warning(unrelated_warning, "datetime")
+    bad_category_warning = {
+        "resourceType": "Bundle",
+        "entry": [{
+            "search": {"mode": "outcome"},
+            "resource": {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "warning",
+                    "code": "banana",
+                    "details": {"text": (
+                        "datetime ignored. Supported parameters: "
+                        "patient, code, status."
+                    )},
+                }],
+            },
+        }],
+    }
+    assert not _has_outcome_warning(bad_category_warning, "datetime")
+
+    safe_warning = {
+        "search": {"mode": "outcome"},
+        "resource": {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "warning",
+                "code": "not-supported",
+                "details": {"text": (
+                    "datetime ignored. Supported parameters: patient, code."
+                )},
+            }],
+        },
+    }
+    hostile_extra_warning = {
+        "search": {"mode": "outcome"},
+        "resource": {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "warning",
+                "code": "not-supported",
+                "details": {"text": "Patient Quintavious Zzyzxbarton"},
+            }],
+        },
+    }
+    assert not _has_outcome_warning({
+        "resourceType": "Bundle",
+        "entry": [safe_warning, hostile_extra_warning],
+    }, "datetime")
+
+    encoded_ignored_key = {
+        "resourceType": "Bundle",
+        "link": [{
+            "relation": "self",
+            "url": "https://example.test/Observation?%64atetime=x",
+        }],
+    }
+    assert not _self_link_omits(encoded_ignored_key, "datetime")
+
+    foreign_match = {
+        "resourceType": "Bundle",
+        "entry": [{
+            "search": {"mode": "match"},
+            "resource": {
+                "resourceType": "Observation",
+                "subject": {"reference": "Patient/real-patient"},
+            },
+        }],
+    }
+    assert not _bundle_matches_subject(
+        foreign_match, "Patient/conformance-synthetic")
+
+    corrective_plus_hostile = {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": "The request was invalid."},
+            },
+            {
+                "severity": "error",
+                "code": "invalid",
+                "diagnostics": "Patient Alice at https://db.internal/secret",
+            },
+        ],
+    }
+    assert not _corrective_outcome(corrective_plus_hostile, {"invalid"})
+
+
+def test_lenient_audit_requires_ignored_parameter_evidence():
+    from r6.conformance.probes import _new_audit_warning_grade
+
+    def bundle(event_id, detail=None):
+        outcome = {"code": {"code": "0"}}
+        if detail is not None:
+            outcome["detail"] = [{"text": detail}]
+        return {
+            "resourceType": "Bundle",
+            "entry": [{"resource": {
+                "resourceType": "AuditEvent",
+                "id": event_id,
+                "outcome": outcome,
+            }}],
+        }
+
+    before = {"resourceType": "Bundle", "entry": []}
+    assert _new_audit_warning_grade(before, bundle("missing"), "datetime") == "C"
+    assert _new_audit_warning_grade(
+        before, bundle("honest", "ignored parameter: datetime"), "datetime") == "A"
+    assert _new_audit_warning_grade(
+        before, bundle("lie", "applied filter: datetime"), "datetime") == "C"
+    assert _new_audit_warning_grade(
+        before,
+        bundle("contradiction", "ignored parameter: datetime; then applied filter datetime"),
+        "datetime",
+    ) == "C"
+    assert _new_audit_warning_grade(
+        before, bundle("echo", "ignored parameter: datetime=x"), "datetime") == "F"
 
 
 def test_local_error_fidelity_records_the_known_f_baseline(client, tenant_id,
@@ -213,6 +397,76 @@ def test_optional_mcp_profile_rejects_unsanitized_operation_outcome(
     assert result.profiles["mcp"]["grade"] != "A"
 
 
+def test_malformed_mcp_result_remains_an_executed_profile(
+        client, tenant_id, step_up_token):
+    class MalformedMCPClient:
+        def call_tool(self, name, arguments):
+            return {"isError": True, "content": None}
+
+    report = run_conformance(
+        FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token),
+        mcp_client=MalformedMCPClient())
+
+    result = next(r for r in report.results if r.key == "error_fidelity")
+    assert result.profiles["mcp"]["status"] == "run"
+    assert result.profiles["mcp"]["grade"] == "C"
+    assert result.coverage == "local+mcp"
+
+
+def test_mcp_safe_outcome_plus_malformed_content_is_not_a():
+    import json
+
+    from r6.conformance.probes import _mcp_profile_grade
+
+    class MixedMCPClient:
+        def call_tool(self, name, arguments):
+            outcome = {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "not-supported",
+                    "details": {"text": "Resource type is not supported."},
+                }],
+            }
+            return {
+                "isError": True,
+                "content": [
+                    {"type": "text", "text": json.dumps(outcome)},
+                    {},
+                ],
+            }
+
+    assert _mcp_profile_grade(MixedMCPClient()) == "C"
+
+
+def test_mcp_safe_outcome_in_non_text_content_block_is_not_a():
+    import json
+
+    from r6.conformance.probes import _mcp_profile_grade
+
+    outcome = {
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "not-supported",
+            "details": {"text": "Resource type is not supported."},
+        }],
+    }
+
+    class MalformedBlockMCPClient:
+        def __init__(self, block):
+            self.block = block
+
+        def call_tool(self, name, arguments):
+            return {"isError": True, "content": [self.block]}
+
+    encoded = json.dumps(outcome)
+    assert _mcp_profile_grade(MalformedBlockMCPClient(
+        {"type": "image", "text": encoded})) == "C"
+    assert _mcp_profile_grade(MalformedBlockMCPClient(
+        {"text": encoded})) == "C"
+
+
 def test_audit_correlation_uses_new_event_ids_not_only_latest_entry():
     from r6.conformance.probes import (
         _new_audit_outcome_codes,
@@ -260,6 +514,50 @@ def test_proxy_a_requires_a_corrective_operation_outcome():
     }, {"invalid"})
 
 
+def test_proxy_profile_does_not_echo_malformed_audit_codes():
+    import json
+
+    from r6.conformance.probes import _proxy_profile
+
+    hostile = "https://db.internal.example/audit-secret"
+
+    def outcome(code):
+        return {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "error",
+                "code": code,
+                "details": {"text": "Synthetic corrective message."},
+            }],
+        }
+
+    def audit(event_id=None, code=None):
+        entries = []
+        if event_id is not None:
+            entries.append({"resource": {
+                "resourceType": "AuditEvent",
+                "id": event_id,
+                "outcome": {"code": {"code": code}},
+            }})
+        return {"resourceType": "Bundle", "entry": entries}
+
+    responses = iter([
+        (200, audit(), ""),
+        (400, outcome("invalid"), ""),
+        (502, outcome("security"), ""),
+        (502, outcome("transient"), ""),
+        (502, outcome("transient"), ""),
+        (200, audit("hostile", hostile), ""),
+    ])
+
+    class Client:
+        def request(self, *args, **kwargs):
+            return next(responses)
+
+    _, checks = _proxy_profile(Client(), ProbeContext("tenant", "token"))
+    assert hostile not in json.dumps([check.detail for check in checks])
+
+
 def test_error_fidelity_crash_does_not_claim_optional_profiles_ran():
     class BrokenLocalClient:
         base = "broken"
@@ -295,10 +593,10 @@ def test_live_mcp_probe_client_initializes_then_calls_tool():
         def __init__(self):
             self.calls = []
             self.responses = [
-                Response({"result": {"protocolVersion": "2025-06-18"}},
+                Response({"id": 1, "result": {"protocolVersion": "2025-06-18"}},
                          {"Mcp-Session-Id": "session-1"}),
                 Response({}),
-                Response({"result": {
+                Response({"id": 2, "result": {
                     "content": [{"type": "text", "text": "{}"}],
                     "isError": True,
                 }}),
@@ -309,14 +607,195 @@ def test_live_mcp_probe_client_initializes_then_calls_tool():
             return self.responses.pop(0)
 
     session = Session()
-    client = LiveMCPProbeClient("https://mcp.example.test/mcp", session=session)
+    client = LiveMCPProbeClient(
+        "https://mcp.example.test/mcp",
+        session=session,
+        tenant="tenant-a",
+        step_up_token="synthetic-token",
+    )
     result = client.call_tool("fhir_search", {"resource_type": "Widget"})
 
     assert result["isError"] is True
     assert len(session.calls) == 3
     assert session.calls[1][1]["json"]["method"] == "notifications/initialized"
     assert session.calls[2][1]["headers"]["Mcp-Session-Id"] == "session-1"
+    assert session.calls[2][1]["headers"]["X-Tenant-Id"] == "tenant-a"
+    assert session.calls[2][1]["headers"]["X-Step-Up-Token"] == "synthetic-token"
     assert session.calls[2][1]["json"]["method"] == "tools/call"
+
+
+def test_live_mcp_probe_client_accepts_stateless_json_transport():
+    from r6.conformance import LiveMCPProbeClient
+
+    class Response:
+        headers = {"Content-Type": "application/json"}
+
+        def __init__(self, body):
+            self._body = body
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._body
+
+    class Session:
+        def __init__(self):
+            self.responses = [
+                Response({"id": 1, "result": {"protocolVersion": "2025-06-18"}}),
+                Response({}),
+                Response({"id": 2, "result": {"isError": True, "content": []}}),
+            ]
+
+        def post(self, url, **kwargs):
+            return self.responses.pop(0)
+
+    result = LiveMCPProbeClient(
+        "https://mcp.example.test/mcp", session=Session()).call_tool(
+            "fhir_search", {"resource_type": "Widget"})
+    assert result["isError"] is True
+
+
+def test_live_mcp_probe_client_decodes_sse_responses():
+    from r6.conformance.probes import _mcp_response_json
+
+    class Response:
+        headers = {"Content-Type": "text/event-stream"}
+        text = (
+            "event: message\n"
+            "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\n\n"
+            "event: message\n"
+            "data: {\"jsonrpc\":\"2.0\",\"id\":1,"
+            "\"result\":{\"content\":[]}}\n\n"
+        )
+
+    assert _mcp_response_json(
+        Response(), expected_id=1)["result"] == {"content": []}
+
+
+def test_local_error_probes_always_bound_searches_to_a_synthetic_subject():
+    from r6.conformance.probes import probe_error_fidelity
+
+    class RecordingClient:
+        base = "recording"
+
+        def __init__(self):
+            self.paths = []
+
+        def request(self, method, path, headers=None, json_body=None):
+            self.paths.append(path)
+            if path.startswith("/AuditEvent"):
+                return 200, {"resourceType": "Bundle", "entry": []}, ""
+            return 200, {
+                "resourceType": "Bundle",
+                "link": [{"relation": "self", "url": path}],
+                "entry": [],
+            }, ""
+
+    client = RecordingClient()
+    probe_error_fidelity(client, ProbeContext("tenant", "token"))
+
+    observation_paths = [
+        path for path in client.paths if path.startswith("/Observation?")]
+    assert observation_paths
+    assert all("patient=" in path for path in observation_paths)
+
+
+def test_scripted_local_contract_can_reach_a_without_reading_real_data():
+    from urllib.parse import parse_qs, urlencode, urlsplit
+
+    from r6.conformance.probes import probe_error_fidelity
+
+    corrective_text = (
+        "datetime is not implemented. Supported parameters: patient, code, status."
+    )
+
+    def audit_event(event_id, code, detail=None):
+        outcome = {"code": {"code": code}}
+        if detail is not None:
+            outcome["detail"] = [{"text": detail}]
+        return {
+            "resourceType": "AuditEvent",
+            "id": event_id,
+            "outcome": outcome,
+        }
+
+    def audit_bundle(*events):
+        return {
+            "resourceType": "Bundle",
+            "entry": [{"resource": event} for event in events],
+        }
+
+    class LocalAClient:
+        base = "scripted-local-a"
+
+        def __init__(self):
+            self.audit_call = 0
+            self.observation_call = 0
+
+        def request(self, method, path, headers=None, json_body=None):
+            if path.startswith("/AuditEvent"):
+                self.audit_call += 1
+                old = audit_event("old", "0")
+                strict = audit_event("strict", "8")
+                if self.audit_call == 1:
+                    body = audit_bundle(old)
+                elif self.audit_call in (2, 3):
+                    body = audit_bundle(strict, old)
+                else:
+                    body = audit_bundle(
+                        audit_event(
+                            "lenient", "0", "ignored parameter: datetime"),
+                        strict,
+                        old,
+                    )
+                return 200, body, ""
+
+            self.observation_call += 1
+            query = parse_qs(urlsplit(path).query)
+            subject = query["patient"][0]
+            if self.observation_call == 1:
+                body = {
+                    "resourceType": "OperationOutcome",
+                    "issue": [{
+                        "severity": "error",
+                        "code": "not-supported",
+                        "details": {"text": corrective_text},
+                    }],
+                }
+                return 400, body, ""
+            if self.observation_call == 2:
+                self_url = "/Observation?" + urlencode({"patient": subject})
+                body = {
+                    "resourceType": "Bundle",
+                    "link": [{"relation": "self", "url": self_url}],
+                    "entry": [{
+                        "search": {"mode": "outcome"},
+                        "resource": {
+                            "resourceType": "OperationOutcome",
+                            "issue": [{
+                                "severity": "warning",
+                                "code": "not-supported",
+                                "details": {"text": corrective_text},
+                            }],
+                        },
+                    }],
+                }
+                return 200, body, ""
+            body = {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "not-supported",
+                    "details": {"text": "The requested modifier is not supported."},
+                }],
+            }
+            return 400, body, ""
+
+    result = probe_error_fidelity(
+        LocalAClient(), ProbeContext("tenant", "token"))
+    assert result.grade == "A"
+    assert result.passed is True
 
 
 def test_injected_mock_proxy_profile_passes_the_full_error_contract(

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -612,6 +612,7 @@ def test_live_mcp_probe_client_initializes_then_calls_tool():
         session=session,
         tenant="tenant-a",
         step_up_token="synthetic-token",
+        mcp_auth_token="synthetic-mcp-transport-token",
     )
     result = client.call_tool("fhir_search", {"resource_type": "Widget"})
 
@@ -621,6 +622,11 @@ def test_live_mcp_probe_client_initializes_then_calls_tool():
     assert session.calls[2][1]["headers"]["Mcp-Session-Id"] == "session-1"
     assert session.calls[2][1]["headers"]["X-Tenant-Id"] == "tenant-a"
     assert session.calls[2][1]["headers"]["X-Step-Up-Token"] == "synthetic-token"
+    assert all(
+        call[1]["headers"]["Authorization"]
+        == "Bearer synthetic-mcp-transport-token"
+        for call in session.calls
+    )
     assert session.calls[2][1]["json"]["method"] == "tools/call"
 
 
@@ -680,10 +686,10 @@ def test_local_error_probes_always_bound_searches_to_a_synthetic_subject():
         base = "recording"
 
         def __init__(self):
-            self.paths = []
+            self.calls = []
 
         def request(self, method, path, headers=None, json_body=None):
-            self.paths.append(path)
+            self.calls.append((path, (headers or {}).get("Prefer")))
             if path.startswith("/AuditEvent"):
                 return 200, {"resourceType": "Bundle", "entry": []}, ""
             return 200, {
@@ -696,9 +702,12 @@ def test_local_error_probes_always_bound_searches_to_a_synthetic_subject():
     probe_error_fidelity(client, ProbeContext("tenant", "token"))
 
     observation_paths = [
-        path for path in client.paths if path.startswith("/Observation?")]
+        path for path, _ in client.calls if path.startswith("/Observation?")]
     assert observation_paths
     assert all("patient=" in path for path in observation_paths)
+    modifier_preferences = [
+        prefer for path, prefer in client.calls if "code%3Aexact" in path]
+    assert modifier_preferences == [None, "handling=strict", "handling=lenient"]
 
 
 def test_scripted_local_contract_can_reach_a_without_reading_real_data():

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -271,6 +271,69 @@ def test_local_contract_rejects_false_a_evidence():
     assert not _corrective_outcome(corrective_plus_hostile, {"invalid"})
 
 
+def test_corrective_outcome_rejects_unsafe_sibling_issue():
+    from r6.conformance.probes import (
+        _outcome_names_parameter_and_supported_set,
+    )
+
+    outcome = {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": (
+                    "Unsupported parameter: datetime. Supported parameters: "
+                    "patient, code, status, _lastUpdated, _count, _sort, "
+                    "_summary, context-id."
+                )},
+            },
+            {
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": (
+                    "Use _lastUpdated instead of datetime for time filtering."
+                )},
+            },
+        ],
+    }
+
+    assert not _outcome_names_parameter_and_supported_set(outcome, "datetime")
+
+
+def test_lenient_warning_rejects_unsafe_sibling_outcome_entry():
+    from r6.conformance.probes import _has_outcome_warning
+
+    def outcome_entry(text):
+        return {
+            "search": {"mode": "outcome"},
+            "resource": {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "warning",
+                    "code": "not-supported",
+                    "details": {"text": text},
+                }],
+            },
+        }
+
+    bundle = {
+        "resourceType": "Bundle",
+        "entry": [
+            outcome_entry(
+                "Unsupported parameter: datetime. Supported parameters: "
+                "patient, code, status, _lastUpdated, _count, _sort, "
+                "_summary, context-id."
+            ),
+            outcome_entry(
+                "Use _lastUpdated instead of datetime for time filtering."
+            ),
+        ],
+    }
+
+    assert not _has_outcome_warning(bundle, "datetime")
+
+
 def test_lenient_audit_requires_ignored_parameter_evidence():
     from r6.conformance.probes import _new_audit_warning_grade
 

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -299,6 +299,10 @@ def test_corrective_outcome_rejects_unsafe_sibling_issue():
     }
 
     assert not _outcome_names_parameter_and_supported_set(outcome, "datetime")
+    outcome["issue"][1]["details"]["text"] = (
+        "Supported parameters: use _lastUpdated instead of datetime"
+    )
+    assert not _outcome_names_parameter_and_supported_set(outcome, "datetime")
 
 
 def test_lenient_warning_rejects_unsafe_sibling_outcome_entry():
@@ -331,6 +335,10 @@ def test_lenient_warning_rejects_unsafe_sibling_outcome_entry():
         ],
     }
 
+    assert not _has_outcome_warning(bundle, "datetime")
+    bundle["entry"][1] = outcome_entry(
+        "Supported parameters: use _lastUpdated instead of datetime"
+    )
     assert not _has_outcome_warning(bundle, "datetime")
 
 


### PR DESCRIPTION
## What & why

Adds **Error Fidelity** as the seventh guardrail property in the existing
`r6/conformance/` harness, following the direction accepted in
[Discussion #75](https://github.com/aks129/HealthClawGuardrails/discussions/75).

The previous six-property scorecard covered successful paths. It could still
award an A while a rejected search was presented as a confident empty result.
This change makes failure-path truthfulness measurable without bundling the
separate local-search or MCP transport fixes.

Closes #96.

## What changed

- Adds conservative F/C/A error-fidelity grading; the property passes only at A.
- Runs deterministic local probes for strict and lenient unknown parameters,
  unsupported modifiers in default/strict/lenient modes, corrective evidence,
  self-link truthfulness, bounded results, and failure/warning audit outcomes.
- Adds optional authenticated Streamable HTTP MCP coverage. Configured profiles
  run independently, report `run`/`not_run`, and cannot be hidden by another
  profile crashing.
- Adds an injected mock-upstream profile covering sanitized 400, auth failure,
  500, timeout, audit outcomes, and hostile name/internal-URL leakage without a
  live third-party dependency or process-global proxy mutation.
- Exposes grade, coverage, profiles, and exact check names in `ProbeResult`, JSON,
  and text. Shields output exposes grade and coverage while retaining only the
  standard endpoint-badge fields.
- Updates the public scorecard and documentation from six properties to the
  honest initial baseline: Grade B (6/7), Error Fidelity F.

## Intentional baseline

The new property is deliberately failing on current `main`:

- local F: unsupported filters are still silently accepted;
- optional MCP C: the tool reports a failure but does not yet return the fully
  corrective `isError: true` OperationOutcome contract;
- injected proxy A: the sanitized proxy error work already on `main` satisfies
  that profile.

Accordingly, `$conformance` returns 503 at B. Follow-up fixes should move the
measured profile grades rather than weaken or delete probes.

## Safety and scope

- Synthetic, subject-bounded searches only; no real patient data.
- No live upstream FHIR calls.
- No changes to write semantics, step-up, redaction, or the underlying
  local-search/MCP behavior being measured.
- Hostile response evidence is checked fail-closed across parsed and raw bodies;
  unsafe `datetime` → `_lastUpdated` suggestions and invented supported
  parameters cannot earn A.

## Verification

- `1392 passed, 1 skipped` locally on CPython 3.11.
- `1390 passed, 1 skipped` in Linux/ARM64 on the Mac Mini's Colima runtime.
- MCP service: `tsc --noEmit` clean; 142/142 Jest tests pass on Node 20.
- Real Colima Compose stack: migration and seed exited 0; Flask and MCP health
  returned 200; missing/wrong/correct MCP bearer auth returned 401/401/200.
- Live CLI with protected MCP returned the intentional B/F baseline with
  `local+mcp` coverage and MCP C.
- Synthetic hostile names, internal hostname, and transport token appeared zero
  times in Flask or MCP container logs.
- `ruff`, Python 3.11 AST parsing, and `git diff --check` are clean.
- Final independent standards, Issue #96/Discussion #75, and Fable adversarial
  reviews found no remaining issues; sibling-evidence smuggling is covered by
  regression tests.
