### PR TITLE
feat(careagents): advisor registry — SmartHealthConnect skills ported (#175)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -226,13 +226,13 @@ class AccountService:
                 c.status = status
 
     def create_agent(self, account_id: str, name: str, persona: str,
-                     connection_id: str) -> str:
+                     connection_id: str, advisor: str | None = None) -> str:
         with self.session() as s:
             if not s.query(Connection).filter_by(
                     id=connection_id, account_id=account_id).first():
                 raise AuthError("That connection isn't yours.")
             a = Agent(account_id=account_id, name=name[:48], persona=persona,
-                      connection_id=connection_id)
+                      connection_id=connection_id, advisor=advisor)
             s.add(a)
             s.flush()
             return a.id
@@ -308,7 +308,7 @@ def _conn_dict(c: Connection) -> dict:
 
 def _agent_dict(a: Agent) -> dict:
     return {"id": a.id, "name": a.name, "persona": a.persona,
-            "connection_id": a.connection_id}
+            "advisor": a.advisor, "connection_id": a.connection_id}
 
 
 def _surf_dict(x: Surface) -> dict:

--- a/careagents/advisors.py
+++ b/careagents/advisors.py
@@ -1,0 +1,177 @@
+"""Advisor registry — capability specializations layered over the agent loop.
+
+Ported from SmartHealthConnect's patient skills (skills/*/SKILL.md, archived —
+see aks129/SmartHealthConnect#12). An advisor is WHAT the agent is good at;
+a persona (personas.py) is HOW it talks. The two are orthogonal: picking the
+refills advisor never changes the user's chosen voice.
+
+Engine-backed by construction: an advisor only contributes a system-prompt
+block. The tool set stays agent.py's guarded six (all HealthClaw HTTP API —
+redaction, audit, tenant scoping inherited), so there is no bypass path for
+an advisor to take. That is the structural fix for the contract violation
+that got SmartHealthConnect archived (39/40 of its tools bypassed the
+engine).
+
+Same honesty rule as the connector catalog: an advisor only advertises as
+available when every capability its guidance mentions actually exists.
+`available: False` entries state their blocker and are refused server-side.
+"""
+
+from __future__ import annotations
+
+# Wearable-sourced Observations carry LOINC codes; naming them makes
+# search_records queries precise. Table inherited from the SHC skills.
+_LOINC_HINTS = (
+    "LOINC codes worth knowing for wearable-sourced Observations: "
+    "heart rate 8867-4, resting HR 40443-4, HRV(SDNN) 80404-7, SpO2 59408-5, "
+    "respiratory rate 9279-1, body temp 8310-5, steps 55423-8, sleep duration "
+    "93832-4, VO2max 65757-1, body weight 29463-7, systolic BP 8480-6, "
+    "diastolic BP 8462-4, blood glucose 15074-8."
+)
+
+ADVISORS: dict[str, dict] = {
+    "general": {
+        "name": "General care",
+        "emoji": "🌿",
+        "blurb": "A well-rounded agent across your whole record.",
+        "available": True,
+        "guidance": "",  # the base system prompt is already the general agent
+    },
+    "healthy-habits": {
+        "name": "Healthy Habits",
+        "emoji": "📊",
+        "blurb": "Trends across sleep, activity, vitals, and adherence.",
+        "available": True,
+        "origin": "SmartHealthConnect skill: healthy-habits",
+        "guidance": (
+            "Specialty: the longitudinal operating picture — sleep, exercise, "
+            "vital-sign trends, and medication adherence as one story.\n"
+            "- Lead with the big picture (get_health_summary), then drill "
+            "into trends with get_labs and search_records.\n"
+            "- Focus on trends over weeks and months, never single readings. "
+            "Celebrate consistency and improvements explicitly.\n"
+            "- Connect domains when the data supports it: better sleep "
+            "alongside lower blood pressure is worth saying out loud.\n"
+            "- Never suggest reducing medication because vitals improved — "
+            "that is the prescriber's decision alone.\n"
+            f"- {_LOINC_HINTS}"
+        ),
+    },
+    "care-completion": {
+        "name": "Care Completion",
+        "emoji": "✅",
+        "blurb": "Screenings, follow-ups, and care gaps — what's due and why.",
+        "available": True,
+        "origin": "SmartHealthConnect skill: care-completion",
+        "guidance": (
+            "Specialty: preventive care and follow-through — screenings, "
+            "referrals, and care gaps against quality measures.\n"
+            "- Start from get_care_gaps for the current picture; use "
+            "get_health_summary and search_records for the why behind each "
+            "gap (age, sex, conditions).\n"
+            "- Explain in plain language why each screening matters. "
+            "Highlight overdue cancer screenings and immunizations with "
+            "appropriate urgency.\n"
+            "- Care-gap logic is guideline-based (HEDIS/USPSTF), not "
+            "individual medical advice — say so, and route specific "
+            "screening decisions to their provider.\n"
+            "- Never dismiss a gap as unimportant; that call belongs to the "
+            "provider."
+        ),
+    },
+    "medication-refills": {
+        "name": "Medication Refills",
+        "emoji": "💊",
+        "blurb": "What you take, what's running low, what to ask about.",
+        "available": True,
+        "origin": "SmartHealthConnect skill: medication-refills",
+        "guidance": (
+            "Specialty: the medication picture — active prescriptions, "
+            "adherence signals, and refill planning.\n"
+            "- Ground every claim in search_records over MedicationRequest "
+            "(plus get_health_summary for the roster).\n"
+            "- Help them plan ahead: what looks close to running out, what "
+            "to raise with the pharmacy or prescriber, and what needs a "
+            "renewal rather than a refill.\n"
+            "- You cannot SUBMIT refill requests yet — requesting a refill "
+            "is a real-world action that will arrive on the approval rail. "
+            "Say so plainly and point them to their pharmacy in the "
+            "meantime; never imply a request was placed.\n"
+            "- Never recommend stopping or changing a dose. If something "
+            "reads as overdue or lapsed, urge them to contact their "
+            "pharmacy or provider."
+        ),
+    },
+    "diet-exercise": {
+        "name": "Diet & Exercise",
+        "emoji": "🏃",
+        "blurb": "How activity and habits show up in your numbers.",
+        "available": True,
+        "origin": "SmartHealthConnect skill: diet-exercise",
+        "guidance": (
+            "Specialty: how activity and lifestyle show up in the clinical "
+            "record — BP, glucose, weight, and wearable signals.\n"
+            "- Read activity through wearable-sourced Observations "
+            "(search_records) and clinical results (get_labs); present "
+            "connections in plain language: 'on weeks with more activity, "
+            "your average BP reads lower.'\n"
+            "- Correlations need enough data — say when the sample is too "
+            "thin to mean anything.\n"
+            "- Encourage consistency over intensity; patterns over single "
+            "workouts.\n"
+            "- Anyone with a cardiac condition gets a see-your-provider note "
+            "before exercise-intensity suggestions; symptoms during exercise "
+            "(chest pain, dizziness) are an immediate seek-care answer.\n"
+            f"- {_LOINC_HINTS}"
+        ),
+    },
+    "research-monitor": {
+        "name": "Research Monitor",
+        "emoji": "🔬",
+        "blurb": "New research and trials relevant to your conditions.",
+        "available": False,
+        "origin": "SmartHealthConnect skill: research-monitor",
+        "note": (
+            "Needs research-source tools (preprints, ClinicalTrials.gov, "
+            "FDA safety signals) that the agent loop does not have yet."
+        ),
+    },
+    "kids-health": {
+        "name": "Kids & Family",
+        "emoji": "👶",
+        "blurb": "Pediatric schedules, school forms, family records.",
+        "available": False,
+        "origin": "SmartHealthConnect skill: kids-health",
+        "note": (
+            "Needs caregiver accounts — an adult acting on a dependent's "
+            "record with the audit trail recording who acted. Blocked on "
+            "the identity work (aks129/HealthClawGuardrails#157)."
+        ),
+    },
+}
+
+DEFAULT_ADVISOR = "general"
+
+
+def catalog() -> list[dict]:
+    """Advisor tiles for the UI — available ones plus honest 'soon' entries."""
+    out = []
+    for key, a in ADVISORS.items():
+        item = {"id": key, "name": a["name"], "emoji": a["emoji"],
+                "blurb": a["blurb"], "available": a["available"]}
+        if not a["available"]:
+            item["note"] = a.get("note", "coming soon")
+        out.append(item)
+    return out
+
+
+def get(key: str) -> dict | None:
+    return ADVISORS.get(key)
+
+
+def prompt_block(key: str | None) -> str:
+    """The system-prompt addition for an advisor; empty for general/unknown."""
+    a = ADVISORS.get(key or DEFAULT_ADVISOR)
+    if not a or not a["available"] or not a.get("guidance"):
+        return ""
+    return f"\n\n{a['guidance']}"

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -21,7 +21,7 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
 
 from careagents.accounts import (AccountService, AuthError, new_binding_code)
