### PR TITLE
fix(wearables): reconcile Open Wearables client to the real 0.6.3 API

### DIFF
--- a/r6/wearables/client.py
+++ b/r6/wearables/client.py
@@ -1,12 +1,31 @@
 """
 HTTP client for the Open Wearables sidecar.
 
-All calls use a single shared API key (OPEN_WEARABLES_API_KEY) as an
-Authorization: Bearer header. No per-user tokens — Open Wearables owns
-those.
+Reconciled against the-momentum/open-wearables @ 0.6.3 source. The prior client
+targeted endpoints that do not exist in Open Wearables (`/api/v1/samples`,
+`/api/v1/providers`) and authenticated with `Authorization: Bearer`; the real
+API uses an `X-Open-Wearables-API-Key` header and these surfaces:
 
-Timeouts default to 15s to match FHIR_UPSTREAM_TIMEOUT; callers can
-override for bulk backfills.
+  GET /api/v1/oauth/providers                      provider settings list
+  GET /api/v1/users/{user_id}/timeseries           granular biometrics/activity
+  GET /api/v1/users/{user_id}/events/sleep         sleep sessions (incl. naps)
+  GET /api/v1/oauth/{provider}/authorize           OAuth kickoff  [see caveat]
+
+NOT verified against a live Open Wearables instance — paths, params, auth
+header, and response shapes are transcribed from the 0.6.3 source. Treat as
+best-effort until exercised end to end.
+
+CAVEAT — OAuth kickoff auth model: `GET /oauth/{provider}/authorize` is guarded
+by *developer-session* auth (`DeveloperDep`) in Open Wearables, not the API key
+this client holds, and it requires a pre-created Open Wearables `user_id`. A
+downstream API-key consumer (HealthClaw) therefore cannot, as things stand,
+initiate the connect handshake itself — that flow appears to be intended for the
+Open Wearables developer/dashboard context. `oauth_authorize_url` is implemented
+to the documented shape but will 401 without developer auth; resolving this is
+an integration decision, tracked separately, not a client bug.
+
+Timeouts default to 15s to match FHIR_UPSTREAM_TIMEOUT; callers can override for
+bulk backfills.
 """
 
 from __future__ import annotations
@@ -19,6 +38,30 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Open Wearables SeriesType -> our METRIC_MAP key (see r6/wearables/mapper.py).
+# Only aliases where the names differ; unlisted types pass through unchanged and
+# fall back to a code.text Observation so no data is lost.
+_SERIES_TO_METRIC = {
+    'heart_rate_variability_sdnn': 'heart_rate_variability',
+    'oxygen_saturation': 'spo2',
+    'weight': 'body_weight',
+}
+
+# The biometric/activity SeriesType values we map with clinical codes today.
+# Passed as explicit `types` so a provider dump doesn't stream every series.
+_WANTED_SERIES = [
+    'heart_rate', 'resting_heart_rate', 'heart_rate_variability_sdnn',
+    'oxygen_saturation', 'respiratory_rate', 'steps', 'body_temperature',
+    'weight', 'blood_pressure_systolic', 'blood_pressure_diastolic',
+    'blood_glucose',
+]
+
+# Providers Open Wearables supports (static fallback when the API is unreachable).
+_STATIC_PROVIDERS = (
+    'garmin', 'oura', 'polar', 'suunto',
+    'whoop', 'fitbit', 'strava', 'ultrahuman',
+)
 
 
 class WearablesClient:
@@ -45,7 +88,9 @@ class WearablesClient:
     def _headers(self) -> dict[str, str]:
         h = {'Accept': 'application/json'}
         if self.api_key:
-            h['Authorization'] = f'Bearer {self.api_key}'
+            # Open Wearables reads the key from this header (utils/auth.py),
+            # NOT an Authorization: Bearer.
+            h['X-Open-Wearables-API-Key'] = self.api_key
         return h
 
     def _client(self) -> httpx.Client:
