### PR TITLE
feat(careagents): iMessage surface — text your agent (closes #135 #136 #137)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -259,10 +259,21 @@ class AccountService:
             s.flush()
             return x.id
 
-    def find_surface_by_code(self, code: str) -> dict | None:
+    def find_surface_by_code(self, code: str,
+                             kind: str = "telegram") -> dict | None:
         with self.session() as s:
             x = (s.query(Surface)
-                 .filter_by(handle=code, kind="telegram", status="pending")
+                 .filter_by(handle=code, kind=kind, status="pending")
+                 .first())
+            return _surf_dict(x) | {"account_id": x.account_id} if x else None
+
+    def find_surface_by_handle(self, handle: str,
+                               kind: str = "imessage") -> dict | None:
+        """Resolve an active surface by the bound external handle — used to
+        route an inbound message to the right agent."""
+        with self.session() as s:
+            x = (s.query(Surface)
+                 .filter_by(handle=handle, kind=kind, status="active")
                  .first())
             return _surf_dict(x) | {"account_id": x.account_id} if x else None
 

--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -183,3 +183,34 @@ def run_turn(cfg, hc: HealthClawClient, tenant: str, system: str,
             history.append({"role": "user", "content": (
                 "(system: tool budget reached — answer now with what you "
                 "have)")})
+
+
+def run_turn_to_message(cfg, hc: HealthClawClient, tenant: str, system: str,
+                        history: list[dict], user_text: str,
+                        *, origin: str = "", agent_id: str = "") -> str:
+    """Run one turn and collapse the streamed UI events into a single plain
+    reply, for non-streaming surfaces (SMS / iMessage).
+
+    Review and PDF cards become links back to the web app — the human approval
+    gate always lives there, never inline in the message thread.
+    """
+    parts: list[str] = []
+    extras: list[str] = []
+    base = (origin or "").rstrip("/")
+    for ev in run_turn(cfg, hc, tenant, system, history, user_text):
+        kind = ev.get("type")
+        if kind == "text" and ev.get("text"):
+            parts.append(ev["text"])
+        elif kind == "error":
+            return ev.get("text") or "Something went wrong on our side."
+        elif kind == "card" and ev.get("kind") == "review":
+            aid = ev.get("action_id", "")
+            link = (f"{base}/review/{agent_id}/{aid}"
+                    if base and agent_id and aid else "")
+            extras.append(
+                "I've prepared a form for your review — approve each item "
+                + (f"here: {link}" if link else "in the CareAgents app."))
+        elif kind == "card" and ev.get("kind") == "pdf" and ev.get("url"):
+            extras.append(f"Your signed document is ready: {ev['url']}")
+    reply = "\n\n".join([*parts, *extras]).strip()
+    return reply or "…"

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -21,7 +21,7 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
 
 from careagents.accounts import (AccountService, AuthError, new_binding_code)
-from careagents.agent import run_turn
+from careagents.agent import run_turn, run_turn_to_message
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
@@ -87,7 +87,8 @@ def create_app(config: Config | None = None,
             "home.html", me=acct, personas=PERSONAS,
             connections=data["connections"], agents=data["agents"],
             surfaces=data["surfaces"], has_passkey=svc.has_passkey(acct.id),
-            telegram_bot=cfg.telegram_bot)
+            telegram_bot=cfg.telegram_bot,
+            imessage_handle=cfg.imessage_handle)
 
     @app.post("/logout")
     def logout():
@@ -380,6 +381,80 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "bind failed"}), 502
         svc.bind_surface(surface["id"], str(chat_id))
         return jsonify({"ok": True})
