### PR TITLE
feat(wearables): map Open Wearables sleep sessions + naps to FHIR

### DIFF
--- a/r6/wearables/mapper.py
+++ b/r6/wearables/mapper.py
@@ -242,6 +242,116 @@ def sample_to_observation(
     return obs
 
 
+def sleep_session_to_observation(
+    session: dict[str, Any],
+    *,
+    patient_ref: str,
+    provider: str,
+    source_base_url: str = 'https://open-wearables.local',
+) -> dict[str, Any] | None:
+    """Map one Open Wearables **sleep session** to a FHIR R4 Observation.
+
+    Sleep sessions (including naps) are event records, not time-series
+    samples — Open Wearables exposes them via
+    ``GET /api/v1/users/{id}/events/sleep`` (the ``SleepSession`` schema),
+    *not* the samples/timeseries feed. A nap is a sleep session with
+    ``is_nap == true``; ``false``/missing is treated as main sleep, mirroring
+    Open Wearables' own ``coalesce(is_nap, False)``.
+
+    Both nap and main sleep use LOINC 93832-4 (Sleep duration); they are
+    distinguished by ``code.text`` and a queryable ``meta.tag`` (``sleep-nap``
+    vs ``sleep-main``) rather than by resource type, so a client can filter
+    either way without a second code system. Note: at Open Wearables 0.6.3,
+    Apple-sourced sessions never set ``is_nap`` — absence of naps for an Apple
+    user is expected, not a mapping gap.
+
+    Expected input keys (SleepSession): ``start_time``, ``end_time``,
+    ``duration_seconds`` (and/or ``sleep_duration_seconds``), optional
+    ``is_nap``, ``efficiency_percent``, ``id``. Returns None if the session
+    lacks a start/end or any usable duration.
+    """
+    start = session.get('start_time')
+    end = session.get('end_time')
+    if not start or not end:
+        return None
+
+    # Prefer asleep time; fall back to session span. Open Wearables reports
+    # seconds; LOINC 93832-4 is conventionally hours.
+    seconds = session.get('sleep_duration_seconds')
+    if seconds is None:
+        seconds = session.get('duration_seconds')
+    if seconds is None:
+        return None
+    try:
+        hours = round(float(seconds) / 3600.0, 3)
+    except (TypeError, ValueError):
+        return None
+
+    is_nap = bool(session.get('is_nap') or False)
+    session_id = session.get('id') or str(uuid.uuid4())
+
+    obs: dict[str, Any] = {
+        'resourceType': 'Observation',
+        'status': 'final',
+        'effectivePeriod': {'start': start, 'end': end},
+        'subject': {'reference': patient_ref},
+        'device': {'display': f'{provider} via Open Wearables'},
+        'identifier': [{
+            'system': f'{source_base_url}/sleep-session',
+            'value': str(session_id),
+        }],
+        'code': {
+            'coding': [{
+                'system': 'http://loinc.org',
+                'code': '93832-4',
+                'display': 'Sleep duration',
+            }],
+            'text': 'Nap duration' if is_nap else 'Sleep duration',
+        },
+        'category': [{'coding': [_CATEGORY_CODING['sleep']]}],
+        'valueQuantity': {
+            'value': hours,
+            'unit': 'h',
+            'system': 'http://unitsofmeasure.org',
+            'code': 'h',
+        },
+        'meta': {
+            'source': source_base_url,
+            'tag': [
+                {
+                    'system': 'https://healthclaw.io/tags',
+                    'code': 'wearable-sourced',
+                    'display': 'Wearable-sourced observation',
+                },
+                {
+                    'system': 'https://healthclaw.io/tags/sleep',
+                    'code': 'sleep-nap' if is_nap else 'sleep-main',
+                    'display': 'Nap' if is_nap else 'Main sleep',
+                },
+            ],
+        },
+    }
+
+    efficiency = session.get('efficiency_percent')
+    if efficiency is not None:
+        try:
+            obs['component'] = [{
+                'code': {'coding': [{
+                    'system': 'http://loinc.org',
+                    'code': '93831-6',
+                    'display': 'Sleep efficiency',
+                }], 'text': 'Sleep efficiency'},
+                'valueQuantity': {
+                    'value': round(float(efficiency), 1), 'unit': '%',
+                    'system': 'http://unitsofmeasure.org', 'code': '%',
+                },
+            }]
+        except (TypeError, ValueError):
+            pass
+
+    return obs
+
+
 def samples_to_bundle(
     samples: list[dict[str, Any]],
     *,

--- a/tests/test_wearables.py
+++ b/tests/test_wearables.py
@@ -24,6 +24,7 @@ import pytest
 from r6.wearables.mapper import (
     sample_to_observation,
     samples_to_bundle,
+    sleep_session_to_observation,
 )
 
 
@@ -130,6 +131,75 @@ class TestSamplesToBundle:
         assert bundle['resourceType'] == 'Bundle'
         assert bundle['type'] == 'collection'
         assert len(bundle['entry']) == 2
+
+
+class TestSleepSessionMapper:
+    """Sleep sessions (incl. naps) come from Open Wearables' events/sleep feed
+    — the SleepSession schema with an `is_nap` flag — not the samples feed."""
+
+    _SESSION = {
+        'id': 'sess-1',
+        'start_time': '2026-07-15T13:20:00Z',
+        'end_time': '2026-07-15T13:50:00Z',
+        'duration_seconds': 1800,
+        'sleep_duration_seconds': 1620,
+        'efficiency_percent': 90.0,
+    }
+
+    def _tags(self, obs):
+        return {t['code'] for t in obs['meta']['tag']}
+
+    def test_main_sleep_tagged_and_coded(self):
+        obs = sleep_session_to_observation(
+            {**self._SESSION, 'is_nap': False, 'sleep_duration_seconds': 27000},
+            patient_ref='Patient/x', provider='oura')
+        assert obs['code']['coding'][0]['code'] == '93832-4'
+        assert obs['code']['text'] == 'Sleep duration'
+        assert obs['valueQuantity'] == {
+            'value': 7.5, 'unit': 'h',
+            'system': 'http://unitsofmeasure.org', 'code': 'h'}
+        assert obs['effectivePeriod']['start'] == '2026-07-15T13:20:00Z'
+        assert 'sleep-main' in self._tags(obs)
+        assert 'sleep-nap' not in self._tags(obs)
+
+    def test_nap_distinguished_by_text_and_tag(self):
+        obs = sleep_session_to_observation(
+            {**self._SESSION, 'is_nap': True},
+            patient_ref='Patient/x', provider='oura')
+        assert obs['code']['text'] == 'Nap duration'
+        assert obs['code']['coding'][0]['code'] == '93832-4'  # still sleep LOINC
+        assert 'sleep-nap' in self._tags(obs)
+        assert obs['valueQuantity']['value'] == 0.45  # 1620s -> 0.45h
+
+    def test_missing_is_nap_treated_as_main_sleep(self):
+        obs = sleep_session_to_observation(
+            self._SESSION, patient_ref='Patient/x', provider='apple')
+        # Apple never flags naps at 0.6.3 — absence is expected, not a bug.
+        assert obs['code']['text'] == 'Sleep duration'
+        assert 'sleep-main' in self._tags(obs)
+
+    def test_efficiency_becomes_component(self):
+        obs = sleep_session_to_observation(
+            self._SESSION, patient_ref='Patient/x', provider='whoop')
+        comp = obs['component'][0]
+        assert comp['code']['coding'][0]['code'] == '93831-6'
+        assert comp['valueQuantity']['value'] == 90.0
+
+    def test_falls_back_to_session_span_when_no_asleep_time(self):
+        obs = sleep_session_to_observation(
+            {'id': 's', 'start_time': '2026-07-15T13:20:00Z',
+             'end_time': '2026-07-15T13:50:00Z', 'duration_seconds': 1800,
+             'is_nap': True},
+            patient_ref='Patient/x', provider='garmin')
+        assert obs['valueQuantity']['value'] == 0.5  # 1800s -> 0.5h
+
+    def test_missing_bounds_or_duration_returns_none(self):
+        assert sleep_session_to_observation(
+            {'start_time': 'x', 'duration_seconds': 1}, patient_ref='P',
+            provider='oura') is None
+        assert sleep_session_to_observation(
+            {'start_time': 'x', 'end_time': 'y'}, patient_ref='P',
+            provider='oura') is None
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Adds nap support to the wearables → FHIR mapper, informed by a read of `the-momentum/open-wearables` @ 0.6.3.

## Key finding: naps aren't samples
Open Wearables exposes sleep sessions (including naps) via **`GET /api/v1/users/{id}/events/sleep`** (the `SleepSession` schema, `is_nap: bool`) — **not** the timeseries/samples feed the existing `sample_to_observation` mapper consumes. So a `METRIC_MAP` entry wouldn't work; naps need a dedicated session mapper.

## What this adds
`sleep_session_to_observation()` — pure, no I/O:
- LOINC **93832-4** (Sleep duration), `effectivePeriod` = session start/end, value in hours (prefers `sleep_duration_seconds`, falls back to `duration_seconds`).
- **Nap vs main sleep** distinguished by `code.text` + a queryable `meta.tag` (`sleep-nap` / `sleep-main`), mirroring OW's `coalesce(is_nap, False)` — a client can filter either way without a second code system.
- `efficiency_percent` → LOINC 93831-6 component when present.
- 6 tests; ruff clean; full `tests/test_wearables.py` green (35).

## Notes for reviewers
- At OW **0.6.3, Apple-sourced sessions never set `is_nap`** (hardcoded `false` upstream at `sleep_service.py:519`; PR #1149 only removed the TODO comment). Absence of Apple naps is expected, documented in the docstring.
- This is the **pure mapper only**. Wiring it into the live poll loop is a separate follow-up and is blocked on a bigger finding: **our wearables client calls `/api/v1/samples` and `/api/v1/providers`, which don't exist in OW's current API** (real surfaces are `/api/v1/users/{id}/timeseries`, `/api/v1/oauth/providers`, `/events/sleep`). Tracking that reconciliation separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)