-from careagents import connectors
+from careagents import advisors, connectors
 from careagents.agent import run_turn, run_turn_to_message
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
@@ -99,6 +99,7 @@ def create_app(config: Config | None = None,
             imessage_handle=cfg.imessage_handle,
             terms_url=f"{cfg.healthclaw_base}/terms",
             privacy_url=f"{cfg.healthclaw_base}/privacy",
+            advisors=advisors.catalog(),
             catalog=connectors.catalog(cfg))
 
     @app.post("/logout")
@@ -240,9 +241,20 @@ def create_app(config: Config | None = None,
         name = (body.get("name") or "Juniper").strip()[:48] or "Juniper"
         persona = body.get("persona") if body.get(
             "persona") in PERSONAS else DEFAULT_PERSONA
+        # Advisor is optional; an unavailable/unknown one is refused rather
+        # than silently downgraded — never pretend a capability exists.
+        advisor = body.get("advisor") or None
+        if advisor:
+            spec = advisors.get(advisor)
+            if spec is None:
+                return jsonify({"error": "unknown advisor"}), 400
+            if not spec["available"]:
+                return jsonify({"error": "advisor_not_available",
+                                "note": spec.get("note", "")}), 400
         try:
             aid = svc.create_agent(acct.id, name, persona,
-                                   body.get("connection_id", ""))
+                                   body.get("connection_id", ""),
+                                   advisor=advisor)
         except AuthError as exc:
             return jsonify({"error": str(exc)}), 400
         return jsonify({"id": aid})