+
+    # --- iMessage surface ----------------------------------------------------
+    # Unlike Telegram (driven by the OpenClaw gateway), careagents runs the
+    # iMessage message loop itself: a Mac-mini relay POSTs inbound texts here
+    # (mint-secret gated) and we return the agent's reply for it to send back.
+
+    @app.post("/api/surfaces/imessage")
+    @login_required
+    def connect_imessage():
+        acct = current_account()
+        body = request.get_json(silent=True) or {}
+        agent_id = body.get("agent_id", "")
+        if not svc.get_agent_context(acct.id, agent_id):
+            return jsonify({"error": "unknown agent"}), 404
+        code = new_binding_code()
+        sid = svc.add_surface(acct.id, agent_id, "imessage", code,
+                              status="pending")
+        return jsonify({"id": sid, "code": code,
+                        "handle": cfg.imessage_handle,
+                        "instructions": (
+                            f"Text  care {code}  to {cfg.imessage_handle}"
+                            if cfg.imessage_handle else
+                            "iMessage isn't configured on this deployment yet.")})
+
+    @app.post("/api/surfaces/imessage/bind")
+    def imessage_bind():
+        """Relay calls this when a user texts `care <code>`: bind the sender's
+        handle to the pending surface. Mint-secret gated (server-to-server)."""
+        if request.headers.get("X-Internal-Secret") != cfg.mint_secret:
+            return jsonify({"error": "forbidden"}), 403
+        body = request.get_json(silent=True) or {}
+        code = str(body.get("code") or "").replace("care_", "").replace(
+            "care ", "").strip()
+        handle = str(body.get("handle") or "").strip()
+        if not handle:
+            return jsonify({"error": "missing handle"}), 400
+        surface = svc.find_surface_by_code(code, kind="imessage")
+        if not surface:
+            return jsonify({"error": "unknown code"}), 404
+        svc.bind_surface(surface["id"], handle)
+        return jsonify({"ok": True})
+
+    @app.post("/api/surfaces/imessage/inbound")
+    def imessage_inbound():
+        """Relay POSTs an inbound message {handle, text}; we route it to the
+        bound agent and return {reply} for the relay to send back."""
+        if request.headers.get("X-Internal-Secret") != cfg.mint_secret:
+            return jsonify({"error": "forbidden"}), 403
+        body = request.get_json(silent=True) or {}
+        handle = str(body.get("handle") or "").strip()
+        text = (body.get("text") or "").strip()
+        surface = svc.find_surface_by_handle(handle, kind="imessage")
+        if not surface:
+            return jsonify({"error": "unbound handle"}), 404
+        ctx = svc.get_agent_context(surface["account_id"], surface["agent_id"])
+        if not ctx:
+            return jsonify({"error": "unknown agent"}), 404
+        if not text or len(text) > 2000:
+            return jsonify({"error": "message must be 1-2000 characters"}), 400
+        if not _allow_turn(surface["account_id"]):
+            return jsonify({"reply": "One moment — too many messages just now. "
+                                     "Try again in a bit."}), 200
+        tenant = ctx["tenant"]
+        agent = ctx["agent"]
+        sysprompt = system_prompt(agent["name"], agent["persona"])
+        with hist_lock:
+            history = histories[tenant]
+        try:
+            reply = run_turn_to_message(cfg, hc, tenant, sysprompt, history,
+                                        text, origin=cfg.origin,
+                                        agent_id=agent["id"])
+        except Exception:  # noqa: BLE001
+            reply = "Something went wrong on our side. Please try again."
+        return jsonify({"reply": reply})
 
     # --- trust + ops ---------------------------------------------------------
 

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -49,6 +49,9 @@ class Config:
         self.fasten_public_key = e.get("FASTEN_PUBLIC_KEY", "")
         # Telegram deep-link target for surface binding.
         self.telegram_bot = e.get("CARE_TELEGRAM_BOT", "")
+        # iMessage handle (phone/email) the Mac-mini relay sends/receives on —
+        # shown to users as "text your agent here". Empty = surface hidden.
+        self.imessage_handle = e.get("CARE_IMESSAGE_HANDLE", "")
         # Secret for minting step-up tokens for careagents' non-public tenants
         # on the HealthClaw layer (X-Internal-Secret). Server-side only.
         self.mint_secret = e.get("HEALTHCLAW_MINT_SECRET", "")

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -95,4 +95,16 @@
     else prompt("Send this code to the CareAgents bot with /start:", res.d.code);
     $("tg-state").textContent = "pending — finish in Telegram";
   });
+
+  // --- iMessage surface ---
+  const im = $("im-surface");
+  if (im) im.addEventListener("click", async () => {
+    const firstAgent = document.querySelector(".agent-card");
+    if (!firstAgent) { alert("Create an agent first, then connect iMessage."); return; }
+    const agentId = new URL(firstAgent.href).searchParams.get("agent");
+    const res = await post("/api/surfaces/imessage", { agent_id: agentId });
+    if (!res.ok) return alert(res.d.error || "Failed");
+    $("im-state").textContent = "pending — text to finish";
+    prompt(res.d.instructions || "Text this code to connect:", "care " + res.d.code);
+  });
 })();

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -72,7 +72,12 @@
       <div class="surface on"><b>Web</b><span>always on</span></div>
       <div class="surface" id="tg-surface"><b>Telegram</b>
         <span id="tg-state">connect →</span></div>
+      {% if imessage_handle %}
+      <div class="surface" id="im-surface"><b>iMessage</b>
+        <span id="im-state">connect →</span></div>
+      {% else %}
       <div class="surface soon"><b>iMessage</b><span>coming soon</span></div>
