### PR TITLE
feat(site): real CareAgents CTA + make healthclaw.io indexable (SEO)

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,16 +131,42 @@ def robots_txt():
     can set ALLOW_INDEXING=1 to serve a permissive robots.txt instead.
     """
     if os.environ.get("ALLOW_INDEXING", "").lower() in ("1", "true", "yes"):
-        body = "User-agent: *\nAllow: /\n"
+        base = os.environ.get("PUBLIC_SITE_URL", "https://healthclaw.io").rstrip("/")
+        body = f"User-agent: *\nAllow: /\n\nSitemap: {base}/sitemap.xml\n"
     else:
         body = "User-agent: *\nDisallow: /\n"
     return Response(body, mimetype="text/plain")
 
 
+# Public pages for search indexing. Only meaningful where ALLOW_INDEXING is on
+# (the healthclaw.io Vercel site); the personal app host stays disallowed.
+_SITEMAP_PATHS = [
+    ("/", "1.0"), ("/r6-dashboard", "0.8"), ("/skills", "0.7"),
+    ("/wiki", "0.7"), ("/faq", "0.6"), ("/privacy", "0.3"), ("/terms", "0.3"),
+]
+
+
+@web_blueprint.route('/sitemap.xml')
+def sitemap_xml():
+    """Minimal sitemap of public, indexable pages."""
+    if os.environ.get("ALLOW_INDEXING", "").lower() not in ("1", "true", "yes"):
+        return Response("Not found", status=404)
+    base = os.environ.get("PUBLIC_SITE_URL", "https://healthclaw.io").rstrip("/")
+    urls = "".join(
+        f"<url><loc>{base}{path}</loc><priority>{pri}</priority></url>"
+        for path, pri in _SITEMAP_PATHS)
+    xml = ('<?xml version="1.0" encoding="UTF-8"?>'
+           '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+           f'{urls}</urlset>')
+    return Response(xml, mimetype="application/xml")
+
+
 @web_blueprint.route('/')
 def index():
     """Landing page."""
-    return render_template('index.html')
+    return render_template(
+        'index.html',
+        google_verification=os.environ.get("GOOGLE_SITE_VERIFICATION", "").strip())
 
 
 @web_blueprint.route('/r6-dashboard')

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HealthClaw Guardrails — healthclaw.io</title>
+  <title>HealthClaw Guardrails — the safety layer between AI agents and your health data</title>
+  <meta name="description" content="HealthClaw is an open-source guardrail layer between AI agents and FHIR health data — redaction, audit, and human sign-off enforced server-side. See it working in CareAgents: connect your records and spin up a health agent that reads them safely.">
+  <link rel="canonical" href="https://healthclaw.io/">
+  <meta name="robots" content="index, follow">
+  {% if google_verification %}<meta name="google-site-verification" content="{{ google_verification }}">{% endif %}
+  <!-- Open Graph / LinkedIn -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="HealthClaw Guardrails">
+  <meta property="og:url" content="https://healthclaw.io/">
+  <meta property="og:title" content="The guardrail layer between AI agents and clinical data">
+  <meta property="og:description" content="Open-source safety layer for AI + FHIR health data. Redaction, audit, and human sign-off enforced server-side. Try CareAgents — connect your records, spin up a guarded health agent.">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The guardrail layer between AI agents and clinical data">
+  <meta name="twitter:description" content="Open-source safety layer for AI + FHIR health data. Try CareAgents — connect your records, spin up a guarded health agent.">
+  <meta name="theme-color" content="#0A0E17">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
@@ -394,13 +409,19 @@
     </h1>
     <p class="hero-sub">
       FHIR standardized health data. MCP standardized how AI connects to tools.
-      Nobody standardized the guardrails in between &mdash; so we're building a shared, open
-      reference for that layer, in the open. Not a product. Use it, fork it, send a PR.
+      Nobody standardized the guardrails in between &mdash; so we built a shared, open
+      reference for that layer. See it working in <strong style="color:var(--white)">CareAgents</strong>:
+      sign in with your face, connect your records, and spin up a health agent
+      that reads them &mdash; redaction, audit, and human sign-off enforced server-side.
     </p>
     <div class="hero-ctas">
-      <a href="{{ url_for('r6_dashboard') }}" class="btn-primary">Try the Live Dashboard</a>
-      <a href="https://github.com/aks129/HealthClawGuardrails/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener" class="btn-outline">Get involved &rarr;</a>
+      <a href="https://careagents.cloud" target="_blank" rel="noopener" class="btn-primary">Try CareAgents &rarr;</a>
+      <a href="{{ url_for('r6_dashboard') }}" class="btn-outline">Explore the live dashboard</a>
     </div>
+    <p style="margin-top:18px;font-size:13px;color:var(--gray)">
+      Building on it? It's MIT-licensed &mdash;
+      <a href="https://github.com/aks129/HealthClawGuardrails/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener" style="color:var(--cyan)">use it, fork it, send a PR</a>.
+    </p>
   </div>
 </div>
 

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,7 @@
     "PUBLIC_TENANTS": "desktop-demo",
     "DISABLE_COMMAND_CENTER": "1",
     "READ_ONLY_DEPLOYMENT": "1",
-    "PYTHONUNBUFFERED": "1"
+    "PYTHONUNBUFFERED": "1",
+    "ALLOW_INDEXING": "1"
   }
 }


### PR DESCRIPTION
Updates the healthclaw.io landing to reflect the shipped work and unblocks search traffic.

## Real CTA
Hero now leads with **Try CareAgents →** (careagents.cloud) — the actual usable product — with the live dashboard as the secondary action and the MIT/"fork it, send a PR" invitation kept as subtext. The sub-headline now describes the CareAgents flow (sign in with your face, connect records, spin up a guarded agent).

## SEO — the site was invisible to Google
- **`robots.txt` was serving `Disallow: /`** on the public site (no `ALLOW_INDEXING`). Nothing could be indexed. This sets `ALLOW_INDEXING=1` **on the Vercel deploy only** (`vercel.json`); the Railway app host (app.healthclaw.io) stays disallowed.
- `robots.txt` now advertises the sitemap; new **`/sitemap.xml`** lists the public pages (gated on `ALLOW_INDEXING`, so the personal host never exposes one).
- `<head>` now has: **meta description**, canonical, **Open Graph + Twitter cards** (Google snippets *and* LinkedIn/social link previews), theme-color, and an **env-driven `google-site-verification`** meta — set `GOOGLE_SITE_VERIFICATION` to verify Search Console without a markup redeploy.

## Verification
Booted the app with `ALLOW_INDEXING=1`: `/` renders the CareAgents CTA + OG + verification meta; `/robots.txt` → `Allow: /` + `Sitemap:` line; `/sitemap.xml` → 200 with page `<loc>`s. `tests/test_site_version_sync.py` green, ruff clean.

## Manual step after merge (yours)
Add the property in Google Search Console, set `GOOGLE_SITE_VERIFICATION` (or use DNS TXT), then submit `https://healthclaw.io/sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)