### PR TITLE
fix(mcp): preserve error fidelity across transports

### DIFF
--- a/services/agent-orchestrator/src/backend-failure.ts
+++ b/services/agent-orchestrator/src/backend-failure.ts
@@ -1,0 +1,257 @@
+import type { Response } from "node-fetch";
+
+const MAX_BACKEND_ERROR_BYTES = 64 * 1024;
+const MAX_OPERATION_OUTCOME_ISSUES = 5;
+
+const SAFE_SEVERITIES = new Set(["fatal", "error", "warning", "information"]);
+const SAFE_ISSUE_CODES = new Set([
+  "invalid",
+  "structure",
+  "required",
+  "value",
+  "invariant",
+  "security",
+  "login",
+  "unknown",
+  "expired",
+  "forbidden",
+  "suppressed",
+  "processing",
+  "not-supported",
+  "duplicate",
+  "multiple-matches",
+  "not-found",
+  "deleted",
+  "too-long",
+  "code-invalid",
+  "extension",
+  "too-costly",
+  "business-rule",
+  "conflict",
+  "transient",
+  "lock-error",
+  "no-store",
+  "exception",
+  "timeout",
+  "incomplete",
+  "throttled",
+  "informational",
+]);
+
+const LOCAL_SEARCH_PARAMETERS = [
+  "patient",
+  "code",
+  "status",
+  "_lastUpdated",
+  "_count",
+  "_sort",
+  "_summary",
+  "context-id",
+] as const;
+const AUDIT_SEARCH_PARAMETERS = ["context-id", "entity-type", "_count"] as const;
+const LOCAL_SEARCH_PARAMETER_SETS = [
+  LOCAL_SEARCH_PARAMETERS,
+  AUDIT_SEARCH_PARAMETERS,
+] as const;
+const SAFE_UNSUPPORTED_SEARCH_KEYS = new Set(["date", "datetime"]);
+const SAFE_MODIFIER_TOKENS = new Set([
+  "above",
+  "below",
+  "contains",
+  "exact",
+  "identifier",
+  "in",
+  "iterate",
+  "missing",
+  "not",
+  "not-in",
+  "of-type",
+  "text",
+  "type",
+  "frobnicate",
+]);
+const FIXED_LOCAL_SEARCH_MESSAGES = new Set([
+  ...[...new Set([...LOCAL_SEARCH_PARAMETERS, ...AUDIT_SEARCH_PARAMETERS])].map(
+    (parameter) => `Repeated ${parameter} parameters are not supported.`
+  ),
+  "_count must be a non-negative integer.",
+  "_sort must be _lastUpdated or -_lastUpdated.",
+  "_summary only supports count.",
+  "Patient reference must match Patient/{id}.",
+  "_lastUpdated must be a valid ISO datetime with optional ge/le/gt/lt prefix.",
+  "context-id must be a valid FHIR id.",
+]);
+
+const ISSUE_CODE_MESSAGES: Record<string, string> = {
+  invalid: "The FHIR backend rejected the request as invalid.",
+  structure: "The FHIR backend rejected the request structure.",
+  required: "The FHIR backend reported a missing required element.",
+  value: "The FHIR backend rejected a submitted value.",
+  "not-supported": "The FHIR backend does not support this request.",
+  security: "FHIR backend authentication or authorization failed.",
+  forbidden: "The FHIR backend forbade this request.",
+  "not-found": "The FHIR backend reported the resource was not found.",
+  conflict: "The request conflicted with the current FHIR backend state.",
+  duplicate: "The FHIR backend reported a duplicate.",
+  "too-costly": "The FHIR backend refused the request as too costly.",
+  throttled: "The FHIR backend is rate-limiting requests.",
+  processing: "The FHIR backend could not process the request.",
+  transient: "The FHIR backend could not complete the request.",
+  timeout: "The FHIR backend timed out.",
+  exception: "The FHIR backend encountered an internal error.",
+};
+
+interface SanitizedIssue {
+  severity: string;
+  code: string;
+  details: { text: string };
+}
+
+interface SanitizedOperationOutcome {
+  resourceType: "OperationOutcome";
+  issue: SanitizedIssue[];
+}
+
+function issueCodeForStatus(status: number): string {
+  const statusCodes: Record<number, string> = {
+    400: "invalid",
+    401: "security",
+    403: "security",
+    404: "not-found",
+    405: "not-supported",
+    409: "conflict",
+    410: "deleted",
+    412: "conflict",
+    422: "processing",
+    429: "throttled",
+  };
+  return statusCodes[status] ?? (status >= 500 ? "transient" : "processing");
+}
+
+function messageForCode(code: string): string {
+  return ISSUE_CODE_MESSAGES[code] ?? "The FHIR backend could not complete the request.";
+}
+
+function safeLocalSearchText(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > 1_000) return undefined;
+  if (FIXED_LOCAL_SEARCH_MESSAGES.has(value)) return value;
+
+  const suffix = LOCAL_SEARCH_PARAMETER_SETS.map(
+    (parameters) => `. Supported parameters: ${parameters.join(", ")}.`
+  ).find((candidate) => value.endsWith(candidate));
+  if (!suffix) return undefined;
+  const prefix = value.slice(0, -suffix.length);
+  if (prefix === "Unknown parameter" || prefix === "Unsupported modifier") {
+    return value;
+  }
+
+  const unknown = /^Unknown parameter: ([A-Za-z_-]+)$/.exec(prefix);
+  if (unknown && SAFE_UNSUPPORTED_SEARCH_KEYS.has(unknown[1])) return value;
+
+  const modifier = /^Unsupported modifier: ([A-Za-z_-]+):([A-Za-z-]+)$/.exec(prefix);
+  if (
+    modifier &&
+    LOCAL_SEARCH_PARAMETERS.includes(
+      modifier[1] as (typeof LOCAL_SEARCH_PARAMETERS)[number]
+    ) &&
+    SAFE_MODIFIER_TOKENS.has(modifier[2])
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function fallbackOutcome(status: number): SanitizedOperationOutcome {
+  const code = issueCodeForStatus(status);
+  return {
+    resourceType: "OperationOutcome",
+    issue: [{ severity: "error", code, details: { text: messageForCode(code) } }],
+  };
+}
+
+function sanitizeOperationOutcome(
+  value: unknown,
+  status: number
+): SanitizedOperationOutcome | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const outcome = value as Record<string, unknown>;
+  if (outcome.resourceType !== "OperationOutcome" || !Array.isArray(outcome.issue)) {
+    return undefined;
+  }
+
+  const fallbackCode = issueCodeForStatus(status);
+  const issues: SanitizedIssue[] = [];
+  for (const rawIssue of outcome.issue.slice(0, MAX_OPERATION_OUTCOME_ISSUES)) {
+    if (!rawIssue || typeof rawIssue !== "object" || Array.isArray(rawIssue)) continue;
+    const issue = rawIssue as Record<string, unknown>;
+    const tokensAreSafe =
+      typeof issue.severity === "string" &&
+      SAFE_SEVERITIES.has(issue.severity) &&
+      typeof issue.code === "string" &&
+      SAFE_ISSUE_CODES.has(issue.code);
+    const severity = tokensAreSafe ? (issue.severity as string) : "error";
+    const code = tokensAreSafe ? (issue.code as string) : fallbackCode;
+    const details = issue.details;
+    const localSearchText =
+      tokensAreSafe && details && typeof details === "object" && !Array.isArray(details)
+        ? safeLocalSearchText((details as Record<string, unknown>).text)
+        : undefined;
+    issues.push({
+      severity,
+      code,
+      details: { text: localSearchText ?? messageForCode(code) },
+    });
+  }
+
+  return issues.length > 0
+    ? { resourceType: "OperationOutcome", issue: issues }
+    : undefined;
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const contentLength = response.headers?.get("content-length");
+  if (contentLength) {
+    const size = Number(contentLength);
+    if (Number.isFinite(size) && size > MAX_BACKEND_ERROR_BYTES) return undefined;
+  }
+
+  try {
+    let text: string;
+    const body = response.body as (AsyncIterable<Uint8Array | string> & {
+      destroy?: () => void;
+    }) | null;
+    if (body && typeof body[Symbol.asyncIterator] === "function") {
+      const chunks: Buffer[] = [];
+      let size = 0;
+      for await (const chunk of body) {
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        size += bytes.length;
+        if (size > MAX_BACKEND_ERROR_BYTES) {
+          body.destroy?.();
+          return undefined;
+        }
+        chunks.push(bytes);
+      }
+      text = Buffer.concat(chunks, size).toString("utf8");
+    } else {
+      // Response-like mocks and adapters may not expose a readable body.
+      text = await response.text();
+      if (Buffer.byteLength(text, "utf8") > MAX_BACKEND_ERROR_BYTES) return undefined;
+    }
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function backendFailureResult(
+  response: Response
+): Promise<Record<string, unknown>> {
+  const body = await readBoundedJson(response);
+  const operationOutcome =
+    sanitizeOperationOutcome(body, response.status) ?? fallbackOutcome(response.status);
+  return {
+    error: operationOutcome,
+    status: response.status,
+  };
+}

--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -22,10 +22,12 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import {
   CallToolRequestSchema,
+  McpError,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import crypto from "crypto";
 import { FHIRTools } from "./tools";
+import { executeMCPTool } from "./mcp-tool-result";
 
 const { version: SERVER_VERSION } = require("../package.json") as {
   version: string;
@@ -280,10 +282,7 @@ function createMCPServer(sessionHeaders: Record<string, string> = {}): Server {
       delete toolArgs._patientId;
     }
 
-    const result = await fhirTools.executeTool(name, toolArgs, toolHeaders);
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
+    return executeMCPTool(fhirTools, name, toolArgs, toolHeaders);
   });
 
   return server;
@@ -376,10 +375,18 @@ app.post("/mcp", async (req, res) => {
           });
         }
 
-        const toolName = params?.name as string;
-        const toolInput = (params?.arguments ?? {}) as Record<string, unknown>;
+        if (!params || typeof params !== "object" || Array.isArray(params)) {
+          return res.json({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32602, message: "Invalid tool call parameters" },
+          });
+        }
 
