### PR TITLE
feat(careagents): accept an Anthropic OAuth token (#145)

### DIFF
--- a/careagents/config.py
+++ b/careagents/config.py
@@ -64,6 +64,13 @@ class Config:
         # LLM provider: Anthropic preferred; OpenAI-compatible fallback so the
         # product works before an Anthropic key is provisioned.
         self.anthropic_api_key = e.get("ANTHROPIC_API_KEY", "")
+        # Claude subscription / OpenClaw OAuth access token (Authorization:
+        # Bearer + oauth beta header) — an alternative to an API key. Short-
+        # lived, so refresh it out of band (e.g. from the Mac-mini OpenClaw
+        # credential) when it expires.
+        self.anthropic_oauth_token = e.get("ANTHROPIC_OAUTH_TOKEN", "")
+        self.anthropic_oauth_beta = e.get(
+            "ANTHROPIC_OAUTH_BETA", "oauth-2025-04-20")
         self.openai_api_key = e.get("OPENAI_API_KEY", "")
         self.openai_base = (e.get("OPENAI_BASE_URL")
                             or "https://api.openai.com/v1").rstrip("/")
@@ -83,10 +90,11 @@ class Config:
                     "CARE_SESSION_SECRET must be at least 32 characters")
             _require("HEALTHCLAW_MINT_SECRET", self.mint_secret,
                      "careagents mints tenant-bound tokens server-side")
-            if not (self.anthropic_api_key or self.openai_api_key):
+            if not (self.anthropic_api_key or self.anthropic_oauth_token
+                    or self.openai_api_key):
                 raise ConfigError(
-                    "an LLM key is required (ANTHROPIC_API_KEY preferred, "
-                    "OPENAI_API_KEY fallback)")
+                    "an LLM credential is required (ANTHROPIC_API_KEY or "
+                    "ANTHROPIC_OAUTH_TOKEN preferred, OPENAI_API_KEY fallback)")
             _require("RESEND_API_KEY", self.resend_api_key,
                      "email verification codes require a transactional sender")
         else:
@@ -94,4 +102,6 @@ class Config:
 
     @property
     def provider(self) -> str:
-        return "anthropic" if self.anthropic_api_key else "openai"
+        if self.anthropic_api_key or self.anthropic_oauth_token:
+            return "anthropic"
+        return "openai"

--- a/careagents/llm.py
+++ b/careagents/llm.py
@@ -56,7 +56,15 @@ def complete(cfg, system: str, messages: list[dict], tools: list[dict]) -> LLMTu
 def _anthropic_complete(cfg, system, messages, tools) -> LLMTurn:
     import anthropic
 
-    client = anthropic.Anthropic(api_key=cfg.anthropic_api_key)
+    # An OAuth access token (Claude subscription / OpenClaw) authenticates as a
+    # Bearer token with the oauth beta header, instead of an x-api-key. The
+    # token is short-lived — refresh it out of band when it expires.
+    if getattr(cfg, "anthropic_oauth_token", ""):
+        client = anthropic.Anthropic(
+            auth_token=cfg.anthropic_oauth_token,
+            default_headers={"anthropic-beta": cfg.anthropic_oauth_beta})
+    else:
+        client = anthropic.Anthropic(api_key=cfg.anthropic_api_key)
     a_tools = [{"name": t["name"], "description": t["description"],
                 "input_schema": t["parameters"]} for t in tools]
     a_messages = _to_anthropic_messages(messages)

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -32,6 +32,20 @@ def test_production_config_requires_every_secret():
     assert ok.provider == "openai" and ok.rp_id == "careagents.cloud"
 
 
+def test_anthropic_oauth_token_selects_anthropic_provider():
+    # An OAuth token (Claude subscription / OpenClaw) is a valid LLM credential
+    # and selects the Anthropic provider without an API key.
+    dev = Config(env={"CARE_DATABASE_URL": "sqlite:///:memory:",
+                      "HEALTHCLAW_MINT_SECRET": "m",
+                      "ANTHROPIC_OAUTH_TOKEN": "oat-abc"})
+    assert dev.provider == "anthropic" and dev.anthropic_oauth_token == "oat-abc"
+    prod = Config(env={"CARE_ENV": "production",
+                       "CARE_SESSION_SECRET": "x" * 32,
+                       "HEALTHCLAW_MINT_SECRET": "m", "RESEND_API_KEY": "r",
+                       "ANTHROPIC_OAUTH_TOKEN": "oat-abc"})
+    assert prod.provider == "anthropic"  # satisfies the prod LLM-cred gate
+
+
 def test_every_persona_shares_the_safety_core():
     for key in PERSONAS:
         p = system_prompt("Juniper", key)


### PR DESCRIPTION
Re-lands #145 — the OAuth-token commit orphaned when #149 fast-merged before this push landed.

careagents now accepts `ANTHROPIC_OAUTH_TOKEN` (Claude subscription / OpenClaw) as an alternative to `ANTHROPIC_API_KEY`: when set, `llm.py` authenticates as `Authorization: Bearer` + the oauth beta header instead of `x-api-key`, and `provider` resolves to `anthropic`. Lets the demo run on real claude-sonnet-5 instead of rate-limited Gemini. Token is short-lived — refresh out of band. Inert unless the env var is set. 25 careagents tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)