### PR TITLE
fix(mcp): stop error paths leaking backend URL + verbatim bodies (#192)

### DIFF
--- a/services/agent-orchestrator/src/backend-failure.ts
+++ b/services/agent-orchestrator/src/backend-failure.ts
@@ -209,7 +209,7 @@ function sanitizeOperationOutcome(
     : undefined;
 }
 
-async function readBoundedJson(response: Response): Promise<unknown> {
+export async function readBoundedJson(response: Response): Promise<unknown> {
   const contentLength = response.headers?.get("content-length");
   if (contentLength) {
     const size = Number(contentLength);
@@ -243,6 +243,29 @@ async function readBoundedJson(response: Response): Promise<unknown> {
   } catch {
     return undefined;
   }
+}
+
+// Non-FHIR endpoints (action rail, SHL, internal token/seed, wearables,
+// sources) return `{ error: "message", ... }` rather than an OperationOutcome.
+// Forwarding that body verbatim leaked infra detail and could echo PHI-dense
+// request payloads to the agent. `sanitizeBackendDetail` surfaces ONLY the
+// controlled `error` string and drops every other field.
+const MAX_BACKEND_DETAIL_CHARS = 500;
+
+// Fixed, URL-free message for the exception path. node-fetch v2 formats a
+// connection error as `request to ${url} failed, reason: ...`, which would
+// otherwise leak FHIR_BASE_URL and the tenant_id query param via String(e).
+export const UPSTREAM_REQUEST_FAILED =
+  "The upstream request could not be completed.";
+
+export function sanitizeBackendDetail(body: unknown): { error: string } {
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const err = (body as Record<string, unknown>).error;
+    if (typeof err === "string" && err.length > 0) {
+      return { error: err.slice(0, MAX_BACKEND_DETAIL_CHARS) };
+    }
+  }
+  return { error: UPSTREAM_REQUEST_FAILED };
 }
 
 export async function backendFailureResult(

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -1542,6 +1542,75 @@ describe("Tool Execution Tests", () => {
     expect(result).toHaveProperty("requires_step_up", true);
   });
 
+  // -- information leakage (issue #192) --
+
+  it("sources_check connection error does not leak the backend URL (String(e))", async () => {
+    // node-fetch v2 formats connection failures as
+    // `request to https://host/path?tenant=... failed, reason: ...`.
+    const netErr = new Error(
+      "request to https://internal-fhir.example.com/command-center/api/sources-summary?tenant=ev-personal failed, reason: getaddrinfo ENOTFOUND"
+    );
+    mockFetch.mockRejectedValueOnce(netErr);
+
+    const result = await tools.executeTool(
+      "sources_check",
+      {},
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("internal-fhir.example.com");
+    expect(serialized).not.toContain("tenant=ev-personal");
+    expect(serialized).not.toContain("ENOTFOUND");
+    expect(result.detail).toBe("The upstream request could not be completed.");
+  });
+
+  it("wearables_sync_status connection error does not leak the backend URL", async () => {
+    mockFetch.mockRejectedValueOnce(
+      new Error(
+        "request to https://internal-fhir.example.com/wearables/sync-status?tenant_id=ev-personal failed, reason: ECONNREFUSED"
+      )
+    );
+
+    const result = await tools.executeTool(
+      "wearables_sync_status",
+      {},
+      { "x-tenant-id": "ev-personal" }
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("internal-fhir.example.com");
+    expect(serialized).not.toContain("ECONNREFUSED");
+    expect(result.detail).toBe("The upstream request could not be completed.");
+  });
+
+  it("action_propose error detail drops non-error fields from the backend body", async () => {
+    // A backend error body could carry PHI-adjacent or infra fields alongside
+    // the controlled `error` string; only the string may be forwarded.
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse(
+        {
+          error: "Proposal validation failed",
+          patient_ssn: "000-00-9999",
+          upstream_url: "https://internal-fhir.example.com",
+        },
+        400
+      )
+    );
+
+    const result = await tools.executeTool(
+      "action_propose",
+      { kind: "phone-call", payload: { to: "Dr. Smith", phone: "+15551234567" } },
+      { "x-step-up-token": "t", "x-tenant-id": "ev-personal" }
+    );
+
+    const detail = result.detail as Record<string, unknown>;
+    expect(detail).toEqual({ error: "Proposal validation failed" });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("000-00-9999");
+    expect(serialized).not.toContain("internal-fhir.example.com");
+  });
+
   // -- shl_generate --
 
   it("shl_generate without step-up token returns requires_step_up (no fetch made)", async () => {

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -25,7 +25,12 @@ import {
   BackendTimeoutError,
   backendTimeoutResult,
 } from "./fetch-timeout";
-import { backendFailureResult } from "./backend-failure";
+import {
+  backendFailureResult,
+  readBoundedJson,
+  sanitizeBackendDetail,
+  UPSTREAM_REQUEST_FAILED,
+} from "./backend-failure";
 import Ajv, { type ErrorObject, type ValidateFunction } from "ajv";
 import { generateMasterSecret, deriveAuth, deriveKey } from "./ktc/hkdf";
 import { encryptJWE } from "./ktc/jwe";
@@ -858,7 +863,8 @@ export class FHIRTools {
             }
           );
           const data = (await resp.json()) as Record<string, unknown>;
-          if (!resp.ok) return { error: "Failed to issue token", detail: data };
+          if (!resp.ok)
+            return { error: "Failed to issue token", detail: sanitizeBackendDetail(data) };
           return {
             token: data.token,
             tenant_id: tokenTenant,
@@ -897,7 +903,7 @@ export class FHIRTools {
             30_000
           );
           const data = (await resp.json()) as Record<string, unknown>;
-          if (!resp.ok) return { error: "Seed failed", detail: data };
+          if (!resp.ok) return { error: "Seed failed", detail: sanitizeBackendDetail(data) };
           return {
             ...data,
             _mcp_summary: `Seeded ${(data.created as unknown[])?.length ?? 0} resources into tenant '${seedTenant}'. The step_up_token is ready for write operations.`,
@@ -1570,14 +1576,14 @@ export class FHIRTools {
       if (!resp.ok) {
         return {
           error: `wearables status failed with ${resp.status}`,
-          detail: status,
+          detail: sanitizeBackendDetail(status),
         };
       }
     } catch (e) {
       if (e instanceof BackendTimeoutError) throw e; // converted centrally in executeTool
       return {
         error: "wearables status request failed",
-        detail: String(e),
+        detail: UPSTREAM_REQUEST_FAILED,
       };
     }
 
@@ -1647,7 +1653,7 @@ export class FHIRTools {
       resp = await fetchWithTimeout(url, { headers });
     } catch (e) {
       if (e instanceof BackendTimeoutError) throw e; // converted centrally in executeTool
-      return { error: "sources_check request failed", detail: String(e) };
+      return { error: "sources_check request failed", detail: UPSTREAM_REQUEST_FAILED };
     }
 
     let data: Record<string, unknown>;
@@ -1660,7 +1666,7 @@ export class FHIRTools {
     if (!resp.ok) {
       const result: Record<string, unknown> = {
         error: `sources_check failed with status ${resp.status}`,
-        detail: data,
+        detail: sanitizeBackendDetail(data),
       };
       if (resp.status === 401) result.requires_step_up = true;
       return result;
@@ -1914,12 +1920,7 @@ export class FHIRTools {
       body: JSON.stringify({ kind, payload }),
     });
     if (!resp.ok) {
-      let detail: unknown = null;
-      try {
-        detail = await resp.json();
-      } catch {
-        try { detail = await resp.text(); } catch { detail = null; }
-      }
+      const detail = sanitizeBackendDetail(await readBoundedJson(resp));
       return { error: `action_propose failed with status ${resp.status}`, detail };
     }
     return (await resp.json()) as Record<string, unknown>;
@@ -1945,12 +1946,7 @@ export class FHIRTools {
       body: JSON.stringify(body),
     });
     if (!resp.ok) {
-      let detail: unknown = null;
-      try {
-        detail = await resp.json();
-      } catch {
-        try { detail = await resp.text(); } catch { detail = null; }
-      }
+      const detail = sanitizeBackendDetail(await readBoundedJson(resp));
       return { error: `rx_transfer_request failed with status ${resp.status}`, detail };
     }
     return (await resp.json()) as Record<string, unknown>;
@@ -1984,16 +1980,9 @@ export class FHIRTools {
       return result;
     }
 
-    let detail: unknown = null;
-    try {
-      detail = await resp.json();
-    } catch {
-      try { detail = await resp.text(); } catch { detail = null; }
-    }
+    const detail = sanitizeBackendDetail(await readBoundedJson(resp));
     const serverMessage =
-      detail && typeof detail === "object" && "error" in (detail as Record<string, unknown>)
-        ? String((detail as Record<string, unknown>).error)
-        : undefined;
+      detail.error !== UPSTREAM_REQUEST_FAILED ? detail.error : undefined;
 
     const result: Record<string, unknown> = { error: `action_commit failed with status ${resp.status}`, detail };
     if (resp.status === 401) {
@@ -2017,12 +2006,7 @@ export class FHIRTools {
       headers,
     });
     if (!resp.ok) {
-      let detail: unknown = null;
-      try {
-        detail = await resp.json();
-      } catch {
-        try { detail = await resp.text(); } catch { detail = null; }
-      }
+      const detail = sanitizeBackendDetail(await readBoundedJson(resp));
       return { error: `action_status failed with status ${resp.status}`, detail };
     }
     return (await resp.json()) as Record<string, unknown>;
@@ -2052,13 +2036,9 @@ export class FHIRTools {
     });
 
     if (!bundleResp.ok) {
-      let detail: unknown = null;
-      try { detail = await bundleResp.json(); } catch {
-        try { detail = await bundleResp.text(); } catch { detail = null; }
-      }
       const result: Record<string, unknown> = {
         error: `share-bundle fetch failed with status ${bundleResp.status}`,
-        detail,
+        detail: sanitizeBackendDetail(await readBoundedJson(bundleResp)),
       };
       if (bundleResp.status === 401) result.requires_step_up = true;
       return result;
@@ -2096,11 +2076,10 @@ export class FHIRTools {
     });
 
     if (!createLinkResp.ok) {
-      let detail: unknown = null;
-      try { detail = await createLinkResp.json(); } catch {
-        try { detail = await createLinkResp.text(); } catch { detail = null; }
-      }
-      return { error: `SHL /api/links failed with status ${createLinkResp.status}`, detail };
+      return {
+        error: `SHL /api/links failed with status ${createLinkResp.status}`,
+        detail: sanitizeBackendDetail(await readBoundedJson(createLinkResp)),
+      };
     }
 
     const linkData = (await createLinkResp.json()) as { id: string; url: string };
@@ -2122,11 +2101,10 @@ export class FHIRTools {
     });
 
     if (!uploadResp.ok) {
-      let detail: unknown = null;
-      try { detail = await uploadResp.json(); } catch {
-        try { detail = await uploadResp.text(); } catch { detail = null; }
-      }
-      return { error: `SHL /api/manage/files failed with status ${uploadResp.status}`, detail };
+      return {
+        error: `SHL /api/manage/files failed with status ${uploadResp.status}`,
+        detail: sanitizeBackendDetail(await readBoundedJson(uploadResp)),
+      };
     }
 
     // Step 6: Build the shlink URI


### PR DESCRIPTION
## Summary

Closes #192 — an external runtime audit (Correctover) reported three information-leakage paths in the MCP server's error handling. Verified all three against current `tools.ts` (the report used v1.8.0 line numbers). The FHIR read/search/write paths already sanitize through `backendFailureResult`; these auxiliary tool paths did not.

| # | Severity | Path | Fix |
|---|----------|------|-----|
| 1 | HIGH | `wearables_sync_status` / `sources_check` catch blocks used `String(e)` — node-fetch v2 embeds the backend URL + `tenant_id` in connection errors | fixed URL-free message (`UPSTREAM_REQUEST_FAILED`) |
| 2 | HIGH | action rail (propose, rx-transfer, commit, status) + SHL (share-bundle, `/api/links`, `/api/manage/files`) forwarded unbounded backend bodies as `detail` | bounded read (`readBoundedJson`, 64 KB cap) + `sanitizeBackendDetail` |
| 3 | MEDIUM | internal token/seed + wearables/sources parsed bodies forwarded verbatim | `sanitizeBackendDetail` |

`sanitizeBackendDetail` surfaces **only** the controlled `error` string and drops every other field, so the action tools' intended UX (surfacing "replay"/"expired"/"executing" messages, `requires_step_up`) is preserved — existing tests hold unchanged.

## Verification

- `npx tsc --noEmit`: clean
- `npm test`: 173 passed (170 + 3 new regression tests asserting the backend URL, `tenant_id`, and PHI-adjacent body fields never reach the agent)
- `npm audit --audit-level=high`: exit 0

## Note on the reporter

The issue is from a vendor (Correctover) pitching an MCP runtime-verification product. The findings are legitimate and fixed here; the product pitch needs no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)