### PR TITLE
feat(careagents): informed consent at the connect-real-records moment

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -208,11 +208,14 @@ class AccountService:
 
     def add_connection(self, account_id: str, kind: str, tenant_id: str,
                        label: str, status: str = "active",
-                       provider: str | None = None) -> str:
+                       provider: str | None = None,
+                       consent_version: str | None = None) -> str:
         with self.session() as s:
             c = Connection(account_id=account_id, kind=kind,
                            tenant_id=tenant_id, label=label[:120],
-                           status=status, provider=provider)
+                           status=status, provider=provider,
+                           consented_at=now() if consent_version else None,
+                           consent_version=consent_version)
             s.add(c)
             s.flush()
             return c.id

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -27,6 +27,11 @@ from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
 
+# Bump when the consent-card copy or the terms/privacy content it points at
+# changes materially. Stored per connection so we always know which version a
+# person agreed to — a later change never silently claims earlier consent.
+CONSENT_VERSION = "2026-07-19"
+
 
 def create_app(config: Config | None = None,
                client: HealthClawClient | None = None,
@@ -77,7 +82,9 @@ def create_app(config: Config | None = None,
     def auth():
         if session.get("account_id"):
             return redirect(url_for("home"))
-        return render_template("auth.html", rp_id=cfg.rp_id)
+        return render_template("auth.html", rp_id=cfg.rp_id,
+                               terms_url=f"{cfg.healthclaw_base}/terms",
+                               privacy_url=f"{cfg.healthclaw_base}/privacy")
 
     @app.get("/home")
     @login_required
@@ -90,6 +97,8 @@ def create_app(config: Config | None = None,
             surfaces=data["surfaces"], has_passkey=svc.has_passkey(acct.id),
             telegram_bot=cfg.telegram_bot,
             imessage_handle=cfg.imessage_handle,
+            terms_url=f"{cfg.healthclaw_base}/terms",
+            privacy_url=f"{cfg.healthclaw_base}/privacy",
             catalog=connectors.catalog(cfg))
 
     @app.post("/logout")
@@ -184,6 +193,15 @@ def create_app(config: Config | None = None,
         if plan.get("soon"):
             # Not live yet — acknowledge intent (never a dead-end button).
             return jsonify({"soon": True, "connector": connector_id})
+        # Real-record connections require informed consent, enforced here so
+        # a client that skips the consent card is refused server-side (CARIN
+        # CoC: proactive consent in advance of personal data disclosure).
+        consent_version = None
+        if plan.get("requires_consent"):
+            if body.get("consent") is not True:
+                return jsonify({"error": "consent_required",
+                                "consent_version": CONSENT_VERSION}), 428
+            consent_version = CONSENT_VERSION
         tenant = plan["tenant"]
         if plan.get("seed"):
             try:
@@ -192,7 +210,8 @@ def create_app(config: Config | None = None,
                 return jsonify({"error": "records service unavailable"}), 503
         cid = svc.add_connection(acct.id, connector_id, tenant, plan["label"],
                                  status=plan["status"],
-                                 provider=plan.get("provider"))
+                                 provider=plan.get("provider"),
+                                 consent_version=consent_version)
         out = {"id": cid, "status": plan["status"]}
         if plan.get("connect_url"):
             out["connect_url"] = plan["connect_url"]

--- a/careagents/connectors.py
+++ b/careagents/connectors.py
@@ -66,6 +66,9 @@ def catalog(cfg) -> list[dict]:
     out = []
     for c in _CATALOG:
         item = {k: c[k] for k in ("id", "label", "blurb", "icon", "tier")}
+        # Every live real-record source gets the consent card; sample doesn't.
+        if c["id"] in ("fasten", "wearable"):
+            item["requires_consent"] = True
         if c["id"] == "fasten" and not getattr(cfg, "fasten_public_key", ""):
             item["tier"] = "soon"
             item["note"] = "not configured on this deployment"
@@ -101,6 +104,8 @@ def start(connector_id: str, provider: str | None, cfg, client) -> dict:
         return {"error": "unknown connector", "code": 404}
 
     if connector_id == "sample":
+        # Synthetic data only — no personal data, so no consent gate. Keeping
+        # the try-it path friction-free is deliberate (see beta-tester-guide).
         return {"tenant": client.new_tenant_id(), "status": "active",
                 "label": "Sample records", "provider": "CareAgents sample",
                 "seed": True}
@@ -112,6 +117,7 @@ def start(connector_id: str, provider: str | None, cfg, client) -> dict:
         tenant = client.new_tenant_id()
         return {"tenant": tenant, "status": "pending",
                 "label": "My health provider", "provider": "Connecting…",
+                "requires_consent": True,
                 "connect_url": client.fasten_connect_url(tenant)}
 
     if connector_id == "wearable":
@@ -123,7 +129,7 @@ def start(connector_id: str, provider: str | None, cfg, client) -> dict:
         label = next(p["label"] for p in WEARABLE_PROVIDERS if p["id"] == prov)
         tenant = client.new_tenant_id()
         return {"tenant": tenant, "status": "pending", "label": label,
-                "provider": label,
+                "provider": label, "requires_consent": True,
                 "connect_url": client.wearables_connect_url(tenant, prov)}
 
     # import + soon tiers: no live flow yet — record intent, never dead-end.

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -71,6 +71,13 @@ class Connection(Base):
     status = Column(String(16), default="active")       # active|pending|error
     provider = Column(String(120), nullable=True)       # e.g. Epic (Fasten)
     connected_at = Column(Float, default=now)
+    # Informed-consent record for real-record connections (CARIN CoC:
+    # "informed, proactive consent... in advance of personal data disclosure").
+    # Null for sample/synthetic connections, which carry no personal data.
+    # consent_version pins WHICH terms were consented to, so a later terms
+    # change doesn't silently claim consent it never obtained.
+    consented_at = Column(Float, nullable=True)
+    consent_version = Column(String(16), nullable=True)
     account = relationship("Account", back_populates="connections")
     agents = relationship("Agent", back_populates="connection")
 
@@ -121,14 +128,24 @@ def _ensure_columns(engine) -> None:
     both support ADD COLUMN ... DEFAULT.
     """
     insp = inspect(engine)
-    if "ca_email_tokens" not in insp.get_table_names():
-        return
-    cols = {c["name"] for c in insp.get_columns("ca_email_tokens")}
-    if "attempts" not in cols:
+    tables = insp.get_table_names()
+    if "ca_email_tokens" in tables:
+        cols = {c["name"] for c in insp.get_columns("ca_email_tokens")}
+        if "attempts" not in cols:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE ca_email_tokens ADD COLUMN attempts INTEGER "
+                    "DEFAULT 0"))
+    if "ca_connections" in tables:
+        cols = {c["name"] for c in insp.get_columns("ca_connections")}
         with engine.begin() as conn:
-            conn.execute(text(
-                "ALTER TABLE ca_email_tokens ADD COLUMN attempts INTEGER "
-                "DEFAULT 0"))
+            if "consented_at" not in cols:
+                conn.execute(text(
+                    "ALTER TABLE ca_connections ADD COLUMN consented_at FLOAT"))
+            if "consent_version" not in cols:
+                conn.execute(text(
+                    "ALTER TABLE ca_connections ADD COLUMN consent_version "
+                    "VARCHAR(16)"))
 
 
 def make_engine(url: str):

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -372,3 +372,16 @@ button.linkish { background: none; border: 0; color: var(--clay-deep);
 .modal-card h3 { font-family: "Fraunces", serif; font-size: 22px; margin-bottom: 6px; }
 .modal-card .field, .modal-card select.field { margin-bottom: 4px; }
 .modal-card .btn-primary { margin-top: 20px; }
+
+/* --- consent card (real-record connections) ------------------------------ */
+.consent-card { max-width: 520px; max-height: 88vh; overflow-y: auto; }
+.consent-lead { color: var(--ink-soft); margin: 4px 0 14px; }
+.consent-points { list-style: none; margin: 0; padding: 0; }
+.consent-points li { margin: 0 0 12px; padding-left: 22px; position: relative;
+  font-size: 14.5px; line-height: 1.5; }
+.consent-points li::before { content: "•"; position: absolute; left: 6px;
+  color: var(--clay-deep); }
+.consent-fine { font-size: 13px; color: var(--ink-soft); margin-top: 10px; }
+.auth-fine { font-size: 12.5px; color: var(--ink-soft); margin-top: 14px;
+  text-align: center; }
+.auth-fine a, .consent-fine a { color: var(--clay-deep); }

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -28,6 +28,13 @@
         if (isNaN(idx) || !provs[idx]) return;
         body.provider = provs[idx].id;
       }
+      // Real-record sources: informed consent before anything happens. The
+      // server refuses (428) without it, so this card is UX, not the gate.
+      if (tile.dataset.consent) {
+        const agreed = await showConsentCard();
+        if (!agreed) return;
+        body.consent = true;
+      }
       tile.disabled = true;
       const res = await post("/api/connections/" + id, body);
       tile.disabled = false;
@@ -37,6 +44,19 @@
       location.reload();
     });
   });
+
+  // Consent card: resolves true only on an explicit "I agree".
+  function showConsentCard() {
+    return new Promise((resolve) => {
+      const modal = document.getElementById("consent-modal");
+      const agree = document.getElementById("consent-agree");
+      const cancel = document.getElementById("consent-cancel");
+      const done = (v) => { modal.hidden = true; resolve(v); };
+      agree.onclick = () => done(true);
+      cancel.onclick = () => done(false);
+      modal.hidden = false;
+    });
+  }
 
   // Poll pending connection cards until active.
   document.querySelectorAll('.conn-card .status-pending').forEach((el) => {

--- a/careagents/templates/auth.html
+++ b/careagents/templates/auth.html
@@ -20,6 +20,10 @@
              autocomplete="email" placeholder="you@example.com" autofocus>
       <button class="btn-secondary btn-block" id="email-btn">
         Email me a code</button>
+      <p class="auth-fine">By continuing you agree to the
+        <a href="{{ terms_url }}" target="_blank" rel="noopener">Terms</a> and
+        <a href="{{ privacy_url }}" target="_blank" rel="noopener">Privacy
+          policy</a>.</p>
     </div>
 
     <!-- Step: code -->

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -63,6 +63,7 @@
       <button type="button" class="connector-tile tier-{{ m.tier }}"
               data-connector="{{ m.id }}"
               {% if m.get('providers') %}data-providers='{{ m.providers|tojson }}'{% endif %}
+              {% if m.get('requires_consent') and m.tier != 'soon' %}data-consent="1"{% endif %}
               {% if m.tier == 'soon' %}data-soon="1"{% endif %}>
         <span class="connector-emoji">{{ m.icon }}</span>
         <span class="connector-label">{{ m.label }}</span>
@@ -93,6 +94,43 @@
     </div>
   </section>
 </main>
+
+<!-- Consent card: shown before any REAL-record connection starts.
+     Sample records skip this on purpose — synthetic data, zero risk.
+     Copy is versioned server-side (CONSENT_VERSION); keep them in step. -->
+<div class="modal" id="consent-modal" hidden>
+  <div class="modal-card consent-card">
+    <h3>Before you connect your real records</h3>
+    <p class="consent-lead">Plain answers to the questions that matter.
+      Take the 30 seconds.</p>
+    <ul class="consent-points">
+      <li><b>You're using your own right of access.</b> You are retrieving your
+        own health records and pointing them at a tool you chose. CareAgents is
+        not your doctor and not a hospital — different rules apply than you may
+        be used to.</li>
+      <li><b>Where your records live:</b> behind the HealthClaw guardrail
+        layer, in a private space scoped to you — with identifier redaction on
+        reads and an audit log of every access.
+        <b>CareAgents itself stores no health data</b> — only your account and
+        a pointer to that space.</li>
+      <li><b>What the AI sees:</b> redacted records, when a question needs
+        them. Your data is <b>never used to train models</b> and never sold.</li>
+      <li><b>The AI can be wrong</b> — and your connected records may be
+        incomplete. Don't treat either as a substitute for your official
+        records or for professional medical judgment.</li>
+      <li><b>Leaving:</b> email
+        <a href="mailto:support@healthclaw.io">support@healthclaw.io</a> and
+        we'll delete your data and confirm when it's done.</li>
+    </ul>
+    <p class="consent-fine">Full detail:
+      <a href="{{ terms_url }}" target="_blank" rel="noopener">Terms</a> ·
+      <a href="{{ privacy_url }}" target="_blank" rel="noopener">Privacy
+        policy</a></p>
+    <button type="button" class="btn-primary btn-block" id="consent-agree">
+      I understand — connect my records</button>
+    <button type="button" class="linkish" id="consent-cancel">Not now</button>
+  </div>
+</div>
 
 <!-- New-agent modal -->
 <div class="modal" id="agent-modal" hidden>

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -341,7 +341,8 @@ def test_wearable_connector_soon_by_default_live_when_enabled(svc, monkeypatch):
     a.config["TESTING"] = True
     c = a.test_client()
     _login(c, svc, monkeypatch, email="wear@example.com")
-    r = c.post("/api/connections/wearable", json={"provider": "apple"})
+    r = c.post("/api/connections/wearable",
+               json={"provider": "apple", "consent": True})
     assert r.status_code == 200
     d = r.get_json()
     assert d["status"] == "pending"
@@ -367,7 +368,7 @@ def test_agent_requires_own_connection(app, svc, monkeypatch):
 def test_fasten_connection_returns_verified_provider_url(app, svc, monkeypatch):
     c = app.test_client()
     _login(c, svc, monkeypatch)
-    r = c.post("/api/connections/fasten")
+    r = c.post("/api/connections/fasten", json={"consent": True})
     assert r.status_code == 200
     d = r.get_json()
     # routes through HealthClaw's own wired-up connect page, not a Fasten URL
@@ -377,6 +378,61 @@ def test_fasten_connection_returns_verified_provider_url(app, svc, monkeypatch):
     # the pending connection polls to active once records land
     assert c.get(f"/api/connections/{tenant}/poll").get_json()["status"] == "active"
     assert c.get("/api/connections/not-mine/poll").status_code == 404
+
+
+# --- consent gate (real records only) ----------------------------------------
+
+def test_real_record_connect_refused_without_consent(app, svc, monkeypatch):
+    """The consent gate is server-side: skipping the card is refused."""
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    for payload in (None, {}, {"consent": False}, {"consent": "yes"},
+                    {"consent": 1}):
+        r = c.post("/api/connections/fasten", json=payload)
+        assert r.status_code == 428, payload
+        d = r.get_json()
+        assert d["error"] == "consent_required"
+        assert d["consent_version"]
+    # nothing was persisted by the refused attempts
+    with svc.session() as s:
+        from careagents.models import Connection
+        assert s.query(Connection).filter_by(kind="fasten").count() == 0
+
+
+def test_sample_connect_needs_no_consent(app, svc, monkeypatch):
+    """Synthetic records stay friction-free — no consent card, no record."""
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    r = c.post("/api/connections/sample")
+    assert r.status_code == 200
+    with svc.session() as s:
+        from careagents.models import Connection
+        conn = s.query(Connection).filter_by(kind="sample").first()
+        assert conn.consented_at is None and conn.consent_version is None
+
+
+def test_consent_is_recorded_with_version(app, svc, monkeypatch):
+    """An agreed consent persists timestamp + the version agreed to."""
+    from careagents.app import CONSENT_VERSION
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    r = c.post("/api/connections/fasten", json={"consent": True})
+    assert r.status_code == 200
+    with svc.session() as s:
+        from careagents.models import Connection
+        conn = s.query(Connection).filter_by(kind="fasten").first()
+        assert conn.consent_version == CONSENT_VERSION
+        assert conn.consented_at is not None
+
+
+def test_catalog_marks_real_record_sources_for_consent(app, svc, monkeypatch):
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    by_id = {x["id"]: x for x in
+             c.get("/api/connections/catalog").get_json()["connectors"]}
+    assert by_id["fasten"].get("requires_consent") is True
+    assert by_id["wearable"].get("requires_consent") is True
+    assert "requires_consent" not in by_id["sample"]
 
 
 # --- review relay ------------------------------------------------------------


### PR DESCRIPTION
Closes #167. The last code-side beta blocker (#166 shipped in #170; #168 is a legal determination).

## What this is

CareAgents asked people to connect **real medical records** with no consent step and no terms link anywhere in the app. This adds both — positioned where the decision is actually made, not buried at signup or in a footer.

## The consent card

Shown before any **real-record** connection starts (Fasten, wearables). The copy is CARIN Code of Conduct-informed and covers, in ~30 seconds of plain language:

- **You're using your own right of access** — CareAgents is not your doctor and not a covered entity; different rules apply
- **Where records live** — behind the HealthClaw guardrails, redaction on reads, audit on every access; **CareAgents stores no health data**, only your account and a pointer
- **What the AI sees** — redacted records when a question needs them; **never used to train models, never sold**
- **The AI can be wrong — and your record may be incomplete** (the Apple Health Records framing: incompleteness is the more dangerous failure mode for an AI reasoning over records, and we previously said nothing about it)
- **Leaving** — the support@healthclaw.io path

**Sample records deliberately skip the card** — synthetic data, zero risk, and the beta guide's synthetic-first track depends on that path staying friction-free.

## Enforcement is server-side, the card is just UX

`POST /api/connections/<id>` for a `requires_consent` connector without `{"consent": true}` → **428 `consent_required`**. The check is strict `is True` — `"yes"`, `1`, and other truthy payloads are refused, and the negative test proves nothing is persisted on refusal. A client that skips the card gets nothing.

Consent is recorded per connection (`consented_at` + `consent_version`), so we always know **which version** of the terms a person agreed to — a later copy change never silently claims earlier consent (CARIN Consent (d)). Columns added via the existing `_ensure_columns` idempotent-migration pattern.

Also: Terms + Privacy links at signup (`auth.html`), pointing at the deployed HealthClaw `/terms` and `/privacy` pages (verified live, HTTP 200).

## What is deliberately NOT here

**No delete/disconnect button.** No deletion path exists in the client or the models yet — and the lesson of #166 is that advertising an unimplemented control is worse than silence. The card states the email path, which is live. A real disconnect + delete flow is follow-up work; I can file the issue.

## Verification

- `tests/test_careagents.py` → **29 passed** (4 new: refusal without consent incl. truthy-but-not-True payloads + nothing persisted; sample unaffected; version recorded; catalog flags)
- Full suite → **1487 passed, 1 skipped** · ruff (whole repo) clean
- Migration verified against a simulated pre-existing DB missing both columns; second run idempotent
- `auth.html` renders the links

Note: careagents.cloud will need a redeploy to pick this up (independent VPS deploy, explicitly gated — not doing it as part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)