### PR TITLE
fix(security): email login code brute-force → account takeover (CareAgents)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import secrets
 import time
 from contextlib import contextmanager
@@ -24,6 +25,10 @@ from careagents.models import (Account, Agent, Connection, EmailToken, Passkey,
                                Surface, make_engine, make_session_factory, now)
 
 CODE_TTL = 600  # 10 minutes
+MAX_CODE_ATTEMPTS = 5   # burn a login code after this many wrong guesses
+RESEND_COOLDOWN = 30    # seconds — don't mint a fresh code (or reset attempts)
+                        # while a recent one is still in flight
+CODE_MAX = 100_000_000  # 8-digit codes (~26.6 bits)
 
 
 class AuthError(RuntimeError):
@@ -58,8 +63,23 @@ class AccountService:
         email = email.strip().lower()
         if "@" not in email or len(email) > 255:
             raise AuthError("Enter a valid email address.")
-        code = f"{secrets.randbelow(1_000_000):06d}"
+        code = None
         with self.session() as s:
+            # If a code was minted very recently, don't send another — this
+            # both avoids code-spam and stops an attacker from resetting the
+            # per-code attempt counter by re-requesting.
+            recent = (s.query(EmailToken)
+                      .filter_by(email=email, used=False)
+                      .filter(EmailToken.exp >= now())
+                      .order_by(EmailToken.exp.desc()).first())
+            if recent is not None and (recent.exp - now()) > (
+                    CODE_TTL - RESEND_COOLDOWN):
+                return
+            # One live code at a time: retire any prior unused codes so an
+            # attacker can't accumulate many simultaneously-valid guesses.
+            s.query(EmailToken).filter_by(
+                email=email, used=False).update({"used": True})
+            code = f"{secrets.randbelow(CODE_MAX):08d}"
             s.add(EmailToken(email=email, code_hash=self._hash(code),
                              purpose=purpose, exp=now() + CODE_TTL))
         mail.send_code(self.cfg, email, code, purpose)
@@ -67,23 +87,42 @@ class AccountService:
     def verify_email_code(self, email: str, code: str) -> Account:
         email = email.strip().lower()
         code = (code or "").strip()
+        # The session manager rolls back on any exception, so we must NOT raise
+        # inside it — that would undo the attempts increment / burn. Record the
+        # outcome, let the session commit, then raise afterwards.
+        error: str | None = None
+        result: _Row | None = None
         with self.session() as s:
+            # Fetch the single live code by email (not by hash) so a wrong
+            # guess is counted against it and the code can be burned.
             tok = (s.query(EmailToken)
-                   .filter_by(email=email, code_hash=self._hash(code),
-                              used=False)
+                   .filter_by(email=email, used=False)
+                   .filter(EmailToken.exp >= time.time())
                    .order_by(EmailToken.exp.desc()).first())
-            if not tok or tok.exp < time.time():
-                raise AuthError("That code is wrong or expired.")
-            tok.used = True
-            acct = s.query(Account).filter_by(email=email).first()
-            if acct is None:
-                acct = Account(email=email, email_verified_at=now())
-                s.add(acct)
-            elif acct.email_verified_at is None:
-                acct.email_verified_at = now()
-            acct.last_login_at = now()
-            s.flush()
-            return _detach(acct)
+            if tok is None:
+                error = "That code is wrong or expired."
+            elif (tok.attempts or 0) >= MAX_CODE_ATTEMPTS:
+                tok.used = True
+                error = "Too many attempts — request a new code."
+            elif not hmac.compare_digest(tok.code_hash, self._hash(code)):
+                tok.attempts = (tok.attempts or 0) + 1
+                if tok.attempts >= MAX_CODE_ATTEMPTS:
+                    tok.used = True
+                error = "That code is wrong or expired."
+            else:
+                tok.used = True
+                acct = s.query(Account).filter_by(email=email).first()
+                if acct is None:
+                    acct = Account(email=email, email_verified_at=now())
+                    s.add(acct)
+                elif acct.email_verified_at is None:
+                    acct.email_verified_at = now()
+                acct.last_login_at = now()
+                s.flush()
+                result = _detach(acct)
+        if error:
+            raise AuthError(error)
+        return result
 
     def get_account(self, account_id: str) -> Account | None:
         with self.session() as s:

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -15,7 +15,7 @@ import secrets
 import time
 
 from sqlalchemy import (Boolean, Column, Float, ForeignKey, Integer,
-                        LargeBinary, String, create_engine)
+                        LargeBinary, String, create_engine, inspect, text)
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
 
 
@@ -108,12 +108,34 @@ class EmailToken(Base):
     purpose = Column(String(16), default="verify")
     exp = Column(Float, nullable=False)
     used = Column(Boolean, default=False)
