### PR TITLE
fix(railway): preDeployCommand must be one element — unblocks the prod deploy

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -20,9 +20,13 @@ healthcheckPath = "/r6/fhir/health"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
+# Railway's preDeployCommand accepts at most ONE element — a multi-element
+# array is a config parse error that fails the whole deploy before anything
+# runs. Chain both steps in a single command: migrate first, then seed only if
+# the migration succeeded (&&). Seeding stays separate from the migration
+# transaction and is never run by WSGI imports.
 preDeployCommand = [
-  "flask --app main init-db",
-  "flask --app main seed-demo --tenant-id desktop-demo",
+  "flask --app main init-db && flask --app main seed-demo --tenant-id desktop-demo",
 ]
 
 # This Railway project is the explicit public synthetic desktop demo. Seeding

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -125,10 +125,17 @@ def test_deploy_configs_run_migrations_before_web_processes():
     }
 
     railway = (ROOT / "railway.toml").read_text()
-    migrate = '"flask --app main init-db"'
-    seed = '"flask --app main seed-demo --tenant-id desktop-demo"'
     assert "preDeployCommand" in railway
-    assert railway.index(migrate) < railway.index(seed)
+    # Migration must run before seeding. They are chained in ONE preDeploy
+    # command because Railway's preDeployCommand accepts at most one element —
+    # a multi-element array is a config parse error that fails the deploy.
+    assert railway.index("flask --app main init-db") < railway.index(
+        "flask --app main seed-demo --tenant-id desktop-demo"
+    )
+    import tomllib
+    pre = tomllib.loads(railway)["deploy"]["preDeployCommand"]
+    assert isinstance(pre, list) and len(pre) == 1, pre
+    assert "&&" in pre[0]
     assert "SEED_DEMO_TENANT" not in railway
 
 


### PR DESCRIPTION
## The prod deploy has been failing since #103 — here's why

Every Railway production deploy since #103 failed. The reason was in the deployment metadata (not in any log stream), found via the Railway GraphQL API:

```
deploy.preDeployCommand: Array must contain at most 1 element(s)
```

Railway's `preDeployCommand` accepts **at most one element**. #103 set it to a **two-element array** (`init-db`, `seed-demo`), so Railway **rejected the entire service config and failed the deploy before running anything**. Consequences that made this hard to pin down:
- Prod's DB was never migrated (preDeploy never executed) — confirmed live via ssh: `alembic_version` absent, still single-column PK.
- It reproduced **nowhere** locally, because the commands themselves are correct — only the array *length* is rejected by Railway's config parser.

## The fix
Chain both steps into a single preDeploy element — migrate first, then seed only if the migration succeeds:
```toml
preDeployCommand = [
  "flask --app main init-db && flask --app main seed-demo --tenant-id desktop-demo",
]
```

## What was ruled out first (exhaustively, against the live prod DB)
init-db legacy-adoption works on prod's exact schema (single-col PK, nullable tenant, 1147 rows), under the full 42-var prod env, and in a `--no-dev` image; `0002`'s DDL preconditions all hold (0 null tenants, 0 duplicate identities, no FKs/views/deps); memory is 8GB (using <200MB); statement/lock timeouts are 0 and no locks are held; the app boots healthy in production mode. The config-parse error was the sole cause.

## Companion fixes already merged / in flight
- **#111** (merged): init-db adopts legacy create_all databases — required for this deploy to migrate prod's real DB once preDeploy actually runs.
- **Infra done via CLI**: provisioned Redis + set `REDIS_URL` (the fail-closed config requires it; there was no Redis service). Redis is healthy.

**Merge this and the deploy should go green** — Railway will accept the config, run `init-db` (which adopts prod's legacy DB via #111) then `seed-demo`, boot gunicorn, and pass the healthcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)