### PR TITLE
ci: lint the whole repo + fix docs linking to unpublished CLAUDE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] Tests added/updated and `uv run python -m pytest tests/ -q` passes
-- [ ] `pipx run ruff check r6/ tests/ scripts/ main.py app.py` passes
+- [ ] `pipx run ruff check .` passes
 - [ ] No PHI in code, tests, fixtures, or logs (synthetic data only)
 - [ ] Touches auth/audit/redaction/tenancy? Note it here so maintainers review against the compliance rules
 - [ ] Node changes: `npx tsc --noEmit && npm test` passes in `services/agent-orchestrator`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           pip install uv
           uv sync --frozen --group dev
-          uv run ruff check r6/ tests/ scripts/ main.py app.py
+          uv run ruff check .
 
       - name: Mypy (gradual typed security core)
         run: uv run mypy

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ Copy this into the release PR/issue and check items off.
 
 - [ ] Full Python suite green: `uv run python -m pytest tests/ -q`
 - [ ] Node suite green: `cd services/agent-orchestrator && npx tsc --noEmit && npm test`
-- [ ] Lint clean: `pipx run ruff check r6/ tests/ scripts/ main.py app.py`
+- [ ] Lint clean: `pipx run ruff check .`
 - [ ] Demo gates pass: `./scripts/demo_e2e.sh` (all 11 gates)
 - [ ] Dependabot alerts triaged (no open high/critical): repo → Security → Dependabot
 

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -104,7 +104,7 @@ STEP_UP_SECRET=dev-secret python main.py            # http://localhost:5000
 
 uv run python -m pytest tests/ -q                    # all Python tests
 uv run python -m pytest tests/test_r6_routes.py::test_name -v   # one test
-uvx ruff check r6/ tests/ scripts/ main.py app.py    # lint (CI-gated)
+uvx ruff check .                                     # lint (CI-gated)
 
 cd services/agent-orchestrator && npm ci && npx tsc --noEmit && npm test
 ```
@@ -126,7 +126,7 @@ Revert incidental `uv.lock` churn before committing.
 An issue is done when all of these hold. State them explicitly in the PR.
 
 - [ ] `uv run python -m pytest tests/ -q` passes — quote the actual counts
-- [ ] `uvx ruff check r6/ tests/ scripts/ main.py app.py` clean
+- [ ] `uvx ruff check .` clean
 - [ ] Node changes: `npx tsc --noEmit` clean and `npm test` passes
 - [ ] Conformance still **Grade A** (`tests/test_guardrail_conformance.py`)
 - [ ] New behavior has tests — including a **negative** test (the guardrail

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -4,8 +4,13 @@ If you (human or coding agent) are starting work on an issue in this repo, read
 this first. It exists so you don't begin from scratch: it tells you where things
 live, what you may not break, and what "done" means here.
 
-**Read order:** this file → [CLAUDE.md](../CLAUDE.md) (architecture + invariants)
-→ [docs/development.md](development.md) (build/test/deploy detail) → the issue.
+**Read order:** this file → [docs/development.md](development.md)
+(build/test/deploy detail) → the issue.
+
+> Maintainers may also have a local `CLAUDE.md` with the same invariants. It is
+> deliberately not published, so everything you need is here or in
+> `docs/development.md` — if something is only in `CLAUDE.md`, that's a bug in
+> this guide and worth an issue.
 
 ---
 
@@ -181,7 +186,6 @@ auditor.
 
 ## Related
 
-- [CLAUDE.md](../CLAUDE.md) — architecture + invariants
 - [docs/development.md](development.md) — full contributor guide
 - [docs/healthcare-ai-advisors-roadmap.md](healthcare-ai-advisors-roadmap.md) — where this is all going
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — ground rules, DCO

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ uv run python -m pytest tests/ -q
 uv run python -m pytest tests/test_r6_routes.py::test_name -v
 
 # Lint (CI-gated)
-pipx run ruff check r6/ tests/ scripts/ main.py app.py
+pipx run ruff check .
 
 # Node MCP server
 cd services/agent-orchestrator && npm ci && npx tsc --noEmit && npm test

--- a/docs/healthcare-ai-advisors-roadmap.md
+++ b/docs/healthcare-ai-advisors-roadmap.md
@@ -325,6 +325,5 @@ Any advisor, any surface, any phase:
 
 - [docs/agent-task-guide.md](agent-task-guide.md) — **start here if you're picking up an issue**
 - [ROADMAP.md](../ROADMAP.md) — the engine roadmap (Now/Next/Later)
-- [CLAUDE.md](../CLAUDE.md) — engine architecture + invariants
 - [docs/development.md](development.md) — contributor guide, deploy steps
 - `.health-context.yaml` — engine/surface declarations (both repos)


### PR DESCRIPTION
Two small correctness fixes found while closing the loose end from #170.

## 1. The ruff gate had holes

CI linted `r6/ tests/ scripts/ main.py app.py`. That list is missing several actively-developed Python directories — most notably **`careagents/`** (12 files, an entire second Flask app) and **`openclaw/`** (the Telegram bot, which is where the `/nophi` issue in #166 lived).

An explicit directory list goes stale silently. `careagents/` was added long after the list was written and nobody noticed it was unguarded — that is the failure mode, and `ruff check .` cannot drift.

**No cleanup was required.** Every previously-unlinted directory already passes, so this is a pure gate change with zero code edits.

Coverage: **250 → 276 files** (careagents 12, migrations 5, adapters 4, openclaw 1, api 1, deploy 1, plus root modules).

**Verified the gate actually works** rather than assuming. Appending an unused import to `careagents/personas.py`:

```
old target: All checks passed!     <- silently missed it
new target: Found 3 errors.        <- caught
```

Updated in CI, `RELEASING.md`, `docs/development.md`, `docs/agent-task-guide.md`, and the PR template so they all agree.

## 2. Public docs linked to a file that is not published

`CLAUDE.md` is **gitignored on purpose** — `.gitignore` puts it in the "Local-only: personal strategy docs + AI-session artifacts (kept on disk, not published)" block alongside `private/` and `.claude/`.

But `docs/agent-task-guide.md` (merged in #165) opened by telling collaborators to read it as step two of the read order, and both that guide and the advisors roadmap linked it under Related. **Those links 404 for everyone except the maintainer** — precisely the audience the guide exists for.

Read order now points at `docs/development.md`, which is published, plus a short note that a local `CLAUDE.md` may exist and that anything found only there is a bug in the guide.

My mistake in #165; caught by running a link check across the four new docs. (The `../../issues/N` links flagged by that check are fine — that is the repo's established GitHub-relative convention, used throughout `ROADMAP.md`.)

## Verification

- `uvx ruff check .` → All checks passed
- `.github/workflows/ci.yml` parses as valid YAML
- Relative links in all four new docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)