+      {% endif %}
       <div class="surface soon"><b>Phone app</b><span>install from browser</span></div>
     </div>
   </section>

--- a/deploy/careagents/deploy.sh
+++ b/deploy/careagents/deploy.sh
@@ -61,6 +61,10 @@ CARE_EMAIL_FROM=CareAgents <login@careagents.cloud>
 FASTEN_PUBLIC_KEY=
 # --- Telegram surface (bot username, no @) ---
 CARE_TELEGRAM_BOT=
+# --- iMessage surface (the handle the Mac-mini relay sends/receives on;
+#     empty = tile hidden). The relay runs deploy/careagents/imessage_relay.py
+#     on the Mac mini with CAREAGENTS_MINT_SECRET=<this mint secret>. ---
+CARE_IMESSAGE_HANDLE=
 
 # Provider: ANTHROPIC_API_KEY (claude-sonnet-5) takes precedence when set.
 # Otherwise the OpenAI-compatible fallback is used — works with OpenAI or,

--- a/deploy/careagents/imessage_relay.py
+++ b/deploy/careagents/imessage_relay.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""CareAgents iMessage relay — runs on the Mac mini, bridges Messages.app to
+CareAgents.
+
+It is a *transport only*: it carries no PHI logic and holds no credentials
+beyond the shared mint secret. Every inbound text is forwarded to CareAgents,
+which resolves the sender's handle to a bound agent, runs the guardrailed turn
+server-side, and returns the reply for this script to send back.
+
+Flow per inbound message:
+  - "care <code>"  → POST /api/surfaces/imessage/bind   {code, handle}
+  - anything else  → POST /api/surfaces/imessage/inbound {handle, text} → reply
+
+Requires macOS **Full Disk Access** for the interpreter (to read
+~/Library/Messages/chat.db) and Automation permission for Messages.
+
+Env:
+  CAREAGENTS_BASE      default https://careagents.cloud
+  CAREAGENTS_MINT_SECRET   the HEALTHCLAW_MINT_SECRET (X-Internal-Secret)  [required]
+  IMESSAGE_POLL_SECONDS    default 3
+  IMESSAGE_STATE_FILE      default ~/.careagents-imessage-relay.json
+
+Run under launchd/systemd-equivalent (a keepalive LaunchAgent). Not imported by
+the CareAgents app.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+BASE = os.environ.get("CAREAGENTS_BASE", "https://careagents.cloud").rstrip("/")
+SECRET = os.environ.get("CAREAGENTS_MINT_SECRET", "")
+POLL = float(os.environ.get("IMESSAGE_POLL_SECONDS", "3"))
+STATE_FILE = Path(os.environ.get(
+    "IMESSAGE_STATE_FILE",
+    str(Path.home() / ".careagents-imessage-relay.json")))
+CHAT_DB = Path.home() / "Library" / "Messages" / "chat.db"
+HTTP_TIMEOUT = 60  # a turn can take a while (LLM + tools)
+
+
+def _post(path: str, payload: dict) -> dict:
+    req = urllib.request.Request(
+        f"{BASE}{path}", method="POST",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json",
+                 "X-Internal-Secret": SECRET})
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:200]
+        print(f"[relay] {path} HTTP {exc.code}: {body}", file=sys.stderr)
+    except Exception as exc:  # network, timeout, JSON
+        print(f"[relay] {path} failed: {type(exc).__name__}", file=sys.stderr)
+    return {}
+
+
+def _send_imessage(handle: str, text: str) -> None:
+    """Send `text` to `handle` via Messages.app (AppleScript)."""
+    script = (
+        'on run {targetHandle, msg}\n'
+        '  tell application "Messages"\n'
+        '    set svc to 1st service whose service type = iMessage\n'
+        '    send msg to buddy targetHandle of svc\n'
+        '  end tell\n'
+        'end run')
+    try:
+        subprocess.run(["osascript", "-e", script, handle, text],
+                       check=True, capture_output=True, timeout=30)
+    except subprocess.CalledProcessError as exc:
+        print(f"[relay] send to {handle} failed: "
+              f"{exc.stderr.decode(errors='replace')[:200]}", file=sys.stderr)
+    except Exception as exc:
+        print(f"[relay] send error: {type(exc).__name__}", file=sys.stderr)
+
+
+def _load_last_rowid() -> int:
+    try:
+        return int(json.loads(STATE_FILE.read_text()).get("last_rowid", 0))
+    except Exception:
+        return 0
+
+
+def _save_last_rowid(rowid: int) -> None:
+    try:
+        STATE_FILE.write_text(json.dumps({"last_rowid": rowid}))
+    except Exception as exc:
+        print(f"[relay] state write failed: {type(exc).__name__}",
+              file=sys.stderr)
+
+
+def _new_inbound(last_rowid: int) -> list[tuple[int, str, str]]:
+    """Return (rowid, handle, text) for inbound messages after last_rowid.
+
+    Reads chat.db read-only. `text` can be NULL for attachment-only messages;
+    those are skipped. Apple stores some bodies in attributedBody only — we
+    take the plain `text` column and skip rows without it.
+    """
+    uri = f"file:{CHAT_DB}?mode=ro"
+    con = sqlite3.connect(uri, uri=True, timeout=5)
+    try:
+        rows = con.execute(
+            "SELECT m.ROWID, h.id, m.text "
+            "FROM message m JOIN handle h ON m.handle_id = h.ROWID "
+            "WHERE m.ROWID > ? AND m.is_from_me = 0 AND m.text IS NOT NULL "
+            "ORDER BY m.ROWID ASC LIMIT 50",
+            (last_rowid,)).fetchall()
+    finally:
+        con.close()
+    return [(r[0], r[1], r[2]) for r in rows if r[1] and r[2]]
+
+
+def _handle_message(handle: str, text: str) -> None:
+    stripped = text.strip()
+    low = stripped.lower()
+    if low.startswith("care ") or low.startswith("care_"):
+        code = stripped[5:].strip()
+        res = _post("/api/surfaces/imessage/bind",
+                    {"code": code, "handle": handle})
+        if res.get("ok"):
+            _send_imessage(handle, "You're connected — I'm your CareAgent. "
+                                   "Ask me anything about your records.")
+        else:
+            _send_imessage(handle, "That code didn't match. Generate a fresh "
+                                   "one in the CareAgents app and try again.")
+        return
+    res = _post("/api/surfaces/imessage/inbound",
+                {"handle": handle, "text": stripped})
+    reply = res.get("reply")
+    if reply:
+        _send_imessage(handle, reply)
+    # No reply + no error → handle isn't bound; stay silent (don't spam
+    # strangers who text the number).
+
+
+def main() -> int:
+    if not SECRET:
+        print("[relay] CAREAGENTS_MINT_SECRET is required", file=sys.stderr)
+        return 2
+    if not CHAT_DB.exists():
+        print(f"[relay] chat.db not found at {CHAT_DB} — grant Full Disk "
+              "Access to this interpreter", file=sys.stderr)
+        return 2
+    last = _load_last_rowid()
+    if last == 0:
+        # First run: start from the newest row so we don't replay history.
+        con = sqlite3.connect(f"file:{CHAT_DB}?mode=ro", uri=True)
+        last = con.execute("SELECT COALESCE(MAX(ROWID), 0) FROM message"
+                           ).fetchone()[0]
+        con.close()
+        _save_last_rowid(last)
+    print(f"[relay] watching {CHAT_DB} from ROWID {last}; base {BASE}")
+    while True:
+        try:
+            for rowid, handle, text in _new_inbound(last):
+                _handle_message(handle, text)
+                last = rowid
+                _save_last_rowid(last)
+        except Exception as exc:  # keep the loop alive
+            print(f"[relay] poll error: {type(exc).__name__}", file=sys.stderr)
+        time.sleep(POLL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -107,7 +107,8 @@ def cfg():
                        "OPENAI_API_KEY": "k",
                        "HEALTHCLAW_MINT_SECRET": "mint-secret",
                        "FASTEN_PUBLIC_KEY": "pub123",
-                       "CARE_TELEGRAM_BOT": "carebot"})
+                       "CARE_TELEGRAM_BOT": "carebot",
+                       "CARE_IMESSAGE_HANDLE": "+15550001111"})
 
 
 @pytest.fixture
