### PR TITLE
docs: advisors-system roadmap + agent task guide

### DIFF
--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -1,0 +1,188 @@
+# Picking up an issue — guide for coding agents and collaborators
+
+If you (human or coding agent) are starting work on an issue in this repo, read
+this first. It exists so you don't begin from scratch: it tells you where things
+live, what you may not break, and what "done" means here.
+
+**Read order:** this file → [CLAUDE.md](../CLAUDE.md) (architecture + invariants)
+→ [docs/development.md](development.md) (build/test/deploy detail) → the issue.
+
+---
+
+## 1. What this project is, in one paragraph
+
+HealthClaw Guardrails is a safety layer between AI agents and FHIR health data.
+Guardrails run **server-side** — redaction on reads, step-up + human confirmation
+on writes, audit on everything — so a client cannot bypass them. That single
+sentence explains most design decisions you'll encounter. If a change would let
+a *client* decide whether a guardrail applies, the change is wrong regardless of
+how clean the code is.
+
+---
+
+## 2. The invariants — non-negotiable
+
+These are enforced by the conformance harness
+(`tests/test_guardrail_conformance.py`, a CI gate that must stay **Grade A**).
+Breaking one fails CI, but more importantly it breaks the product's core claim.
+
+- `validate_step_up_token` returns `(bool, str)` — **destructure both**. Never
+  truthiness-test the tuple; a non-empty tuple is always truthy, so this silently
+  authorizes everything.
+- **Every FHIR resource access emits an AuditEvent**, and audit `detail` stays
+  **PHI-free**. Never interpolate a caller-supplied value into audit detail.
+- Writes require a step-up token. **Clinical** writes additionally require
+  out-of-band human confirmation via a separate approval endpoint. There is no
+  header that grants this — the old spoofable `X-Human-Confirmed` is gone, and
+  nothing may reintroduce that pattern.
+- No code path may let an agent approve its own action.
+- Redaction goes through `r6.redaction`: `apply_redaction` (Safe Harbor) or
+  `apply_patient_controlled_redaction(resource, patient_id)`.
+- **"No known allergies" is never inferred** — only from an explicit human
+  attestation in the SDC populate/review flow.
+- Resource identity is composite: `(tenant_id, resource_type, id)`. **Every
+  query must be tenant-scoped.** Ids can collide across tenants.
+- CareAgents and SmartHealthConnect store **no PHI**.
+- Never print, log, or commit secrets or PHI. Demo/test data is synthetic only.
+
+### The reflection rule (easy to get wrong)
+
+Do not copy caller-supplied or backend-supplied text into error messages,
+warnings, or audit detail. The established pattern is an **allowlist that
+constructs rather than filters**: derive the output from a finite, code-owned
+set, and fall back to a generic message when input isn't in it. See
+`_safe_unsupported_key` in `r6/routes.py` and `sanitizeOperationOutcome` in
+`services/agent-orchestrator/src/backend-failure.ts` for the two reference
+implementations — one Python, one TypeScript.
+
+---
+
+## 3. Where things live
+
+```text
+r6/                      Flask FHIR facade + guardrail engine
+  routes.py              REST facade (large — see #56 for the carve-up plan)
+  redaction.py           Safe Harbor + patient-controlled redaction
+  audit.py, models.py    AuditEvent + persistence
+  actions/               action rail — the plugin surface for real-world actions
+    rails/*.py           ActionExecutors, registered in rails/__init__.py
+  quality/ labs/ sdc/ conformance/ shc/ smbp/ wearables/
+                         pure engines + register_*_routes(blueprint, deps)
+careagents/              hosted consumer app — SEPARATE Flask app, no PHI
+services/agent-orchestrator/   Node/TypeScript MCP server
+tests/                   pytest; fixtures in conftest.py
+e2e/                     Playwright
+```
+
+**The module pattern.** New feature modules follow `r6/quality`: a **pure
+engine** (no Flask, no DB), report builders, and a `register_*_routes(...)`
+wired into `r6/routes.py`. Follow it — it's what makes the engines testable
+without a request context.
+
+**The action rail is the extension point.** Adding a real-world capability means
+writing an `ActionExecutor` and registering it — it then inherits the whole rail
+(propose-time validation → out-of-band human gate → audit → reconciliation)
+without touching core code. See
+[docs/extending-the-action-rail.md](extending-the-action-rail.md). If you find
+yourself building a *new* approval mechanism, stop: use the rail.
+
+**Two more repos.** [SmartHealthConnect](https://github.com/aks129/SmartHealthConnect)
+is the patient-facing surface (skills + MCP app); this repo is the engine. The
+split is declared in `.health-context.yaml` in each (`role: engine` /
+`role: surface`). Surfaces never read FHIR directly.
+
+---
+
+## 4. Build, test, verify
+
+`.env` is **not auto-loaded** — export vars in your shell. A key present only in
+`.env` behaves as unset.
+
+```bash
+uv sync
+STEP_UP_SECRET=dev-secret python main.py            # http://localhost:5000
+
+uv run python -m pytest tests/ -q                    # all Python tests
+uv run python -m pytest tests/test_r6_routes.py::test_name -v   # one test
+uvx ruff check r6/ tests/ scripts/ main.py app.py    # lint (CI-gated)
+
+cd services/agent-orchestrator && npm ci && npx tsc --noEmit && npm test
+```
+
+**CI runs Python 3.11**; local dev works on 3.13. Avoid 3.12+-only syntax (e.g.
+backslash escapes inside f-string expressions) or CI will fail on code that
+passes locally.
+
+**There is a Postgres CI lane** because SQLite masks a real bug class (varchar
+length limits). If you add a column, match its width to real values — and know
+that a local SQLite-only run does **not** prove the Postgres lane passes.
+
+Revert incidental `uv.lock` churn before committing.
+
+---
+
+## 5. Definition of done
+
+An issue is done when all of these hold. State them explicitly in the PR.
+
+- [ ] `uv run python -m pytest tests/ -q` passes — quote the actual counts
+- [ ] `uvx ruff check r6/ tests/ scripts/ main.py app.py` clean
+- [ ] Node changes: `npx tsc --noEmit` clean and `npm test` passes
+- [ ] Conformance still **Grade A** (`tests/test_guardrail_conformance.py`)
+- [ ] New behavior has tests — including a **negative** test (the guardrail
+      actually refuses the thing it claims to refuse)
+- [ ] No caller/backend text reflected into errors, warnings, or audit detail
+- [ ] Every new query is tenant-scoped
+- [ ] Commits signed off (`git commit -s`, DCO — no CLA)
+
+**Report results honestly.** If tests fail, say so and quote the output. A PR
+description that claims a passing suite it didn't run is worse than a failing
+PR — this is health infrastructure, and the review process assumes descriptions
+are true. Scope security claims to what you actually changed: saying "the layer
+never forwards backend text" when you fixed six call sites will mislead the next
+auditor.
+
+---
+
+## 6. Traps that have actually bitten this project
+
+- **Version/tool-count drift.** `tests/test_site_version_sync.py` and
+  `tests/test_gemini_extension.py` fail if `pyproject.toml`, the manifests, the
+  README, and the site templates disagree. Bump them together; see
+  [RELEASING.md](../RELEASING.md).
+- **The MCP server does not auto-deploy.** Pushing `main` deploys the Flask app
+  (Railway) and site (Vercel), but MCP tool changes are live in the repo and
+  *not* in Claude until a manual deploy runs.
+- **CareAgents deploys independently** to a shared prod VPS. That deploy needs
+  explicit authorization — don't roll it into unrelated work.
+- **Playwright e2e is currently red on `main`** for environment reasons, so it
+  gives no signal. Don't read a green/red Playwright result as evidence either
+  way until that's fixed.
+- **`create_all` never alters existing tables.** Adding a column to a model needs
+  a migration; CareAgents uses an idempotent `_ensure_columns(engine)` for this.
+- **A stale branch can silently drop work.** If your branch predates a squash
+  merge of the same feature, merging can revert files. Rebase onto current
+  `origin/main` and confirm the files you expect are present before pushing.
+
+---
+
+## 7. Working style
+
+- Ask before large refactors of `r6/routes.py` — a carve-up is already planned
+  (#56) and uncoordinated splits will conflict.
+- Prefer small, reviewable PRs. Every PR gets an automated standards review
+  ([.github/REVIEW_STANDARDS.md](../.github/REVIEW_STANDARDS.md)) plus CI.
+- **A maintainer approves before merge.** Agent-authored PRs do not
+  self-merge — the human stays the final authority on this project.
+- If an issue's requirements turn out to be wrong once you're in the code, say
+  so in the issue rather than silently building something different.
+
+---
+
+## Related
+
+- [CLAUDE.md](../CLAUDE.md) — architecture + invariants
+- [docs/development.md](development.md) — full contributor guide
+- [docs/healthcare-ai-advisors-roadmap.md](healthcare-ai-advisors-roadmap.md) — where this is all going
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — ground rules, DCO
+- [GEMINI.md](../GEMINI.md) — how agents should behave when *calling* the deployed tools

--- a/docs/beta-program.md
+++ b/docs/beta-program.md
@@ -1,0 +1,404 @@
+# Beta program — plan
+
+Internal. How we get from "a lot of working code" to "people actually using
+this." Companion to [beta-tester-guide.md](beta-tester-guide.md) (the
+user-facing doc).
+
+---
+
+## 1. The honest situation
+
+The concern that prompted this — *"is this just an AI code-builder marathon to
+nowhere?"* — deserves a direct answer.
+
+**The building is not the problem. The evidence:**
+
+- Guardrail conformance is **Grade A, 7/7, verifiable live** on prod right now
+  (`GET /r6/fhir/$conformance`).
+- The own-data path is **proven end to end**: a real Epic record, 250 resources,
+  Fasten connect → verify → export → webhook → ingest → agent read →
+  `$interpret` + `$care-gaps`, all on prod.
+- CareAgents is live, the connector marketplace ships 7 sources, the MCP server
+  is published in the registry, and 14 skills are live on ClawHub.
+- There is one real clinician user (Gigi) already onboarded.
+
+**What's actually blocking users, from our own tracking:**
+
+| Blocker | Type | Owner |
+| --- | --- | --- |
+| Consumer directory listings (Claude Connectors, ChatGPT Apps) | **All technical prereqs done.** Blocked on: buy Claude Team plan, OpenAI org verification | Human, hours |
+| 2 outreach emails (HBO reply, Fasten) | Drafted, unsent | Human, minutes |
+| 9 ecosystem touchpoints | Sent ~Jul 4-5, awaiting maintainer response | **Waiting — do not push** |
+| Consent at connect-real-records (#167) | Small code change | Engineering, hours |
+| `/nophi` promises an unimplemented control (#166) | Two-line removal, or implement | Engineering, minutes |
+| FTC HBNR applicability (#168) | Legal determination | Counsel |
+
+**So the bottleneck is a handful of human actions, not more features.** That is
+worth sitting with before writing another line of code. The marathon produced a
+real thing; what it hasn't produced is the twenty minutes of account setup and
+two emails that would put it in front of people.
+
+The most useful thing this plan can do is stop recommending building.
+
+---
+
+## 2. What actually works — evidence
+
+Researched from primary sources (GitHub API, founder posts, HN threads).
+Confidence is flagged; folklore is called out as folklore.
+
+### The uncomfortable finding: launches mostly don't work
+
+Four data points, all verified:
+
+- **OpenClaw** (383,460 stars, 80,545 forks, ~368 contributors, repo created
+  2025-11-24). Steinberger announced to **50,000 X followers and it landed
+  flat.** What worked was a public Discord run as a **showcase** — building
+  where people could watch the agent actually do things.
+- **LangChain** posted to HN twice in late 2022 and got **3 points and 2
+  points.** It broke out three months later riding the post-ChatGPT wave, in a
+  submission *someone else* posted.
+- **Ollama's** Show HN (284 pts) was **not their biggest hit** — later release
+  posts hit 607 and 633. The launch was a starting gun, not the race. They also
+  timed it **two days after Llama 2 shipped**, riding someone else's wave.
+- **Medplum** got 251 points at launch and then **nothing above 15 points** ever
+  again.
+
+**Implication for Aug 18:** the webinar is not distribution. Treated as a launch
+it will land like Steinberger's. Treated as a *showcase* — plus a reason to
+follow up with every pending ecosystem contact — it's worth a lot.
+
+### Medplum is our closest comparable — steal from it directly
+
+Open-source FHIR platform, YC, same "engine" layer, launched Nov 2022. Four
+moves, all verified from their Launch HN:
+
+1. **They shipped a running demo application, not a README.** `foomedical.com`,
+   full source public, plus a video. People replied "checking things out today"
+   instead of asking what it did.
+2. **Two names for the same product, by audience.** Cody Ebberson said so
+   publicly: *"Among technical decision makers, the Firebase analogy clicks much
+   faster. Among traditional healthcare administrators, 'EHR' or 'API first EHR'
+   or 'Headless EHR' resonate more."* We have exactly this problem — "guardrails
+   for AI agents on FHIR" lands with engineers and means nothing to a clinician.
+3. **They absorbed the ugly, relationship-heavy work** for early customers —
+   lab and e-prescribe network access — as a wedge, intending to productize
+   later. Our analogue is obvious: do the record-connection work *for* our first
+   testers rather than waiting for the connector to be self-serve.
+4. **They named competitors generously** (Redox, HAPI FHIR, Google Health API).
+   Ollama did the same with llama.cpp. It costs nothing and buys standing.
+
+And the metric lesson: **their case studies lead with time-to-launch** ("initial
+build in 16 weeks"). We should decide now what our equivalent single number is.
+"Connect your records and get a guardrailed answer in X minutes" is probably it.
+
+### Immich — the model that fits us best
+
+Immich ran **no formal beta program at all.** No invite list, no cohort. Instead:
+a permanent, prominent **"this is not production software" warning banner**
+sustained for ~3.5 years, and shipping in the open. Alex Tran, June 2022, asked
+whether it was safe for family photos — *while his own wife used it daily*:
+
+> "I would still advise you to treat the application in the beta stage."
+
+That honesty didn't repel users; it grew to 108,000 stars. And retiring the
+banner at v2.0.0 became a **celebration event** (2,156 reactions).
+
+This matches our ethos better than a cohort program does — this is a project
+whose whole pitch is truthful failure paths. **An honest, prominent beta warning
+is more on-brand and far cheaper than a gated program.**
+
+One concrete tactic worth copying: Immich indexes its Discord publicly via
+**Answer Overflow**, so support answers are searchable from Google. It fixes
+chat's biggest weakness.
+
+### Release cadence is the engagement mechanism
+
+- **Home Assistant**: monthly releases, and **the last week before each release
+  is beta week** — opt-in in settings, a dedicated `#beta` channel, a beta-week
+  forum thread per release, and release-party livestreams.
+- **OpenClaw**: 23 stable releases in ~3 months, betas every 2-3 days.
+
+But Home Assistant also documented the failure mode, and it's the one that
+applies to a solo maintainer. Their biweekly cadence burned out both developers
+and community:
+
+> "We were sprinting while we had to run a marathon; it wasn't sustainable."
+
+They moved to monthly. **Monthly is the right target here, not weekly.**
+
+### Our unfair advantage — use it
+
+Most health-AI products ask you to trust a claim. We can **show the receipts
+live**: the conformance endpoint grades itself A–F in public, the audit trail is
+inspectable, and the human gate is demonstrable — *watch the AI try to approve
+its own action and fail.* Almost nobody in this space can do that on camera.
+
+That is the showcase, and it is a demonstration rather than a deck — exactly
+what the HIMSS audience was told to expect.
+
+---
+
+## 3. Gates before we recruit anyone
+
+Do not invite people to connect real medical records until these are closed.
+This is not bureaucratic caution — each one is a promise we'd otherwise be
+breaking.
+
+**Hard gates (block real-record recruitment):**
+
+- [ ] **#166** — remove or implement `/nophi`. We currently advertise a privacy
+      control that does not exist. Two-line fix available today.
+- [ ] **#167** — consent + terms at the connect-real-records moment.
+- [ ] **#168** — FTC HBNR determination, and reconcile the privacy policy. The
+      policy currently frames the hosted instance as a reference/demo; recruiting
+      real-record testers contradicts that unless it's updated **first**.
+- [ ] Verify **delete actually works** end to end before the guide promises it.
+
+**Soft gates (block *scaling*, not starting):**
+
+- [ ] Signup is currently **wide open** — no invite, no waitlist, no allowlist.
+      Fine for 10 invited testers who are told the URL; not fine for a public
+      launch. Decide before any wide announcement.
+- [ ] Chat rate limit is 20 turns / 10 min, in-memory. It resets on restart and
+      is per-worker, so real LLM spend exposure is higher than the number
+      suggests. Bound it before opening the doors.
+- [ ] **#154** — Playwright gives no e2e signal, so the consumer flows testers
+      will hit are unverified by CI.
+
+**Track 1 (synthetic records) has none of these gates.** Anyone can be invited to
+the sample-record experience today. That's the move while the gates close.
+
+---
+
+## 4. Program design
+
+### Cohort: start at 10, not 100
+
+Ten engaged testers who reply beat a hundred who signed up once. At ten you can
+personally read every piece of feedback and reply the same day — which is the
+single thing that keeps early testers engaged.
+
+**Cohort 1 (~10, invited, synthetic-only).** Recruit now; no gates block this.
+People who will tell you the truth: clinician colleagues, health-IT peers, the
+HL7/FHIR connectathon contacts, Gigi's colleagues.
+
+**Cohort 2 (~10-15, invited, real records).** Only after the hard gates close.
+These are the people who prove the product, and the ones who carry the most risk
+— pick people you can call.
+
+**Cohort 3 (open).** After directory listings land and the soft gates close.
+
+### Channel: GitHub Discussions, and no Discord
+
+The research changed my recommendation here, so it's worth showing the reasoning.
+
+**Plausible — a two-person team — deliberately ran GitHub Discussions and never
+opened a Discord**, with an explicit no-support-guarantee for self-hosters. Uku's
+stated reason was survival: *"early on we tried to help each and every support
+request from self-hosters and it quickly turned out an impossible task."* That is
+our situation exactly, minus one person.
+
+**The one real dataset on OSS chat channels** (DoltHub, 3+ years) is sobering:
+15.5k GitHub stars produced **1,894 Discord joins (~12%), about half active in
+30 days** — and it worked only because they staff a greeter who welcomes every
+joiner, many times a day. Their conclusion: *"People don't like to just talk to
+the maintainers of the project, they also want to meet other users."* A chat
+channel survives as a **staffed support desk**; it dies when framed as a
+self-sustaining community. We cannot staff a greeter.
+
+**Cal.com's free Slack silently auto-deleted years of community knowledge**
+before they migrated. **LangChain ran the most famous dev Discord of the LLM era
+and has since moved to Slack + Forum, explicitly telling people not to ask
+questions in chat.** Two independent projects concluding chat was the wrong
+place for support.
+
+If chat ever happens, copy **Immich's Answer Overflow** trick so answers are
+searchable from Google — that fixes chat's fatal flaw.
+
+### The warning most relevant to a solo maintainer
+
+Nadia Eghbal's *Working in Public* is the load-bearing source here. Her finding:
+most consequential modern projects are **"stadiums"** — high user growth, low
+contributor growth — and the usual advice actively harms maintainers:
+
+> "Pushing a larger number of people to make open source contributions, or
+> expecting maintainers to foster a sense of community participation, can be
+> counterproductive, as it requires the maintainers to spend more time on
+> reviews and discussions."
+
+So: **optimize for users, not contributors.** Do not measure success by
+contributor count or stars. (On stars — a peer-reviewed ICSE 2026 study found
+~6M suspected *fake* GitHub stars, and a survey of 791 developers found the
+modal star is a **bookmark**. Stars are a credibility asset, not a user count.)
+
+The documented failure mode for projects like this is not indifference — it is
+**maintainer burnout**: core-js, colors.js, actix-web, and xz, where burnout was
+literally the attack surface. Home Assistant named it directly: *"We were
+sprinting while we had to run a marathon."*
+
+Guard the cadence accordingly. Monthly, not weekly.
+
+### The single highest-leverage artifact: adversarial positioning
+
+Both Plausible and Cal.com won on the same move — define yourself against a
+dominant incumbent, not by describing what you are:
+
+- *"Why you should stop using Google Analytics on your website"* took Plausible
+  from 27,300 visitors in 15 months to **48,000 in one week**, 166 new trials
+  (more than the prior four months combined), doubled GitHub stars, and moved
+  brand search from 10 to 121/week.
+- Cal.com's entire pitch was six words: *"An open source Calendly alternative."*
+
+Our version writes itself, and we have the receipts to back it where nobody else
+does. Something in the shape of **"Why you shouldn't let a chatbot read your
+medical records — and what to do instead."** That is the post, and the live
+conformance grade is the proof.
+
+Both founders also **under-sold on HN** — founder-submitted, no promotional
+text, no gaming. For a project whose entire claim is trustworthiness, a gamed
+launch would undercut the pitch itself.
+
+### Timeline realism — the antidote to "marathon to nowhere"
+
+**Plausible took 324 days to reach $400 MRR.** Fourteen months of near-flat
+growth, building in public the whole time. Their self-hosted build shipped 16
+months *after* the cloud beta, with a beta exit bar of "5 people running it
+smoothly."
+
+That is what this phase looks like from the inside. The feeling of building
+toward nothing is the normal texture of month 8, not evidence of failure.
+
+One caution against over-correcting: Justin Kan coined *"first-time founders are
+obsessed with product, second-time founders are obsessed with distribution"* —
+and then **publicly retracted it** after Atrium died with $75.5M raised. His
+revised lesson: distribution doesn't save a product people don't want. The goal
+is users who'd be upset if it disappeared, not traffic.
+
+### The feedback loop
+
+- A **standing question**, not "any feedback?" — ask "where did you hesitate or
+  distrust it?" That's the question the tester guide leads with, and it surfaces
+  the trust gaps that kill health products.
+- **Reply to everything within 24h**, even just "seen, filed as #N."
+- **Ship something visible weekly**, and tell testers which of their reports it
+  came from. Naming the reporter is the whole retention mechanism.
+- **Never ask for their health data.** Reports describe shape, not values.
+
+### Where to find testers — free channels first
+
+Paid recruitment was researched and is **not worth it yet**:
+
+| Channel | Cost (20-50) | Verdict |
+| --- | --- | --- |
+| Warm network (Gigi's colleagues, HL7 connectathon, HIMSS attendees) | $0 | **Start here** |
+| User Interviews | ~$3.5k-8.9k | Later, if warm runs dry |
+| Rare Patient Voice | ~$12.4k+ | Overkill now |
+| Inspire / PatientsLikeMe | ~$15k-50k (quote-only) | No |
+
+Two findings make paid recruitment a poor fit *today*. The patient-community
+platforms **sell insights to a sponsor, not testers who go authenticate into
+your app** — asking members to connect live medical records is off-menu and
+triggers privacy review at all of them. And the self-serve platforms bill **per
+session, not per tester**, so a multi-week beta with three touchpoints can bill
+3× what you budgeted.
+
+We already have the better channel: a clinician partner with colleagues, a
+connectathon network, CMS/HL7 contacts, and a webinar audience on Aug 18. Those
+people are pre-qualified for exactly the trust question this product asks.
+
+### What to measure
+
+Vanity metrics will lie to you here. Signups are meaningless if nobody returns.
+
+- Did they come back a second time? (the only early metric that matters)
+- Did they connect a real source after trying synthetic? (the trust conversion)
+- How many reported a *wrong answer*? (low numbers mean they aren't really using
+  it, not that it's correct)
+- Time from report → shipped fix.
+
+**Do not reach for the standard playbook at this size** — most of it doesn't
+apply, and some of it is folklore:
+
+- **The Sean Ellis / Superhuman 40% PMF survey needs ~40 *respondents*** to be
+  directionally valid — at a 30% response rate that's a 130-user beta. Below
+  that it doesn't apply on its own terms. It's also asymmetric: **below 40% is
+  informative, above 40% is not** (it measures problem-solution fit and
+  false-positives easily).
+- **The famous activation numbers are folklore.** Facebook's "7 friends in 10
+  days" traces only to conference talks — the internal instruction was reportedly
+  10 in 14. Twitter's "30 follows" was never said by Josh Elman; his actual essay
+  reports 7 visits/month. Don't set targets from them.
+- **Activation regression needs sample we don't have.**
+
+What works at 10-50 users instead: **watch nearly every session** (PostHog's own
+pre-PMF advice is session recordings first, and explicitly *not* funnel
+optimization — "it encourages premature optimization, or worse, hides bigger
+problems"), interview weekly, and judge by **pull vs push** — when someone keeps
+using it, is it because they want it or because you asked them to? Rob Snyder's
+bar is finding a "Hell Yes" user in the first 5-10. Nielsen's model says 5 users
+surface ~85% of usability problems, so small N is genuinely sufficient here.
+
+And do outreach as a human, not on a timer. PostHog found a shared channel per
+customer got **20× the response rate of email**.
+
+---
+
+## 5. Ecosystem — convert, don't expand
+
+The instinct to reach out to Medplum, Fasten, and others is right in direction
+and wrong in timing.
+
+**We already contacted them.** Medplum PR #9746 + issue #9616 comment, a comment
+on Fasten #207, plus 7 more touchpoints — all opened ~Jul 4-5, **all still
+awaiting maintainer response**. Our own pacing rule is explicit: *do not fire
+new external contributions into cold trackers until some respond — saturation
+reads as spam.*
+
+Firing another round now makes us look like a bot to exactly the people whose
+respect we need. Health IT is a small world with long memories.
+
+**So: convert the pending nine rather than open a tenth.**
+
+- **Send the two drafted emails.** The HBO reply (Bo + Jason Choe) and the
+  Fasten one. A direct human email to someone who knows you outperforms a cold
+  PR comment by a wide margin, and both are already written.
+- **Health Samurai is warm and unblocked** — they *asked* for the joint blog
+  post. That's the one ecosystem relationship with active reciprocal interest.
+  Finish it; it's the highest-yield item on this list.
+- **Use the webinar as the forcing function.** A talk with a live demo gives you
+  a legitimate, non-spammy reason to follow up with every pending contact:
+  "we're presenting this Aug 18, thought you'd want to see it." That converts
+  cold threads warm without a new ask.
+- **Then** open new touchpoints, one per day max, from the prepped wave-2 drafts.
+
+**On Medplum specifically:** they're an open-source FHIR platform — the same
+"engine" layer we sit on top of. The natural collaboration is the same story
+we're telling Health Samurai (store → guard → advise), so the Aidbox post is
+effectively a template. Wait for the existing PR to get a response first.
+
+---
+
+## 6. What I'd do this week
+
+In order, highest leverage first:
+
+1. **Ship #166** (remove the `/nophi` promise). Minutes. It's a live false
+   assurance.
+2. **Send the two drafted emails.** Minutes. Already written.
+3. **Invite 5-10 people to Cohort 1 (synthetic).** No gates block this. Use the
+   tester guide.
+4. **Do the human gates** — Claude Team plan, OpenAI org verification. Hours,
+   and they unblock the directory listings that produce actual strangers.
+5. **Close #167** (consent) and get the #168 determination.
+6. **Finish the Health Samurai post.**
+
+Notably, only one of those six is writing code.
+
+---
+
+## Related
+
+- [beta-tester-guide.md](beta-tester-guide.md) — the user-facing guide
+- [healthcare-ai-advisors-roadmap.md](healthcare-ai-advisors-roadmap.md) — where the product is going
+- Issues: #166, #167, #168 (beta gates) · #154 (e2e signal)

--- a/docs/beta-tester-guide.md
+++ b/docs/beta-tester-guide.md
@@ -1,0 +1,210 @@
+# CareAgents Beta — tester guide
+
+Thanks for trying this. This guide tells you what you're getting into, what's
+protected, what isn't, and what we're asking from you.
+
+We'd rather you trust this because you understand it than because we told you
+to. So this document is blunt about the limits.
+
+---
+
+## What this is
+
+CareAgents lets you connect your own health records and talk to an AI agent
+about them — on the web, or by text.
+
+Underneath it sits **HealthClaw Guardrails**, an open-source safety layer
+between AI agents and health data. The guardrails run on the server, not in
+the app, so they apply no matter which surface you use and cannot be turned off
+by the AI:
+
+- **Redaction on reads** — identifiers are stripped before data reaches the model
+- **An audit trail on everything** — every record access is logged
+- **A human gate on actions** — the AI can *propose* a real-world action, but it
+  cannot execute one. Only you can approve it, through a separate step the AI's
+  own tools cannot reach.
+
+All of it is public: <https://github.com/aks129/HealthClawGuardrails>. You can
+read exactly what happens to your data. You can also run the whole thing
+yourself instead of using our hosted version.
+
+## What this is *not*
+
+Read this part twice.
+
+- **Not medical advice.** It's decision support. It can be wrong, and it can be
+  confidently wrong. Do not make a medical decision because an AI agent said so.
+- **Not your doctor, and not a covered entity under HIPAA.** This works under
+  your individual **right of access** to your own records — you're using a tool
+  to reach your own data. That's a different legal posture than a hospital
+  or insurer, and it means the protections you may be assuming are *not* the
+  ones that apply here.
+- **Not an emergency service.** If you're having chest pain, trouble breathing,
+  stroke symptoms, or thoughts of harming yourself — call 911 or your local
+  emergency number. Don't ask the agent first.
+- **Not a finished product.** This is a beta. Things break. That's why you're here.
+
+---
+
+## Two ways to test — please start with the first
+
+### Track 1: synthetic records (zero risk)
+
+Use the built-in sample patient. Nothing about you is involved. You can try
+every feature, break things freely, and screenshot anything.
+
+**Start here even if you intend to connect your own records.** It costs you ten
+minutes and tells you whether this is worth your real data.
+
+### Track 2: your own records (real data)
+
+Connect a real provider, wearable, or health record source. This is where the
+product actually proves itself — and where you should be deliberate.
+
+Before you do:
+
+- Understand where your data goes (next section).
+- Know you can disconnect and delete.
+- Don't put it on a screen you're sharing or recording. If you demo this to
+  someone, **use the synthetic track.**
+
+---
+
+## Where your data goes
+
+| Thing | Where it lives |
+| --- | --- |
+| Your health records | Behind the HealthClaw guardrails, scoped to your own private tenant |
+| Your account (email, passkey) | CareAgents' own database |
+| Which sources you connected | CareAgents' own database |
+| **Your health records in CareAgents** | **Never. CareAgents stores no health data.** |
+
+CareAgents holds an account and a pointer. The records themselves stay behind
+the guardrails. That separation is deliberate and it's the thing to check us on.
+
+**Your passkey/biometric never leaves your device.** Face or fingerprint unlock
+happens locally; we receive a cryptographic signature, never your biometric.
+
+**What the AI model sees:** redacted records, when a question requires them. Not
+your whole file, not continuously.
+
+### A real limitation, stated plainly
+
+If you use the **Telegram or iMessage** surfaces: consumer chat apps are not
+encrypted medical channels. Messages pass through Apple's or Telegram's
+infrastructure under their terms, not under a healthcare agreement. You're
+choosing to reach your own data over a consumer channel. That's a legitimate
+choice — but make it knowingly. The web app doesn't have this exposure.
+
+---
+
+## Getting started
+
+1. **Sign up** at [careagents.cloud](https://careagents.cloud) — email code, then
+   add a passkey.
+2. **Connect the sample records** first. Confirm things work.
+3. **Create an agent.** Pick a name and a voice (Calm Guide, Straight Shooter,
+   or Sunny Coach — this is tone only; capability is identical).
+4. **Ask it something.** Try "what are my recent labs?" or "am I due for
+   anything?"
+5. **When you're ready**, connect a real source from the connect menu.
+
+Sources marked **coming soon** aren't wired yet — that label is honest, not
+sandbagging. Please don't spend time trying to make them work.
+
+---
+
+## What we're asking from you
+
+Honest reactions, not politeness. Specifically:
+
+**The most valuable thing you can send us is a moment of confusion or distrust.**
+Where did you hesitate? What made you unsure whether to continue? Where did it
+feel like it was hiding something? That's worth more than a feature request.
+
+Also useful:
+
+1. **Wrong answers.** If the agent says something incorrect about your health
+   data, tell us — with the question you asked. This is the highest-severity
+   category. Don't include the actual clinical values in the report (see below).
+2. **Where it broke.** What you were doing, what you expected, what happened.
+3. **Where it was useful.** Which question did it actually answer well? We need
+   to know what to protect as much as what to fix.
+4. **What you expected that didn't exist.**
+
+### Reporting safely
+
+**Never paste real health data, screenshots of your records, or access tokens
+into a bug report, GitHub issue, or chat.** We do not need them and we do not
+want them.
+
+Report the *shape* of the problem: "I asked about my cholesterol trend and it
+gave me a value from the wrong year." That's enough for us to reproduce it
+against synthetic data.
+
+If you think you've found a **security or privacy problem**, don't file it
+publicly — see [SECURITY.md](../SECURITY.md).
+
+### Where to send it
+
+- **Bugs / features:** [GitHub issues](https://github.com/aks129/HealthClawGuardrails/issues)
+- **Security or privacy:** [SECURITY.md](../SECURITY.md) — private disclosure
+- **Anything else:** support@healthclaw.io
+
+---
+
+## Leaving
+
+You can stop at any time and you don't owe us an explanation.
+
+- **Disconnect a source** — stops new data flowing in.
+- **Delete your data** — email support@healthclaw.io and we'll remove your
+  tenant and confirm when it's done.
+- **Just stop using it** — nothing will contact you.
+
+If deleting is ever harder than connecting was, that's a bug. Tell us.
+
+---
+
+## What we owe you
+
+- **We'll tell you when we break something** that affected you.
+- **We won't sell or share your data.** There is no third party buying this.
+- **We won't use your health records to train models.**
+- **We'll answer you.** If you send feedback and hear nothing, that's a failure
+  on our side — ping us again.
+- **We'll be honest about what's real.** If something is half-built, it'll say
+  so rather than pretending.
+
+---
+
+## Known limitations right now
+
+Current as of the beta launch — kept honest deliberately:
+
+- Some connectors are **coming soon** and labeled as such.
+- The agent can be wrong about your records. Always check anything that matters
+  against the source.
+- Real-world actions (calls, forms, refills) are **early**. Everything requires
+  your explicit approval, and some are not built yet.
+- This is a small team. Response times vary.
+
+---
+
+## Questions worth asking us
+
+If you're the kind of tester who wants to pressure-test the claims rather than
+the features — please do. Good ones:
+
+- "Show me the audit trail for what you just read."
+- "What exactly did the model see when I asked that?"
+- "What happens if I revoke access right now?"
+- "Prove the AI can't approve its own action."
+
+All of those have real answers, and if any answer disappoints you we want to
+know before someone else finds out.
+
+---
+
+*This guide is versioned with the project. If something here doesn't match what
+the product does, the guide is wrong and we want to hear about it.*

--- a/docs/healthcare-ai-advisors-roadmap.md
+++ b/docs/healthcare-ai-advisors-roadmap.md
@@ -1,0 +1,330 @@
+# The Healthcare AI Advisors System — Setup + Roadmap
+
+How HealthClaw Guardrails, CareAgents, and SmartHealthConnect compose into one
+guardrailed advisor system inside Claude — what works today, and what it takes
+to finish it.
+
+**Status:** drafted 2026-07-19. Part 1 is a verified inventory; Part 2 is
+runnable today; Part 3 is the build plan. Items marked ⚠️ are gaps I found
+while writing this, not speculation.
+
+---
+
+## 0. The system in one picture
+
+Three repos, one contract: **the engine owns policy, the surfaces own
+experience.** No surface ever touches FHIR directly.
+
+```text
+                        ┌──────────────── Claude ────────────────┐
+                        │  MCP connectors + MCP Apps (views)      │
+                        │  the advisor's tool surface             │
+                        └────────┬───────────────────┬────────────┘
+                                 │                   │
+              ┌──────────────────┘                   └──────────────┐
+              │                                                     │
+    ┌─────────▼──────────┐                              ┌───────────▼─────────┐
+    │ SmartHealthConnect │  surface                     │     CareAgents      │  surface
+    │  (Liara AI Health) │  patient skills + 7 MCP-App  │  (careagents/)      │  consumer app
+    │  v1.2.0            │  views + React client        │  accounts, agents,  │
+    │  role: surface     │                              │  web/Telegram/iMsg  │
+    └─────────┬──────────┘                              └───────────┬─────────┘
+              │                                                     │
+              │            HTTP / MCP only — never direct FHIR      │
+              └──────────────────────┬──────────────────────────────┘
+                                     │
+                      ┌──────────────▼───────────────┐
+                      │   HealthClaw Guardrails      │  ENGINE
+                      │   role: engine               │
+                      │  • FHIR store + facade       │
+                      │  • PHI redaction (Safe Harbor)│
+                      │  • immutable audit           │
+                      │  • step-up auth              │
+                      │  • tenant isolation          │
+                      │  • Compiled Truth            │
+                      │  • action rail (human gate)  │
+                      └──────────────┬───────────────┘
+                                     │
+        ┌────────────┬───────────────┼──────────────┬──────────────┐
+     Fasten      Wearables      SMART Health     Medent        HealthEx /
+   (verified   (Open Wearables:   Links/Cards   (direct EMR)  Health Bank One
+    provider)   Apple, Oura,       (r6/shc)                    (r6/shc callbacks)
+                Whoop, Garmin…)
+```
+
+The engine/surface split is **declared, not just conventional**:
+`.health-context.yaml` in each repo (`role: engine` / `role: surface`) names the
+counterpart. That file is the thing to update first if the topology changes.
+
+### Why this shape matters
+
+The advisor is only as trustworthy as its narrowest gate. Because every surface
+reaches PHI through HealthClaw's HTTP/MCP API, the guardrails cannot be bypassed
+by a chatty model, a compromised surface, or a clever prompt. Redaction,
+audit, and the human approval gate run **server-side, once** — adding a fourth
+surface adds zero new policy surface area.
+
+---
+
+## 1. What's actually live today
+
+Verified against the repos, not aspirational.
+
+| Layer | Component | State |
+| --- | --- | --- |
+| Engine | HealthClaw Flask app (`app.healthclaw.io`, Railway) | ✅ live, auto-deploys on `main` |
+| Engine | MCP server (Streamable HTTP, Railway) | ✅ live, **manual deploy only** |
+| Engine | Guardrail conformance, graded A–F | ✅ Grade A, CI-gated |
+| Engine | Action rail + out-of-band human gate | ✅ forms rail end-to-end |
+| Engine | Compiled Truth (`fhir_compiled_truth`) | ✅ |
+| Surface | SmartHealthConnect v1.2.0 — 6 patient skills | ✅ built |
+| Surface | SHC MCP App — 7 views | ✅ built, ⚠️ not submitted |
+| Surface | SHC MCP server — ~30 tools | ✅ built, ⚠️ contract drift (§4.2) |
+| Surface | CareAgents (`careagents.cloud`) | ✅ live, **independent deploy** |
+| Surface | CareAgents connector marketplace | ✅ live (7 sources) |
+| Surface | CareAgents iMessage | 🟡 code shipped, blocked on TCC grants |
+| Claude | HealthClaw MCP in registry (`server.json` v1.8.0) | ✅ published |
+| Claude | SmartHealthConnect MCP App in directory | ⚠️ blocked (§4.1) |
+
+**The advisor roster today.** Six patient skills (`healthy-habits`,
+`care-completion`, `medication-refills`, `diet-exercise`, `kids-health`,
+`research-monitor`) plus three CareAgents personas (Calm Guide, Straight
+Shooter, Sunny Coach). That is the "advisors" layer — specialized agents over
+one shared, guarded record.
+
+**Connector tiers in CareAgents** (`careagents/connectors.py`): `live` — sample,
+Fasten (verified provider), Apple Health + wearables. `import` — SMART Health
+Link, upload. `soon` — HealthEx, Health Bank One. Tiers are **config-gated**, so
+a source only advertises as live where its flow is genuinely wired. Keep that
+discipline; it is why the marketplace doesn't lie.
+
+---
+
+## 2. Setup — stand it up in Claude today
+
+This is the working path with what exists now. ~30 minutes.
+
+### 2.1 Connect the engine to Claude
+
+HealthClaw is already in the MCP registry as a remote Streamable HTTP server, so
+no local install is needed.
+
+- **URL:** the `remotes[0].url` in [`server.json`](../server.json)
+- **`X-Tenant-Id`** — the public demo tenant `desktop-demo` works with no
+  credentials. Use it to verify the connection before touching real data.
+- **`X-Step-Up-Token`** — a tenant-bound HMAC. Required for write-tier tools and
+  for reads on any non-public tenant.
+
+> **Never paste a step-up token into a chat, an issue, or a prompt.** Tokens are
+> minted server-side only (`HEALTHCLAW_MINT_SECRET`). CareAgents mints them for
+> its own tenants; nothing client-side should ever hold the mint secret.
+
+Verify with a read-only call first — `guardrail_conformance` is ideal: it
+returns the live grade and proves the connection without touching PHI.
+
+### 2.2 Get records into a tenant
+
+Pick the path that matches the source:
+
+| Source | Path | Notes |
+| --- | --- | --- |
+| Verified provider | CareAgents → Fasten | Runs on HealthClaw's `/connect/<tenant>` Stitch page |
+| Apple Health / wearables | Open Wearables sidecar | Needs `CARE_WEARABLES_ENABLED` + sidecar wired |
+| SMART Health Link / Card | `r6/shc` ingest | Import tier |
+| Direct EMR (Medent) | `r6/shc/medent/callback` | OAuth callback + bundle ingest |
+| Health Bank One | `r6/shc/hbo/callback` | Callback exists; CareAgents tile still `soon` |
+| Demo | sample records | Synthetic only — use for every rehearsal |
+
+### 2.3 Add the patient surface
+
+SmartHealthConnect's MCP server proxies into the engine. Configure:
+
+```bash
+HEALTHCLAW_MCP_URL=https://<your-mcp-host>/mcp/rpc   # or http://localhost:3001/mcp/rpc
+HEALTHCLAW_TENANT_ID=<tenant>
+```
+
+The **rule that makes this safe**: a skill making a resource-specific claim to a
+patient must call `get_compiled_truth` first — it returns current redacted state
+plus `curation_state`, `quality_score`, and the Provenance timeline. An advisor
+that asserts "your A1c is 7.2" without a Provenance trail is exactly the failure
+mode this system exists to prevent. Every skill's `SKILL.md` states the rule.
+
+### 2.4 Spin up an advisor
+
+Either surface, same engine:
+
+- **CareAgents** (`careagents.cloud`) — sign in with a passkey, connect records,
+  create an agent with a persona, chat on web/Telegram. Non-developer path.
+- **Claude directly** — talk to the HealthClaw MCP tools with the SHC skills
+  loaded. Developer path, and the one to use for the HIMSS/partner demos.
+
+### 2.5 Prove the guardrails before you trust it
+
+Do this once per deployment, and before any live demo:
+
+1. `guardrail_conformance` → confirm **Grade A**.
+2. Read a resource → confirm an AuditEvent was emitted and its `detail` is
+   PHI-free.
+3. Attempt a clinical write with a valid step-up token → confirm it returns
+   **202 (submitted)**, not executed.
+4. Confirm execution requires the separate approval endpoint. **No agent
+   toolchain can approve its own action** — if it can, stop and fix that first.
+
+---
+
+## 3. Phased roadmap
+
+Ordered by dependency, not date. Each phase has an exit gate.
+
+### Phase 0 — Unblock what's already built ⚡ *highest value per hour*
+
+Three finished things aren't reachable by users. Fix those before building more.
+
+- **Fix the SHC MCP App manifest misattribution** (§4.1) — blocks directory
+  submission today. ([SmartHealthConnect#10](https://github.com/aks129/SmartHealthConnect/issues/10))
+- **Land iMessage** — code is shipped; needs two GUI TCC grants on the Mac mini
+  (Full Disk Access + Automation→Messages), then load the launch agent. ([#136](../../issues/136), [#137](../../issues/137))
+- **Reconcile the SHC tool surface with the compiled-truth rule** (§4.2). ([SmartHealthConnect#11](https://github.com/aks129/SmartHealthConnect/issues/11))
+
+**Exit gate:** SHC App submittable, iMessage answering, contract drift closed.
+
+### Phase 1 — One patient identity across surfaces
+
+> Tracked in **[#157](../../issues/157)** (epic).
+
+Today there are three identity models: HealthClaw step-up tokens, CareAgents
+passkeys + email codes, SmartHealthConnect Passport sessions. A person is a
+different subject in each, so an advisor cannot follow them across surfaces.
+
+- Decide the canonical subject (recommendation: **the HealthClaw tenant**, since
+  it already scopes every resource and audit row).
+- Map CareAgents accounts and SHC sessions onto it.
+- Keep biometrics on-device; passkeys never leave the client.
+
+**Exit gate:** one person, one tenant, reachable from web + Claude + iMessage
+with a single connection story. This is the prerequisite for a *system* rather
+than three apps sharing a backend.
+
+### Phase 2 — The advisor roster becomes a team
+
+> Tracked in **[#158](../../issues/158)** (router), **[#159](../../issues/159)** (shared memory), **[#160](../../issues/160)** (escalation).
+
+Nine advisors exist as isolated skills/personas. Make them compose.
+
+- A **router**: which advisor should answer this? (refills → `medication-refills`;
+  a kid's fever → `kids-health`).
+- **Shared memory** across advisors, scoped to the tenant, PHI-free in logs.
+- **Escalation**: an advisor that hits an action needing approval hands off to
+  the human gate with a review card, rather than dead-ending.
+- Every advisor inherits the disclaimer + red-flag emergency screen. Non-optional.
+
+**Exit gate:** a single question routes to the right advisor, gets a
+Provenance-backed answer, and escalates cleanly when it needs a human.
+
+### Phase 3 — Advisors that act, not just answer
+
+> Tracked in **[#161](../../issues/161)** (comms rail, epic), **[#162](../../issues/162)** (refills), **[#163](../../issues/163)** (appointments).
+
+The action rail exists and the forms rail proves it end-to-end. Extend it.
+
+- Comms rail (calls/SMS to allowlisted, patient-registered contacts) — already
+  "Now" on the main roadmap.
+- Refill requests through the rail rather than a bare tool call.
+- Appointment prep + booking.
+- **Every one** behind propose → 202 → out-of-band approval → audit →
+  reconciliation. No exceptions, no new gates invented per-capability.
+
+**Exit gate:** an advisor completes a real-world task where the human approved
+exactly once, and the audit trail reconstructs the whole chain.
+
+### Phase 4 — Distribution
+
+> Tracked in **[#164](../../issues/164)** (epic).
+
+- SHC MCP App in the directory; HealthClaw already in the MCP registry.
+- Partner path: Aidbox/Health Samurai as the store, HealthClaw as the guard,
+  CareAgents + SHC as advisors (the joint blog post covers this narrative).
+- Consumer listings + the HIMSS Keystone webinar (Aug 18) as the forcing function.
+
+**Exit gate:** someone who has never met you installs it and connects a real record.
+
+---
+
+## 4. Gaps found while writing this
+
+### 4.1 ⚠️ SHC MCP App manifest misattributes the project to Anthropic
+
+> [SmartHealthConnect#10](https://github.com/aks129/SmartHealthConnect/issues/10)
+
+`mcp-app/manifest.json` points `author.url`, `homepage`, `repository.url`, and
+the **privacy policy URL** at `github.com/anthropics/SmartHealthConnect`. The
+real repo is `github.com/aks129/SmartHealthConnect`.
+
+Three separate problems: it misattributes authorship to Anthropic; the privacy
+policy link **404s**, which for a health app is a directory-review failure and a
+trust problem; and it would likely be rejected on review. Low effort, high
+consequence — fix before any submission.
+
+### 4.2 ⚠️ SHC MCP server tool surface vs. the compiled-truth rule
+
+> [SmartHealthConnect#11](https://github.com/aks129/SmartHealthConnect/issues/11)
+
+`mcp-server/src/index.ts` exposes ~30 tools including `get_conditions`,
+`get_medications`, `get_vitals`, `get_allergies`. The declared contract says
+patient skills route resource-specific claims through `get_compiled_truth` and
+"never read FHIR directly."
+
+I did **not** verify whether these proxy to the engine or read independently —
+that's the open question. If they bypass, the guarantee is weaker than the
+contract claims. Two honest resolutions: route them through the engine, or
+narrow the contract's wording to match reality. The version-bump ritual makes
+§2 of each retrospective the natural place to enforce whichever you pick.
+
+### 4.3 ⚠️ Playwright e2e is red on `main`
+
+> [#154](../../issues/154)
+
+Every recent `main` run fails, producing no report — an environment/setup
+failure, not a code regression. It's been failing across at least five commits.
+The cost is that e2e currently provides **no signal** on any PR, so a real
+break would look identical to today. Worth fixing before the demo push.
+
+### 4.4 Deployment asymmetry — easy to get wrong
+
+> [#155](../../issues/155)
+
+Three different deploy models, and two are manual:
+
+- HealthClaw Flask app — auto-deploys on `main` (Railway)
+- MCP server — **manual** staging-dir deploy
+- CareAgents — **independent** VPS deploy; shared prod host, needs explicit
+  authorization
+
+A change to MCP tools is live in the repo but not in Claude until the manual
+deploy runs. That gap has already bitten this project once.
+
+---
+
+## 5. The invariants none of this may break
+
+Any advisor, any surface, any phase:
+
+- Redaction, audit, step-up, and the human gate run **server-side** — a surface
+  cannot weaken them.
+- Every FHIR access emits an AuditEvent; audit `detail` stays **PHI-free**.
+- Clinical writes need out-of-band human confirmation via a separate endpoint.
+- **"No known allergies" is never inferred** — only from explicit human attestation.
+- CareAgents and SmartHealthConnect store **no PHI**.
+- Conformance stays **Grade A** (CI-gated).
+- Demo data is synthetic. Always.
+
+---
+
+## Related
+
+- [docs/agent-task-guide.md](agent-task-guide.md) — **start here if you're picking up an issue**
+- [ROADMAP.md](../ROADMAP.md) — the engine roadmap (Now/Next/Later)
+- [CLAUDE.md](../CLAUDE.md) — engine architecture + invariants
+- [docs/development.md](development.md) — contributor guide, deploy steps
+- `.health-context.yaml` — engine/surface declarations (both repos)


### PR DESCRIPTION
Two docs so collaborators — human or coding agent — start with context instead of a blank page. **Docs only; no code, no behavior change.**

## What's here

**`docs/healthcare-ai-advisors-roadmap.md`** — how HealthClaw (engine), CareAgents, and SmartHealthConnect (surfaces) compose into one guardrailed advisor system in Claude:

- the engine/surface topology and why it makes the guardrails unbypassable
- a **verified** live-vs-not inventory (checked against the repos, not aspirational)
- runnable setup steps for standing it up in Claude today, including a "prove the guardrails before you trust it" checklist
- five phases with exit gates, each linked to its tracking issue

**`docs/agent-task-guide.md`** — what to read before picking up an issue: the invariants that may not be broken, where things live, the module + action-rail patterns, build/test commands, a definition of done, and the traps that have actually bitten this project (version/tool-count drift, the manual MCP deploy, `create_all` not altering tables, stale-branch merges silently dropping work).

Every new issue links here rather than restating context.

## Issues opened alongside this

| Phase | Issues |
| --- | --- |
| Ops gaps | #154 (Playwright), #155 (MCP deploy drift), #156 (allowlist drift guard — good first issue) |
| 1 — identity | #157 (epic) |
| 2 — advisor team | #158 (router), #159 (memory), #160 (escalation) |
| 3 — act | #161 (comms rail, epic), #162 (refills), #163 (appointments) |
| 4 — distribution | #164 (epic) |
| Cross-repo | aks129/SmartHealthConnect#10, #11 |

## Three gaps this records

1. **The SmartHealthConnect MCP App manifest attributes the project to Anthropic** — `author.url`, `homepage`, `repository`, and the **privacy-policy URL** all point at `github.com/anthropics/SmartHealthConnect`. The privacy link 404s, which for a health app is a directory-review failure. Cheapest high-consequence fix on the list.
2. **The ~30 SHC MCP tools may bypass the compiled-truth rule.** `get_conditions` / `get_medications` / `get_vitals` exist as their own tools while the contract says surfaces never read FHIR directly. **I did not verify which** — that audit is step one of the issue, and the honest resolutions are either route them through the engine or narrow the contract's wording.
3. **Playwright e2e is red on `main`** across at least five commits, producing no report. So e2e gives **no signal** on any PR right now — a real break looks identical to today.

## Note on the roadmap's status line

It is dated and marked as a draft inventory. The live/not-live table will go stale as things ship; the issue links are the durable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)