### PR TITLE
fix(careagents): sign-in code input truncated 8-digit codes to 6 — UI login always failed

### DIFF
--- a/careagents/templates/auth.html
+++ b/careagents/templates/auth.html
@@ -28,10 +28,10 @@
 
     <!-- Step: code -->
     <div id="step-code" hidden>
-      <p class="setup-sub">We sent a 6-digit code to <b id="code-email"></b>.</p>
+      <p class="setup-sub">We sent an 8-digit code to <b id="code-email"></b>.</p>
       <label class="field-label" for="code">Code</label>
       <input class="field code-input" id="code" inputmode="numeric"
-             maxlength="6" placeholder="••••••" autocomplete="one-time-code">
+             maxlength="8" placeholder="••••••••" autocomplete="one-time-code">
       <button class="btn-primary btn-block" id="verify-btn">Continue</button>
       <button class="linkish" id="back-btn">← use a different email</button>
     </div>

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -565,6 +565,17 @@ def test_landing_and_auth_render(app):
     assert a.status_code == 200 and b"passkey" in a.data.lower()
 
 
+def test_auth_code_input_fits_minted_codes(app):
+    # The server mints zero-padded codes of len(str(CODE_MAX - 1)) digits; the
+    # input's maxlength must match or the UI truncates the code and every
+    # sign-in fails (shipped broken as 6 vs 8 once — keep them locked).
+    from careagents.accounts import CODE_MAX
+    digits = len(str(CODE_MAX - 1))
+    body = app.test_client().get("/auth").get_data(as_text=True)
+    assert f'maxlength="{digits}"' in body
+    assert f"{digits}-digit code" in body
+
+
 def test_healthz_and_manifest(app):
     c = app.test_client()
     assert c.get("/healthz").get_json()["accounts"] is True


### PR DESCRIPTION
The server mints **8-digit** codes but the sign-in input had `maxlength="6"` (and the copy promised a 6-digit code) — the UI truncated every emailed code, so email-code sign-in through the browser could never succeed on prod. Found while scripting the v1.9.0 demo recording: the real prod email delivered `37929263`, and the input refused the last two digits.

Fix: input + copy now derive-checked against `CODE_MAX` — a new test locks `maxlength` and the '8-digit code' copy to `len(str(CODE_MAX - 1))`, so the three can't drift again.

Verified: `tests/test_careagents.py` 34 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)