### PR TITLE
feat(conformance): report states its own scope — self-test ≠ audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 [![Tests](https://img.shields.io/badge/tests-1490%2B%20Python%20%2B%20170%20Node-22c55e?style=flat-square)](#testing)
 [![MCP tools](https://img.shields.io/badge/MCP%20tools-29-6366f1?style=flat-square&logo=anthropic)](#mcp-tools-29)
 [![FHIR](https://img.shields.io/badge/FHIR-R4%20US%20Core%20v9-0ea5e9?style=flat-square)](#fhir-version-support)
-[![Guardrail conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.healthclaw.io%2Fr6%2Ffhir%2F%24conformance%3Fformat%3Dshields&style=flat-square)](#prove-it-guardrail-conformance)
+[![Guardrail conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.healthclaw.io%2Fr6%2Ffhir%2F%24conformance%3Fformat%3Dshields&style=flat-square)](#what-this-grade-means-and-what-it-doesnt)
 [![Glama score](https://glama.ai/mcp/servers/aks129/HealthClawGuardrails/badges/score.svg)](https://glama.ai/mcp/servers/aks129/HealthClawGuardrails)
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](pyproject.toml)
 [![Docker](https://img.shields.io/badge/docker-compose-2496ED?style=flat-square&logo=docker&logoColor=white)](#docker)
@@ -146,6 +146,18 @@ report; `--mcp-url` additionally grades MCP `tools/call` error signaling as a
 separate profile. For an authenticated MCP deployment, set `MCP_AUTH_TOKEN` or
 pass `--mcp-auth-token`. Library API:
 `from r6.conformance import LiveProbeClient, ProbeContext, run_conformance`.
+
+### What this grade means (and what it doesn't)
+
+The grade covers the **HealthClaw guardrail layer only** — a self-test of the
+seven properties against synthetic data it just created. It is **not** a HIPAA
+Security Rule assessment, a third-party audit, or a penetration test of your
+deployment: infrastructure, BAAs, encryption at rest/in transit, and access
+controls remain the deployer's responsibility (see
+[Known Limitations](#known-limitations)). Because the harness is
+deployment-agnostic, a third party *can* run it against any instance as one
+input to a real assessment — it does not substitute for one. The report states
+this scope itself in every output format.
 
 ## Install as a Claude Plugin
 
@@ -654,6 +666,9 @@ in-process cache when Redis is unavailable).
 
 ## Known Limitations
 
+- **The conformance grade is a self-test of the guardrail layer, not a HIPAA
+  assessment or third-party audit** — see
+  [What this grade means](#what-this-grade-means-and-what-it-doesnt)
 - Local mode: JSON blob storage with table-scan search (no indexed fields)
 - **Redaction is HIPAA Safe-Harbor-*style* field redaction** (demographics), **not Expert Determination**. It's a compensating control that removes identifier-class fields; it is not a legal de-identification determination. Production de-id rigor (profile-specific recursive allowlists, an Expert-Determination path) is on the [roadmap](ROADMAP.md) ([#112](../../issues/112)).
 - **Validation is structural**, not full StructureDefinition/profile conformance or terminology binding. What's demonstrated is the guardrail *contract* (redact + audit + step-up + human-confirm + tenant isolation + error fidelity), not production validation depth — that's tracked in [#112](../../issues/112).

--- a/docs/beta-program.md
+++ b/docs/beta-program.md
@@ -14,7 +14,9 @@ nowhere?"* — deserves a direct answer.
 **The building is not the problem. The evidence:**
 
 - Guardrail conformance is **Grade A, 7/7, verifiable live** on prod right now
-  (`GET /r6/fhir/$conformance`).
+  (`GET /r6/fhir/$conformance`). Scope, stated in the report itself: a
+  self-test of the guardrail layer against synthetic data — not a HIPAA
+  assessment, third-party audit, or pentest of the deployment ([#186](../../../issues/186)).
 - The own-data path is **proven end to end**: a real Epic record, 250 resources,
   Fasten connect → verify → export → webhook → ingest → agent read →
   `$interpret` + `$care-gaps`, all on prod.

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -14,10 +14,23 @@ from __future__ import annotations
 
 import json
 import re
+import textwrap
 import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit
+
+# Stated in every report output (#186): the grade must declare its own scope
+# so a Grade A is never mistaken for a HIPAA assessment or third-party audit.
+SCOPE_STATEMENT = (
+    "This grade covers the HealthClaw guardrail layer only (self-test, "
+    "synthetic data). It is NOT a HIPAA Security Rule assessment, a "
+    "third-party audit, or a penetration test of your deployment. "
+    "Infrastructure, BAAs, encryption, and access controls are the "
+    "deployer's responsibility. A third party can run this same harness "
+    "against any instance as one input to a real assessment — it does not "
+    "substitute for one."
+)
 
 # Distinctive synthetic tokens — if any survive a redacted read, redaction failed.
 _SSN = "000-00-9999"
@@ -157,6 +170,7 @@ class ConformanceReport:
         return {
             "target": self.base, "tenant": self.tenant,
             "passed": self.passed, "grade": self.grade,
+            "scope": SCOPE_STATEMENT,
             "score": {"passed": p, "total": t},
             "properties": [
                 {"key": r.key, "property": r.property, "passed": r.passed,
@@ -173,6 +187,10 @@ class ConformanceReport:
         lines = [f"HealthClaw Guardrail Conformance — {self.base or 'local'} "
                  f"[tenant={self.tenant}]",
                  f"  Grade: {self.grade}   ({p}/{t} properties)", ""]
+        lines += textwrap.wrap(
+            f"SCOPE: {SCOPE_STATEMENT}", width=78,
+            initial_indent="  ", subsequent_indent="  ")
+        lines.append("")
         for r in self.results:
             label = r.property
             if r.grade is not None:

--- a/tests/test_conformance_endpoint.py
+++ b/tests/test_conformance_endpoint.py
@@ -54,6 +54,24 @@ def test_conformance_shields_badge_format(client):
     assert set(b) == {"schemaVersion", "label", "message", "color"}
 
 
+def test_conformance_report_states_its_own_scope(client):
+    # #186: a Grade A must never read as a HIPAA assessment or third-party
+    # audit — the report says so itself in every substantive output format.
+    from r6.conformance.probes import SCOPE_STATEMENT
+
+    assert "NOT a HIPAA Security Rule assessment" in SCOPE_STATEMENT
+    assert "guardrail layer only" in SCOPE_STATEMENT
+
+    body = client.get("/r6/fhir/$conformance").get_json()
+    assert body["scope"] == SCOPE_STATEMENT
+
+    text = client.get("/r6/fhir/$conformance?format=text").get_data(as_text=True)
+    assert "SCOPE:" in text
+    assert "NOT a HIPAA Security Rule assessment" in text
+    # Scope sits between the grade and the property scorecard.
+    assert text.index("Grade:") < text.index("SCOPE:") < text.index("[PASS]")
+
+
 def test_conformance_is_cached_between_calls(client):
     # ?fresh=1 forces a new run (so badge/monitor traffic can reuse the cache
     # instead of re-running the harness — and its synthetic writes — each hit).


### PR DESCRIPTION
## Summary

Closes #186 — first community-test-drive feedback (Rick, via #184): the Grade A conformance report should say what it does *not* mean. Both his points (guardrail-layer-only scope; self-test ≠ third-party audit) are now stated by the report itself.

- **One canonical `SCOPE_STATEMENT`** in `r6/conformance/probes.py`, so formats can't drift:
  - JSON report gains a `scope` field
  - `format=text` renders a wrapped `SCOPE:` block between the grade and the scorecard (per the issue's proposed placement)
- **`format=shields`** payload untouched (shields.io schema is closed — existing test asserts exact key set); instead the README badge now anchors to a new **"What this grade means (and what it doesn't)"** section, which also notes the harness is deployment-agnostic — a third party can run it against any instance as one input to a real assessment, without it substituting for one
- **Known Limitations** gains a first bullet cross-linking that section
- **docs/beta-program.md** evidence bullet carries the same caveat
- Regression test asserts the statement appears in JSON and text and sits between grade and scorecard

## Sample text output

```
HealthClaw Guardrail Conformance — https://app.healthclaw.io [tenant=conformance-selftest]
  Grade: A   (7/7 properties)

  SCOPE: This grade covers the HealthClaw guardrail layer only (self-test,
  synthetic data). It is NOT a HIPAA Security Rule assessment, a third-party
  audit, or a penetration test of your deployment. Infrastructure, BAAs,
  encryption, and access controls are the deployer's responsibility. A third
  party can run this same harness against any instance as one input to a real
  assessment — it does not substitute for one.

  [PASS] PHI Redaction
  ...
```

## Verification

- `uv run python -m pytest tests/ -q`: 1497 passed
- `uvx ruff check .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)