### PR TITLE
docs: SmartHealthConnect archived — CareAgents is the declared surface

### DIFF
--- a/.health-context.yaml
+++ b/.health-context.yaml
@@ -5,8 +5,9 @@
 # or tool that needs to know jurisdiction/audience/sensitivity without
 # re-asking.
 #
-# Sister file lives in SmartHealthConnect declaring the patient-facing surface
-# that calls into this engine. See ENGINE_CONTRACT.md.
+# The patient-facing surface is CareAgents (careagents/ in this repo), which
+# declares itself below. SmartHealthConnect, the original sister surface, was
+# archived 2026-07-19 (its skills live on as CareAgents advisors).
 
 name: HealthClaw Guardrails
 version: 1.8.0
@@ -39,6 +40,9 @@ audit_agent_default: healthclaw-guardrails
 
 # Surface products that call into this engine. Informational — not enforced.
 surfaces:
-  - name: SmartHealthConnect
-    repo: https://github.com/aks129/SmartHealthConnect
-    role: patient-facing PHR
+  - name: CareAgents
+    repo: https://github.com/aks129/HealthClawGuardrails/tree/main/careagents
+    role: consumer app (accounts, advisors, web/Telegram/iMessage)
+  # SmartHealthConnect (patient-facing PHR) archived 2026-07-19 —
+  # https://github.com/aks129/SmartHealthConnect (read-only; salvage record
+  # in its issue #12).

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ claude plugin marketplace add aks129/HealthClawGuardrails
 # Install the FHIR guardrail plugin (this repo)
 claude plugin install healthclaw-guardrails@healthclaw-marketplace
 
-# Install the personal-health companion plugin (SmartHealthConnect)
+# Install the personal-health companion plugin (frozen — upstream archived)
 claude plugin install smarthealthconnect@healthclaw-marketplace
 ```
 
 | Plugin | Skills | Source |
 | --- | --- | --- |
 | `healthclaw-guardrails` | curatr, fasten-connect, fhir-r6-guardrails, fhir-upstream-proxy, healthex-export, phi-redaction | [aks129/HealthClawGuardrails](https://github.com/aks129/HealthClawGuardrails) |
-| `smarthealthconnect` | care-completion, diet-exercise, healthy-habits, kids-health, medication-refills, research-monitor | [aks129/SmartHealthConnect](https://github.com/aks129/SmartHealthConnect) |
+| `smarthealthconnect` | care-completion, diet-exercise, healthy-habits, kids-health, medication-refills, research-monitor | [aks129/SmartHealthConnect](https://github.com/aks129/SmartHealthConnect) *(archived — skills frozen at v1.2.0; live successors are CareAgents advisors)* |
 
 Each skill is auto-discoverable — Claude loads it when your prompt matches the skill's trigger phrases (e.g. "check my care gaps", "redact this bundle", "run Curatr on my conditions").
 

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -91,10 +91,12 @@ without touching core code. See
 [docs/extending-the-action-rail.md](extending-the-action-rail.md). If you find
 yourself building a *new* approval mechanism, stop: use the rail.
 
-**Two more repos.** [SmartHealthConnect](https://github.com/aks129/SmartHealthConnect)
-is the patient-facing surface (skills + MCP app); this repo is the engine. The
-split is declared in `.health-context.yaml` in each (`role: engine` /
-`role: surface`). Surfaces never read FHIR directly.
+**The engine/surface split.** This repo is the engine; CareAgents
+(`careagents/`, in-repo) is the consumer surface. The split is declared in
+`.health-context.yaml` (`role: engine`, with surfaces listed). Surfaces never
+read FHIR directly. SmartHealthConnect, the original external surface, was
+archived 2026-07-19 after violating exactly that rule — its skills live on as
+CareAgents advisors (`careagents/advisors.py`).
 
 ---
 

--- a/docs/healthcare-ai-advisors-roadmap.md
+++ b/docs/healthcare-ai-advisors-roadmap.md
@@ -77,14 +77,14 @@ Verified against the repos, not aspirational.
 | Engine | Guardrail conformance, graded A–F | ✅ Grade A, CI-gated |
 | Engine | Action rail + out-of-band human gate | ✅ forms rail end-to-end |
 | Engine | Compiled Truth (`fhir_compiled_truth`) | ✅ |
-| Surface | SmartHealthConnect v1.2.0 — 6 patient skills | ✅ built |
-| Surface | SHC MCP App — 7 views | ✅ built, ⚠️ not submitted |
-| Surface | SHC MCP server — ~30 tools | ✅ built, ⚠️ contract drift (§4.2) |
+| Surface | SmartHealthConnect v1.2.0 — 6 patient skills | 📦 archived — live on as CareAgents advisors (#175) |
+| Surface | SHC MCP App — 7 views | 📦 resolved — care-gaps ported to the engine, rest merged/dropped (#176) |
+| Surface | SHC MCP server — ~30 tools | 📦 archived — bypass closed by construction (SHC#12) |
 | Surface | CareAgents (`careagents.cloud`) | ✅ live, **independent deploy** |
 | Surface | CareAgents connector marketplace | ✅ live (7 sources) |
 | Surface | CareAgents iMessage | 🟡 code shipped, blocked on TCC grants |
 | Claude | HealthClaw MCP in registry (`server.json` v1.8.0) | ✅ published |
-| Claude | SmartHealthConnect MCP App in directory | ⚠️ blocked (§4.1) |
+| Claude | SmartHealthConnect MCP App in directory | 📦 mooted by archive; future App tracked in #164 |
 
 **The advisor roster today.** Six patient skills (`healthy-habits`,
 `care-completion`, `medication-refills`, `diet-exercise`, `kids-health`,

--- a/docs/plugin-desktop-verification.md
+++ b/docs/plugin-desktop-verification.md
@@ -1,5 +1,7 @@
 # Claude Desktop Verification
 
+> **Note (2026-07-19):** SmartHealthConnect is archived — its plugin skills remain installable (frozen at v1.2.0) but new capability lands in CareAgents advisors. Verification steps below still work against the archived repo.
+
 Step-by-step test plan to verify `healthclaw-guardrails` and `smarthealthconnect` work in Claude Desktop before plugin submission. Run through once; every box must tick.
 
 The plugins ship **two surfaces**:


### PR DESCRIPTION
Completes the HealthClaw side of the SmartHealthConnect archive
(aks129/SmartHealthConnect#12; repo archived 2026-07-19).

- .health-context.yaml: surfaces block now names CareAgents (in-repo
  consumer app) as the patient-facing surface; SHC recorded as archived
  with a pointer to the salvage record.
- README: marketplace row annotated — the smarthealthconnect plugin
  remains installable (archived repos stay clonable) but is frozen at
  v1.2.0; live successors are the CareAgents advisors.
- docs/agent-task-guide.md: engine/surface section now teaches the split
  with CareAgents, and names SHC's archival as the cautionary example of
  violating the surfaces-never-read-FHIR-directly rule.
- docs/healthcare-ai-advisors-roadmap.md: inventory rows flipped from
  built/blocked to archived/resolved with issue pointers.
- docs/plugin-desktop-verification.md: archived note under the title;
  the verification steps still work against the read-only repo.

Left alone deliberately: CHANGELOG.md (history), INTEGRATION.md (its
"SmartHealthConnect" is a different project — a HAPI FHIR upstream at
github.com/healthconnect/fhir-server, not the archived surface).

Verification: .health-context.yaml parses; drift guards 9 passed;
ruff clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Eugene Vestel <44978768+aks129@users.noreply.github.com>
