### PR TITLE
fix(mcp): root package.json so `npm start` launches the stdio MCP server (Glama score build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "healthclaw-guardrails-mcp",
+  "version": "1.8.0",
+  "private": true,
+  "description": "Root entry for the HealthClaw Guardrails MCP stdio server. Delegates to services/agent-orchestrator so MCP catalogs (Glama, the MCP registry, Claude Desktop) that expect `npm start` at the repository root launch the stdio transport, which lists all tools without a live FHIR backend.",
+  "license": "MIT",
+  "scripts": {
+    "build": "cd services/agent-orchestrator && npm ci && npm run build",
+    "start": "node services/agent-orchestrator/dist/stdio.js"
+  }
+}


### PR DESCRIPTION
Fixes the Glama score-calculation build, which runs `mcp-proxy -- npm start` at the repo root and failed with `ENOENT /app/package.json`.

## Root cause
- No `package.json` at the repo root — the Node MCP server lives in `services/agent-orchestrator/`.
- Even if found, `npm start` there runs the **HTTP** server (`dist/index.js`), not the **stdio** transport a catalog pings.
- Glama's build only ran `uv sync` (Python), never building the Node server.

## Fix
A small delegating root `package.json`:
- `npm run build` → `cd services/agent-orchestrator && npm ci && npm run build`
- `npm start` → `node services/agent-orchestrator/dist/stdio.js` (the stdio MCP entry)

Verified locally: `npm start` answers `initialize` + `tools/list` (**29 tools**) over stdio with **no live FHIR backend** — exactly what Glama's probe needs.

## Safety
- **Vercel**: explicit `builds` array (`@vercel/python`), `framework: null` — no Node auto-detection, unaffected.
- **Docker/Railway**: Python/gunicorn; `COPY . .` just includes the extra file.
- **CI**: `node-tests` already `cd`s into the service dir; unaffected.

## Glama build spec (set in Glama admin once this is on main)
```json
{
  "buildSteps": ["npm run build"],
  "cmdArguments": ["mcp-proxy", "--", "npm", "start"]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)