### PR TITLE
feat(mcp-apps): care-gaps embedded UI — SmartHealthConnect view ported (#176)

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2841,6 +2841,33 @@ def mcp_app_compiled_truth(resource_type, resource_id):
     return resp
 
 
+@r6_blueprint.route('/mcp-apps/care-gaps/', methods=['GET'])
+@r6_blueprint.route('/mcp-apps/care-gaps', methods=['GET'])
+def mcp_app_care_gaps():
+    """
+    MCP App: Preventive Care Gaps.
+
+    Renders the Patient/$care-gaps Parameters response (summary buckets,
+    per-rule cards, consumer lines, disclaimer). Linked from the
+    `care_gaps` MCP tool via `_meta.ui.resourceUri`. Layout ported from
+    SmartHealthConnect's care-gaps view (archived); data path rebuilt on
+    the engine's own operation so redaction + audit apply by construction.
+    """
+    tenant_id = (
+        request.headers.get('X-Tenant-Id')
+        or request.args.get('tenant_id')
+        or ''
+    )
+    html = render_template(
+        'mcp_apps/care_gaps.html',
+        tenant_id=tenant_id,
+    )
+    resp = Response(html, mimetype='text/html')
+    resp.headers['Content-Type'] = 'text/html; profile=mcp-app'
+    resp.headers['X-MCP-App'] = 'care-gaps'
+    return resp
+
+
 @r6_blueprint.route('/mcp-apps/wearables/', methods=['GET'])
 @r6_blueprint.route('/mcp-apps/wearables', methods=['GET'])
 def mcp_app_wearables():

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -1092,6 +1092,37 @@ describe("Tool Execution Tests", () => {
     expect(url).toBe(`${BASE}/Patient/$care-gaps`);
   });
 
+  it("care_gaps attaches the MCP App resourceUri (same pattern as wearables)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse({ resourceType: "Parameters", parameter: [] })
+    );
+
+    const result = (await tools.executeTool(
+      "care_gaps",
+      {},
+      { "x-tenant-id": "t-app" }
+    )) as Record<string, unknown>;
+
+    const meta = result._meta as { ui?: { resourceUri?: string; profile?: string } };
+    expect(meta?.ui?.profile).toBe("mcp-app");
+    expect(meta?.ui?.resourceUri).toBe(
+      `${BASE}/mcp-apps/care-gaps/?tenant_id=t-app`
+    );
+  });
+
+  it("care_gaps failure carries no resourceUri (no UI over an error)", async () => {
+    mockFetch.mockResolvedValueOnce(fakeResponse({}, 500));
+
+    const result = (await tools.executeTool(
+      "care_gaps",
+      {},
+      { "x-tenant-id": "t1" }
+    )) as Record<string, unknown>;
+
+    expect(result.error).toBeDefined();
+    expect(result._meta).toBeUndefined();
+  });
+
   // -- fhir.permission_evaluate --
 
   it("fhir.permission_evaluate posts to Permission/$evaluate", async () => {

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -576,10 +576,10 @@ export class FHIRTools {
         name: "care_gaps",
         title: "Preventive Care Gaps",
         description:
-          "Check which preventive-care screenings/immunizations a patient may be due for (blood pressure, cholesterol, colorectal/cervical/breast cancer screening, flu, diabetes A1c), from their own connected records. Decision support based on USPSTF/ACIP/ADA guidelines — not a diagnosis or directive.",
+          "Check which preventive-care screenings/immunizations a patient may be due for (blood pressure, cholesterol, colorectal/cervical/breast cancer screening, flu, diabetes A1c), from their own connected records. Decision support based on USPSTF/ACIP/ADA guidelines — not a diagnosis or directive. Response includes _meta.ui.resourceUri pointing to an embeddable review UI.",
         tier: "read",
-        handler: ({ input, headers }) =>
-          this.careGaps(input.subject as string | undefined, headers),
+        handler: ({ input, headers, tenantId }) =>
+          this.careGaps(input.subject as string | undefined, headers, tenantId),
         annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
         inputSchema: {
           type: "object",
@@ -1747,7 +1747,8 @@ export class FHIRTools {
 
   private async careGaps(
     subject: string | undefined,
-    headers: Record<string, string>
+    headers: Record<string, string>,
+    tenantId = ""
   ): Promise<Record<string, unknown>> {
     const params = new URLSearchParams();
     if (subject) params.set("subject", subject);
@@ -1760,7 +1761,18 @@ export class FHIRTools {
     if (!resp.ok) {
       return { error: `$care-gaps failed with status ${resp.status}` };
     }
-    return (await resp.json()) as Record<string, unknown>;
+    const result = (await resp.json()) as Record<string, unknown>;
+    // Embeddable review UI (same pattern as wearables / compiled-truth):
+    // MCP clients that understand `_meta.ui.resourceUri` render it inline.
+    result._meta = {
+      ui: {
+        resourceUri:
+          `${this.baseUrl}/mcp-apps/care-gaps/` +
+          `?tenant_id=${encodeURIComponent(tenantId)}`,
+        profile: "mcp-app",
+      },
+    };
+    return result;
   }
 
   // --- Curatr: patient-facing data quality tools ---

--- a/templates/mcp_apps/care_gaps.html
+++ b/templates/mcp_apps/care_gaps.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Care Gaps · HealthClaw</title>
+<meta name="mcp-app" content="care-gaps">
+<!-- Layout ported from SmartHealthConnect's care-gaps MCP-App view
+     (aks129/SmartHealthConnect, archived) — rebuilt on the engine's own
+     $care-gaps operation so redaction + audit + tenant scoping apply by
+     construction. Statuses follow the engine (due / up_to_date /
+     not_applicable / indeterminate), not SHC's overdue/completed. -->
+<style>
+  :root{
+    --bg:#0b0f14;--panel:#0f141b;--ink:#dbe3ef;--dim:#7b8496;
+    --border:#1c242f;--cyan:#22d3ee;--green:#34d399;--amber:#fbbf24;
+    --red:#f87171;--mono:ui-monospace,SFMono-Regular,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);
+    font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:1080px;margin:0 auto;padding:24px}
+  header{display:flex;align-items:center;justify-content:space-between;
+    padding-bottom:16px;border-bottom:1px solid var(--border);
+    margin-bottom:20px;flex-wrap:wrap;gap:12px}
+  .title{font-size:18px;font-weight:600}
+  .title small{display:block;color:var(--dim);font-size:12px;margin-top:2px;
+    font-family:var(--mono)}
+  .stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));
+    gap:12px;margin-bottom:20px}
+  .stat{background:var(--panel);border:1px solid var(--border);
+    border-radius:8px;padding:14px;text-align:center}
+  .stat .num{font-size:26px;font-weight:700;font-family:var(--mono)}
+  .stat .label{color:var(--dim);font-size:11.5px;margin-top:2px;
+    text-transform:uppercase;letter-spacing:.04em}
+  .stat.due .num{color:var(--amber)}
+  .stat.ok .num{color:var(--green)}
+  .stat.na .num{color:var(--dim)}
+  .card{background:var(--panel);border:1px solid var(--border);
+    border-radius:8px;padding:16px;margin-bottom:12px}
+  .card h3{margin:0 0 6px;font-size:15px;font-weight:600}
+  .card .note{color:var(--dim);font-size:13px}
+  .pill{display:inline-block;padding:3px 10px;border-radius:999px;
+    font-size:11.5px;border:1px solid var(--border);background:var(--panel);
+    font-family:var(--mono);margin-right:6px}
+  .pill.due{color:var(--amber);border-color:rgba(251,191,36,.35)}
+  .pill.up_to_date{color:var(--green);border-color:rgba(52,211,153,.35)}
+  .pill.not_applicable,.pill.indeterminate{color:var(--dim)}
+  .consumer{background:rgba(34,211,238,.05);border:1px solid
+    rgba(34,211,238,.2);border-radius:8px;padding:14px 16px;margin:20px 0}
+  .consumer h3{margin:0 0 8px;font-size:13px;color:var(--cyan);
+    text-transform:uppercase;letter-spacing:.05em}
+  .consumer li{margin:4px 0}
+  .empty{color:var(--dim);padding:24px;text-align:center}
+  .err-box{color:var(--red);padding:12px;background:rgba(248,113,113,.06);
+    border:1px solid rgba(248,113,113,.2);border-radius:6px;margin:0 0 16px}
+  .tenant-input{background:var(--panel);color:var(--ink);
+    border:1px solid var(--border);padding:6px 10px;border-radius:6px;
+    font-family:var(--mono);font-size:12px;min-width:180px}
+  button{background:transparent;color:var(--ink);border:1px solid
+    var(--border);padding:7px 14px;border-radius:6px;font-size:12.5px;
+    cursor:pointer;font-family:inherit}
+  button:hover{border-color:var(--cyan);color:var(--cyan)}
+  .footer-note{color:var(--dim);font-size:11.5px;font-family:var(--mono);
+    margin-top:24px;padding-top:16px;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+  <div class="title">
+    Preventive Care Gaps
+    <small id="tenant-label">tenant: —</small>
+  </div>
+  <div style="display:flex;gap:8px;align-items:center">
+    <input class="tenant-input" id="tenant-input"
+           placeholder="tenant id" value="{{ tenant_id }}">
+    <button id="load-btn">Load</button>
+  </div>
+</header>
+
+<div id="err" class="err-box" hidden></div>
+<div id="content"><div class="empty">Enter a tenant id and press Load.</div></div>
+
+<p class="footer-note">Decision support from your own connected records
+  (USPSTF/ACIP/ADA guideline logic) — not a diagnosis or a directive.
+  Screening decisions belong with you and your clinician. Every read is
+  redacted and audited by the HealthClaw guardrail layer.</p>
+</div>
+
+<script>
+  const TENANT_ID = {{ tenant_id | tojson }};
+  const errEl = document.getElementById('err');
+  const contentEl = document.getElementById('content');
+
+  function param(parameters, name){
+    const p = (parameters.parameter || []).find(x => x.name === name);
+    if(!p) return null;
+    try { return JSON.parse(p.valueString); } catch { return p.valueString; }
+  }
+
+  function esc(s){
+    return String(s ?? '').replace(/[&<>"']/g,
+      c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function render(parameters){
+    const summary = param(parameters, 'summary') || {};
+    const consumer = param(parameters, 'consumerSummary') || {};
+    const detail = param(parameters, 'detail') || [];
+    const stats = `
+      <div class="stats">
+        <div class="stat due"><div class="num">${summary.due || 0}</div>
+          <div class="label">Due</div></div>
+        <div class="stat ok"><div class="num">${summary.up_to_date || 0}</div>
+          <div class="label">Up to date</div></div>
+        <div class="stat na"><div class="num">${summary.not_applicable || 0}</div>
+          <div class="label">Not applicable</div></div>
+        <div class="stat na"><div class="num">${summary.indeterminate || 0}</div>
+          <div class="label">Needs data</div></div>
+      </div>`;
+    const cards = (detail || []).map(r => `
+      <div class="card">
+        <h3>${esc(r.title || r.rule_id || 'Check')}</h3>
+        <div><span class="pill ${esc(r.status)}">${esc(
+          (r.status || '').replace(/_/g, ' '))}</span></div>
+        ${r.note ? `<div class="note">${esc(r.note)}</div>` : ''}
+      </div>`).join('');
+    const lines = (consumer.lines || []).map(l => `<li>${esc(l)}</li>`).join('');
+    const consumerBox = lines ? `
+      <div class="consumer"><h3>In plain terms</h3><ul>${lines}</ul>
+        ${consumer.note ? `<div class="note">${esc(consumer.note)}</div>` : ''}
+      </div>` : '';
+    contentEl.innerHTML = stats + consumerBox +
+      (cards || '<div class="empty">No screenings evaluated.</div>');
+  }
+
+  async function load(){
+    const tenant = document.getElementById('tenant-input').value.trim();
+    if(!tenant){ return; }
+    document.getElementById('tenant-label').textContent = 'tenant: ' + tenant;
+    errEl.hidden = true;
+    contentEl.innerHTML = '<div class="empty">Loading…</div>';
+    try{
+      const res = await fetch('/r6/fhir/Patient/$care-gaps', {
+        method: 'POST',
+        headers: {'X-Tenant-Id': tenant, 'Content-Type': 'application/json'},
+        body: '{}',
+      });
+      if(!res.ok){
+        throw new Error('care-gaps returned HTTP ' + res.status +
+          (res.status === 401 ? ' — this tenant requires a step-up token' : ''));
+      }
+      render(await res.json());
+    }catch(e){
+      errEl.textContent = e.message || 'Failed to load care gaps.';
+      errEl.hidden = false;
+      contentEl.innerHTML = '<div class="empty">—</div>';
+    }
+  }
+
+  document.getElementById('load-btn').addEventListener('click', load);
+  if(TENANT_ID){ load(); }
+</script>
+</body>
+</html>

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -67,3 +67,37 @@ def test_care_gaps_unknown_patient_is_ok_but_indeterminate(client, tenant_header
     summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
     # No patient found -> no birthDate/gender available -> indeterminate/not-run rules
     assert summary["total"] >= 0
+
+
+# ─────────────────────────────────────────────
+# MCP App page (embedded HTML surface)
+# ─────────────────────────────────────────────
+
+class TestCareGapsMcpApp:
+    """The care-gaps MCP App page — layout ported from SmartHealthConnect
+    (archived), data path rebuilt on the engine's own $care-gaps operation."""
+
+    def test_serves_html_with_mcp_app_profile(self, client):
+        resp = client.get('/r6/fhir/mcp-apps/care-gaps/?tenant_id=desktop-demo')
+        assert resp.status_code == 200
+        assert 'text/html' in resp.headers['Content-Type']
+        assert 'profile=mcp-app' in resp.headers['Content-Type']
+        assert resp.headers.get('X-MCP-App') == 'care-gaps'
+        body = resp.get_data(as_text=True)
+        assert '<title>Care Gaps' in body
+        assert 'desktop-demo' in body
+
+    def test_page_reads_through_the_guarded_operation_only(self, client):
+        """The page's only data path is the engine's $care-gaps operation —
+        no direct table reads, no alternate endpoints (the SHC failure mode)."""
+        body = client.get('/r6/fhir/mcp-apps/care-gaps/').get_data(as_text=True)
+        assert '/r6/fhir/Patient/$care-gaps' in body
+        # no other fetch targets appear in the page
+        import re
+        fetches = re.findall(r"fetch\('([^']+)'", body)
+        assert fetches == ['/r6/fhir/Patient/$care-gaps']
+
+    def test_no_tenant_renders_empty_shell(self, client):
+        resp = client.get('/r6/fhir/mcp-apps/care-gaps/')
+        assert resp.status_code == 200
+        assert 'Enter a tenant id' in resp.get_data(as_text=True)


### PR DESCRIPTION
Part 2 of the SmartHealthConnect consolidation (#176,
aks129/SmartHealthConnect#12).

Discovery that reshaped the work: HealthClaw already HAS the MCP-App
pattern — engine-rendered HTML at /r6/fhir/mcp-apps/* linked from tool
responses via _meta.ui.resourceUri (compiled-truth and wearables views
exist today). So the port follows the house pattern instead of SHC's
separate ext-apps server: no second server, no vite build, no manifest,
no new data paths.

What ships — the one genuinely missing view, care-gaps:

- templates/mcp_apps/care_gaps.html: layout ported from SHC's care-gaps
  view (stat buckets + per-rule cards), rebuilt on the engine's own
  Patient/$care-gaps operation. Statuses follow the engine (due /
  up_to_date / not_applicable / indeterminate), not SHC's invented
  overdue/completed. Values HTML-escaped; the page's ONLY fetch target
  is the guarded operation — a test greps the served page and asserts
  exactly one fetch URL, so the SHC bypass failure mode cannot recur.
- GET /r6/fhir/mcp-apps/care-gaps/ route (Content-Type text/html;
  profile=mcp-app, X-MCP-App header, tenant via header or query —
  identical shape to the wearables route).
- care_gaps MCP tool now attaches _meta.ui.resourceUri (same pattern as
  wearables/compiled-truth); no UI is attached to an error response.
  Tool count unchanged — drift guards untouched.

Verification:
- node: tsc clean, 170 passed (2 new: resourceUri attach with resolved
  tenant; no _meta on failure — first attempt read the raw header and
  failed, fixed to use the handler's resolved tenantId)
- python: 1492 passed, 1 skipped (3 new route tests incl. the
  single-fetch-target guard); ruff clean

Note: the MCP server does not auto-deploy — the tool-side _meta goes
live on the next manual MCP deploy; the engine page goes live on the
next main push (Railway).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Eugene Vestel <44978768+aks129@users.noreply.github.com>
