### PR TITLE
fix(prod): adopt legacy create_all databases in init-db (unblocks Railway deploy)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,24 @@ services:
       - FHIR_VALIDATOR_URL=${FHIR_VALIDATOR_URL:-http://localhost:8080}
       - REDIS_URL=redis://redis:6379/0
       - STEP_UP_SECRET=${STEP_UP_SECRET:-dev-step-up-secret-change-in-production}
+      # Read authorization (hardening): when enabled, non-public tenants
+      # require a tenant-bound step-up token / OAuth read scope on reads.
+      # PUBLIC_TENANTS is the explicit allowlist that may be read anonymously.
+      - READ_AUTH_ENABLED=${READ_AUTH_ENABLED:-}
+      - PUBLIC_TENANTS=${PUBLIC_TENANTS:-desktop-demo}
+      # SMART OAuth token signing (hardening). Falls back to STEP_UP_SECRET
+      # when unset so local tokens still validate.
+      - OAUTH_SECRET=${OAUTH_SECRET:-}
+      - OAUTH_ISSUER=${OAUTH_ISSUER:-}
       # Upstream FHIR server proxy (set to connect to real data)
       # Examples: https://hapi.fhir.org/baseR4, https://r4.smarthealthit.org
       - FHIR_UPSTREAM_URL=${FHIR_UPSTREAM_URL:-}
       - FHIR_UPSTREAM_TIMEOUT=${FHIR_UPSTREAM_TIMEOUT:-15}
       - FHIR_LOCAL_BASE_URL=http://localhost:5000/r6/fhir
+      # Base URL for links handed to humans (form-fill delivery links, action
+      # webhook callbacks). The form-fill rail fails loud without it — give
+      # the local stack a working default; real deployments set their host.
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-http://127.0.0.1:${HOST_PORT:-5000}}
       # Fasten Connect (https://docs.connect.fastenhealth.com)
       - FASTEN_PUBLIC_KEY=${FASTEN_PUBLIC_KEY:-}
       - FASTEN_PRIVATE_KEY=${FASTEN_PRIVATE_KEY:-}

--- a/migrations/versions/0002_current_schema_contract.py
+++ b/migrations/versions/0002_current_schema_contract.py
@@ -73,7 +73,14 @@ def _upgrade_resource_identity() -> None:
         if not needs_rebuild:
             return
         constraint_name = pk.get("name") or "pk_r6_resources_legacy"
-        with op.batch_alter_table("r6_resources", recreate="always") as batch:
+        batch_kwargs = {"recreate": "always"}
+        if not pk.get("name"):
+            # A legacy-boot-era SQLite PK is unnamed; drop_constraint would
+            # raise "No such constraint". Alembic's documented recipe: give
+            # reflection a naming convention so the legacy PK gets exactly the
+            # deterministic name we then drop.
+            batch_kwargs["naming_convention"] = {"pk": "pk_%(table_name)s_legacy"}
+        with op.batch_alter_table("r6_resources", **batch_kwargs) as batch:
             batch.alter_column(
                 "id",
                 existing_type=sa.String(64),

--- a/r6/database_migrations.py
+++ b/r6/database_migrations.py
@@ -2,15 +2,30 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
+from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
 
 
+logger = logging.getLogger(__name__)
+
 _ROOT = Path(__file__).resolve().parents[1]
+
+# The revision that mirrors the schema every pre-Alembic deployment built via
+# db.create_all(). A database that has real tables but no alembic_version row
+# is exactly that legacy state and must be ADOPTED (stamped at this baseline),
+# never re-created — running the baseline migration against it dies with
+# "table ... already exists".
+_BASELINE_REVISION = "0001_v1_8_0"
+
+# A table that has existed since long before v1.8.0 — its presence (without
+# alembic_version) is the legacy-database fingerprint.
+_LEGACY_SENTINEL_TABLE = "r6_resources"
 
 
 def alembic_config() -> Config:
@@ -20,13 +35,47 @@ def alembic_config() -> Config:
     return config
 
 
+def _is_unstamped_legacy_database(connection) -> bool:
+    """True when the schema was built by pre-Alembic create_all: real tables
+    exist but Alembic has never recorded a revision.
+
+    Checks the recorded REVISION, not mere table presence — an interrupted
+    earlier run can leave an empty alembic_version table behind, and that
+    state is still unstamped."""
+    current = MigrationContext.configure(connection).get_current_revision()
+    if current is not None:
+        return False
+    inspector = inspect(connection)
+    return _LEGACY_SENTINEL_TABLE in inspector.get_table_names()
+
+
 def upgrade_database(engine: Engine, revision: str = "head") -> str:
-    """Upgrade an existing SQLAlchemy engine and return its applied revision."""
+    """Upgrade an existing SQLAlchemy engine and return its applied revision.
+
+    Handles all three deployment states:
+      - fresh database          -> run every migration from scratch
+      - legacy create_all-era   -> stamp the v1.8.0 baseline, then upgrade;
+                                   0002 reconciles any drift idempotently
+      - already Alembic-managed -> normal upgrade to the target revision
+    """
     config = alembic_config()
     with engine.connect() as connection:
         config.attributes["connection"] = connection
+        if _is_unstamped_legacy_database(connection):
+            logger.info(
+                "Existing pre-Alembic schema detected (no alembic_version); "
+                "stamping baseline %s before upgrading", _BASELINE_REVISION,
+            )
+            command.stamp(config, _BASELINE_REVISION)
         command.upgrade(config, revision)
         current = MigrationContext.configure(connection).get_current_revision()
+        # Alembic treats a SUPPLIED connection as externally managed and does
+        # not commit it; SQLAlchemy 2.0 rolls back at connection close. On
+        # SQLite the DDL autocommits at the driver level but the
+        # alembic_version row insert does not — leaving tables present with no
+        # recorded revision, so the NEXT deploy re-runs every migration and
+        # dies with "table already exists". Commit explicitly.
+        connection.commit()
     if current is None:
         raise RuntimeError("Alembic upgrade completed without recording a revision")
     return current

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -214,3 +214,79 @@ def test_postgres_fresh_install_and_v1_8_upgrade_path():
             connection.execute(text("DROP SCHEMA public CASCADE"))
             connection.execute(text("CREATE SCHEMA public"))
         engine.dispose()
+
+
+def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
+    """THE PROD UPGRADE PATH: every deployed database predating #103 was built
+    by db.create_all() and has real tables but NO alembic_version. Running the
+    baseline migration against it dies with 'table already exists' (found live:
+    the compose migrate service failed exactly this way on a reused volume).
+    upgrade_database() must detect that state, STAMP the baseline, and then
+    upgrade to head — 0002 reconciles drift idempotently (inspects first)."""
+    from r6.database_migrations import upgrade_database
+    import main as main_module  # registers every model on db.metadata
+    from models import db
+
+    main_module.register_model_metadata()
+    url = f"sqlite:///{tmp_path / 'legacy.db'}"
+    engine = create_engine(url)
+    db.metadata.create_all(engine)  # what every pre-Alembic deploy did at boot
+
+    inspector = inspect(engine)
+    assert "r6_resources" in inspector.get_table_names()
+    assert "alembic_version" not in inspector.get_table_names()
+
+    revision = upgrade_database(engine)  # must NOT raise 'already exists'
+
+    assert revision == "0002_current_contract"
+    inspector = inspect(engine)
+    assert "alembic_version" in inspector.get_table_names()
+    # And it must be repeatable (deploys run it every release).
+    assert upgrade_database(engine) == "0002_current_contract"
+
+
+def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
+    """A pre-W0 SQLite deployment (docker-compose default) has r6_resources
+    with an UNNAMED single-column primary key, VARCHAR(64) id, and nullable
+    tenant_id. 0002 must rebuild it to the composite identity without dying on
+    'No such constraint' (found live: compose migrate failed exactly here on a
+    reused volume)."""
+    from r6.database_migrations import upgrade_database
+    import main as main_module
+    from models import db
+
+    main_module.register_model_metadata()
+    url = f"sqlite:///{tmp_path / 'pre-w0.db'}"
+    engine = create_engine(url)
+    # Realistic legacy state: the complete schema the old boot path built,
+    # with r6_resources swapped for its pre-W0 shape (single unnamed PK,
+    # 64-char id, nullable tenant). A DB missing whole tables is older than
+    # any supported deployment — 0002 fails loud there by design.
+    db.metadata.create_all(engine)
+    with engine.begin() as c:
+        c.execute(text("DROP TABLE r6_resources"))
+        c.execute(text(
+            "CREATE TABLE r6_resources ("
+            " id VARCHAR(64) NOT NULL PRIMARY KEY,"
+            " resource_type VARCHAR(64) NOT NULL,"
+            " tenant_id VARCHAR(64),"
+            " resource_json TEXT NOT NULL,"
+            " version_id INTEGER,"
+            " last_updated DATETIME)"
+        ))
+        c.execute(text(
+            "INSERT INTO r6_resources (id, resource_type, tenant_id,"
+            " resource_json, version_id) VALUES"
+            " ('p1', 'Patient', 't1', '{}', 1)"
+        ))
+
+    revision = upgrade_database(engine)
+    assert revision == "0002_current_contract"
+
+    inspector = inspect(engine)
+    pk = inspector.get_pk_constraint("r6_resources")
+    assert pk["constrained_columns"] == ["tenant_id", "resource_type", "id"]
+    # Data survives the rebuild.
+    with engine.connect() as c:
+        rows = list(c.execute(text("SELECT id, tenant_id FROM r6_resources")))
+    assert rows == [("p1", "t1")]

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -290,3 +290,49 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
     with engine.connect() as c:
         rows = list(c.execute(text("SELECT id, tenant_id FROM r6_resources")))
     assert rows == [("p1", "t1")]
+
+
+def test_legacy_create_all_upgrade_on_configured_database():
+    """The prod-down bug: a create_all-era database (real tables, no
+    alembic_version) must be ADOPTED, not re-created. Runs against whatever
+    SQLALCHEMY_DATABASE_URI is configured — the Postgres CI lane exercises the
+    real Railway scenario; elsewhere it uses a temp SQLite file."""
+    import tempfile
+    from r6.database_migrations import upgrade_database
+    import main as main_module
+    from models import db
+
+    main_module.register_model_metadata()
+
+    url = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
+    is_pg = url.startswith(("postgresql://", "postgres://"))
+    if is_pg:
+        engine = create_engine(url.replace("postgres://", "postgresql://", 1))
+        with engine.begin() as c:
+            c.execute(text("DROP SCHEMA public CASCADE"))
+            c.execute(text("CREATE SCHEMA public"))
+        cleanup = engine
+    else:
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.close()
+        engine = create_engine(f"sqlite:///{tmp.name}")
+        cleanup = None
+
+    try:
+        db.metadata.create_all(engine)  # pre-Alembic boot path
+        assert "alembic_version" not in inspect(engine).get_table_names()
+
+        revision = upgrade_database(engine)  # must not raise "already exists"
+
+        assert revision == "0002_current_contract"
+        assert "alembic_version" in inspect(engine).get_table_names()
+        assert upgrade_database(engine) == "0002_current_contract"  # idempotent
+        assert inspect(engine).get_pk_constraint("r6_resources")[
+            "constrained_columns"
+        ] == ["tenant_id", "resource_type", "id"]
+    finally:
+        if cleanup is not None:
+            with cleanup.begin() as c:
+                c.execute(text("DROP SCHEMA public CASCADE"))
+                c.execute(text("CREATE SCHEMA public"))
+        engine.dispose()


### PR DESCRIPTION
## Prod-down hotfix

The Railway **production deploy of HealthClawGuardrails is failing** (deployments `fa5171cb`, `11719a47`). Prod is still serving the pre-#103 deployment because the new one can't get past its `preDeployCommand`.

### Root cause
`railway.toml` runs `flask --app main init-db` before the web process. That calls `upgrade_database()`, which — on main — runs Alembic from base against Railway's **real Postgres database**. But every existing deployment's DB was built by the old `db.create_all()` boot path: it has all the tables but **no `alembic_version`**. Running the baseline migration against it crashes with *"relation already exists"* → preDeploy exits 1 → deploy fails.

I found and fixed this during the e2e sweep, but the fix landed on the `integrate/security-hardening` branch **after #103 had already been squash-merged**, so it never reached main. This PR brings it over.

### The fix (commit cherry-picked from the merged branch + a new Postgres test)
- `upgrade_database()`: detect an unstamped legacy DB (no recorded revision + the `r6_resources` sentinel table) and **stamp the baseline before upgrading**. Also `connection.commit()` so the `alembic_version` row persists with a supplied connection (SQLAlchemy 2.0 rolls back at close otherwise).
- `0002`: give `batch_alter_table` a naming convention so the create_all-era **unnamed** SQLite PK can be dropped (`No such constraint` otherwise).
- `docker-compose.yml`: pass through `PUBLIC_BASE_URL` + the read-auth knobs (came with the same commit).

### Verified
- Reproduced against **real Postgres 16**: legacy create_all DB → `upgrade_database` stamps + upgrades to `0002`, **no crash**, idempotent on repeat, composite PK `(tenant_id, resource_type, id)` applied.
- New regression test `test_legacy_create_all_upgrade_on_configured_database` runs against real Postgres in the `postgres-tests` lane (the gap that let this ship — the old Postgres test only covered the clean alembic-managed path).
- Migration suite: 8 passed; ruff clean.

**Merge this to unblock the prod deploy.** Railway env is already correctly provisioned (SESSION_SECRET, STEP_UP_SECRET, READ_AUTH_ENABLED, PUBLIC_TENANTS, Postgres URI all set), so once `init-db` stops crashing the deploy will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)