@@ -288,7 +300,8 @@ def create_app(config: Config | None = None,
 
         tenant = ctx["tenant"]
         agent = ctx["agent"]
-        sysprompt = system_prompt(agent["name"], agent["persona"])
+        sysprompt = system_prompt(agent["name"], agent["persona"],
+                                  agent.get("advisor"))
 
         def stream():
             with hist_lock:
@@ -469,7 +482,8 @@ def create_app(config: Config | None = None,
                                      "Try again in a bit."}), 200
         tenant = ctx["tenant"]
         agent = ctx["agent"]
-        sysprompt = system_prompt(agent["name"], agent["persona"])
+        sysprompt = system_prompt(agent["name"], agent["persona"],
+                                  agent.get("advisor"))
         with hist_lock:
             history = histories[tenant]
         try:

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -88,6 +88,8 @@ class Agent(Base):
     account_id = Column(String(32), ForeignKey("ca_accounts.id"), index=True)
     connection_id = Column(String(32), ForeignKey("ca_connections.id"))
     name = Column(String(48), default="Juniper")
+    # Capability specialization (advisors.py); persona stays the voice.
+    advisor = Column(String(32), nullable=True)
     persona = Column(String(16), default="calm")
     created_at = Column(Float, default=now)
     account = relationship("Account", back_populates="agents")