-        if (!toolName) {
+        const toolName = params.name as string;
+        const rawToolInput = params.arguments;
+
+        if (typeof toolName !== "string" || !toolName) {
           return res.json({
             jsonrpc: "2.0",
             id,
@@ -387,13 +394,28 @@ app.post("/mcp", async (req, res) => {
           });
         }
 
-        const result = await fhirTools.executeTool(toolName, toolInput, reqHeaders);
+        if (
+          rawToolInput !== undefined &&
+          (!rawToolInput || typeof rawToolInput !== "object" || Array.isArray(rawToolInput))
+        ) {
+          return res.json({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32602, message: "Tool arguments must be an object" },
+          });
+        }
+        const toolInput = (rawToolInput ?? {}) as Record<string, unknown>;
+
+        const result = await executeMCPTool(
+          fhirTools,
+          toolName,
+          toolInput,
+          reqHeaders
+        );
         return res.json({
           jsonrpc: "2.0",
           id,
-          result: {
-            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-          },
+          result,
         });
       }
 
@@ -405,6 +427,13 @@ app.post("/mcp", async (req, res) => {
         });
     }
   } catch (error: unknown) {
+    if (error instanceof McpError) {
+      return res.json({
+        jsonrpc: "2.0",
+        id,
+        error: { code: error.code, message: error.message },
+      });
+    }
     const detail = error instanceof Error ? error.message : "Unknown error";
     console.error("Streamable HTTP error for method:", method, "-", detail);
     return res.json({
@@ -508,7 +537,7 @@ app.post("/messages", async (req, res) => {
     return res.status(400).json({ error: "Invalid or expired session" });
   }
   session.lastActivity = Date.now();
-  await session.transport.handlePostMessage(req, res);
+  await session.transport.handlePostMessage(req, res, req.body);
 });
 
 // --- Legacy HTTP Bridge (for Python agent_client) ---

--- a/services/agent-orchestrator/src/mcp-tool-result.ts
+++ b/services/agent-orchestrator/src/mcp-tool-result.ts
@@ -1,0 +1,43 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { FHIRTools } from "./tools";
+
+export function toMCPToolResult(result: Record<string, unknown>): CallToolResult {
+  const callToolResult: CallToolResult = {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+  if (Object.prototype.hasOwnProperty.call(result, "error")) {
+    callToolResult.isError = true;
+  }
+  return callToolResult;
+}
+
+export async function executeMCPTool(
+  tools: FHIRTools,
+  name: string,
+  input: Record<string, unknown>,
+  headers: Record<string, string>
+): Promise<CallToolResult> {
+  if (!tools.hasTool(name)) {
+    throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+  }
+
+  try {
+    return toMCPToolResult(await tools.executeTool(name, input, headers));
+  } catch (error) {
+    const errorType = error instanceof Error ? error.name : typeof error;
+    console.error(`[mcp] tool execution failed name=${name} type=${errorType}`);
+    return toMCPToolResult({
+      error: {
+        resourceType: "OperationOutcome",
+        issue: [
+          {
+            severity: "error",
+            code: "exception",
+            details: { text: "The tool could not complete the request." },
+          },
+        ],
+      },
+    });
+  }
+}

--- a/services/agent-orchestrator/src/stdio.ts
+++ b/services/agent-orchestrator/src/stdio.ts
@@ -17,6 +17,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { FHIRTools } from "./tools";
+import { executeMCPTool } from "./mcp-tool-result";
 
 const { version: SERVER_VERSION } = require("../package.json") as {
   version: string;
@@ -62,19 +63,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     delete toolArgs._humanConfirmed;
   }
 
-  try {
-    const result = await fhirTools.executeTool(name, toolArgs, headers);
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[healthclaw-guardrails] tool error (${name}):`, msg);
-    return {
-      content: [{ type: "text", text: JSON.stringify({ error: msg }) }],
-      isError: true,
-    };
-  }
+  return executeMCPTool(fhirTools, name, toolArgs, headers);
 });
 
 const transport = new StdioServerTransport();

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -49,6 +49,16 @@ function fakeResponse(body: Record<string, unknown>, status = 200) {
     ok: status >= 200 && status < 300,
     status,
     json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  };
+}
+
+function fakeTextResponse(body: string, status: number) {
+  return {
+    ok: false,
+    status,
+    json: jest.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+    text: jest.fn().mockResolvedValue(body),
   };
 }
 
@@ -315,8 +325,10 @@ describe("Tool Execution Tests", () => {
       resource_id: "nonexistent",
     });
 
-    expect(result).toHaveProperty("error");
-    expect((result as Record<string, unknown>).error).toContain("404");
+    expect(result).toMatchObject({
+      status: 404,
+      error: { resourceType: "OperationOutcome" },
+    });
   });
 
   // -- fhir.search --
@@ -512,6 +524,255 @@ describe("Tool Execution Tests", () => {
     const summary = (result as Record<string, unknown>)._mcp_summary as Record<string, unknown>;
     expect(summary.total).toBe(0);
     expect(summary.note).toContain("No Observation resources found");
+  });
+
+  it("fhir.search preserves a bounded backend OperationOutcome and HTTP status", async () => {
+    const hostileText = "Patient Jane Doe https://internal.example?token=secret";
+    const issue = {
+      severity: "error",
+      code: "not-supported",
+      details: {
+        text: hostileText,
+      },
+      diagnostics: "must not survive",
+      extension: [{ url: "https://internal.example/secret" }],
+    };
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: Array.from({ length: 8 }, () => ({ ...issue })),
+          text: { div: "must not survive" },
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "Observation",
+    });
+
+    expect(result).toEqual({
+      status: 400,
+      error: {
+        resourceType: "OperationOutcome",
+        issue: Array.from({ length: 5 }, () => ({
+          severity: "error",
+          code: "not-supported",
+          details: {
+            text: "The FHIR backend does not support this request.",
+          },
+        })),
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(hostileText);
+    expect(JSON.stringify(result)).not.toContain("internal.example");
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it("fhir.search synthesizes a bounded failure without exposing a non-JSON body", async () => {
+    const hostileBody =
+      "<html>stack trace for Patient Jane Doe at https://internal.example?token=secret</html>";
+    mockFetch.mockResolvedValueOnce(fakeTextResponse(hostileBody, 502));
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "Observation",
+    });
+
+    expect(result).toEqual({
+      status: 502,
+      error: {
+        resourceType: "OperationOutcome",
+        issue: [
+          {
+            severity: "error",
+            code: "transient",
+            details: { text: "The FHIR backend could not complete the request." },
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(hostileBody);
+    expect(JSON.stringify(result)).not.toContain("Jane Doe");
+    expect(JSON.stringify(result)).not.toContain("internal.example");
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it("fhir.search preserves only allowlisted local corrective guidance", async () => {
+    const localGuidance =
+      "Unknown parameter: datetime. Supported parameters: patient, code, status, _lastUpdated, _count, _sort, _summary, context-id.";
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "not-supported",
+              details: { text: localGuidance },
+            },
+          ],
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "Observation",
+    });
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: {
+        issue: [{ details: { text: localGuidance } }],
+      },
+    });
+  });
+
+  it("fhir.search preserves the allowlisted AuditEvent corrective vocabulary", async () => {
+    const localGuidance =
+      "Unknown parameter: datetime. Supported parameters: context-id, entity-type, _count.";
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "not-supported",
+              details: { text: localGuidance },
+            },
+          ],
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "AuditEvent",
+    });
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: {
+        issue: [{ details: { text: localGuidance } }],
+      },
+    });
+  });
+
+  it.each([
+    ["context_get", { context_id: "ctx-1" }],
+    ["fhir_read", { resource_type: "Patient", resource_id: "pt-1" }],
+    ["fhir_search", { resource_type: "Observation" }],
+    ["fhir_validate", { resource: { resourceType: "Patient" } }],
+    ["search", { query: "Observation?status=final" }],
+    ["fetch", { id: "Patient/pt-1" }],
+  ])("%s preserves the shared backend failure envelope", async (toolName, input) => {
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "invalid",
+              details: { text: "The locally sanitized corrective message." },
+            },
+          ],
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool(toolName, input);
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: {
+        resourceType: "OperationOutcome",
+        issue: [
+          {
+            severity: "error",
+            code: "invalid",
+            details: { text: "The FHIR backend rejected the request as invalid." },
+          },
+        ],
+      },
+    });
+  });
+
+  it("does not preserve details text when OperationOutcome tokens are malformed", async () => {
+    const hostileText = "Patient Jane Doe https://internal.example?token=secret";
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: { hostile: true },
+              code: ["invalid"],
+              details: { text: hostileText },
+            },
+          ],
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "Observation",
+    });
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: {
+        issue: [
+          {
+            severity: "error",
+            code: "invalid",
+            details: { text: "The FHIR backend rejected the request as invalid." },
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(hostileText);
+  });
+
+  it("does not parse or expose an oversized backend failure body", async () => {
+    const oversizedSecret = `Patient Jane Doe ${"x".repeat(70_000)}`;
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "invalid",
+              details: { text: oversizedSecret },
+            },
+          ],
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool("fhir_search", {
+      resource_type: "Observation",
+    });
+
+    expect(result).toMatchObject({
+      status: 400,
+      error: {
+        issue: [
+          {
+            severity: "error",
+            code: "invalid",
+            details: { text: "The FHIR backend rejected the request as invalid." },
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("Jane Doe");
   });
 
   // -- fhir.commit_write (step-up enforcement) --
@@ -1446,8 +1707,10 @@ describe("Tool Execution Tests", () => {
 
     const result = await tools.executeTool("search", { query: "Patient" });
 
-    expect(result).toHaveProperty("error");
-    expect((result.error as string)).toContain("500");
+    expect(result).toMatchObject({
+      status: 500,
+      error: { resourceType: "OperationOutcome" },
+    });
   });
 
   it("fetch returns document shape for a valid ResourceType/id", async () => {
@@ -1498,8 +1761,10 @@ describe("Tool Execution Tests", () => {
 
     const result = await tools.executeTool("fetch", { id: "Patient/nonexistent" });
 
-    expect(result).toHaveProperty("error");
-    expect((result.error as string)).toContain("404");
+    expect(result).toMatchObject({
+      status: 404,
+      error: { resourceType: "OperationOutcome" },
+    });
   });
 });
 

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -25,6 +25,7 @@ import {
   BackendTimeoutError,
   backendTimeoutResult,
 } from "./fetch-timeout";
+import { backendFailureResult } from "./backend-failure";
 import Ajv, { type ErrorObject, type ValidateFunction } from "ajv";
 import { generateMasterSecret, deriveAuth, deriveKey } from "./ktc/hkdf";
 import { encryptJWE } from "./ktc/jwe";
@@ -1108,6 +1109,10 @@ export class FHIRTools {
     }
   }
 
+  hasTool(toolName: string): boolean {
+    return this.registry.has(toolName as ToolName);
+  }
+
   private async executeToolInner(
     toolName: string,
     input: Record<string, unknown>,
@@ -1195,15 +1200,7 @@ export class FHIRTools {
       { headers }
     );
     if (!resp.ok) {
-      if (resp.status === 404) {
-        return {
-          error: "context not found",
-          detail:
-            "No context envelope with that id (envelopes are created by Bundle/$ingest-context and expire after ~30 minutes). " +
-            "To explore the record instead, use fhir_search / fhir_stats / fhir_read; for clinical summaries use fhir_interpret_labs or care_gaps.",
-        };
-      }
-      return { error: `Context fetch failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
     return (await resp.json()) as Record<string, unknown>;
   }
@@ -1218,7 +1215,7 @@ export class FHIRTools {
       { headers }
     );
     if (!resp.ok) {
-      return { error: `Read failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
     return (await resp.json()) as Record<string, unknown>;
   }
@@ -1248,7 +1245,7 @@ export class FHIRTools {
       { headers }
     );
     if (!resp.ok) {
-      return { error: `Search failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
     const result = (await resp.json()) as Record<string, unknown>;
 
@@ -1286,7 +1283,7 @@ export class FHIRTools {
       }
     );
     if (!resp.ok) {
-      return { error: `Validation request failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
     return (await resp.json()) as Record<string, unknown>;
   }
@@ -2205,7 +2202,7 @@ export class FHIRTools {
       { headers }
     );
     if (!resp.ok) {
-      return { error: `search failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
 
     const bundle = (await resp.json()) as Record<string, unknown>;
@@ -2247,7 +2244,7 @@ export class FHIRTools {
       { headers }
     );
     if (!resp.ok) {
-      return { error: `fetch failed with status ${resp.status}` };
+      return backendFailureResult(resp);
     }
 
     const resource = (await resp.json()) as Record<string, unknown>;

--- a/services/agent-orchestrator/src/transport-errors.test.ts
+++ b/services/agent-orchestrator/src/transport-errors.test.ts
@@ -1,0 +1,417 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+jest.mock("node-fetch", () => jest.fn());
+import nodeFetch from "node-fetch";
+import { app, closeMCPServerForTests } from "./index";
+
+const mockFetch = nodeFetch as unknown as jest.Mock;
+
+jest.setTimeout(30_000);
+
+const localSearchGuidance =
+  "Unknown parameter: datetime. Supported parameters: patient, code, status, _lastUpdated, _count, _sort, _summary, context-id.";
+
+const backendOperationOutcome = {
+  resourceType: "OperationOutcome",
+  issue: [
+    {
+      severity: "error",
+      code: "not-supported",
+      details: { text: localSearchGuidance },
+    },
+  ],
+};
+
+const safeOperationOutcome = {
+  resourceType: "OperationOutcome",
+  issue: [
+    {
+      severity: "error",
+      code: "not-supported",
+      details: { text: localSearchGuidance },
+    },
+  ],
+};
+
+function mockedBackendFailure() {
+  return {
+    ok: false,
+    status: 400,
+    headers: { get: jest.fn().mockReturnValue(null) },
+    json: jest.fn().mockResolvedValue(backendOperationOutcome),
+    text: jest.fn().mockResolvedValue(JSON.stringify(backendOperationOutcome)),
+  };
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function parseTextContent(result: unknown): unknown {
+  if (!result || typeof result !== "object" || !("content" in result)) {
+    throw new Error("Expected tool result content");
+  }
+  const content = (result as { content: unknown }).content;
+  if (!Array.isArray(content)) throw new Error("Expected tool result content");
+  const block = content[0] as { type?: unknown; text?: unknown } | undefined;
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    throw new Error("Expected text tool result");
+  }
+  return JSON.parse(block.text) as unknown;
+}
+
+interface JSONRPCResponse {
+  jsonrpc: "2.0";
+  id?: string | number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+interface SSEConnection {
+  endpoint: string;
+  nextMessage(id: string | number): Promise<JSONRPCResponse>;
+  close(): void;
+}
+
+function openSSE(baseUrl: string): Promise<SSEConnection> {
+  return new Promise((resolve, reject) => {
+    const messages: JSONRPCResponse[] = [];
+    const waiters = new Map<string | number, (message: JSONRPCResponse) => void>();
+    let buffer = "";
+    let endpoint = "";
+    let response: http.IncomingMessage | undefined;
+
+    const req = http.get(`${baseUrl}/sse`, (res) => {
+      response = res;
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        buffer += chunk;
+        const frames = buffer.split(/\r?\n\r?\n/);
+        buffer = frames.pop() ?? "";
+        for (const frame of frames) {
+          const event = /^event:\s*(.+)$/m.exec(frame)?.[1];
+          const data = /^data:\s*(.+)$/m.exec(frame)?.[1];
+          if (!data) continue;
+          if (event === "endpoint") {
+            endpoint = new URL(data, baseUrl).toString();
+            resolve({
+              endpoint,
+              nextMessage(id) {
+                const queued = messages.find((message) => message.id === id);
+                if (queued) return Promise.resolve(queued);
+                return new Promise((resolveMessage) => waiters.set(id, resolveMessage));
+              },
+              close() {
+                response?.destroy();
+                req.destroy();
+              },
+            });
+          } else if (event === "message") {
+            const message = JSON.parse(data) as JSONRPCResponse;
+            const waiter = message.id === undefined ? undefined : waiters.get(message.id);
+            if (waiter && message.id !== undefined) {
+              waiters.delete(message.id);
+              waiter(message);
+            } else {
+              messages.push(message);
+            }
+          }
+        }
+      });
+      res.once("error", reject);
+    });
+    req.once("error", reject);
+  });
+}
+
+async function postJSON(url: string, body: Record<string, unknown>): Promise<Response> {
+  return globalThis.fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+type TransportKind = "streamable-http" | "sse" | "stdio";
+
+describe("MCP transport error parity", () => {
+  const appServer = http.createServer(app);
+  let backendMode: "failure" | "disconnect" | "hang" = "failure";
+  const backendServer = http.createServer((_req, res) => {
+    if (backendMode === "disconnect") {
+      res.destroy();
+      return;
+    }
+    if (backendMode === "hang") return;
+    res.writeHead(400, { "content-type": "application/fhir+json" });
+    res.end(JSON.stringify(backendOperationOutcome));
+  });
+  let appPort: number;
+  let backendPort: number;
+
+  beforeAll(async () => {
+    [appPort, backendPort] = await Promise.all([listen(appServer), listen(backendServer)]);
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    backendMode = "failure";
+  });
+
+  afterAll(async () => {
+    closeMCPServerForTests();
+    await Promise.all([close(appServer), close(backendServer)]);
+  });
+
+  async function callTool(
+    kind: TransportKind,
+    name: string,
+    scenario: "normal" | "timeout" = "normal"
+  ): Promise<JSONRPCResponse> {
+    if (kind === "streamable-http") {
+      const init = await postJSON(`http://127.0.0.1:${appPort}/mcp`, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      });
+      const sessionId = init.headers.get("mcp-session-id");
+      if (!sessionId) throw new Error("Expected Streamable HTTP session id");
+      const response = await globalThis.fetch(`http://127.0.0.1:${appPort}/mcp`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "mcp-session-id": sessionId,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name, arguments: { resource_type: "Observation" } },
+        }),
+      });
+      return (await response.json()) as JSONRPCResponse;
+    }
+
+    if (kind === "sse") {
+      const connection = await openSSE(`http://127.0.0.1:${appPort}`);
+      try {
+        await postJSON(connection.endpoint, {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "sse-wire-test", version: "1.0.0" },
+          },
+        });
+        await connection.nextMessage(1);
+        await postJSON(connection.endpoint, {
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        await postJSON(connection.endpoint, {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name, arguments: { resource_type: "Observation" } },
+        });
+        return await connection.nextMessage(2);
+      } finally {
+        connection.close();
+      }
+    }
+
+    const inheritedEnv = Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] =>
+        typeof entry[1] === "string"
+      )
+    );
+    const client = new Client({ name: "stdio-wire-test", version: "1.0.0" });
+    const stdioArgs =
+      scenario === "timeout"
+        ? [
+            "-e",
+            [
+              "const originalTimeout = AbortSignal.timeout.bind(AbortSignal);",
+              "Object.defineProperty(AbortSignal, 'timeout', { value: (ms) => originalTimeout(Math.min(ms, 25)) });",
+              "require('ts-node/register');",
+              "require('./src/stdio.ts');",
+            ].join(" "),
+          ]
+        : ["-r", "ts-node/register", "src/stdio.ts"];
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: stdioArgs,
+      cwd: process.cwd(),
+      env: {
+        ...inheritedEnv,
+        FHIR_BASE_URL: `http://127.0.0.1:${backendPort}/r6/fhir`,
+        READ_TOKEN_AUTOMINT: "false",
+      },
+      stderr: "pipe",
+    });
+    try {
+      await client.connect(transport);
+      try {
+        const result = await client.callTool({
+          name,
+          arguments: { resource_type: "Observation" },
+        });
+        return { jsonrpc: "2.0", id: 2, result };
+      } catch (error) {
+        const protocolError = error as { code: number; message: string };
+        return {
+          jsonrpc: "2.0",
+          id: 2,
+          error: { code: protocolError.code, message: protocolError.message },
+        };
+      }
+    } finally {
+      await client.close();
+    }
+  }
+
+  it.each(["streamable-http", "sse", "stdio"] as const)(
+    "returns equivalent isError content through %s",
+    async (kind) => {
+      mockFetch.mockResolvedValueOnce(mockedBackendFailure());
+      const response = await callTool(kind, "fhir_search");
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).toBe(true);
+      expect(parseTextContent(response.result)).toEqual({
+        error: safeOperationOutcome,
+        status: 400,
+      });
+    }
+  );
+
+  it.each(["streamable-http", "sse", "stdio"] as const)(
+    "marks backend_timeout as isError through %s",
+    async (kind) => {
+      const secret = "Patient Jane Doe https://internal.example?token=secret";
+      if (kind === "stdio") {
+        backendMode = "hang";
+      } else {
+        mockFetch.mockRejectedValueOnce(
+          Object.assign(new Error(secret), { name: "AbortError" })
+        );
+      }
+
+      const response = await callTool(kind, "fhir_search", "timeout");
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).toBe(true);
+      expect(parseTextContent(response.result)).toMatchObject({
+        error: "backend_timeout",
+        retryable: true,
+      });
+      expect(JSON.stringify(response)).not.toContain(secret);
+    }
+  );
+
+  it.each(["streamable-http", "sse", "stdio"] as const)(
+    "turns thrown executor failures into sanitized tool errors through %s",
+    async (kind) => {
+      const secret = "Patient Jane Doe https://internal.example?token=secret";
+      if (kind === "stdio") {
+        backendMode = "disconnect";
+      } else {
+        mockFetch.mockRejectedValueOnce(new Error(secret));
+      }
+
+      const response = await callTool(kind, "fhir_search");
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.isError).toBe(true);
+      expect(parseTextContent(response.result)).toEqual({
+        error: {
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "exception",
+              details: { text: "The tool could not complete the request." },
+            },
+          ],
+        },
+      });
+      expect(JSON.stringify(response)).not.toContain(secret);
+      expect(JSON.stringify(response)).not.toContain("internal.example");
+    }
+  );
+
+  it.each(["streamable-http", "sse", "stdio"] as const)(
+    "keeps unknown tools as protocol errors through %s",
+    async (kind) => {
+      const response = await callTool(kind, "fhir_nonexistent");
+
+      expect(response.result).toBeUndefined();
+      expect(response.error).toMatchObject({ code: -32601 });
+    }
+  );
+
+  it("keeps non-object Streamable HTTP arguments as a protocol error", async () => {
+    const init = await postJSON(`http://127.0.0.1:${appPort}/mcp`, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+    const response = await globalThis.fetch(`http://127.0.0.1:${appPort}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "mcp-session-id": init.headers.get("mcp-session-id") ?? "",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "fhir_search", arguments: "not-an-object" },
+      }),
+    });
+    const body = (await response.json()) as JSONRPCResponse;
+
+    expect(body.result).toBeUndefined();
+    expect(body.error).toMatchObject({ code: -32602 });
+  });
+
+  it("keeps /mcp/rpc raw while enriching its backend failure", async () => {
+    mockFetch.mockResolvedValueOnce(mockedBackendFailure());
+    const response = await postJSON(`http://127.0.0.1:${appPort}/mcp/rpc`, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "fhir_search",
+        arguments: { resource_type: "Observation" },
+      },
+    });
+    const body = (await response.json()) as JSONRPCResponse;
+
+    expect(body.result).toEqual({
+      error: safeOperationOutcome,
+      status: 400,
+    });
+    expect(body.result).not.toHaveProperty("content");
+    expect(body.result).not.toHaveProperty("isError");
+  });
+});