@@ -362,6 +363,67 @@ def test_telegram_connect_and_bind_handshake(app, svc, monkeypatch, cfg):
     assert bind.post("/api/surfaces/telegram/bind",
                      json={"code": "care_bogus", "chat_id": 1},
                      headers={"X-Internal-Secret": cfg.mint_secret}).status_code == 404
+
+
+def test_imessage_connect_bind_inbound_flow(app, svc, monkeypatch, cfg):
+    """iMessage runs the message loop in careagents itself: connect (get a
+    code + handle) → relay binds the sender handle → relay forwards an inbound
+    message and gets the agent's reply. Both server-to-server hops are
+    mint-secret gated; the agent turn is faked (no LLM/network)."""
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "Iris", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    r = c.post("/api/surfaces/imessage", json={"agent_id": agent})
+    assert r.status_code == 200
+    body = r.get_json()
+    code = body["code"]
+    assert body["handle"] == "+15550001111" and code in body["instructions"]
+
+    relay = app.test_client()
+    hdrs = {"X-Internal-Secret": cfg.mint_secret}
+    # bind requires the mint secret
+    assert relay.post("/api/surfaces/imessage/bind",
+                      json={"code": code, "handle": "+15559998888"}
+                      ).status_code == 403
+    assert relay.post("/api/surfaces/imessage/bind", headers=hdrs,
+                      json={"code": code, "handle": "+15559998888"}
+                      ).status_code == 200
+    assert relay.post("/api/surfaces/imessage/bind", headers=hdrs,
+                      json={"code": "bogus", "handle": "+1"}
+                      ).status_code == 404
+
+    # inbound: fake the agent turn, assert the reply is relayed back
+    monkeypatch.setattr("careagents.app.run_turn_to_message",
+                        lambda *a, **k: "Your last A1c was 6.1% — in range.")
+    assert relay.post("/api/surfaces/imessage/inbound",
+                      json={"handle": "+15559998888", "text": "how's my a1c?"}
+                      ).status_code == 403  # needs mint secret
+    ok = relay.post("/api/surfaces/imessage/inbound", headers=hdrs,
+                    json={"handle": "+15559998888", "text": "how's my a1c?"})
+    assert ok.status_code == 200
+    assert "6.1%" in ok.get_json()["reply"]
+    # an unbound handle is not routed (don't answer strangers)
+    assert relay.post("/api/surfaces/imessage/inbound", headers=hdrs,
+                      json={"handle": "+1000", "text": "hi"}
+                      ).status_code == 404
+
+
+def test_imessage_reply_collapses_review_card_to_link(monkeypatch, cfg):
+    """run_turn_to_message turns a review card into a link back to the web app
+    (the human approval gate never happens inline in the thread)."""
+    from careagents import agent as agent_mod
+    from careagents.llm import LLMTurn, ToolCall
+    seq = iter([LLMTurn(tool_calls=[ToolCall("1", "start_intake_form", {})]),
+                LLMTurn(text="I've drafted your intake form.")])
+    monkeypatch.setattr(agent_mod.llm, "complete", lambda *a, **k: next(seq))
+    reply = agent_mod.run_turn_to_message(
+        cfg, FakeClient(), "ca-x", "sys", [], "fill my intake form",
+        origin="https://careagents.cloud", agent_id="agent_1")
+    assert "drafted your intake form" in reply
+    assert "https://careagents.cloud/review/agent_1/act-1" in reply
 
 
 # --- agent loop (unchanged contract) -----------------------------------------


