### PR TITLE
fix(medent): default to launch/patient scope (profile did nothing)

### DIFF
--- a/scripts/medent_oauth.py
+++ b/scripts/medent_oauth.py
@@ -35,7 +35,7 @@ Environment variables:
   MEDENT_CLIENT_SECRET   From registration if not public client
   MEDENT_PRACTICE_ID     Your practice's MEDENT ID (find via 'practices')
   MEDENT_REDIRECT_URI    Default: http://localhost:8743/medent/callback
-  MEDENT_SCOPES          Default: patient/*.read openid fhirUser profile offline_access
+  MEDENT_SCOPES          Default: patient/*.read launch/patient openid fhirUser offline_access
   MEDENT_TOKEN_CACHE     Default: ~/.healthclaw/medent_tokens.json
   MEDENT_CLIENT_CACHE    Default: ~/.healthclaw/medent_client.json
 
@@ -66,10 +66,12 @@ from pathlib import Path
 _MEDENT_BASE = "https://fhir.medent.com/fhir/R4"
 _DCR_URL = f"{_MEDENT_BASE}/dynamicregistration/"
 _PRACTICES_URL = "https://fhir.medent.com/fhir/resources/practices.php"
-# MEDENT identifies the logged-in patient via SMART's fhirUser claim (their
-# spec supports fhirUser, not the bare `patient` launch-context parameter) —
 # fhirUser MUST be in scope or the ID token carries no patient identity.
-_DEFAULT_SCOPES = "patient/*.read openid fhirUser profile offline_access"
+# launch/patient establishes patient context at the authorize endpoint — the
+# `profile` scope did nothing on MEDENT's side (confirmed on the 2026-07-29
+# troubleshooting call); swapping it for launch/patient is what made the
+# authorize → login → callback flow complete and return records.
+_DEFAULT_SCOPES = "patient/*.read launch/patient openid fhirUser offline_access"
 # MEDENT validates redirect_uris are publicly reachable — use Railway broker.
 # The broker stores the code at /shc/medent/callback; we poll /shc/medent/code.
 _DEFAULT_REDIRECT_URI = "https://app.healthclaw.io/shc/medent/callback"


### PR DESCRIPTION
## Summary

Makes the proven scope fix permanent. On the 2026-07-29 MEDENT troubleshooting call, `profile` was confirmed to do nothing on their authorize endpoint — patient context comes from `launch/patient`. With the swap, the authorize → patient-portal login → callback flow completed and pulled **~315 resources** into `ev-personal` (up from June's 243), including DocumentReferences that were previously 403.

`_DEFAULT_SCOPES`: `patient/*.read openid fhirUser profile offline_access` → `patient/*.read launch/patient openid fhirUser offline_access`. Applies to both the authorize request and future DCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)