### PR DESCRIPTION
Closes #93.

## What changed

- Preserve non-2xx read-path failures as a bounded error envelope containing the original HTTP status and a sanitized FHIR `OperationOutcome`.
- Apply the shared failure parser to `context_get`, `fhir_read`, `fhir_search`, `fhir_validate`, and the connector-compatible `search` / `fetch` tools.
- Use one MCP result adapter for stdio, legacy SSE, and Streamable HTTP so returned tool failures and `backend_timeout` consistently set `isError: true`.
- Keep unknown tools and malformed MCP calls as JSON-RPC protocol errors (`-32601` / `-32602`).
- Keep `/mcp/rpc` compatibility: it still returns the raw executor payload, now with the richer bounded failure.
- Pass the already-parsed Express body into the SDK SSE handler; without this, real SSE `tools/call` requests failed because the request stream had already been consumed.

## Security contract

The MCP layer never forwards arbitrary backend error text. It retains only allowlisted FHIR severity/code tokens, caps the body at 64 KiB and issues at five, drops diagnostics/extensions/extra fields, and synthesizes human text locally. The only preserved corrective text is the exact finite grammar generated by the local general-search and `AuditEvent` search contracts; hostile lookalikes fall back to code-derived text.

Malformed JSON, HTML, oversized bodies, thrown exceptions, URLs, tokens, stack text, and PHI-shaped hostile values are covered by adversarial tests and do not reach MCP content.

## Verification

- Agent orchestrator (Node 22): **168 passed**
- TypeScript: `tsc --noEmit` clean
- Full Python suite: **1,481 passed, 1 skipped**
- Ruff: clean
- Real transport tests exercise Streamable HTTP, SSE wire traffic, and a spawned stdio server for returned failures, thrown failures, timeouts, and unknown tools.
- DCO sign-off present; tool/version counts unchanged.
