### PR TITLE
fix(guardrails): harden error fidelity edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,13 @@ self-tenants internally and returns 200 at Grade A (503 otherwise):
 curl "https://app.healthclaw.io/r6/fhir/\$conformance?format=text"
 ```
 
-All seven properties pass, including error fidelity — the deployment tells an
-agent the truth on the failure paths (unknown search parameters and unsupported
-modifiers are rejected or flagged, never silently swallowed), not just the happy
-path. The same harness runs against the Flask test client as a **CI baseline**
-(`tests/test_guardrail_conformance.py`), so grade movement is explicit rather
-than hidden. `--json` emits a machine-readable report; `--mcp-url` also probes
-MCP `tools/call` error signaling. For an authenticated MCP deployment, set
-`MCP_AUTH_TOKEN` or pass `--mcp-auth-token`. Library API:
+The local FHIR profile is Grade A: unsupported local-search inputs are rejected
+or reported according to `Prefer: handling`, and every failure path is audited.
+The same harness runs against the Flask test client as a **CI baseline**
+(`tests/test_guardrail_conformance.py`). `--json` emits a machine-readable
+report; `--mcp-url` additionally grades MCP `tools/call` error signaling as a
+separate profile. For an authenticated MCP deployment, set `MCP_AUTH_TOKEN` or
+pass `--mcp-auth-token`. Library API:
 `from r6.conformance import LiveProbeClient, ProbeContext, run_conformance`.
 
 ## Install as a Claude Plugin
@@ -327,6 +326,14 @@ cd e2e && npm run test:ui        # interactive UI mode
 | `/r6/fhir/oauth/*` | * | OAuth 2.1 + PKCE + SMART discovery |
 | `/r6/fhir/{type}/{id}/$curatr-evaluate` | GET | Evaluate resource data quality (Curatr) |
 | `/r6/fhir/{type}/{id}/$curatr-apply-fix` | POST | Apply patient-approved fixes with Provenance |
+
+Local search accepts the parameters advertised by `/r6/fhir/metadata`.
+Unknown parameters default to lenient handling (a bounded
+`search.mode="outcome"` warning); `Prefer: handling=strict` returns a 400
+`OperationOutcome`. Unsupported modifiers and malformed supported values always
+return 400. `_count=0` and `_summary=count` are count-only searches. Self links
+contain exactly the applied, URL-encoded parameters, and audit output never
+echoes submitted filter values or arbitrary parameter names.
 
 ## Upstream Proxy
 

--- a/docs/demos/forms-rail-run-of-show.md
+++ b/docs/demos/forms-rail-run-of-show.md
@@ -45,9 +45,8 @@ Green all the way down means the demo is ready to present.
    (Penicillin) so the review page has something to confirm.
 3. Mint a step-up token: `POST /r6/fhir/internal/step-up-token {"tenant_id": "desktop-demo"}`.
 4. Open the guardrail scorecard in a browser tab you can flip to:
-   `GET /r6/fhir/$conformance?format=text` — **Grade A (7/7)**: every guardrail
-   property passes, including Error Fidelity (the deployment tells an agent the
-   truth on the failure paths, not just the happy path).
+   `GET /r6/fhir/$conformance?format=text` — the local FHIR profile should show
+   Grade A, with all seven properties passing.
 
 ## Run of show
 
@@ -60,7 +59,7 @@ Green all the way down means the demo is ready to present.
 | **5. Honest submit** | Confirm the Penicillin allergy (or check NKA if that were true), confirm meds, submit. The review page issues the confirmation. | "Now I attest, item by item. This is the human-in-the-loop, and it's recorded." |
 | **6. Execute** | The out-of-band confirm (`POST /r6/actions/<id>/confirm`) runs `execute()`: reviewed answers → PDF → FHIR `DocumentReference` → signed link. Show the action now `completed` with a `delivery_link`. | "Only *after* I approved does it render anything. No approval, no PDF — it fails closed." |
 | **7. The artifact** | Open the `delivery_link` in a fresh browser (no login, no headers — the signature in the URL is the credential). The PDF opens with the provenance footer: *populated from records by an automated system, reviewed by the patient on <date>.* | "Here's the shareable form. It's stamped with exactly how it was made and that a human reviewed it. That footer is the difference between a document a clinic can trust and one it can't." |
-| **8. Prove it** | Flip to the `$conformance` tab: **Grade A (7/7)** — all seven guardrail properties pass, including error fidelity. | "None of this is 'trust me.' The guardrails grade themselves A–F in CI across all seven properties — redaction, audit, step-up, human-in-the-loop, tenant isolation, disclaimers, and truthful failure paths. This deployment is A. Run it against your own stack and see your grade." |
+| **8. Prove it** | Flip to the `$conformance` tab: Grade A (7/7), including Error Fidelity. | "None of this is 'trust me.' The guardrails grade themselves A–F in CI, including strict rejection, lenient warnings, and their audit evidence." |
 
 ## Fallbacks if something misbehaves
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,10 +92,10 @@ Flask/DB), report builders, and a `register_*_routes` function wired in
   or `apply_patient_controlled_redaction(resource, patient_id)`.
 - The whole set is enforced by the **conformance harness**:
   `tests/test_guardrail_conformance.py` pins the measured CI baseline, and
-  `GET /r6/fhir/$conformance` grades any live deployment. The current baseline
-  is intentionally Grade B (6/7): the in-process error-fidelity profile remains
-  F until the local-search follow-up lands. The optional CLI MCP profile remains
-  C until its separate transport follow-up lands.
+  `GET /r6/fhir/$conformance` grades any live deployment. The in-process local
+  FHIR profile is Grade A (7/7). The optional CLI MCP profile remains a separate
+  grade until its transport follow-up lands; enabling it can therefore lower the
+  combined result without changing the local profile.
 
 ## Deploy notes (maintainers)
 

--- a/docs/quickstarts/README.md
+++ b/docs/quickstarts/README.md
@@ -60,7 +60,8 @@ stack. Everything runs against the synthetic demo tenant.
    > Run the guardrail conformance check and show me the grade.
 
    (Returns a live A–F scorecard proving PHI redaction, audit, step-up,
-   human-in-the-loop, tenant isolation, and disclaimers are all active.)
+   human-in-the-loop, tenant isolation, disclaimers, and error fidelity are
+   active.)
 
 8. **Show that writes are gated**
    > Try to write an observation to the record.

--- a/docs/recipes/healthclaw-in-front-of-aidbox.md
+++ b/docs/recipes/healthclaw-in-front-of-aidbox.md
@@ -87,5 +87,6 @@ curl "$BASE/r6/fhir/\$conformance?format=text"
 Redaction is HIPAA Safe-Harbor-style field redaction (demographics), not Expert
 Determination; validation is structural, not full StructureDefinition/terminology
 conformance. The guardrail *contract* (redact + audit + step-up + human-confirm +
-tenant isolation) is what's demonstrated here — production de-id/validation rigor
-is on the roadmap.
+tenant isolation) is what's demonstrated here; Grade-A error fidelity currently
+applies to local-store search, while proxied-search behavior remains
+upstream-dependent. Production de-id/validation rigor is on the roadmap.

--- a/docs/recipes/healthclaw-in-front-of-healthbankone.md
+++ b/docs/recipes/healthclaw-in-front-of-healthbankone.md
@@ -56,7 +56,7 @@ at the HBO-backed deployment:
 ```bash
 python scripts/guardrail_conformance.py --base-url https://<deployment> \
   --tenant <hbo-tenant> --step-up-token <token>
-# → Current baseline Grade B (6/7): the original six pass; Error Fidelity is F
+# → Local FHIR profile Grade A (7/7), including Error Fidelity
 ```
 
 A partner (or a regulator) can run it on synthetic data and see exactly which

--- a/docs/recipes/healthclaw-in-front-of-medplum.md
+++ b/docs/recipes/healthclaw-in-front-of-medplum.md
@@ -81,5 +81,6 @@ PASS/FAIL per guardrail. See `scripts/smoke_medplum.py` for details.
 Redaction is HIPAA Safe-Harbor-style field redaction (demographics), not Expert
 Determination; validation is structural, not full StructureDefinition/terminology
 conformance. The guardrail *contract* (redact + audit + step-up + human-confirm +
-tenant isolation) is what's demonstrated here — production de-id/validation rigor
-is on the roadmap.
+tenant isolation) is what's demonstrated here; Grade-A error fidelity currently
+applies to local-store search, while proxied-search behavior remains
+upstream-dependent. Production de-id/validation rigor is on the roadmap.

--- a/migrations/versions/0003_audit_outcome_detail.py
+++ b/migrations/versions/0003_audit_outcome_detail.py
@@ -1,0 +1,37 @@
+"""Separate public AuditEvent outcome evidence from internal audit detail.
+
+Revision ID: 0003_audit_outcome_detail
+Revises: 0002_current_contract
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "0003_audit_outcome_detail"
+down_revision = "0002_current_contract"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(name: str) -> bool:
+    return name in {
+        column["name"]
+        for column in inspect(op.get_bind()).get_columns("audit_events")
+    }
+
+
+def upgrade() -> None:
+    # Legacy databases are stamped at 0001 after loading current model
+    # metadata, so they may already have this column when Alembic reaches 0003.
+    if not _has_column("outcome_detail_code"):
+        op.add_column(
+            "audit_events",
+            sa.Column("outcome_detail_code", sa.String(64), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_column("outcome_detail_code"):
+        op.drop_column("audit_events", "outcome_detail_code")

--- a/r6/audit.py
+++ b/r6/audit.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def _new_audit_event(event_type, resource_type=None, resource_id=None,
                      agent_id=None, context_id=None, outcome='success',
-                     detail=None, tenant_id=None):
+                     detail=None, tenant_id=None, outcome_detail_code=None):
     return AuditEventRecord(
         event_type=event_type,
         resource_type=resource_type,
@@ -28,13 +28,14 @@ def _new_audit_event(event_type, resource_type=None, resource_id=None,
             or _hc_get('audit_agent_default', 'healthclaw-guardrails')
         ),
         outcome=outcome,
+        outcome_detail_code=outcome_detail_code,
         detail=detail,
     )
 
 
 def add_audit_event(event_type, resource_type=None, resource_id=None,
                     agent_id=None, context_id=None, outcome='success',
-                    detail=None, tenant_id=None):
+                    detail=None, tenant_id=None, outcome_detail_code=None):
     """Add and flush an AuditEvent inside the caller-owned transaction.
 
     Write paths should use this function before their domain commit so the
@@ -43,7 +44,7 @@ def add_audit_event(event_type, resource_type=None, resource_id=None,
     """
     audit = _new_audit_event(
         event_type, resource_type, resource_id, agent_id, context_id,
-        outcome, detail, tenant_id,
+        outcome, detail, tenant_id, outcome_detail_code,
     )
     db.session.add(audit)
     db.session.flush()
@@ -52,7 +53,7 @@ def add_audit_event(event_type, resource_type=None, resource_id=None,
 
 def record_audit_event(event_type, resource_type=None, resource_id=None,
                        agent_id=None, context_id=None, outcome='success',
-                       detail=None, tenant_id=None):
+                       detail=None, tenant_id=None, outcome_detail_code=None):
     """
     Record an audit event for a FHIR operation.
 
@@ -68,12 +69,13 @@ def record_audit_event(event_type, resource_type=None, resource_id=None,
         outcome: Event outcome (success, failure)
         detail: Additional detail text
         tenant_id: Tenant identifier for isolation
+        outcome_detail_code: Allowlisted public outcome-evidence code
     """
     try:
         nested = db.session.begin_nested()
         audit = _new_audit_event(
             event_type, resource_type, resource_id, agent_id, context_id,
-            outcome, detail, tenant_id,
+            outcome, detail, tenant_id, outcome_detail_code,
         )
         db.session.add(audit)
         nested.commit()

--- a/r6/models.py
+++ b/r6/models.py
@@ -12,6 +12,24 @@ from datetime import datetime, timezone
 from models import db
 
 
+_AUDIT_OUTCOME_DETAIL_TEXT = {
+    'ignored-date': 'ignored unsupported parameter date',
+    'ignored-datetime': 'ignored unsupported parameter datetime',
+    'ignored-date-datetime': (
+        'ignored unsupported parameters date and datetime'),
+    'ignored-unnamed': 'ignored unsupported parameters',
+    'ignored-date-unnamed': (
+        'ignored unsupported parameter date; additional unsupported '
+        'parameters ignored'),
+    'ignored-datetime-unnamed': (
+        'ignored unsupported parameter datetime; additional unsupported '
+        'parameters ignored'),
+    'ignored-date-datetime-unnamed': (
+        'ignored unsupported parameters date and datetime; additional '
+        'unsupported parameters ignored'),
+}
+
+
 class R6Resource(db.Model):
     """
     Minimal resource store for FHIR R6 resources.
@@ -193,11 +211,16 @@ class AuditEventRecord(db.Model):
     tenant_id = db.Column(db.String(64), nullable=True, index=True)
     agent_id = db.Column(db.String(128), nullable=True)
     outcome = db.Column(db.String(32), default='success')  # success, failure
+    # Only allowlisted codes cross the public FHIR boundary. Generic detail is
+    # an internal operational note and is never projected into the response.
+    outcome_detail_code = db.Column(db.String(64), nullable=True)
     detail = db.Column(db.Text, nullable=True)
     recorded = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
 
     def to_fhir_json(self):
         """Convert to a FHIR R6 AuditEvent-like JSON."""
+        outcome_detail_text = _AUDIT_OUTCOME_DETAIL_TEXT.get(
+            self.outcome_detail_code)
         # Build entity list carefully to avoid null references
         entity = []
         if self.resource_type and self.resource_id:
@@ -231,10 +254,8 @@ class AuditEventRecord(db.Model):
                     'code': '0' if self.outcome == 'success' else '8',
                     'display': 'Success' if self.outcome == 'success' else 'Serious failure'
                 },
-                # Surface the PHI-free outcome note (e.g. "ignored unsupported
-                # parameter <name>") so the audit trail truthfully records
-                # corrective/failure detail, not just the coarse code.
-                **({'detail': [{'text': self.detail}]} if self.detail else {}),
+                **({'detail': [{'text': outcome_detail_text}]}
+                   if outcome_detail_text else {}),
             },
             'agent': [
                 {
@@ -244,6 +265,15 @@ class AuditEventRecord(db.Model):
             ],
             'entity': entity
         }
+
+    @staticmethod
+    def ignored_parameters_outcome_code(safe_keys, has_unnamed):
+        """Return an allowlisted code for ignored-parameter audit evidence."""
+        parts = ['ignored', *safe_keys]
+        if has_unnamed:
+            parts.append('unnamed')
+        code = '-'.join(parts)
+        return code if code in _AUDIT_OUTCOME_DETAIL_TEXT else None
 
     def _map_event_code(self):
         mapping = {

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -20,6 +20,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import urlencode
 from flask import (
     Blueprint, request, jsonify, Response, stream_with_context,
     render_template,
@@ -108,6 +109,31 @@ _VALID_BUNDLE_TYPES = {
 
 # Valid FHIR search patient reference pattern
 _PATIENT_REF_PATTERN = re.compile(r'^Patient/[A-Za-z0-9\-.]{1,64}$')
+
+# Local-search contract: discovery, validation, corrective messages, and self
+# links all derive from this ordered registry.
+_SEARCH_PARAMETER_SPECS = (
+    {'name': 'patient', 'type': 'reference',
+     'documentation': 'Filter by subject.reference (Patient/{id})'},
+    {'name': 'code', 'type': 'token',
+     'documentation': 'Filter by code.coding[].code (JSON string match)'},
+    {'name': 'status', 'type': 'token',
+     'documentation': 'Filter by status field'},
+    {'name': '_lastUpdated', 'type': 'date',
+     'documentation': 'Filter by last updated (ge/le/gt/lt prefix)'},
+    {'name': '_count', 'type': 'number',
+     'documentation': 'Max results (0-200)'},
+    {'name': '_sort', 'type': 'string',
+     'documentation': '_lastUpdated or -_lastUpdated'},
+    {'name': '_summary', 'type': 'token',
+     'documentation': 'count'},
+    {'name': 'context-id', 'type': 'token',
+     'documentation': 'Filter by local context envelope'},
+)
+_SUPPORTED_SEARCH_PARAMS = frozenset(
+    spec['name'] for spec in _SEARCH_PARAMETER_SPECS)
+_SUPPORTED_PARAMS_TEXT = ', '.join(
+    spec['name'] for spec in _SEARCH_PARAMETER_SPECS)
 
 # The blueprint's url_prefix. Exemptions are matched against the full request
 # path, so they must be anchored to this prefix — NOT matched by suffix.
@@ -380,22 +406,13 @@ def _resource_capability(resource_type):
         {'code': 'update'},
         {'code': 'search-type'},
     ]
-    search_params = [
-        {'name': '_count', 'type': 'number', 'documentation': 'Max results (1-200)'},
-        {'name': '_sort', 'type': 'string', 'documentation': '_lastUpdated or -_lastUpdated'},
-        {'name': '_lastUpdated', 'type': 'date', 'documentation': 'Filter by last updated (ge/le prefix)'},
-        {'name': '_summary', 'type': 'token', 'documentation': 'count'},
-        {'name': 'code', 'type': 'token', 'documentation': 'Filter by code.coding[].code (JSON string match)'},
-        {'name': 'status', 'type': 'token', 'documentation': 'Filter by status field'},
-        {'name': 'patient', 'type': 'reference', 'documentation': 'Filter by subject.reference (Patient/{id})'},
-    ]
     return {
         'type': resource_type,
         'interaction': interactions,
         'versioning': 'versioned',
         'readHistory': False,
         'updateCreate': False,
-        'searchParam': search_params,
+        'searchParam': [dict(spec) for spec in _SEARCH_PARAMETER_SPECS],
     }
 
 
@@ -685,17 +702,32 @@ def update_resource(resource_type, resource_id):
     return response
 
 
-# Error-fidelity contract (guardrail property 7): the search facade must tell
-# an agent the truth on the failure paths. The supported set below is the
-# single source of truth for both the query logic and the corrective error
-# text; keep them in sync.
-_SUPPORTED_SEARCH_PARAMS = frozenset({
-    'patient', 'code', 'status', '_lastUpdated',
-    '_count', '_sort', '_summary', 'context-id',
+# Query keys are untrusted input too. Only these locally defined semantic
+# aliases may be named in responses or audit evidence; every other unsupported
+# key gets a generic corrective message.
+_SAFE_UNSUPPORTED_SEARCH_KEYS = frozenset({'date', 'datetime'})
+_SAFE_MODIFIER_TOKENS = frozenset({
+    'above', 'below', 'contains', 'exact', 'identifier', 'in', 'iterate',
+    'missing', 'not', 'not-in', 'of-type', 'text', 'type',
+    # Fixed synthetic token used by the public issue contract.
+    'frobnicate',
 })
-_SUPPORTED_PARAMS_TEXT = (
-    'patient, code, status, _lastUpdated, _count, _sort, _summary, context-id'
-)
+
+
+def _safe_unsupported_key(key):
+    if key in _SAFE_UNSUPPORTED_SEARCH_KEYS:
+        return key
+    if ':' in key:
+        base, modifier = key.split(':', 1)
+        if (base in _SUPPORTED_SEARCH_PARAMS
+                and modifier in _SAFE_MODIFIER_TOKENS):
+            return key
+    return None
+
+
+def _unsupported_input_text(kind, key):
+    safe_key = _safe_unsupported_key(key)
+    return f'{kind}: {safe_key}' if safe_key else kind
 
 
 def _error_fidelity_outcome(severity, code, text):
@@ -712,10 +744,27 @@ def _error_fidelity_outcome(severity, code, text):
     }
 
 
+def _reject_local_search(resource_type, agent_id, tenant_id, code, message):
+    """Return and audit a static, value-free local-search rejection."""
+    audit_detail = {
+        'invalid': 'search rejected: invalid parameter',
+        'not-supported': 'search rejected: unsupported parameter',
+    }.get(code, 'search rejected')
+    record_audit_event('read', resource_type, None, agent_id=agent_id,
+                       tenant_id=tenant_id, outcome='failure',
+                       detail=audit_detail)
+    return jsonify(_error_fidelity_outcome(
+        'error', code, message)), 400
+
+
 def _parse_prefer_handling():
     """Return 'strict' or 'lenient' (default) from the Prefer header."""
     prefer = request.headers.get('Prefer', '') or ''
-    m = re.search(r'handling\s*=\s*(strict|lenient)', prefer, re.IGNORECASE)
+    m = re.search(
+        r'(?:^|,)\s*handling\s*=\s*(strict|lenient)\s*(?=;|,|$)',
+        prefer,
+        re.IGNORECASE,
+    )
     return m.group(1).lower() if m else 'lenient'
 
 
@@ -739,8 +788,9 @@ def search_resources(resource_type):
         return search_audit_events()
 
     if not R6Resource.is_supported_type(resource_type):
-        return _operation_outcome('error', 'not-supported',
-                                  f'Resource type {resource_type} is not supported'), 400
+        return jsonify(_error_fidelity_outcome(
+            'error', 'not-supported',
+            'Resource type is not supported.')), 400
 
     tenant_id = request.headers.get('X-Tenant-Id')
 
@@ -834,14 +884,12 @@ def search_resources(resource_type):
     # caller. Audited as a failure, in every handling mode.
     if modifier_keys:
         modifier = sorted(modifier_keys)[0]
-        record_audit_event('read', resource_type, None, agent_id=agent_id,
-                           tenant_id=tenant_id, outcome='failure',
-                           detail=('search rejected: unsupported modifier '
-                                   f'{modifier}'))
-        return jsonify(_error_fidelity_outcome(
-            'error', 'not-supported',
-            f'Unsupported modifier: {modifier}. '
-            f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.')), 400
+        modifier_text = _unsupported_input_text('Unsupported modifier', modifier)
+        return _reject_local_search(
+            resource_type, agent_id, tenant_id, 'not-supported',
+            f'{modifier_text}. '
+            f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.',
+        )
 
     # An unknown parameter under strict handling is rejected; under lenient
     # handling (the default) it is ignored but reported — a warning entry in
@@ -849,14 +897,46 @@ def search_resources(resource_type):
     # silently swallowed.
     if ignored_params and handling == 'strict':
         unknown = sorted(ignored_params)[0]
-        record_audit_event('read', resource_type, None, agent_id=agent_id,
-                           tenant_id=tenant_id, outcome='failure',
-                           detail=('search rejected: unknown parameter '
-                                   f'{unknown}'))
-        return jsonify(_error_fidelity_outcome(
-            'error', 'not-supported',
-            f'Unknown parameter: {unknown}. '
-            f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.')), 400
+        unknown_text = _unsupported_input_text('Unknown parameter', unknown)
+        return _reject_local_search(
+            resource_type, agent_id, tenant_id, 'not-supported',
+            f'{unknown_text}. '
+            f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.',
+        )
+
+    repeated_control = next((
+        spec['name'] for spec in _SEARCH_PARAMETER_SPECS
+        if len(request.args.getlist(spec['name'])) > 1
+    ), None)
+    if repeated_control:
+        return _reject_local_search(
+            resource_type, agent_id, tenant_id, 'invalid',
+            f'Repeated {repeated_control} parameters are not supported.',
+        )
+
+    # Supported controls with invalid values are failures, not permission to
+    # silently substitute defaults. Messages and audit notes name only the
+    # locally defined control, never the submitted value.
+    invalid_control = None
+    count_param = request.args.get('_count')
+    if (count_param is not None
+            and (len(count_param) > 10
+                 or not re.fullmatch(r'[0-9]+', count_param))):
+        invalid_control = ('_count', '_count must be a non-negative integer.')
+    sort_control = request.args.get('_sort')
+    if (invalid_control is None and sort_control is not None
+            and sort_control not in ('_lastUpdated', '-_lastUpdated')):
+        invalid_control = (
+            '_sort', '_sort must be _lastUpdated or -_lastUpdated.')
+    summary_control = request.args.get('_summary')
+    if (invalid_control is None and summary_control is not None
+            and summary_control != 'count'):
+        invalid_control = ('_summary', '_summary only supports count.')
+    if invalid_control:
+        _, message = invalid_control
+        return _reject_local_search(
+            resource_type, agent_id, tenant_id, 'invalid', message,
+        )
 
     # --- Local mode: query SQLite ---
     query = R6Resource.query.filter_by(
@@ -867,8 +947,10 @@ def search_resources(resource_type):
     patient_ref = request.args.get('patient')
     if patient_ref:
         if not _PATIENT_REF_PATTERN.match(patient_ref):
-            return _operation_outcome('error', 'invalid',
-                                      'Patient reference must match Patient/{id}'), 400
+            return _reject_local_search(
+                resource_type, agent_id, tenant_id, 'invalid',
+                'Patient reference must match Patient/{id}.',
+            )
         query = query.filter(
             db.or_(
                 R6Resource.resource_json.contains(f'"reference":"{patient_ref}"'),
@@ -912,12 +994,20 @@ def search_resources(resource_type):
                 dt = datetime.fromisoformat(last_updated_param.replace('Z', '+00:00'))
                 query = query.filter(R6Resource.last_updated >= dt)
         except (ValueError, TypeError):
-            return _operation_outcome('error', 'invalid',
-                                      '_lastUpdated must be a valid ISO datetime with optional ge/le/gt/lt prefix'), 400
+            return _reject_local_search(
+                resource_type, agent_id, tenant_id, 'invalid',
+                '_lastUpdated must be a valid ISO datetime with optional '
+                'ge/le/gt/lt prefix.',
+            )
 
     # --- context-id filter (restrict to resources in a context envelope) ---
     context_id = request.args.get('context-id')
     if context_id:
+        if not _FHIR_ID_PATTERN.match(context_id):
+            return _reject_local_search(
+                resource_type, agent_id, tenant_id, 'invalid',
+                'context-id must be a valid FHIR id.',
+            )
         from r6.models import ContextItem
         context_refs = [item.resource_ref for item in
                         ContextItem.query.filter_by(context_id=context_id).all()]
@@ -937,21 +1027,20 @@ def search_resources(resource_type):
     else:
         query = query.order_by(R6Resource.last_updated.desc())
 
-    # Support _summary=count
+    # Support _summary=count without bypassing response finalization. Count
+    # summaries omit matching resources, but still need a truthful self link,
+    # lenient warning evidence, and an AuditEvent.
     summary = request.args.get('_summary')
-    if summary == 'count':
+    summary_count = summary == 'count' or count_param == '0'
+    if summary_count:
         total = query.count()
-        bundle = {
-            'resourceType': 'Bundle',
-            'type': 'searchset',
-            'total': total,
-        }
-        return jsonify(bundle)
-
-    # Clamp _count to [1, 200]
-    count = request.args.get('_count', 50, type=int)
-    count = max(1, min(count, 200))
-    resources = query.limit(count).all()
+        resources = []
+    else:
+        # Clamp _count to [1, 200]
+        count = int(count_param) if count_param is not None else 50
+        count = max(1, min(count, 200))
+        resources = query.limit(count).all()
+        total = len(resources)
 
     # Apply redaction and disclaimer on all search results
     entries = []
@@ -965,13 +1054,14 @@ def search_resources(resource_type):
 
     # Build self link with search params for transparency
     search_params = []
-    for key in ('patient', 'code', 'status', '_lastUpdated', '_count', '_sort'):
+    for spec in _SEARCH_PARAMETER_SPECS:
+        key = spec['name']
         val = request.args.get(key)
         if val:
-            search_params.append(f'{key}={val}')
+            search_params.append((key, val))
     self_link = f'{request.host_url.rstrip("/")}/r6/fhir/{resource_type}'
     if search_params:
-        self_link += '?' + '&'.join(search_params)
+        self_link += '?' + urlencode(search_params)
 
     # Lenient handling of an unknown parameter: append a corrective warning
     # entry (search.mode=outcome) naming the ignored parameter + the supported
@@ -979,39 +1069,51 @@ def search_resources(resource_type):
     # set above), so the caller can see exactly which query actually ran.
     audit_note = ''
     if ignored_params:
-        ignored = sorted(ignored_params)[0]
-        entries.append({
-            'search': {'mode': 'outcome'},
-            'resource': _error_fidelity_outcome(
-                'warning', 'not-supported',
-                f'Unknown parameter: {ignored}. '
-                f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.'),
-        })
-        # PHI-free, and deliberately without "<param>=" or any URL so the audit
-        # trail's truthfulness check sees a clean corrective note.
-        audit_note = f'; ignored unsupported parameter {ignored}'
+        safe_ignored = sorted({key for key in ignored_params
+                               if _safe_unsupported_key(key)})
+        has_unnamed = any(not _safe_unsupported_key(key)
+                          for key in ignored_params)
+        # The allowlist has two unknown semantic aliases, plus at most one
+        # generic warning for every other key. This caps attacker-controlled
+        # warning growth at three entries regardless of query size.
+        warning_keys = [*safe_ignored]
+        if has_unnamed:
+            warning_keys.append(None)
+        for ignored in warning_keys:
+            ignored_text = ('Unknown parameter'
+                            if ignored is None else
+                            f'Unknown parameter: {ignored}')
+            entries.append({
+                'search': {'mode': 'outcome'},
+                'resource': _error_fidelity_outcome(
+                    'warning', 'not-supported',
+                    f'{ignored_text}. '
+                    f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.'),
+            })
+
+        ignored_count = len(ignored_params)
+        audit_note = ('; unsupported search parameter ignored'
+                      if ignored_count == 1 else
+                      f'; {ignored_count} unsupported search parameters ignored')
 
     bundle = {
         'resourceType': 'Bundle',
         'type': 'searchset',
-        'total': len(resources),
+        'total': total,
         'link': [{'relation': 'self', 'url': self_link}],
-        'entry': entries
     }
-
-    detail_parts = [f'{len(resources)} results']
-    if patient_ref:
-        detail_parts.append(f'patient={patient_ref}')
-    if code_param:
-        detail_parts.append(f'code={code_param}')
-    if status_param:
-        detail_parts.append(f'status={status_param}')
+    if entries:
+        bundle['entry'] = entries
 
     record_audit_event('read', resource_type, None,
                        agent_id=request.headers.get('X-Agent-Id'),
                        context_id=context_id,
                        tenant_id=tenant_id,
-                       detail=f'search: {", ".join(detail_parts)}{audit_note}')
+                       detail=f'search: {total} results{audit_note}',
+                       outcome_detail_code=(
+                           AuditEventRecord.ignored_parameters_outcome_code(
+                               safe_ignored, has_unnamed)
+                           if ignored_params else None))
 
     return jsonify(bundle)
 

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -25,6 +25,11 @@ from flask import (
     Blueprint, request, jsonify, Response, stream_with_context,
     render_template,
 )
+from werkzeug.http import (
+    parse_list_header,
+    parse_options_header,
+    unquote_header_value,
+)
 from models import db
 from r6.models import R6Resource, ContextEnvelope, ContextItem, AuditEventRecord
 from r6.context_builder import ContextBuilder
@@ -135,6 +140,19 @@ _SUPPORTED_SEARCH_PARAMS = frozenset(
 _SUPPORTED_PARAMS_TEXT = ', '.join(
     spec['name'] for spec in _SEARCH_PARAMETER_SPECS)
 
+_AUDIT_SEARCH_PARAMETER_SPECS = (
+    {'name': 'context-id', 'type': 'token',
+     'documentation': 'Filter by local context envelope'},
+    {'name': 'entity-type', 'type': 'token',
+     'documentation': 'Filter by audited resource type'},
+    {'name': '_count', 'type': 'number',
+     'documentation': 'Max results (0-200)'},
+)
+_AUDIT_SEARCH_PARAMS = frozenset(
+    spec['name'] for spec in _AUDIT_SEARCH_PARAMETER_SPECS)
+_AUDIT_PARAMS_TEXT = ', '.join(
+    spec['name'] for spec in _AUDIT_SEARCH_PARAMETER_SPECS)
+
 # The blueprint's url_prefix. Exemptions are matched against the full request
 # path, so they must be anchored to this prefix — NOT matched by suffix.
 # FHIR resource ids match [A-Za-z0-9.\-]{1,64}, so a suffix test like
@@ -218,7 +236,7 @@ def enforce_tenant_id():
             }]
         }), 400
     # Validate tenant_id format
-    if not _TENANT_ID_PATTERN.match(tenant_id):
+    if not _TENANT_ID_PATTERN.fullmatch(tenant_id):
         return jsonify({
             'resourceType': 'OperationOutcome',
             'issue': [{
@@ -406,13 +424,16 @@ def _resource_capability(resource_type):
         {'code': 'update'},
         {'code': 'search-type'},
     ]
+    search_specs = (_AUDIT_SEARCH_PARAMETER_SPECS
+                    if resource_type == 'AuditEvent'
+                    else _SEARCH_PARAMETER_SPECS)
     return {
         'type': resource_type,
         'interaction': interactions,
         'versioning': 'versioned',
         'readHistory': False,
         'updateCreate': False,
-        'searchParam': [dict(spec) for spec in _SEARCH_PARAMETER_SPECS],
+        'searchParam': [dict(spec) for spec in search_specs],
     }
 
 
@@ -457,7 +478,7 @@ def create_resource(resource_type):
 
     # Validate client-supplied id if present
     client_id = body.get('id')
-    if client_id and not _FHIR_ID_PATTERN.match(client_id):
+    if client_id and not _FHIR_ID_PATTERN.fullmatch(client_id):
         return _operation_outcome('error', 'invalid',
                                   'Resource id must match [A-Za-z0-9\\-.]{1,64}'), 400
 
@@ -744,6 +765,31 @@ def _error_fidelity_outcome(severity, code, text):
     }
 
 
+def _lenient_search_warning_entries(ignored_params, supported_params_text):
+    """Build bounded, value-free warnings for ignored local search keys."""
+    safe_ignored = sorted({key for key in ignored_params
+                           if _safe_unsupported_key(key)})
+    has_unnamed = any(not _safe_unsupported_key(key)
+                      for key in ignored_params)
+    warning_keys = [*safe_ignored]
+    if has_unnamed:
+        warning_keys.append(None)
+
+    entries = []
+    for ignored in warning_keys:
+        ignored_text = ('Unknown parameter' if ignored is None else
+                        f'Unknown parameter: {ignored}')
+        entries.append({
+            'search': {'mode': 'outcome'},
+            'resource': _error_fidelity_outcome(
+                'warning', 'not-supported',
+                f'{ignored_text}. '
+                f'Supported parameters: {supported_params_text}.',
+            ),
+        })
+    return entries, safe_ignored, has_unnamed
+
+
 def _reject_local_search(resource_type, agent_id, tenant_id, code, message):
     """Return and audit a static, value-free local-search rejection."""
     audit_detail = {
@@ -760,12 +806,19 @@ def _reject_local_search(resource_type, agent_id, tenant_id, code, message):
 def _parse_prefer_handling():
     """Return 'strict' or 'lenient' (default) from the Prefer header."""
     prefer = request.headers.get('Prefer', '') or ''
-    m = re.search(
-        r'(?:^|,)\s*handling\s*=\s*(strict|lenient)\s*(?=;|,|$)',
-        prefer,
-        re.IGNORECASE,
-    )
-    return m.group(1).lower() if m else 'lenient'
+    for item in parse_list_header(prefer):
+        preference, _parameters = parse_options_header(item)
+        name, separator, raw_value = preference.partition('=')
+        if name.strip().lower() != 'handling':
+            continue
+        # RFC 7240 applies only the first occurrence of a preference. An
+        # absent or unsupported value therefore stays at our lenient default;
+        # a later duplicate must not override it.
+        if not separator:
+            return 'lenient'
+        value = unquote_header_value(raw_value.strip()).lower()
+        return value if value in ('strict', 'lenient') else 'lenient'
+    return 'lenient'
 
 
 @r6_blueprint.route('/<resource_type>', methods=['GET'])
@@ -946,7 +999,7 @@ def search_resources(resource_type):
     # --- patient reference filter ---
     patient_ref = request.args.get('patient')
     if patient_ref:
-        if not _PATIENT_REF_PATTERN.match(patient_ref):
+        if not _PATIENT_REF_PATTERN.fullmatch(patient_ref):
             return _reject_local_search(
                 resource_type, agent_id, tenant_id, 'invalid',
                 'Patient reference must match Patient/{id}.',
@@ -963,14 +1016,16 @@ def search_resources(resource_type):
     if code_param:
         # Match "code":"<value>" inside the JSON — works for coding arrays
         query = query.filter(
-            R6Resource.resource_json.contains(f'"code":"{code_param}"')
+            R6Resource.resource_json.contains(
+                f'"code":"{code_param}"', autoescape=True)
         )
 
     # --- status filter (matches "status":"<value>" in JSON) ---
     status_param = request.args.get('status')
     if status_param:
         query = query.filter(
-            R6Resource.resource_json.contains(f'"status":"{status_param}"')
+            R6Resource.resource_json.contains(
+                f'"status":"{status_param}"', autoescape=True)
         )
 
     # --- _lastUpdated filter (ge/le prefix on DB column) ---
@@ -1003,7 +1058,7 @@ def search_resources(resource_type):
     # --- context-id filter (restrict to resources in a context envelope) ---
     context_id = request.args.get('context-id')
     if context_id:
-        if not _FHIR_ID_PATTERN.match(context_id):
+        if not _FHIR_ID_PATTERN.fullmatch(context_id):
             return _reject_local_search(
                 resource_type, agent_id, tenant_id, 'invalid',
                 'context-id must be a valid FHIR id.',
@@ -1032,15 +1087,14 @@ def search_resources(resource_type):
     # lenient warning evidence, and an AuditEvent.
     summary = request.args.get('_summary')
     summary_count = summary == 'count' or count_param == '0'
+    total = query.order_by(None).count()
     if summary_count:
-        total = query.count()
         resources = []
     else:
         # Clamp _count to [1, 200]
         count = int(count_param) if count_param is not None else 50
         count = max(1, min(count, 200))
         resources = query.limit(count).all()
-        total = len(resources)
 
     # Apply redaction and disclaimer on all search results
     entries = []
@@ -1069,27 +1123,13 @@ def search_resources(resource_type):
     # set above), so the caller can see exactly which query actually ran.
     audit_note = ''
     if ignored_params:
-        safe_ignored = sorted({key for key in ignored_params
-                               if _safe_unsupported_key(key)})
-        has_unnamed = any(not _safe_unsupported_key(key)
-                          for key in ignored_params)
         # The allowlist has two unknown semantic aliases, plus at most one
         # generic warning for every other key. This caps attacker-controlled
         # warning growth at three entries regardless of query size.
-        warning_keys = [*safe_ignored]
-        if has_unnamed:
-            warning_keys.append(None)
-        for ignored in warning_keys:
-            ignored_text = ('Unknown parameter'
-                            if ignored is None else
-                            f'Unknown parameter: {ignored}')
-            entries.append({
-                'search': {'mode': 'outcome'},
-                'resource': _error_fidelity_outcome(
-                    'warning', 'not-supported',
-                    f'{ignored_text}. '
-                    f'Supported parameters: {_SUPPORTED_PARAMS_TEXT}.'),
-            })
+        warning_entries, safe_ignored, has_unnamed = (
+            _lenient_search_warning_entries(
+                ignored_params, _SUPPORTED_PARAMS_TEXT))
+        entries.extend(warning_entries)
 
         ignored_count = len(ignored_params)
         audit_note = ('; unsupported search parameter ignored'
@@ -1274,9 +1314,55 @@ def get_context(context_id):
 def search_audit_events():
     """Search AuditEvent records, optionally filtered by context-id."""
     tenant_id = request.headers.get('X-Tenant-Id')
+    agent_id = request.headers.get('X-Agent-Id')
+    modifier_keys = [key for key in request.args if ':' in key]
+    ignored_params = [key for key in request.args
+                      if ':' not in key and key not in _AUDIT_SEARCH_PARAMS]
+
+    if modifier_keys:
+        modifier = sorted(modifier_keys)[0]
+        modifier_text = _unsupported_input_text(
+            'Unsupported modifier', modifier)
+        return _reject_local_search(
+            'AuditEvent', agent_id, tenant_id, 'not-supported',
+            f'{modifier_text}. Supported parameters: {_AUDIT_PARAMS_TEXT}.',
+        )
+
+    if ignored_params and _parse_prefer_handling() == 'strict':
+        unknown = sorted(ignored_params)[0]
+        unknown_text = _unsupported_input_text('Unknown parameter', unknown)
+        return _reject_local_search(
+            'AuditEvent', agent_id, tenant_id, 'not-supported',
+            f'{unknown_text}. Supported parameters: {_AUDIT_PARAMS_TEXT}.',
+        )
+
+    repeated_control = next((
+        spec['name'] for spec in _AUDIT_SEARCH_PARAMETER_SPECS
+        if len(request.args.getlist(spec['name'])) > 1
+    ), None)
+    if repeated_control:
+        return _reject_local_search(
+            'AuditEvent', agent_id, tenant_id, 'invalid',
+            f'Repeated {repeated_control} parameters are not supported.',
+        )
+
+    count_param = request.args.get('_count')
+    if (count_param is not None
+            and (len(count_param) > 10
+                 or not re.fullmatch(r'[0-9]+', count_param))):
+        return _reject_local_search(
+            'AuditEvent', agent_id, tenant_id, 'invalid',
+            '_count must be a non-negative integer.',
+        )
+
     context_id = request.args.get('context-id')
+    if context_id and not _FHIR_ID_PATTERN.fullmatch(context_id):
+        return _reject_local_search(
+            'AuditEvent', agent_id, tenant_id, 'invalid',
+            'context-id must be a valid FHIR id.',
+        )
     resource_type = request.args.get('entity-type')
-    count = request.args.get('_count', 50, type=int)
+    count = int(count_param) if count_param is not None else 50
     count = max(1, min(count, 200))
 
     # Enforce tenant isolation on audit events
@@ -1289,20 +1375,58 @@ def search_audit_events():
     if resource_type:
         query = query.filter_by(resource_type=resource_type)
 
-    events = query.limit(count).all()
+    total = query.order_by(None).count()
+    events = [] if count_param == '0' else query.limit(count).all()
+    entries = [
+        {
+            'fullUrl': (
+                f'{request.host_url.rstrip("/")}/r6/fhir/AuditEvent/{event.id}'
+            ),
+            'resource': event.to_fhir_json(),
+        }
+        for event in events
+    ]
+
+    safe_ignored = []
+    has_unnamed = False
+    audit_note = ''
+    if ignored_params:
+        warning_entries, safe_ignored, has_unnamed = (
+            _lenient_search_warning_entries(
+                ignored_params, _AUDIT_PARAMS_TEXT))
+        entries.extend(warning_entries)
+
+        ignored_count = len(ignored_params)
+        audit_note = ('; unsupported search parameter ignored'
+                      if ignored_count == 1 else
+                      f'; {ignored_count} unsupported search parameters ignored')
+
+    search_params = []
+    for spec in _AUDIT_SEARCH_PARAMETER_SPECS:
+        value = request.args.get(spec['name'])
+        if value:
+            search_params.append((spec['name'], value))
+    self_link = f'{request.host_url.rstrip("/")}/r6/fhir/AuditEvent'
+    if search_params:
+        self_link += '?' + urlencode(search_params)
 
     bundle = {
         'resourceType': 'Bundle',
         'type': 'searchset',
-        'total': len(events),
-        'entry': [
-            {
-                'fullUrl': f'{request.host_url.rstrip("/")}/r6/fhir/AuditEvent/{e.id}',
-                'resource': e.to_fhir_json()
-            }
-            for e in events
-        ]
+        'total': total,
+        'link': [{'relation': 'self', 'url': self_link}],
     }
+    if entries:
+        bundle['entry'] = entries
+
+    record_audit_event(
+        'read', 'AuditEvent', None, agent_id=agent_id,
+        tenant_id=tenant_id, detail=f'search: {total} results{audit_note}',
+        outcome_detail_code=(
+            AuditEventRecord.ignored_parameters_outcome_code(
+                safe_ignored, has_unnamed)
+            if ignored_params else None),
+    )
 
     return jsonify(bundle)
 
@@ -1915,7 +2039,7 @@ def bind_telegram_chat():
         chat_id = int(chat_id_raw)
     except (TypeError, ValueError):
         return jsonify({'error': 'chat_id must be an integer'}), 400
-    if not _TENANT_ID_PATTERN.match(tenant_id):
+    if not _TENANT_ID_PATTERN.fullmatch(tenant_id):
         return jsonify({'error': 'invalid tenant_id format'}), 400
 
     from r6.stepup import validate_step_up_token

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -57,6 +57,31 @@ def test_fresh_install_builds_current_schema_without_flask_app(tmp_path):
         column["name"]: column for column in schema.get_columns("r6_resources")
     }
     assert resource_columns["id"]["type"].length == 255
+    assert "outcome_detail_code" in {
+        column["name"] for column in schema.get_columns("audit_events")
+    }
+    engine.dispose()
+
+
+def test_audit_outcome_detail_migration_is_reversible(tmp_path):
+    url = f"sqlite:///{tmp_path / 'audit-outcome.db'}"
+    config = _config(url)
+    engine = create_engine(url)
+
+    command.upgrade(config, "head")
+    assert "outcome_detail_code" in {
+        column["name"] for column in inspect(engine).get_columns("audit_events")
+    }
+
+    command.downgrade(config, "0002_current_contract")
+    assert "outcome_detail_code" not in {
+        column["name"] for column in inspect(engine).get_columns("audit_events")
+    }
+
+    command.upgrade(config, "head")
+    assert "outcome_detail_code" in {
+        column["name"] for column in inspect(engine).get_columns("audit_events")
+    }
     engine.dispose()
 
 
@@ -92,7 +117,7 @@ def test_initialize_database_runs_alembic_on_the_app_engine(monkeypatch):
         assert schema.get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]
-    assert revision == "0002_current_contract"
+    assert revision == "0003_audit_outcome_detail"
 
 
 def test_legacy_environment_flag_cannot_run_ddl_during_factory(monkeypatch):
@@ -245,11 +270,11 @@ def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
 
     revision = upgrade_database(engine)  # must NOT raise 'already exists'
 
-    assert revision == "0002_current_contract"
+    assert revision == "0003_audit_outcome_detail"
     inspector = inspect(engine)
     assert "alembic_version" in inspector.get_table_names()
     # And it must be repeatable (deploys run it every release).
-    assert upgrade_database(engine) == "0002_current_contract"
+    assert upgrade_database(engine) == "0003_audit_outcome_detail"
 
 
 def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
@@ -288,7 +313,7 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
         ))
 
     revision = upgrade_database(engine)
-    assert revision == "0002_current_contract"
+    assert revision == "0003_audit_outcome_detail"
 
     inspector = inspect(engine)
     pk = inspector.get_pk_constraint("r6_resources")
@@ -331,9 +356,9 @@ def test_legacy_create_all_upgrade_on_configured_database():
 
         revision = upgrade_database(engine)  # must not raise "already exists"
 
-        assert revision == "0002_current_contract"
+        assert revision == "0003_audit_outcome_detail"
         assert "alembic_version" in inspect(engine).get_table_names()
-        assert upgrade_database(engine) == "0002_current_contract"  # idempotent
+        assert upgrade_database(engine) == "0003_audit_outcome_detail"  # idempotent
         assert inspect(engine).get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -76,6 +76,13 @@ def test_audit_resource_id_column_fits_real_ehr_ids():
             >= R6Resource.__table__.c.id.type.length)
 
 
+def test_audit_public_outcome_detail_code_is_bounded():
+    from r6.models import AuditEventRecord
+    column = AuditEventRecord.__table__.c.outcome_detail_code
+    assert column.type.length == 64
+    assert column.nullable is True
+
+
 def test_curatr_engine_api_matches_ingester_usage():
     # The Fasten post-ingest scan imports CuratrEngine and calls
     # evaluate(resource) -> result.issues. Pin that contract so the import/

--- a/tests/test_r6_routes.py
+++ b/tests/test_r6_routes.py
@@ -47,6 +47,42 @@ class TestR6Metadata:
         data = resp.get_json()
         assert data['software']['version'] == expected
 
+    def test_search_discovery_matches_applied_parameters_and_correction(
+            self, client, tenant_headers):
+        from urllib.parse import parse_qsl, urlencode, urlsplit
+
+        metadata = client.get('/r6/fhir/metadata').get_json()
+        observation = next(resource for resource in
+                           metadata['rest'][0]['resource']
+                           if resource['type'] == 'Observation')
+        documented = {param['name'] for param in observation['searchParam']}
+        values = {
+            'patient': 'Patient/test-subject',
+            'code': 'code with spaces',
+            'status': 'final',
+            '_lastUpdated': 'ge1970-01-01T00:00:00Z',
+            '_count': '1',
+            '_sort': '_lastUpdated',
+            '_summary': 'count',
+            'context-id': 'test-context',
+        }
+
+        bundle = client.get(
+            f'/r6/fhir/Observation?{urlencode(values)}',
+            headers=tenant_headers,
+        ).get_json()
+        self_url = bundle['link'][0]['url']
+        applied = dict(parse_qsl(urlsplit(self_url).query))
+        assert applied == values
+        assert documented == set(applied)
+
+        strict_headers = {**tenant_headers, 'Prefer': 'handling=strict'}
+        outcome = client.get('/r6/fhir/Observation?datetime=x',
+                             headers=strict_headers).get_json()
+        supported_text = outcome['issue'][0]['details']['text'].split(
+            'Supported parameters: ', 1)[1].removesuffix('.')
+        assert set(supported_text.split(', ')) == documented
+
 
 class TestTenantEnforcement:
     """Test mandatory tenant isolation."""
@@ -458,13 +494,49 @@ class TestSearchFeatures:
         assert data['total'] >= 1
         assert 'entry' not in data
 
+    def test_summary_count_preserves_lenient_warning_link_and_audit(
+            self, client, tenant_headers):
+        response = client.get(
+            '/r6/fhir/Observation?_summary=count&datetime=x',
+            headers=tenant_headers,
+        )
+
+        assert response.status_code == 200
+        bundle = response.get_json()
+        assert bundle['link'][0]['relation'] == 'self'
+        assert '_summary=count' in bundle['link'][0]['url']
+        assert 'datetime=' not in bundle['link'][0]['url']
+        assert bundle['entry'][0]['search'] == {'mode': 'outcome'}
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        assert audit_response.status_code == 200
+        assert 'ignored unsupported parameter datetime' in json.dumps(
+            audit_response.get_json())
+
+    def test_count_zero_is_a_count_only_search(
+            self, client, sample_patient, auth_headers, tenant_headers):
+        client.post('/r6/fhir/Patient',
+                    data=json.dumps(sample_patient),
+                    content_type='application/json',
+                    headers=auth_headers)
+
+        response = client.get('/r6/fhir/Patient?_count=0',
+                              headers=tenant_headers)
+        bundle = response.get_json()
+
+        assert response.status_code == 200
+        assert bundle['total'] >= 1
+        assert 'entry' not in bundle
+        assert '_count=0' in bundle['link'][0]['url']
+
     def test_patient_ref_validation(self, client, tenant_headers):
         """Invalid patient reference format should be rejected."""
         resp = client.get('/r6/fhir/Observation?patient=bad-ref',
                          headers=tenant_headers)
         assert resp.status_code == 400
         data = resp.get_json()
-        assert 'Patient/' in data['issue'][0]['diagnostics']
+        assert 'Patient/' in data['issue'][0]['details']['text']
 
     def test_valid_patient_ref_search(self, client, tenant_headers):
         """Valid patient reference format should work."""
@@ -474,6 +546,181 @@ class TestSearchFeatures:
         data = resp.get_json()
         assert data['resourceType'] == 'Bundle'
         assert data['type'] == 'searchset'
+
+    def test_search_audit_response_omits_filter_values(self, client,
+                                                       tenant_headers):
+        client.get(
+            '/r6/fhir/Observation?patient=Patient/audit-secret-subject'
+            '&code=audit-secret-code&status=audit-secret-status',
+            headers=tenant_headers,
+        )
+
+        response = client.get('/r6/fhir/AuditEvent?_count=200',
+                              headers=tenant_headers)
+        body = json.dumps(response.get_json())
+
+        assert response.status_code == 200
+        assert 'audit-secret-subject' not in body
+        assert 'audit-secret-code' not in body
+        assert 'audit-secret-status' not in body
+
+    def test_audit_outcome_detail_codes_fail_closed(self, client,
+                                                    tenant_headers):
+        from models import db
+        from r6.models import AuditEventRecord
+
+        db.session.add(AuditEventRecord(
+            event_type='read',
+            resource_type='Observation',
+            tenant_id=tenant_headers['X-Tenant-Id'],
+            outcome='success',
+            outcome_detail_code='Patient Alice',
+        ))
+        db.session.commit()
+
+        response = client.get('/r6/fhir/AuditEvent?_count=200',
+                              headers=tenant_headers)
+        assert response.status_code == 200
+        assert 'Patient Alice' not in json.dumps(response.get_json())
+
+    def test_search_never_reflects_hostile_parameter_name(self, client,
+                                                          tenant_headers):
+        headers = {**tenant_headers, 'Prefer': 'handling=strict'}
+        response = client.get(
+            '/r6/fhir/Observation?Patient%20Alice=secret-value',
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert 'Patient Alice' not in json.dumps(response.get_json())
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        assert audit_response.status_code == 200
+        assert 'Patient Alice' not in json.dumps(audit_response.get_json())
+
+        modifier_response = client.get(
+            '/r6/fhir/Observation?code:frobnicate=x',
+            headers=tenant_headers,
+        )
+        assert modifier_response.status_code == 400
+        assert 'code:frobnicate' in json.dumps(modifier_response.get_json())
+
+        hostile_modifier = client.get(
+            '/r6/fhir/Observation?code:Patient%20Alice=x',
+            headers=tenant_headers,
+        )
+        hostile_body = json.dumps(hostile_modifier.get_json())
+        assert hostile_modifier.status_code == 400
+        assert 'Patient Alice' not in hostile_body
+
+        hostile_resource_type = client.get(
+            '/r6/fhir/Patient%20Alice?datetime=x',
+            headers=tenant_headers,
+        )
+        assert hostile_resource_type.status_code == 400
+        assert 'Patient Alice' not in json.dumps(
+            hostile_resource_type.get_json())
+
+    def test_prefer_handling_requires_an_exact_preference(self, client,
+                                                          tenant_headers):
+        malformed = (
+            'handling=strictly',
+            'xhandling=strict',
+            'foo="handling=strict"',
+        )
+        for prefer in malformed:
+            headers = {**tenant_headers, 'Prefer': prefer}
+            response = client.get('/r6/fhir/Observation?datetime=x',
+                                  headers=headers)
+            assert response.status_code == 200, prefer
+
+        strict_headers = {
+            **tenant_headers,
+            'Prefer': 'respond-async, handling=strict',
+        }
+        strict_response = client.get('/r6/fhir/Observation?datetime=x',
+                                     headers=strict_headers)
+        assert strict_response.status_code == 400
+
+    def test_invalid_search_controls_fail_without_reflecting_values(
+            self, client, tenant_headers):
+        cases = (
+            ('_count', 'secret-count-value'),
+            ('_count', '9' * 5000),
+            ('_sort', 'secret-sort-value'),
+            ('_summary', 'secret-summary-value'),
+        )
+        for key, value in cases:
+            response = client.get(f'/r6/fhir/Observation?{key}={value}',
+                                  headers=tenant_headers)
+            body = response.get_json()
+            assert response.status_code == 400, key
+            assert body['issue'][0]['code'] == 'invalid'
+            assert value not in json.dumps(body)
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        audit_events = [entry['resource'] for entry in
+                        audit_response.get_json().get('entry', [])]
+        failures = [event for event in audit_events
+                    if event['outcome']['code']['code'] == '8']
+        assert len(failures) >= len(cases)
+        audit_body = json.dumps(audit_response.get_json())
+        for _, value in cases:
+            assert value not in audit_body
+
+    def test_lenient_unknown_parameter_warnings_are_safe_and_bounded(
+            self, client, tenant_headers):
+        response = client.get(
+            '/r6/fhir/Observation?datetime=x&date=y'
+            '&Patient%20Alice=one&Secret%20Bob=two',
+            headers=tenant_headers,
+        )
+        bundle = response.get_json()
+        body = json.dumps(bundle)
+
+        assert response.status_code == 200
+        warnings = [entry for entry in bundle.get('entry', [])
+                    if entry.get('search') == {'mode': 'outcome'}]
+        assert len(warnings) <= 3
+        assert 'datetime' in body
+        assert 'date' in body
+        assert 'Patient Alice' not in body
+        assert 'Secret Bob' not in body
+        assert '=x' not in body
+        assert '=y' not in body
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        audit_body = json.dumps(audit_response.get_json())
+        assert 'Patient Alice' not in audit_body
+        assert 'Secret Bob' not in audit_body
+
+    def test_invalid_filters_and_repeated_controls_are_audited(
+            self, client, tenant_headers):
+        cases = (
+            ('patient=secret-patient-value', 'secret-patient-value'),
+            ('_lastUpdated=secret-date-value', 'secret-date-value'),
+            ('context-id=secret%20context', 'secret context'),
+            ('_sort=_lastUpdated&_sort=-_lastUpdated', None),
+        )
+        for query, hostile_value in cases:
+            response = client.get(f'/r6/fhir/Observation?{query}',
+                                  headers=tenant_headers)
+            body = response.get_json()
+            assert response.status_code == 400, query
+            assert body['issue'][0]['code'] == 'invalid'
+            assert set(body['issue'][0]) == {'severity', 'code', 'details'}
+            if hostile_value:
+                assert hostile_value not in json.dumps(body)
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        failures = [entry['resource'] for entry in
+                    audit_response.get_json().get('entry', [])
+                    if entry['resource']['outcome']['code']['code'] == '8']
+        assert len(failures) >= len(cases)
 
 
 # ===== Phase 2-5: New Feature Tests =====

--- a/tests/test_r6_routes.py
+++ b/tests/test_r6_routes.py
@@ -83,6 +83,16 @@ class TestR6Metadata:
             'Supported parameters: ', 1)[1].removesuffix('.')
         assert set(supported_text.split(', ')) == documented
 
+    def test_audit_search_discovery_matches_its_dedicated_contract(
+            self, client):
+        metadata = client.get('/r6/fhir/metadata').get_json()
+        audit_event = next(resource for resource in
+                           metadata['rest'][0]['resource']
+                           if resource['type'] == 'AuditEvent')
+
+        assert {param['name'] for param in audit_event['searchParam']} == {
+            'context-id', 'entity-type', '_count'}
+
 
 class TestTenantEnforcement:
     """Test mandatory tenant isolation."""
@@ -110,6 +120,15 @@ class TestTenantEnforcement:
         assert resp.status_code == 400
         data = resp.get_json()
         assert 'X-Tenant-Id must match' in data['issue'][0]['diagnostics']
+
+    def test_line_terminated_tenant_id_is_rejected(self, client):
+        response = client.get(
+            '/r6/fhir/Patient',
+            environ_overrides={'HTTP_X_TENANT_ID': 'test-tenant\n'},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()['issue'][0]['code'] == 'invalid'
 
     def test_valid_tenant_id_formats(self, client):
         """Valid tenant IDs with hyphens and underscores should work."""
@@ -164,6 +183,20 @@ class TestR6CRUD:
         assert data['resourceType'] == 'Patient'
         assert 'meta' in data
         assert data['meta']['versionId'] == '1'
+
+    def test_create_rejects_line_terminated_resource_id(
+            self, client, sample_patient, auth_headers):
+        sample_patient['id'] = 'test-patient-1\n'
+
+        response = client.post(
+            '/r6/fhir/Patient',
+            data=json.dumps(sample_patient),
+            content_type='application/json',
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()['issue'][0]['code'] == 'invalid'
 
     def test_read_resource(self, client, sample_patient, auth_headers, tenant_headers):
         # Create first
@@ -411,6 +444,23 @@ class TestR6ContextIngestion:
 class TestR6AuditEvents:
     """Test AuditEvent recording and querying."""
 
+    def test_clean_audit_event_search_is_audited(
+            self, client, tenant_headers):
+        from r6.models import AuditEventRecord
+
+        response = client.get('/r6/fhir/AuditEvent?_count=0',
+                              headers=tenant_headers)
+
+        assert response.status_code == 200
+        evidence = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_headers['X-Tenant-Id'],
+            event_type='read',
+            resource_type='AuditEvent',
+        ).all()
+        assert len(evidence) == 1
+        assert evidence[0].detail == 'search: 0 results'
+        assert evidence[0].outcome_detail_code is None
+
     def test_read_generates_audit_event(self, client, sample_patient,
                                          auth_headers, tenant_headers):
         client.post('/r6/fhir/Patient',
@@ -453,6 +503,98 @@ class TestR6AuditEvents:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data['total'] == 0
+
+    def test_audit_event_search_honors_strict_unknown_parameters(
+            self, client, tenant_headers):
+        headers = {**tenant_headers, 'Prefer': 'handling=strict'}
+        response = client.get(
+            '/r6/fhir/AuditEvent?Patient%20Alice=secret-value',
+            headers=headers,
+        )
+        body = response.get_json()
+
+        assert response.status_code == 400
+        assert body['issue'][0]['code'] == 'not-supported'
+        assert set(body['issue'][0]) == {'severity', 'code', 'details'}
+        assert 'Patient Alice' not in json.dumps(body)
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        failures = [entry['resource'] for entry in
+                    audit_response.get_json().get('entry', [])
+                    if entry['resource']['outcome']['code']['code'] == '8']
+        assert failures
+
+    def test_audit_event_search_reports_lenient_unknown_parameters(
+            self, client, tenant_headers):
+        response = client.get('/r6/fhir/AuditEvent?datetime=x',
+                              headers=tenant_headers)
+        bundle = response.get_json()
+
+        assert response.status_code == 200
+        assert bundle['link'][0]['relation'] == 'self'
+        assert 'datetime=' not in bundle['link'][0]['url']
+        warnings = [entry for entry in bundle.get('entry', [])
+                    if entry.get('search') == {'mode': 'outcome'}]
+        assert len(warnings) == 1
+        assert 'datetime' in json.dumps(warnings[0])
+
+        audit_response = client.get('/r6/fhir/AuditEvent?_count=200',
+                                    headers=tenant_headers)
+        assert 'ignored unsupported parameter datetime' in json.dumps(
+            audit_response.get_json())
+
+    def test_audit_event_search_rejects_invalid_controls(
+            self, client, tenant_headers):
+        cases = (
+            '_count=secret-count',
+            '_count=1&_count=2',
+            'entity-type=Observation&entity-type=Patient',
+            'context-id=test-context%0A',
+            'entity-type:exact=Observation',
+        )
+
+        for query in cases:
+            response = client.get(f'/r6/fhir/AuditEvent?{query}',
+                                  headers=tenant_headers)
+            body = response.get_json()
+
+            assert response.status_code == 400, query
+            assert body['issue'][0]['code'] in {
+                'invalid', 'not-supported'}, query
+            assert set(body['issue'][0]) == {
+                'severity', 'code', 'details'}
+
+    def test_audit_event_count_reports_all_matches_and_supports_zero(
+            self, client, auth_headers, tenant_headers):
+        for resource_id in ('audit-count-one', 'audit-count-two',
+                            'audit-count-three'):
+            client.post(
+                '/r6/fhir/Patient',
+                data=json.dumps({
+                    'resourceType': 'Patient',
+                    'id': resource_id,
+                    'name': [{'family': 'Synthetic'}],
+                }),
+                content_type='application/json',
+                headers=auth_headers,
+            )
+
+        limited = client.get(
+            '/r6/fhir/AuditEvent?entity-type=Patient&_count=1',
+            headers=tenant_headers,
+        ).get_json()
+        count_only = client.get(
+            '/r6/fhir/AuditEvent?entity-type=Patient&_count=0',
+            headers=tenant_headers,
+        ).get_json()
+
+        assert limited['total'] == 3
+        assert len(limited['entry']) == 1
+        assert count_only['total'] == 3
+        assert count_only['link'][0]['url'].endswith(
+            'entity-type=Patient&_count=0')
+        assert 'entry' not in count_only
 
 
 class TestR6ImportStub:
@@ -537,6 +679,23 @@ class TestSearchFeatures:
         assert resp.status_code == 400
         data = resp.get_json()
         assert 'Patient/' in data['issue'][0]['details']['text']
+
+    def test_search_ids_reject_line_terminated_values(self, client,
+                                                       tenant_headers):
+        for query in (
+            'patient=Patient/test-id%0A',
+            'patient=Patient/test-id%0D',
+            'context-id=test-context%0A',
+            'context-id=test-context%0D',
+        ):
+            response = client.get(f'/r6/fhir/Observation?{query}',
+                                  headers=tenant_headers)
+            body = response.get_json()
+
+            assert response.status_code == 400, query
+            assert body['issue'][0]['code'] == 'invalid', query
+            assert set(body['issue'][0]) == {
+                'severity', 'code', 'details'}
 
     def test_valid_patient_ref_search(self, client, tenant_headers):
         """Valid patient reference format should work."""
@@ -642,6 +801,26 @@ class TestSearchFeatures:
         strict_response = client.get('/r6/fhir/Observation?datetime=x',
                                      headers=strict_headers)
         assert strict_response.status_code == 400
+
+        quoted_strict_headers = {
+            **tenant_headers,
+            'Prefer': 'respond-async, handling="strict"',
+        }
+        quoted_strict_response = client.get(
+            '/r6/fhir/Observation?datetime=x',
+            headers=quoted_strict_headers,
+        )
+        assert quoted_strict_response.status_code == 400
+
+        first_duplicate_wins = {
+            **tenant_headers,
+            'Prefer': 'handling=unsupported, handling=strict',
+        }
+        duplicate_response = client.get(
+            '/r6/fhir/Observation?datetime=x',
+            headers=first_duplicate_wins,
+        )
+        assert duplicate_response.status_code == 200
 
     def test_invalid_search_controls_fail_without_reflecting_values(
             self, client, tenant_headers):
@@ -1281,6 +1460,42 @@ class TestEnhancedSearch:
         for entry in data.get('entry', []):
             resource_json = json.dumps(entry['resource'])
             assert '2339-0' in resource_json
+
+    def test_token_search_treats_sql_wildcards_as_literal_characters(
+            self, client, auth_headers, tenant_headers):
+        self._seed_observations(client, auth_headers, [
+            {'resourceType': 'Observation', 'id': 'literal-token-glucose',
+             'status': 'final', 'code': {'coding': [{'code': '2339-0'}]}},
+            {'resourceType': 'Observation', 'id': 'literal-token-heart-rate',
+             'status': 'preliminary',
+             'code': {'coding': [{'code': '8867-4'}]}},
+        ])
+
+        for query in ('status=%25', 'status=f_nal', 'code=2339_0'):
+            response = client.get(f'/r6/fhir/Observation?{query}',
+                                  headers=tenant_headers)
+            bundle = response.get_json()
+
+            assert response.status_code == 200, query
+            assert bundle['total'] == 0, query
+            assert 'entry' not in bundle, query
+
+    def test_count_limits_entries_without_truncating_total(
+            self, client, auth_headers, tenant_headers):
+        self._seed_observations(client, auth_headers, [
+            {'resourceType': 'Observation', 'id': f'count-total-{index}',
+             'status': 'final',
+             'code': {'coding': [{'code': f'count-code-{index}'}]}}
+            for index in range(3)
+        ])
+
+        response = client.get('/r6/fhir/Observation?_count=1',
+                              headers=tenant_headers)
+        bundle = response.get_json()
+
+        assert response.status_code == 200
+        assert bundle['total'] == 3
+        assert len(bundle['entry']) == 1
 
     def test_search_by_status(self, client, auth_headers, tenant_headers):
         """Search Permission by status parameter."""


### PR DESCRIPTION
Follow-up to #117, which closed #116. Refs #116.

## Why

The initial implementation restored Error Fidelity to Grade A, but adversarial review found edge cases where local search behavior could still become misleading or leak attacker-controlled input:

- malformed or repeated controls could fall back to a different query;
- hostile parameter names could reach corrective text or audit evidence;
- the dedicated `AuditEvent` search path bypassed the generic strict/lenient contract;
- `Bundle.total` reflected the page size rather than the true match count;
- SQL `LIKE` wildcard characters were interpreted semantically in token filters;
- quoted `Prefer: handling="strict"` and line-terminated identifiers were parsed incorrectly.

## What changed

- Centralizes bounded, allowlisted corrective warnings for lenient searches.
- Rejects unsupported modifiers, repeated controls, invalid values, and malformed identifiers without reflecting submitted values.
- Adds an allowlisted `AuditEvent.outcome.detail` code with a reversible migration, keeping audit evidence useful and PHI-free.
- Gives `AuditEvent` search its own advertised and enforced parameter contract, including strict/lenient behavior, truthful self links, count-only searches, and mandatory clean-search audit evidence.
- Makes `Bundle.total` pre-pagination and treats token-search `%` / `_` characters literally.
- Parses quoted and duplicate `Prefer` preferences according to first-occurrence semantics.
- Updates operator documentation so local FHIR, MCP, and proxy grades are described as separate profiles.

## Safety

- No upstream or caller-supplied free text is copied into errors or audit detail.
- Warning growth is capped using a local allowlist plus one generic warning.
- Tenant isolation remains part of every resource and audit query.
- The database migration is covered for upgrade and downgrade.

## Verification

- `1418 passed, 1 skipped`
- Ruff clean
- Mypy clean for `r6/routes.py`, `r6/audit.py`, and `r6/models.py`
- `git diff --check` clean
- Independent standards and issue/spec reviews clean after remediation