### PR DESCRIPTION
The Aug 18 headline (#134): **text your health agent on iMessage.** Implements the surface end-to-end — #135 relay bridge, #136 hub binding + routing, #137 shared reply pipeline.

## How it works
Unlike Telegram (driven by the OpenClaw gateway), CareAgents runs the iMessage loop itself. A **Mac-mini relay** (`deploy/careagents/imessage_relay.py`) polls Messages' `chat.db` read-only, forwards inbound texts to CareAgents, and sends the reply back via AppleScript. It's **transport only** — no PHI logic, no credentials beyond the shared mint secret.

- **`run_turn_to_message()`** (agent.py) collapses the streamed turn into one plain reply for non-streaming surfaces. **Review/PDF cards become links back to the web app** — the human approval gate never happens inline in a text thread.
- **Endpoints:** `POST /api/surfaces/imessage` (login) mints a bind code + shows the handle; `/bind` and `/inbound` are **mint-secret gated** (server-to-server). Inbound resolves `handle → agent → tenant`, runs the guardrailed turn, returns `{reply}`. Account-scoped rate limit reused; **unbound handles 404** (don't answer strangers).
- **Hub:** an iMessage tile (shown only when `CARE_IMESSAGE_HANDLE` is set) with the same connect flow as Telegram.

## Security
Same posture as the rest of CareAgents: all guardrails server-side on HealthClaw; careagents stores only the surface pointer; the mint secret stays server/relay-side. The relay holds no PHI and only the mint secret.

## Tests
`connect → bind → inbound` flow (both hops mint-gated, agent faked, no network) + review-card-collapses-to-link. **Full suite: 1471 passed.**

## Deploy
Set `CARE_IMESSAGE_HANDLE` on careagents.cloud; run `imessage_relay.py` on the Mac mini with `CAREAGENTS_MINT_SECRET=<mint secret>` (needs Full Disk Access + Automation permission for Messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)