### PR TITLE
fix(e2e): landing CTA locator strict-mode collision with audience card

### DIFF
--- a/e2e/tests/landing.spec.ts
+++ b/e2e/tests/landing.spec.ts
@@ -30,7 +30,9 @@ test.describe('Landing page', () => {
   });
 
   test('primary CTA points at CareAgents', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /Try CareAgents/ });
+    // Exact name: the audience card's link also contains "Try CareAgents",
+    // so a substring match resolves to 2 elements and trips strict mode.
+    const cta = page.getByRole('link', { name: 'Try CareAgents →', exact: true });
     await expect(cta).toBeVisible();
     // External link — assert the target rather than navigating away.
     await expect(cta).toHaveAttribute('href', 'https://careagents.cloud');


### PR DESCRIPTION
## Summary

Follow-up to #185 — this fix was pushed to that branch two minutes after auto-merge fired on the required checks, so it never reached main.

The v1.9.0 landing tidy (#180) added a CareAgents audience card whose link text also contains "Try CareAgents", so the hero-CTA substring locator resolves to 2 elements and trips Playwright strict mode. The playwright-tests job only surfaced it on #185's second run (it was skipped when e2e paths didn't trigger). Locator now matches the hero button's exact accessible name.

## Verification

`E2E_PORT=5055 npx playwright test tests/landing.spec.ts`: 9/9 pass (port override because macOS AirPlay binds :5000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)