@@ -136,6 +138,12 @@ def _ensure_columns(engine) -> None:
                 conn.execute(text(
                     "ALTER TABLE ca_email_tokens ADD COLUMN attempts INTEGER "
                     "DEFAULT 0"))
+    if "ca_agents" in tables:
+        cols = {c["name"] for c in insp.get_columns("ca_agents")}
+        if "advisor" not in cols:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE ca_agents ADD COLUMN advisor VARCHAR(32)"))
     if "ca_connections" in tables:
         cols = {c["name"] for c in insp.get_columns("ca_connections")}
         with engine.begin() as conn:

--- a/careagents/personas.py
+++ b/careagents/personas.py
@@ -60,7 +60,9 @@ PERSONAS = {
 DEFAULT_PERSONA = "calm"
 
 
-def system_prompt(agent_name: str, persona_key: str) -> str:
+def system_prompt(agent_name: str, persona_key: str,
+                  advisor_key: str | None = None) -> str:
+    from careagents.advisors import prompt_block
     p = PERSONAS.get(persona_key, PERSONAS[DEFAULT_PERSONA])
     return (
         f"You are {agent_name}, a personal care agent on careagents.cloud, "
@@ -71,4 +73,5 @@ def system_prompt(agent_name: str, persona_key: str) -> str:
         "message, not a report. When you start the intake form, tell them a "
         "review card will appear and that nothing is sent until they approve "
         "each item."
+        + prompt_block(advisor_key)
     )

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -105,6 +105,7 @@
     const res = await post("/api/agents", {
       name: $("a-name").value.trim() || "Juniper",
       persona: persona ? persona.value : "calm",
+      advisor: ($("a-advisor") && $("a-advisor").value) || "general",
       connection_id: conn,
     });
     if (res.ok) { location.href = "/chat?agent=" + res.d.id; return; }

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -146,6 +146,16 @@
         <span class="persona-name">{{ p.name }}</span></label>
       {% endfor %}
     </div>
+    <span class="field-label">Specialty</span>
+    <select class="field" id="a-advisor">
+      {% for adv in advisors %}
+      {% if adv.available %}
+      <option value="{{ adv.id }}">{{ adv.emoji }} {{ adv.name }} — {{ adv.blurb }}</option>
+      {% else %}
+      <option value="" disabled>{{ adv.emoji }} {{ adv.name }} — {{ adv.note }}</option>
+      {% endif %}
+      {% endfor %}
+    </select>
     <span class="field-label">Records</span>
     <select class="field" id="a-conn">
       {% for c in connections %}<option value="{{ c.id }}">{{ c.label }} ({{ c.status }})</option>{% endfor %}

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -570,3 +570,72 @@ def test_healthz_and_manifest(app):
     assert c.get("/healthz").get_json()["accounts"] is True
     m = c.get("/manifest.webmanifest").get_json()
     assert m["name"] == "CareAgents" and m["start_url"] == "/home"
+
+# --- advisors (ported from SmartHealthConnect skills) -------------------------
+
+def test_advisor_catalog_shape_and_honesty():
+    """Available advisors have guidance; deferred ones state their blocker."""
+    from careagents import advisors
+    cat = {a["id"]: a for a in advisors.catalog()}
+    # 4 live specialties + general; research-monitor + kids-health deferred
+    for key in ("general", "healthy-habits", "care-completion",
+                "medication-refills", "diet-exercise"):
+        assert cat[key]["available"] is True, key
+    for key in ("research-monitor", "kids-health"):
+        assert cat[key]["available"] is False, key
+        assert cat[key]["note"]  # honest reason, never a silent dead tile
+    # guidance may only reference tools the agent loop actually has
+    from careagents.agent import TOOLS
+    real = {t["name"] for t in TOOLS}
+    import re
+    for key, a in advisors.ADVISORS.items():
+        for tool in re.findall(r"\b(get_[a-z_]+|search_records|start_intake_form|check_form_status|log_[a-z_]+|request_[a-z_]+|check_[a-z_]+|track_[a-z_]+|monitor_[a-z_]+)\b",
+                               a.get("guidance", "")):
+            assert tool in real, f"{key} guidance references nonexistent tool {tool}"
+
+
+def test_agent_with_advisor_gets_specialized_prompt(app, svc, monkeypatch):
+    from careagents.personas import system_prompt
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    r = c.post("/api/agents", json={"name": "Meds", "persona": "direct",
+                                    "advisor": "medication-refills",
+                                    "connection_id": conn})
+    assert r.status_code == 200
+    aid = r.get_json()["id"]
+    with svc.session() as s:
+        from careagents.models import Account
+        acct_id = s.query(Account).filter_by(
+            email="gene@example.com").one().id
+    ctx = svc.get_agent_context(acct_id, aid)
+    assert ctx["agent"]["advisor"] == "medication-refills"
+    sp = system_prompt(ctx["agent"]["name"], ctx["agent"]["persona"],
+                       ctx["agent"]["advisor"])
+    assert "medication picture" in sp            # advisor guidance present
+    assert "cannot SUBMIT refill requests" in sp  # rail honesty preserved
+    # persona (voice) is orthogonal: direct persona text still present
+    base = system_prompt(ctx["agent"]["name"], ctx["agent"]["persona"])
+    assert base in sp  # advisor only APPENDS; never rewrites the voice/safety
+
+
+def test_unavailable_advisor_refused_not_downgraded(app, svc, monkeypatch):
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    for adv in ("kids-health", "research-monitor"):
+        r = c.post("/api/agents", json={"name": "X", "persona": "calm",
+                                        "advisor": adv,
+                                        "connection_id": conn})
+        assert r.status_code == 400, adv
+        assert r.get_json()["error"] == "advisor_not_available"
+        assert r.get_json()["note"]
+    r = c.post("/api/agents", json={"name": "X", "persona": "calm",
+                                    "advisor": "nonsense",
+                                    "connection_id": conn})
+    assert r.status_code == 400
+    # no advisor at all still works (general agent)
+    r = c.post("/api/agents", json={"name": "Plain", "persona": "calm",
+                                    "connection_id": conn})
+    assert r.status_code == 200
+


### PR DESCRIPTION
Closes #175. Part 1 of the SmartHealthConnect consolidation
(aks129/SmartHealthConnect#12): the six patient skills become CareAgents
advisor definitions; the SHC repo can be archived without losing them.

An advisor is WHAT the agent is good at; a persona stays HOW it talks —
the two are orthogonal, and a test proves the advisor block only appends
to the persona prompt, never rewrites voice or safety.

Engine-backed by construction: an advisor contributes only a system-
prompt block. The tool set remains agent.py's guarded six (HealthClaw
HTTP API — redaction, audit, tenant scoping inherited), so there is no
bypass path for an advisor to take. That is the structural fix for the
contract violation that got SHC archived (39/40 of its tools bypassed
the engine). A test greps every advisor's guidance for tool names and
fails if one references a tool the loop does not have.

Ported live (4 + general): healthy-habits (trends + LOINC hints),
care-completion (care gaps, HEDIS framing), medication-refills
(READ-side only — guidance states plainly it cannot submit refill
requests; that action arrives via the rail, #162), diet-exercise
(wearable correlations, cardiac cautions).

Deferred honestly (2), refused server-side with a stated reason —
never a silent downgrade:
- research-monitor: needs research-source tools the loop lacks
- kids-health: needs caregiver identity (#157)

Wiring: Agent.advisor column (+ idempotent _ensure_columns migration),
create_agent + /api/agents validation, advisor picker in the new-agent
modal (deferred entries visible but disabled with their reason),
system_prompt(advisor_key) at both chat call sites.

Verification:
- tests/test_careagents.py: 32 passed (3 new: catalog honesty + tool-
  reference guard; specialized prompt + persona orthogonality;
  unavailable-advisor refusal)
- full suite 1492 passed, 1 skipped; ruff clean
- migration verified against a pre-existing DB, idempotent

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Eugene Vestel <44978768+aks129@users.noreply.github.com>
