### PR TITLE
fix: stop advertising an unimplemented summary-only privacy control

### DIFF
--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -346,13 +346,16 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # consumer channel, not BAA-covered transport; this is patient-directed
     # access to one's own records. See templates/privacy.html "Messaging
     # Platforms" for the full posture.
-    # TODO(nophi): wire a real /nophi toggle that flips this chat into
-    # summary-only mode (persist per chat_id, gate read formatters on it).
-    # Disclosure line is shipped now; the toggle is not yet implemented.
+    #
+    # This text must promise only controls that actually exist. A summary-only
+    # mode was advertised here before it was built; offering a privacy control
+    # that does nothing leaves the user worse off than saying nothing, because
+    # they choose to continue on the strength of it. If summary-only ships,
+    # add it back here and to the privacy policy's mitigations list together.
     risk_line = (
         '⚠️ Heads up: chat apps aren’t encrypted medical channels. '
         'You’re accessing your own records here; by continuing you accept '
-        'that for your own data. Reply /nophi to keep responses summary-only.'
+        'that for your own data.'
     )
 
     text = (

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -170,7 +170,6 @@
       <ul>
         <li><strong>PHI redaction on reads</strong> — the same redaction applied to all read paths (initials, masked identifiers, stripped addresses, year-only birth dates).</li>
         <li><strong>PHI-free notifications</strong> — push notifications carry only counts, status, and tenant identifiers, never names, identifiers, or clinical values.</li>
-        <li><strong>Optional summary-only mode</strong> — responses can be limited to summaries rather than full record content.</li>
       </ul>
       <p>
         To be candid about the trade-off: messaging-app transport combined with HealthClaw's guardrails (redaction,

--- a/tests/test_metadata_security.py
+++ b/tests/test_metadata_security.py
@@ -121,4 +121,30 @@ class TestBotStartDisclosure:
         assert 'cmd_start' in src
         assert 'risk_line' in src
         assert 'chat apps aren' in src  # apostrophe variant tolerant
-        assert '/nophi' in src
+
+    def test_start_promises_no_unimplemented_privacy_control(self):
+        """The disclosure must not offer a control that does not exist.
+
+        A summary-only mode was advertised in /start (and listed as a live
+        mitigation in the privacy policy) before it was built. Offering a
+        privacy control that does nothing is worse than silence: the user
+        continues on an unencrypted consumer channel partly *because* they
+        were told a mitigation was available. Both claims were removed; this
+        test keeps them from returning ahead of an implementation.
+
+        If summary-only ships, assert the real toggle here instead of
+        deleting this test.
+        """
+        src = (
+            Path(__file__).resolve().parent.parent / 'openclaw' / 'bot.py'
+        ).read_text(encoding='utf-8')
+        assert '/nophi' not in src, (
+            'bot.py references /nophi — do not advertise summary-only mode '
+            'until a toggle is implemented and gates the read formatters')
+
+    def test_privacy_policy_lists_no_unimplemented_mitigation(self, client):
+        """Same claim, second location — the policy is a legal document."""
+        body = client.get('/privacy').get_data(as_text=True)
+        assert 'summary-only mode' not in body.lower(), (
+            'privacy policy lists summary-only mode as a mitigation, but it '
+            'is not implemented')


### PR DESCRIPTION
Closes #166.

## The problem

Two user-facing surfaces promised a privacy control that does not exist.

**The Telegram `/start` disclosure** (`openclaw/bot.py`):

> ⚠️ Heads up: chat apps aren't encrypted medical channels. You're accessing your own records here; by continuing you accept that for your own data. **Reply /nophi to keep responses summary-only.**

**The privacy policy** (`templates/privacy.html`), listing it among live mitigations for consumer messaging channels:

> **Optional summary-only mode** — responses can be limited to summaries rather than full record content.

Neither was implemented. `bot.py` carried an explicit `TODO(nophi)` stating the toggle was not built — the disclosure line shipped, the control did not.

## Why this is worse than saying nothing

A user who replies `/nophi` believing they have limited their PHI exposure over an unencrypted consumer channel has **strictly less protection than they were told they have** — and they chose to continue partly *because* the mitigation was offered. Silence would have left them better informed.

The privacy-policy claim is the more serious of the two. It is a legal document representing a control that does not exist, on exactly the axis the FTC has pursued elsewhere: under the Health Breach Notification Rule a breach expressly includes unauthorized *disclosure*, and misrepresented privacy controls are what the GoodRx and BetterHelp actions turned on (context in #168).

The rest of the disclosure is accurate, honest, and worth keeping. One sentence was undermining it.

## What changed

- Removed the `/nophi` sentence from the `/start` risk line; kept the accurate disclosure.
- Removed the summary-only bullet from the privacy policy's mitigations list.
- Replaced the test that **asserted the false promise was present** (`assert '/nophi' in src`) with two guards that assert neither claim returns — one reading `bot.py`, one asserting against the rendered policy.
- Left a comment at the site explaining why, so the next person adding a control here adds it to both places together.

This is **Option A** from the issue. Option B (implement the real toggle) remains open on #166: persist per `chat_id`, gate the read formatters, and prove it with a **negative** test showing summary-only emits no clinical values.

## Verification

Observed, not assumed:

- `uv run python -m pytest tests/ -q` → **1483 passed, 1 skipped**
- `uv run python -m pytest tests/test_guardrail_conformance.py -q` → **28 passed, Grade A held**
- `uvx ruff check r6/ tests/ scripts/ main.py app.py` → clean

I also confirmed the new guards are not vacuous: reintroducing each claim makes them fail, and removing it makes them pass.

```
2 failed, 11 passed   # with both claims reintroduced
13 passed             # restored
```

## Note

`openclaw/` is not in the CI ruff target (`r6/ tests/ scripts/ main.py app.py`), so this file is not lint-gated. Not changed here, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)