@@ -58,17 +103,17 @@ class WearablesClient:
     # -- provider discovery -------------------------------------------------
 
     def list_providers(self) -> list[dict[str, Any]]:
-        """
-        Return the providers supported by the sidecar, each annotated with
-        whether its OAuth app credentials are configured. The sidecar does
-        not expose this exactly; we return the static Open Wearables set and
-        let the caller layer availability from env inspection.
+        """Providers Open Wearables exposes, from GET /api/v1/oauth/providers.
+
+        Returns the raw provider-settings list; falls back to the static
+        supported set if the endpoint is unreachable. Callers layer per-app
+        credential availability on top (from env inspection).
         """
         if not self.enabled():
             return []
         try:
             with self._client() as c:
-                resp = c.get('/api/v1/providers')
+                resp = c.get('/api/v1/oauth/providers')
                 resp.raise_for_status()
                 data = resp.json()
                 if isinstance(data, list):
@@ -79,41 +124,48 @@ class WearablesClient:
                     return data['providers']
         except Exception as exc:
             logger.info(
-                'Open Wearables /api/v1/providers unavailable (%s); '
+                'Open Wearables /api/v1/oauth/providers unavailable (%s); '
                 'returning static list', exc,
             )
-        # Static fallback — what Open Wearables supports today.
-        return [
-            {'name': n}
-            for n in (
-                'garmin', 'oura', 'polar', 'suunto',
-                'whoop', 'fitbit', 'strava', 'ultrahuman',
-            )
-        ]
+        return [{'name': n} for n in _STATIC_PROVIDERS]
 
     # -- OAuth kickoff ------------------------------------------------------
 
-    def oauth_kickoff_url(
+    def oauth_authorize_url(
         self,
         provider: str,
         *,
         ow_user_id: str,
-        callback_url: str,
-        state: str,
-    ) -> str:
-        """
-        Build the URL the patient should be redirected to in order to start
-        an OAuth handshake with the given provider. Open Wearables hosts the
-        redirect targets itself.
-        """
-        from urllib.parse import urlencode
+        redirect_uri: str | None = None,
+    ) -> str | None:
+        """Ask Open Wearables for the URL to redirect the patient to.
 
-        qs = urlencode({
-            'user_id': ow_user_id,
-            'redirect_uri': callback_url,
-            'state': state,
-        })
-        return f'{self.base_url}/api/v1/providers/{provider}/connect?{qs}'
+        Hits GET /api/v1/oauth/{provider}/authorize?user_id=...&redirect_uri=...
+        which returns JSON `{auth_url, state}`. NOTE: that endpoint is guarded
+        by developer-session auth upstream, so this call will 401 with only an
+        API key — see the module docstring. Returns the auth_url on success,
+        None otherwise (caller surfaces a "not configured" state).
+        """
+        if not self.enabled():
+            return None
+        params: dict[str, Any] = {'user_id': ow_user_id}
+        if redirect_uri:
+            params['redirect_uri'] = redirect_uri
+        try:
+            with self._client() as c:
+                resp = c.get(
+                    f'/api/v1/oauth/{provider}/authorize', params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception as exc:
+            logger.warning(
+                'Open Wearables authorize for %s failed (%s) — likely the '
+                'developer-auth requirement; see client docstring', provider, exc,
+            )
+            return None
+        if isinstance(data, dict):
+            return data.get('auth_url') or data.get('url')
+        return None
 
     # -- delta fetch --------------------------------------------------------
 
@@ -125,34 +177,93 @@ class WearablesClient:
         since: datetime | None,
         limit: int = 200,
     ) -> list[dict[str, Any]]:
-        """
-        Fetch new samples for an Open Wearables user since `since`.
+        """Fetch new timeseries samples for an Open Wearables user since `since`.
 
-        Returns a list of raw sample dicts. Empty list on no new data.
-        Raises on non-recoverable errors so the caller can mark the sync
-        status appropriately.
+        Hits GET /api/v1/users/{user_id}/timeseries (required start_time/
+        end_time, repeated `types`, capped `limit`) and normalizes each
+        `TimeSeriesSample` (`type`/`timestamp`) into the shape the mapper
+        expects (`kind`/`recorded_at`), applying the SeriesType alias table.
+
+        Sleep sessions are a *separate* Open Wearables surface
+        (`/events/sleep`) and are not returned here — see fetch_sleep_sessions.
+        Empty list on no new data. Raises on non-recoverable HTTP errors so the
+        caller can mark the sync status.
         """
         if not self.enabled():
             return []
 
