### PR TITLE
docs: name de-id/validation rigor limits + track as next-phase work (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,8 @@ in-process cache when Redis is unavailable).
 ## Known Limitations
 
 - Local mode: JSON blob storage with table-scan search (no indexed fields)
-- Structural validation only (no StructureDefinition conformance or terminology binding)
+- **Redaction is HIPAA Safe-Harbor-*style* field redaction** (demographics), **not Expert Determination**. It's a compensating control that removes identifier-class fields; it is not a legal de-identification determination. Production de-id rigor (profile-specific recursive allowlists, an Expert-Determination path) is on the [roadmap](ROADMAP.md) ([#112](../../issues/112)).
+- **Validation is structural**, not full StructureDefinition/profile conformance or terminology binding. What's demonstrated is the guardrail *contract* (redact + audit + step-up + human-confirm + tenant isolation + error fidelity), not production validation depth — that's tracked in [#112](../../issues/112).
 - SubscriptionTopic stored but notifications not dispatched
 - Clinical FHIR writes gate human-in-the-loop with a header flag (`X-Human-Confirmed`), not cryptographic confirmation — a compensating control for the demo, not proof a human acted. Real-world actions (phone/SMS/etc.) no longer use that header: `commit` only submits the action for out-of-band approval (202 `awaiting_confirmation`), and the patient's Approve tap consumes a single-use `ActionConfirmation` credential server-side before anything executes.
 - OAuth endpoints are for discovery/SMART advertisement; route enforcement is via step-up + read-auth tokens, and the auto-approve authorize flow is limited to public/demo tenants (no per-user consent screen)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ Making the first two actions *real*:
 
 - **Encrypted SMART Health Link delivery.** The forms rail ships a signed, expiring download link today; the next step wraps it in a full SHL envelope (encrypted manifest + one-time flag), reusing the Node server's SHL builder, so the PDF can be shared through the standard SHL viewer ecosystem.
 - **FHIR Implementation Guide.** A continuous-build IG so the guardrails are reviewable in the community's own terms: a two-agent AuditEvent profile (AI agent + human verifier), a Provenance-per-action profile, SDC-conformant questionnaires, and the six guardrail properties as testable requirements. Standards-native expression of what the code already does.
+- **Production rigor for de-identification and validation** ([#112](../../issues/112)). Today redaction is HIPAA **Safe-Harbor-*style* field redaction** (demographics), not Expert Determination, and `fhir_validate` is **structural**, not full StructureDefinition/terminology conformance. The guardrail *contract* (redact + audit + step-up + human-confirm + tenant isolation + [error fidelity](../../pull/108)) is what's demonstrated today; closing the de-id gap (profile-specific recursive allowlists, an Expert-Determination path, PHI-canary tests) and the validation gap (profile-aware conformance + terminology binding) is how it becomes production-grade. Pairs with the IG above.
 - **Granular SMART v2 scopes** per tool; regulatory-posture doc (patient-directed access under 45 CFR 164.524; FTC Health Breach Notification Rule).
 
 ## 🔭 Later — booking, consumer, ecosystem


### PR DESCRIPTION
Adds the honest-limits framing to the **README Known Limitations** and the **ROADMAP** (Next phase), and links both to the new tracking issue #112.

The wording, verbatim from the request:
> Redaction is HIPAA Safe-Harbor-style field redaction (demographics), not Expert Determination; validation is structural, not full StructureDefinition/terminology conformance. The guardrail contract (redact + audit + step-up + human-confirm + tenant isolation) is what's demonstrated here — production de-id/validation rigor is on the roadmap.

## Changes
- **README**: replaced the terse "structural validation only" bullet with two explicit bullets — redaction is Safe-Harbor-*style* (not Expert Determination) and validation is structural — each linking #112.
- **ROADMAP** (Next — standards + delivery hardening): a "Production rigor for de-identification and validation" bullet, next to the FHIR IG it pairs with.
- Issue **#112** holds the scoped workstreams (recursive allowlists, Expert-Determination path, PHI-canary tests; profile-aware validation + terminology binding).

Docs-only; version-sync drift guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)