### PR TITLE
fix(e2e): un-break Playwright on main — stale CTA locator + no report

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Overridable so the suite can run where :5000 is taken (macOS AirPlay
+// Receiver binds it by default). CI keeps the default.
+const PORT = process.env.E2E_PORT || '5000';
+
 export default defineConfig({
   testDir: './tests',
   // Serial execution — shared SQLite instance, tests create resources
@@ -7,10 +11,16 @@ export default defineConfig({
   workers: 1,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  // CI gets BOTH the inline annotations and an HTML report — the report is
+  // what the failure-artifact upload ships, and with only the 'github'
+  // reporter no report directory was ever produced (issue #154: every red
+  // run ended with "No files were found ... e2e/playwright-report/").
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : 'list',
 
   use: {
-    baseURL: 'http://localhost:5000',
+    baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
   },
 
@@ -26,7 +36,7 @@ export default defineConfig({
     // explicit Alembic migrations). Initialize the DB, then serve — both
     // processes share one absolute SQLite path so the server sees the tables.
     command: 'cd .. && uv run flask --app main init-db && uv run python main.py',
-    url: 'http://localhost:5000/r6/fhir/health',
+    url: `http://localhost:${PORT}/r6/fhir/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
     env: {
@@ -35,6 +45,7 @@ export default defineConfig({
       STEP_UP_SECRET: 'e2e-test-secret-not-for-production',
       SQLALCHEMY_DATABASE_URI: 'sqlite:////tmp/e2e-healthclaw.db',
       FLASK_ENV: 'testing',
+      PORT,
     },
   },
 });

--- a/e2e/tests/landing.spec.ts
+++ b/e2e/tests/landing.spec.ts
@@ -20,9 +20,20 @@ test.describe('Landing page', () => {
     await expect(page.locator('h1.hero-title')).toContainText('AI agents');
   });
 
-  test('Try the Live Dashboard button navigates to dashboard', async ({ page }) => {
-    await page.getByRole('link', { name: 'Try the Live Dashboard' }).click();
+  // The hero CTAs were reworded in the SEO/CTA pass ("Try the Live Dashboard"
+  // → "Explore the live dashboard" + a new primary "Try CareAgents" link).
+  // The old locator matched nothing and timed out on every run — the sole
+  // red test behind issue #154.
+  test('dashboard CTA navigates to the live dashboard', async ({ page }) => {
+    await page.getByRole('link', { name: 'Explore the live dashboard' }).click();
     await expect(page).toHaveURL('/r6-dashboard');
+  });
+
+  test('primary CTA points at CareAgents', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /Try CareAgents/ });
+    await expect(cta).toBeVisible();
+    // External link — assert the target rather than navigating away.
+    await expect(cta).toHaveAttribute('href', 'https://careagents.cloud');
   });
 
   test('PHI before/after section is visible', async ({ page }) => {

--- a/main.py
+++ b/main.py
@@ -375,6 +375,8 @@ app = create_app()
 if __name__ == "__main__":
     app.run(
         host="0.0.0.0",
-        port=5000,
+        # Overridable so the e2e suite can run on machines where :5000 is
+        # taken (macOS AirPlay Receiver binds it by default).
+        port=int(os.environ.get("PORT", "5000")),
         debug=os.environ.get("FLASK_DEBUG") == "1",
     )


### PR DESCRIPTION
Closes #154.

Root cause, from the actual CI logs (not the environment theories): the
server started fine and 36 tests ran. ONE test failed on every run —
landing.spec.ts clicked a link named "Try the Live Dashboard", but the
hero CTA was reworded to "Explore the live dashboard" during the SEO/CTA
pass (which also added the primary "Try CareAgents" link). The locator
matched nothing, timed out at 30s, and with 2 CI retries burned ~2.5min
per run before failing.

Second, separable bug: CI used only the 'github' reporter, which writes
no report directory — so every failure ended with "No files were found
... e2e/playwright-report/" and the artifact upload shipped nothing.
The one signal that would have made this a 5-minute diagnosis was
discarded on every red run.

Changes:
- landing.spec.ts: point the locator at the current CTA; add a test that
  the primary "Try CareAgents" CTA is present and targets
  careagents.cloud (asserted via href — external link, no navigation).
- playwright.config.ts: CI reporter is now [github, html(open:never)] so
  a red run always leaves an inspectable report for the artifact upload.
- Port made overridable (E2E_PORT, threaded to Flask via PORT): on macOS
  the AirPlay Receiver binds :5000, so the suite could not run locally
  at all — which is why this regression was only ever visible in CI.

Verification (observed):
- CI-mode local run: 37 passed (36 + 1 new), playwright-report/index.html
  produced
- ruff (whole repo) clean; Python suite 1489 passed, 1 skipped

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Eugene Vestel <44978768+aks129@users.noreply.github.com>