-        params: dict[str, Any] = {
-            'user_id': ow_user_id,
-            'provider': provider,
-            'limit': limit,
-        }
-        if since is not None:
-            # Open Wearables expects ISO 8601 UTC
-            if since.tzinfo is None:
-                since = since.replace(tzinfo=timezone.utc)
-            params['since'] = since.isoformat()
+        end = datetime.now(timezone.utc)
+        start = since if since is not None else end.replace(
+            year=end.year - 1)
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+
+        # Open Wearables caps limit at 100 per call.
+        params = [
+            ('start_time', start.isoformat()),
+            ('end_time', end.isoformat()),
+            ('limit', str(min(limit, 100))),
+        ]
+        params += [('types', s) for s in _WANTED_SERIES]
 
         with self._client() as c:
-            resp = c.get('/api/v1/samples', params=params)
+            resp = c.get(
+                f'/api/v1/users/{ow_user_id}/timeseries', params=params)
             resp.raise_for_status()
             data = resp.json()
 
+        raw = data if isinstance(data, list) else (
+            data.get('data') or data.get('items') or []
+            if isinstance(data, dict) else []
+        )
+        return [self._normalize_sample(s, provider) for s in raw
+                if isinstance(s, dict)]
+
+    def fetch_sleep_sessions(
+        self,
+        *,
+        ow_user_id: str,
+        since: datetime | None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Fetch sleep sessions (including naps) for an Open Wearables user.
+
+        Hits GET /api/v1/users/{user_id}/events/sleep and returns the raw
+        `SleepSession` dicts (`start_time`, `end_time`, `is_nap`, ...) for
+        r6.wearables.mapper.sleep_session_to_observation. Sleep is an event
+        record, never a timeseries sample.
+        """
+        if not self.enabled():
+            return []
+        end = datetime.now(timezone.utc)
+        start = since if since is not None else end.replace(year=end.year - 1)
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+        params = {
+            'start_time': start.isoformat(),
+            'end_time': end.isoformat(),
+            'limit': min(limit, 100),
+        }
+        with self._client() as c:
+            resp = c.get(
+                f'/api/v1/users/{ow_user_id}/events/sleep', params=params)
+            resp.raise_for_status()
+            data = resp.json()
         if isinstance(data, list):
             return data
-        if isinstance(data, dict) and isinstance(data.get('samples'), list):
-            return data['samples']
+        if isinstance(data, dict):
+            return data.get('data') or data.get('items') or []
         return []
+
+    @staticmethod
+    def _normalize_sample(sample: dict[str, Any], provider: str) -> dict[str, Any]:
+        """Map an Open Wearables TimeSeriesSample to the mapper's input shape."""
+        series = sample.get('type')
+        return {
+            'kind': _SERIES_TO_METRIC.get(series, series),
+            'value': sample.get('value'),
+            'unit': sample.get('unit'),
+            'recorded_at': sample.get('timestamp'),
+            'provider': provider,
+            'sample_id': sample.get('id'),
+        }

--- a/r6/wearables/routes.py
+++ b/r6/wearables/routes.py
@@ -13,7 +13,6 @@ import hmac
 import json
 import logging
 import os
-import secrets
 import time
 from datetime import datetime, timezone
 
@@ -135,22 +134,24 @@ def oauth_start():
     # the same patient can hold multiple provider connections.
     ow_user_id = f'hc-{tenant_id}'
 
-    state = _sign_state({
-        'tenant_id': tenant_id,
-        'provider': provider,
-        'ow_user_id': ow_user_id,
-        'nonce': secrets.token_hex(8),
-        'exp': int(time.time()) + _STATE_TTL_SECONDS,
-    })
-
     base = request.host_url.rstrip('/')
     callback_url = f'{base}/wearables/oauth/callback'
-    kickoff = wc.oauth_kickoff_url(
+    # NOTE: Open Wearables owns the OAuth authorize+callback; its
+    # /oauth/{provider}/authorize returns the redirect URL but is guarded by
+    # developer-session auth (not our API key), so this returns None with only
+    # an API key. Reconciling the full connect flow (who holds developer auth,
+    # whose callback runs) is an open integration decision — see client.py.
+    kickoff = wc.oauth_authorize_url(
         provider,
         ow_user_id=ow_user_id,
-        callback_url=callback_url,
-        state=state,
+        redirect_uri=callback_url,
     )
+    if not kickoff:
+        return jsonify({
+            'error': 'wearables connect is not available on this deployment',
+            'detail': 'Open Wearables authorize requires developer-session '
+                      'auth; the connect flow needs integration wiring.',
+        }), 503
     return redirect(kickoff, code=302)
 
 

--- a/tests/test_wearables.py
+++ b/tests/test_wearables.py
@@ -132,6 +132,101 @@ class TestSamplesToBundle:
         assert len(bundle['entry']) == 2
 
 
+class TestWearablesClientOWApi:
+    """The client must target Open Wearables' real API surface (reconciled
+    against 0.6.3 source): X-Open-Wearables-API-Key auth and the real paths.
+
+    HTTP is mocked with httpx.MockTransport — no live instance is contacted.
+    """
+
+    def _client(self, handler):
+        import httpx
+
+        from r6.wearables.client import WearablesClient
+        wc = WearablesClient(base_url='https://ow.test', api_key='k-123')
+        wc._client = lambda: httpx.Client(  # type: ignore[method-assign]
+            base_url='https://ow.test',
+            transport=httpx.MockTransport(handler),
+            headers=wc._headers())
+        return wc
+
+    def test_uses_x_open_wearables_api_key_header(self):
+        seen = {}
+
+        def handler(request):
+            import httpx
+            seen['auth'] = request.headers.get('X-Open-Wearables-API-Key')
+            seen['bearer'] = request.headers.get('Authorization')
+            return httpx.Response(200, json=[])
+        self._client(handler).list_providers()
+        assert seen['auth'] == 'k-123'
+        assert seen['bearer'] is None  # not Bearer
+
+    def test_list_providers_hits_oauth_providers(self):
+        seen = {}
+
+        def handler(request):
+            import httpx
+            seen['path'] = request.url.path
+            return httpx.Response(200, json=[{'name': 'oura'}])
+        out = self._client(handler).list_providers()
+        assert seen['path'] == '/api/v1/oauth/providers'
+        assert out == [{'name': 'oura'}]
+
+    def test_fetch_deltas_hits_timeseries_and_normalizes(self):
+        seen = {}
+
+        def handler(request):
+            import httpx
+            seen['path'] = request.url.path
+            seen['types'] = request.url.params.get_list('types')
+            return httpx.Response(200, json=[
+                {'type': 'oxygen_saturation', 'value': 98, 'unit': '%',
+                 'timestamp': '2026-07-15T10:00:00Z', 'id': 's1'},
+                {'type': 'heart_rate', 'value': 61, 'unit': 'bpm',
+                 'timestamp': '2026-07-15T10:01:00Z', 'id': 's2'},
+            ])
+        out = self._client(handler).fetch_deltas(
+            ow_user_id='u1', provider='oura', since=None, limit=200)
+        assert seen['path'] == '/api/v1/users/u1/timeseries'
+        assert 'oxygen_saturation' in seen['types']
+        # SeriesType aliased to our METRIC_MAP key; timestamp -> recorded_at
+        assert out[0]['kind'] == 'spo2'
+        assert out[0]['recorded_at'] == '2026-07-15T10:00:00Z'
+        assert out[0]['value'] == 98 and out[0]['sample_id'] == 's1'
+        assert out[1]['kind'] == 'heart_rate'
+
+    def test_fetch_sleep_sessions_hits_events_sleep(self):
+        seen = {}
+
+        def handler(request):
+            import httpx
+            seen['path'] = request.url.path
+            return httpx.Response(200, json=[{'id': 'z', 'is_nap': True}])
+        out = self._client(handler).fetch_sleep_sessions(
+            ow_user_id='u1', since=None)
+        assert seen['path'] == '/api/v1/users/u1/events/sleep'
+        assert out == [{'id': 'z', 'is_nap': True}]
+
+    def test_oauth_authorize_url_returns_auth_url(self):
+        def handler(request):
+            import httpx
+            assert request.url.path == '/api/v1/oauth/oura/authorize'
+            return httpx.Response(200, json={'auth_url': 'https://oura/x',
+                                             'state': 'abc'})
+        url = self._client(handler).oauth_authorize_url(
+            'oura', ow_user_id='u1', redirect_uri='https://cb')
+        assert url == 'https://oura/x'
+
+    def test_oauth_authorize_url_none_on_developer_auth_401(self):
+        def handler(request):
+            import httpx
+            return httpx.Response(401, json={'detail': 'developer auth'})
+        url = self._client(handler).oauth_authorize_url(
+            'oura', ow_user_id='u1')
+        assert url is None  # surfaces as "not configured", not a crash
+
+
 # ─────────────────────────────────────────────
 # Model tests
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Our wearables client was built against an API that **doesn't exist** in Open Wearables. Reconciled against `the-momentum/open-wearables` @ 0.6.3 **source**.

## The mismatch (verified in their source)
| Our client (before) | Open Wearables actually exposes |
|---|---|
| `Authorization: Bearer <key>` | **`X-Open-Wearables-API-Key`** header (`utils/auth.py`) |
| `GET /api/v1/providers` | `GET /api/v1/oauth/providers` |
| `GET /api/v1/samples?since=` | `GET /api/v1/users/{id}/timeseries` (required `start_time`/`end_time`, repeated `types`, `limit`≤100) |
| — (no sleep) | `GET /api/v1/users/{id}/events/sleep` (naps live here) |
| `GET /api/v1/providers/{p}/connect` | `GET /api/v1/oauth/{p}/authorize` → `{auth_url, state}` |

So the connector could never have worked against a live instance.

## What this does
- Correct auth header + real endpoint paths.
- `fetch_deltas` now reads the timeseries endpoint and **normalizes** each `TimeSeriesSample` (`type`/`timestamp`) into the mapper's `kind`/`recorded_at` shape via a `SeriesType` alias table (`oxygen_saturation`→`spo2`, `heart_rate_variability_sdnn`→`heart_rate_variability`, `weight`→`body_weight`) — **the mapper and its 35 tests stay untouched** (blast radius bounded at the client boundary).
- Adds `fetch_sleep_sessions` for the sleep/nap feed.
- New client tests use `httpx.MockTransport` (no network) asserting the header, paths, and normalization. Full `tests/test_wearables.py` green (35); ruff clean.

## Honest limits (also in the client docstring)
- **NOT verified against a live Open Wearables instance** — transcribed from source, unit-tested with mocked HTTP only.
- **OAuth connect flow needs an integration decision, not just this swap:** OW's `/oauth/{provider}/authorize` is guarded by **developer-session auth** (not the API key we hold), requires a pre-created OW `user_id`, and **OW owns its own OAuth callback** — whereas our `/wearables/oauth/callback` signs its own state. Who holds developer auth and whose callback runs is an open design question. `oauth_authorize_url` is implemented to the documented shape and returns `None` (→ 503) rather than guessing.
- **Wiring `fetch_sleep_sessions` into the poller** depends on the nap mapper (#126); separate follow-up.

Related: nap mapper #126, connector spec #125, upstream Apple-nap issue the-momentum/open-wearables#1312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)