### PR TITLE
feat(mcp): public demo mode — open, but hard-pinned to a synthetic tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ The hosted demo runs synthetic data behind the full guardrail stack:
 curl "https://app.healthclaw.io/r6/fhir/\$conformance?format=text"
 ```
 
-Point any MCP client at the live server — URL `https://mcp-server-production-5112.up.railway.app/mcp`,
-header `X-Tenant-Id: desktop-demo` — then ask: *"Search my health records for lab results and explain
-them in plain language."* One-command installs:
+Point any MCP client at the **public demo server** — URL `https://mcp-demo-production-ee2c.up.railway.app/mcp`,
+no key required — then ask: *"Search my health records for lab results and explain them in plain
+language."* The demo server is unauthenticated but hard-pinned to a synthetic demo tenant, so it can
+only ever serve fake data. The **production endpoint** (`https://mcp-server-production-5112.up.railway.app/mcp`)
+requires a deployment-scoped `Authorization: Bearer <token>` — real records stay behind auth, always.
+One-command installs:
 `gemini extensions install https://github.com/aks129/HealthClawGuardrails` ·
 `claude plugin marketplace add aks129/HealthClawGuardrails` ·
 skills on [ClawHub](https://clawhub.ai/aks129/skills/fhir-r6-guardrails)
@@ -517,6 +520,8 @@ Coverage, ServiceRequest, Specimen, FamilyMemberHistory
 | `PUBLIC_TENANTS` | Production | — | Explicit comma-separated synthetic/demo tenant allowlist |
 | `REDIS_URL` | Production | — | Shared nonce, OAuth, rate-limit, and worker state |
 | `MCP_AUTH_TOKEN` | HTTP MCP | — | Bearer credential required by MCP HTTP transports |
+| `MCP_PUBLIC_DEMO` | No | `false` | Run an **unauthenticated** MCP server hard-pinned to a synthetic demo tenant (the public keyless demo). Never set on a server that reaches real tenants |
+| `MCP_DEMO_TENANT` | No | `desktop-demo` | Synthetic tenant the demo server is pinned to when `MCP_PUBLIC_DEMO` is set |
 | `FHIR_UPSTREAM_TIMEOUT` | No | 15 | Upstream request timeout (seconds) |
 | `FHIR_LOCAL_BASE_URL` | No | — | Local URL for response URL rewriting |
 

--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -36,6 +36,22 @@ const { version: SERVER_VERSION } = require("../package.json") as {
 const app = express();
 app.use(express.json());
 
+// Public demo mode: an explicit, opt-in exception to the production auth
+// requirement. When MCP_PUBLIC_DEMO is set, the server runs UNAUTHENTICATED but
+// is hard-pinned to a single synthetic demo tenant — an open caller can never
+// reach a real tenant or bring-your-own PHI. This is how the keyless
+// "60-second" demo endpoint runs; the real product server keeps its
+// MCP_AUTH_TOKEN and never sets this flag. Read per-request (like
+// MCP_AUTH_TOKEN) rather than cached, so config is authoritative at call time.
+function isPublicDemo(): boolean {
+  return (
+    process.env.MCP_PUBLIC_DEMO === "true" || process.env.MCP_PUBLIC_DEMO === "1"
+  );
+}
+function demoTenant(): string {
+  return process.env.MCP_DEMO_TENANT || "desktop-demo";
+}
+
 // Minimal request access log so we can see which probes from marketplace
 // platforms (PromptOpinion, Devpost reviewers, Claude Desktop) actually reach
 // us. Logs to stderr only; bodies are NOT logged.
@@ -83,6 +99,7 @@ app.use((req, res, next) => {
   if (
     req.method === "OPTIONS" ||
     !expectedToken ||
+    isPublicDemo() ||
     !isMCPTransportPath(req.path)
   ) {
     return next();
@@ -162,6 +179,13 @@ app.use((req, res, next) => {
 
 function extractHeaders(req: express.Request): Record<string, string> {
   const h: Record<string, string> = {};
+  if (isPublicDemo()) {
+    // Open demo endpoint: pin to the synthetic demo tenant and ignore every
+    // client-supplied tenant, step-up, or bring-your-own-FHIR header, so an
+    // unauthenticated caller can only ever reach synthetic demo data.
+    h["x-tenant-id"] = demoTenant();
+    return h;
+  }
   const tenantId = req.headers["x-tenant-id"];
   if (typeof tenantId === "string") h["x-tenant-id"] = tenantId;
   const stepUp = req.headers["x-step-up-token"];
@@ -282,7 +306,12 @@ function createMCPServer(sessionHeaders: Record<string, string> = {}): Server {
       delete toolArgs._patientId;
     }
 
-    return executeMCPTool(fhirTools, name, toolArgs, toolHeaders);
+    // Demo mode overrides every client-supplied header (incl. _tenantId tool
+    // args) with the pinned synthetic tenant — an open caller stays boxed in.
+    const finalHeaders = isPublicDemo()
+      ? { "x-tenant-id": demoTenant() }
+      : toolHeaders;
+    return executeMCPTool(fhirTools, name, toolArgs, finalHeaders);
   });
 
   return server;
@@ -650,8 +679,13 @@ app.get("/health", (_req, res) => {
 // --- Start Server ---
 
 function assertMCPAuthConfigured(env: NodeJS.ProcessEnv = process.env): void {
-  if (env.NODE_ENV === "production" && !env.MCP_AUTH_TOKEN?.trim()) {
-    throw new Error("MCP_AUTH_TOKEN is required when NODE_ENV=production");
+  const demo =
+    env.MCP_PUBLIC_DEMO === "true" || env.MCP_PUBLIC_DEMO === "1";
+  if (env.NODE_ENV === "production" && !env.MCP_AUTH_TOKEN?.trim() && !demo) {
+    throw new Error(
+      "MCP_AUTH_TOKEN is required when NODE_ENV=production " +
+        "(or set MCP_PUBLIC_DEMO=true to run an unauthenticated, demo-tenant-only server)"
+    );
   }
 }
 
@@ -664,6 +698,9 @@ if (require.main === module) {
     console.error(`SSE endpoint:    http://localhost:${PORT}/sse`);
     console.error(`HTTP bridge:     http://localhost:${PORT}/mcp/rpc`);
     console.error(`CORS: ${ALLOWED_ORIGINS.length > 0 ? `allowlist (${ALLOWED_ORIGINS.join(", ")})` : "deny-all (set ALLOWED_ORIGINS to enable)"}`);
+    if (isPublicDemo()) {
+      console.error(`PUBLIC DEMO MODE: unauthenticated, hard-pinned to synthetic tenant '${demoTenant()}'`);
+    }
   });
 }
 

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -2492,6 +2492,8 @@ describe("Express App Tests", () => {
     afterEach(() => {
       if (originalToken === undefined) delete process.env.MCP_AUTH_TOKEN;
       else process.env.MCP_AUTH_TOKEN = originalToken;
+      delete process.env.MCP_PUBLIC_DEMO;
+      delete process.env.MCP_DEMO_TENANT;
     });
 
     it.each([
@@ -2596,6 +2598,64 @@ describe("Express App Tests", () => {
       expect(() =>
         assertMCPAuthConfigured({ NODE_ENV: "production", MCP_AUTH_TOKEN: "configured" })
       ).not.toThrow();
+    });
+
+    // --- Public demo mode (MCP_PUBLIC_DEMO): open, but demo-tenant-only ---
+
+    it("allows production startup without a token when MCP_PUBLIC_DEMO is set", () => {
+      const assertMCPAuthConfigured = (
+        indexModule as unknown as {
+          assertMCPAuthConfigured: (env: NodeJS.ProcessEnv) => void;
+        }
+      ).assertMCPAuthConfigured;
+
+      expect(() =>
+        assertMCPAuthConfigured({ NODE_ENV: "production", MCP_PUBLIC_DEMO: "true" })
+      ).not.toThrow();
+      // Guard still fires when neither a token nor demo mode is configured.
+      expect(() => assertMCPAuthConfigured({ NODE_ENV: "production" })).toThrow(
+        "MCP_AUTH_TOKEN"
+      );
+    });
+
+    it("serves MCP unauthenticated in public demo mode", async () => {
+      delete process.env.MCP_AUTH_TOKEN;
+      process.env.MCP_PUBLIC_DEMO = "true";
+
+      const res = await request(app)
+        .post("/mcp/rpc")
+        .send({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.tools.length).toBeGreaterThan(0);
+    });
+
+    it("pins the synthetic demo tenant and drops a client-supplied tenant in demo mode", async () => {
+      delete process.env.MCP_AUTH_TOKEN;
+      process.env.MCP_PUBLIC_DEMO = "true";
+      mockFetch.mockResolvedValueOnce(
+        fakeResponse({ resourceType: "Patient", id: "pt-1" })
+      );
+
+      await request(app)
+        .post("/mcp/rpc")
+        .set("X-Tenant-Id", "attacker-real-tenant")
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "fhir_read",
+            arguments: { resource_type: "Patient", resource_id: "pt-1" },
+          },
+        })
+        .expect(200);
+
+      // An open caller can never steer the backend at a real tenant: the
+      // request is forwarded as the pinned demo tenant, the attacker's is gone.
+      const serialized = JSON.stringify(mockFetch.mock.calls);
+      expect(serialized).toContain("desktop-demo");
+      expect(serialized).not.toContain("attacker-real-tenant");
     });
   });
 });


### PR DESCRIPTION
## Summary

Splits the MCP surface so **the real product stays token-locked** while the **"60-second, no-keys" demo pitch gets its own open endpoint** — which can only ever serve synthetic data.

New `MCP_PUBLIC_DEMO=true` flag:
- Explicit, opt-in exception to the `MCP_AUTH_TOKEN` fail-closed guard (the server boots + serves unauthenticated).
- Every request is **hard-pinned to a synthetic demo tenant**: `extractHeaders` and the CallTool path ignore all client-supplied tenant / step-up / bring-your-own-FHIR headers, so an open caller can never reach a real tenant or external PHI.
- Read per-request (like `MCP_AUTH_TOKEN`) — testable, and config is authoritative at call time.
- `MCP_DEMO_TENANT` (default `desktop-demo`) picks the pinned tenant.

The production `mcp-server` never sets the flag and stays bearer-locked.

## Deployment (already live)
- New `mcp-demo` service in `awake-serenity`, `MCP_PUBLIC_DEMO=true`, deployed and verified: `/health` 200, `/mcp/rpc` unauthenticated 200, and a hostile `X-Tenant-Id` is dropped in favor of `desktop-demo` (confirmed live).
- Public URL: `https://mcp-demo-production-ee2c.up.railway.app/mcp`
- README quickstart repointed there; the real endpoint is documented as requiring `Authorization: Bearer <token>`.

## Verification
- `npx tsc --noEmit`: clean
- `npm test`: 176 passed (3 new: boot allowed with demo flag / guard still fires otherwise, unauthenticated serving, and a real-tenant header dropped for the pinned demo tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)