### PR TITLE
fix(security): validate Fasten download host by URL, not substring (CodeQL HIGH)

### DIFF
--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -17,6 +17,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import httpx
 
@@ -28,6 +29,26 @@ logger = logging.getLogger(__name__)
 
 _PROGRESS_BATCH = 10  # commit progress every N resources (observability)
 _DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0)
+
+
+def _is_fasten_download_host(url: str) -> bool:
+    """True only when *url* is an https link whose host is fastenhealth.com or
+    a subdomain of it.
+
+    The Fasten private key is attached as Basic auth for the download hop, so
+    the host must be validated exactly — a substring check (`'fastenhealth.com'
+    in url`) would send the credentials to a look-alike host such as
+    ``https://evil.com/fastenhealth.com`` or ``https://fastenhealth.com.evil.com/``.
+    Requiring https also stops the key from ever going over cleartext.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme != 'https':
+        return False
+    host = (parsed.hostname or '').lower()
+    return host == 'fastenhealth.com' or host.endswith('.fastenhealth.com')
 
 # Clinical types eligible for automatic Curatr scan after ingestion
 _CURATR_ELIGIBLE = frozenset({
@@ -68,7 +89,7 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
                 _auth = None
                 _pub = os.environ.get('FASTEN_PUBLIC_KEY', '').strip()
                 _priv = os.environ.get('FASTEN_PRIVATE_KEY', '').strip()
-                if _pub and _priv and 'fastenhealth.com' in url:
+                if _pub and _priv and _is_fasten_download_host(url):
                     _auth = (_pub, _priv)
                 with httpx.stream(
                     'GET', url, timeout=_DOWNLOAD_TIMEOUT,

--- a/tests/test_fasten_download_host.py
+++ b/tests/test_fasten_download_host.py
@@ -1,0 +1,38 @@
+"""The Fasten private key is attached as Basic auth only for the real Fasten
+download host — never a look-alike. Guards CodeQL py/incomplete-url-substring-
+sanitization at r6/fasten/ingester.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from r6.fasten.ingester import _is_fasten_download_host
+
+
+@pytest.mark.parametrize("url", [
+    "https://fastenhealth.com/export/abc.ndjson",
+    "https://api.fastenhealth.com/v1/download/xyz",
+    "https://connect.fastenhealth.com/files/1",
+])
+def test_real_fasten_hosts_get_credentials(url):
+    assert _is_fasten_download_host(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    # substring / look-alike hosts that the old `'fastenhealth.com' in url`
+    # check would have wrongly trusted with the private key
+    "https://evil.com/fastenhealth.com",
+    "https://fastenhealth.com.evil.com/export",
+    "https://evil.com/?redir=fastenhealth.com",
+    "https://notfastenhealth.com/export",
+    "https://fastenhealth.com.attacker.io/x",
+    # cleartext must never carry Basic-auth credentials
+    "http://fastenhealth.com/export",
+    # malformed / empty
+    "not a url",
+    "",
+    "ftp://fastenhealth.com/x",
+])
+def test_lookalike_and_cleartext_hosts_are_rejected(url):
+    assert _is_fasten_download_host(url) is False


### PR DESCRIPTION
Closes a **CodeQL HIGH** (`py/incomplete-url-substring-sanitization`) surfaced by the security scan on the merge queue.

## Finding
`r6/fasten/ingester.py` gated attaching the **Fasten private key** (Basic auth) on `'fastenhealth.com' in url` — a substring test. A look-alike download link would receive the credentials:
- `https://evil.com/fastenhealth.com`
- `https://fastenhealth.com.evil.com/export`
- `http://fastenhealth.com/...` (cleartext — key over the wire)

Download links arrive from the **HMAC-verified** `patient.export_success` webhook, so exploitation requires that trust to fail — this is defense-in-depth — but a private key must never hinge on a substring.

## Fix
`_is_fasten_download_host(url)` parses the URL and attaches credentials only when the **host is exactly `fastenhealth.com` or a subdomain** *and* the scheme is **https** (so the key can't cross cleartext). Malformed URLs → rejected.

## Tests
`tests/test_fasten_download_host.py` — real hosts trusted; look-alike/substring, cleartext, and malformed URLs rejected. ruff clean.

## Note on the other CodeQL alerts (reported, not in this PR)
- `py/stack-trace-exposure` (MEDIUM ×4: r6/routes.py, app.py:444, command_center) — error detail in responses.
- `actions/missing-workflow-permissions` (MEDIUM ×~12: .github/workflows) — add explicit least-privilege `permissions:`.
- The `tests/test_security_hardening.py:190` substring hit is a test assertion (false positive).

All pre-existing; happy to follow up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)