+    # Failed-guess counter so a login code can be burned after a few misses
+    # (anti-brute-force). See AccountService.verify_email_code.
+    attempts = Column(Integer, default=0)
+
+
+def _ensure_columns(engine) -> None:
+    """Idempotently add columns introduced after a table first shipped.
+
+    create_all() only creates missing tables, never new columns on an existing
+    one — so the live SQLite DB needs this for `attempts`. SQLite and Postgres
+    both support ADD COLUMN ... DEFAULT.
+    """
+    insp = inspect(engine)
+    if "ca_email_tokens" not in insp.get_table_names():
+        return
+    cols = {c["name"] for c in insp.get_columns("ca_email_tokens")}
+    if "attempts" not in cols:
+        with engine.begin() as conn:
+            conn.execute(text(
+                "ALTER TABLE ca_email_tokens ADD COLUMN attempts INTEGER "
+                "DEFAULT 0"))
 
 
 def make_engine(url: str):
     connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
     engine = create_engine(url, connect_args=connect_args, future=True)
     Base.metadata.create_all(engine)
+    _ensure_columns(engine)
     return engine
 
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -171,6 +171,54 @@ def test_wrong_email_code_rejected(app, svc, monkeypatch):
     assert r.status_code == 400
 
 
+def test_email_code_burns_after_max_attempts(svc, monkeypatch):
+    """Anti-brute-force: a login code is burned after MAX_CODE_ATTEMPTS wrong
+    guesses — even the correct code no longer works afterwards."""
+    from careagents.accounts import MAX_CODE_ATTEMPTS, AuthError
+    import careagents.mail as mailmod
+    cap = {}
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: cap.__setitem__("c", code))
+    svc.start_email_code("brute@example.com")
+    real = cap["c"]
+    assert len(real) == 8  # higher entropy than 6 digits
+    for _ in range(MAX_CODE_ATTEMPTS):
+        with pytest.raises(AuthError):
+            svc.verify_email_code("brute@example.com", "00000001")
+    with pytest.raises(AuthError):  # correct code is now burned
+        svc.verify_email_code("brute@example.com", real)
+
+
+def test_email_resend_invalidates_prior_code(svc, monkeypatch):
+    """One live code at a time: a fresh send retires the previous code so an
+    attacker can't accumulate many simultaneously-valid guesses."""
+    from careagents.accounts import AuthError
+    import careagents.mail as mailmod
+    codes = []
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: codes.append(code))
+    monkeypatch.setattr("careagents.accounts.RESEND_COOLDOWN", 0)  # skip cooldown
+    svc.start_email_code("rotate@example.com")
+    first = codes[-1]
+    svc.start_email_code("rotate@example.com")
+    second = codes[-1]
+    with pytest.raises(AuthError):  # the old code was invalidated
+        svc.verify_email_code("rotate@example.com", first)
+    acct = svc.verify_email_code("rotate@example.com", second)
+    assert acct.email == "rotate@example.com"
+
+
+def test_email_resend_cooldown_suppresses_duplicate_send(svc, monkeypatch):
+    """Within the cooldown a repeat request does not mint/send a new code."""
+    import careagents.mail as mailmod
+    codes = []
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: codes.append(code))
+    svc.start_email_code("cool@example.com")
+    svc.start_email_code("cool@example.com")  # within cooldown → suppressed
+    assert len(codes) == 1
+
+
 def test_gated_pages_redirect_or_401_without_session(app):
     c = app.test_client()
     assert c.get("/home").status_code == 302


### PR DESCRIPTION
**Security review finding — HIGH, confirmed 9/10.** Unauthenticated account takeover via the CareAgents email login code. The vulnerable code is live at careagents.cloud.

## The vulnerability
- Login code was a **6-digit** value (`secrets.randbelow(1_000_000)`) with a 10-min TTL.
- **No attempt cap / lockout** on the unauthenticated `/api/auth/verify`.
- `start_email_code` (also unauthenticated) minted a **new** `EmailToken` on every call and **never invalidated prior ones** — so K sends left K simultaneously-valid codes, amplifying each guess's success to ≈ K/1,000,000.
- On a matching guess the server sets `session["account_id"]` and the attacker is logged in **as the victim's existing account** — controlling their connections, agents, Telegram surfaces, and the credential-injecting **review relay** for their HealthClaw tenants.

This is broken-auth *logic* (CWE-307 + no OTP-lifecycle invalidation + low entropy), not merely missing rate-limiting.

## The fix (coordinated, not just a limiter)
- **Single live code:** `start_email_code` retires prior unused codes before minting.
- **Per-code attempt cap:** new `EmailToken.attempts`; `verify_email_code` burns the code after **5** wrong guesses. Mutations are committed *then* the error is raised — the session manager rolls back on exception, which would otherwise undo the increment (caught by a test).
- **Resend cooldown (30s):** so the attempt counter can't be reset by re-requesting.
- **Higher entropy:** 8-digit codes (~26.6 bits).
- **Constant-time compare** (`hmac.compare_digest`).
- **Live-DB migration:** `models._ensure_columns` idempotently `ALTER TABLE ADD COLUMN attempts` (create_all never alters existing tables).

## What the review cleared (no change needed)
WebAuthn (challenge bound to server session, rp_id/origin pinned, signature verified vs stored key), cross-account authorization scoping, the Telegram `/bind` mint-secret gate, agent-cannot-self-approve, template/DOM XSS (Jinja autoescape + `textContent`), SSRF/path-traversal/SQLi, and secret handling.

## Tests
Burn-after-cap, resend-invalidates-prior, cooldown-suppresses-duplicate. Full suite green (**1414 passed**).

> Stacked on #120 (which carries the vulnerable code; #121 already merged). **This should ship to careagents.cloud promptly** given it's a live ATO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)