### PR TITLE
fix(deps): override brace-expansion ^5.0.9 — un-break the audit gate on main

### DIFF
--- a/services/agent-orchestrator/package-lock.json
+++ b/services/agent-orchestrator/package-lock.json
@@ -942,16 +942,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -2191,11 +2181,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
@@ -2248,14 +2241,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2526,13 +2521,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -3871,16 +3859,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4230,16 +4208,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {

--- a/services/agent-orchestrator/package.json
+++ b/services/agent-orchestrator/package.json
@@ -37,5 +37,8 @@
     "testMatch": [
       "**/*.test.ts"
     ]
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

`dependency-audit` went red on `main` (surfaced on #196) from a newly published high advisory: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — brace-expansion DoS via unbounded expansion, covering `<=5.0.7`. That range includes **every** 1.x and 2.x release, so both transitively installed copies were flagged:

- `1.1.16` ← test-exclude → minimatch@3 (jest coverage)
- `2.1.2` ← glob → minimatch@9

`npm audit fix --force` wanted to downgrade **jest to 25.0.0**. Instead this pins the transitive dep forward with an `overrides` entry.

## Verified, not assumed

Forcing 5.x onto consumers that request `^1.1.7` / `^2.0.1` is exactly the kind of override that works until it doesn't, so I checked the real consumers:

- `npx tsc --noEmit` — clean
- `npm test` — **176/176 pass**
- `npx jest --coverage` — works, and this is the important one: `test-exclude` → `minimatch@3` is the coverage filter and the riskiest consumer of the old major
- `npm audit --audit-level=high` — exit 0 (only the 2 known `@hono/node-server` moderates remain, below the gate)

## Exposure

`npm ls brace-expansion --omit=dev` returns **zero** matches — the chain is entirely jest/dev tooling. Nothing deployed was reachable, and `npm audit --omit=dev --audit-level=high` was already clean. Fixing it anyway to keep the gate honest rather than scoping the gate down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)