### PR TITLE
feat(careagents): Postgres readiness — CI coverage, boot warning, migration doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,13 @@ jobs:
         env:
           SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/test
           MIGRATION_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+          # careagents keeps its own engine + metadata, so SQLite-only coverage
+          # would miss Postgres-specific schema problems in its tables too.
+          CARE_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
         run: |
           uv run python -m pytest \
             tests/actions/ \
+            tests/test_careagents.py \
             tests/test_ingest_resilience.py \
             tests/test_actions_models.py \
             tests/test_fasten_export_trigger.py \

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -6,7 +6,10 @@ half-configured rather than running with weakened guarantees.
 
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigError(RuntimeError):
@@ -97,6 +100,19 @@ class Config:
                     "ANTHROPIC_OAUTH_TOKEN preferred, OPENAI_API_KEY fallback)")
             _require("RESEND_API_KEY", self.resend_api_key,
                      "email verification codes require a transactional sender")
+            # SQLite is single-writer and file-local: it does not survive a
+            # host rebuild, cannot be backed up consistently while running,
+            # and serialises concurrent users. Fine for one tester, wrong for
+            # real accounts. Warn rather than refuse, because the live
+            # deployment is still on SQLite and a hard failure here would take
+            # it down instead of migrating it — flip this to _require once
+            # CARE_DATABASE_URL points at Postgres (see docs/development.md).
+            if self.database_url.startswith("sqlite"):
+                logger.warning(
+                    "CareAgents is running production on SQLite (%s). Migrate "
+                    "CARE_DATABASE_URL to Postgres before onboarding real "
+                    "users: SQLite serialises writes and is lost with the host.",
+                    self.database_url)
         else:
             self.session_secret = self.session_secret or "dev-careagents-secret"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,6 +112,29 @@ Flask/DB), report builders, and a `register_*_routes` function wired in
     && railway up --service mcp-server --detach
   ```
 
+- **CareAgents: migrating from SQLite to Postgres.** CareAgents keeps its own
+  engine and metadata (`careagents/models.py`), separate from the Flask app's.
+  Production still defaults to SQLite, which is single-writer, host-local, and
+  lost with the host — fine for one tester, wrong for real accounts. It logs a
+  warning at boot until `CARE_DATABASE_URL` points at Postgres.
+
+  ```bash
+  # 1. Provision Postgres and set the URL on the careagents.cloud host
+  CARE_DATABASE_URL=postgresql://user:pass@host:5432/careagents
+
+  # 2. Tables are created on first boot (create_all + _ensure_columns);
+  #    no Alembic chain here, unlike the Flask app.
+  # 3. Copy existing rows if the SQLite file has real accounts — dump
+  #    ca_accounts / ca_passkeys / ca_connections / ca_agents / ca_surfaces
+  #    BEFORE cutover; passkeys are binary columns, so use a real client
+  #    rather than a CSV round-trip.
+  ```
+
+  Once cut over, change the SQLite warning in `careagents/config.py` to a
+  `_require` so a regression fails closed instead of warning. CI runs the
+  CareAgents suite against real Postgres (`CARE_TEST_DATABASE_URL` in the
+  `postgres-tests` lane), so schema incompatibilities surface before deploy.
+
 - Release process: [RELEASING.md](../RELEASING.md). Drift guards
   (`tests/test_site_version_sync.py`, `tests/test_gemini_extension.py`) fail
   the suite if versions/tool counts diverge between `pyproject.toml`, the

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -32,6 +32,33 @@ def test_production_config_requires_every_secret():
     assert ok.provider == "openai" and ok.rp_id == "careagents.cloud"
 
 
+def test_production_on_sqlite_warns_loudly(caplog):
+    # SQLite in production is single-writer and host-local. It is not a hard
+    # failure yet (the live deployment still runs on it, and refusing to boot
+    # would take it down rather than migrate it) — but it must never be quiet.
+    import logging
+    with caplog.at_level(logging.WARNING, logger="careagents.config"):
+        Config(env={"CARE_ENV": "production", "CARE_SESSION_SECRET": "x" * 32,
+                    "HEALTHCLAW_MINT_SECRET": "m", "OPENAI_API_KEY": "k",
+                    "RESEND_API_KEY": "r",
+                    "CARE_DATABASE_URL": "sqlite:///careagents.db"})
+    assert any("SQLite" in r.message and "Postgres" in r.message
+               for r in caplog.records)
+
+
+def test_production_on_postgres_does_not_warn(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING, logger="careagents.config"):
+        cfg = Config(env={"CARE_ENV": "production",
+                          "CARE_SESSION_SECRET": "x" * 32,
+                          "HEALTHCLAW_MINT_SECRET": "m", "OPENAI_API_KEY": "k",
+                          "RESEND_API_KEY": "r",
+                          "CARE_DATABASE_URL":
+                              "postgresql://u:p@db:5432/care"})
+    assert cfg.database_url.startswith("postgresql")
+    assert not any("SQLite" in r.message for r in caplog.records)
+
+
 def test_anthropic_oauth_token_selects_anthropic_provider():
     # An OAuth token (Claude subscription / OpenClaw) is a valid LLM credential
     # and selects the Anthropic provider without an API key.
@@ -124,7 +151,24 @@ class FakeClient:
 
 @pytest.fixture
 def cfg():
-    return Config(env={"CARE_DATABASE_URL": "sqlite:///:memory:",
+    """App config for tests.
+
+    Defaults to in-memory SQLite. CI's Postgres lane sets
+    CARE_TEST_DATABASE_URL so this same suite runs against real Postgres —
+    careagents keeps its own engine and metadata, so SQLite-only coverage
+    would never catch a Postgres-specific schema or type problem (exactly
+    the class of bug the main app's Postgres lane exists to catch).
+    """
+    import os
+    url = os.environ.get("CARE_TEST_DATABASE_URL", "sqlite:///:memory:")
+    if not url.startswith("sqlite"):
+        # A shared server-side database persists between tests; start each one
+        # from a clean schema so ordering can't make the suite flaky.
+        from careagents.models import Base, make_engine
+        engine = make_engine(url)
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+    return Config(env={"CARE_DATABASE_URL": url,
                        "CARE_RP_ID": "localhost",
                        "CARE_ORIGIN": "http://localhost",
                        "OPENAI_API_KEY": "k",


### PR DESCRIPTION
## Summary

Tier 0 item 3. CareAgents defaults to `sqlite:///careagents.db`, which is single-writer, host-local, and lost with the host — fine for one tester, wrong for real accounts.

The bigger finding while scoping it: **CareAgents keeps its own engine and metadata**, and the `postgres-tests` CI lane only covered the Flask app's tables. So its schema had *never* run against Postgres — a Postgres-specific problem would have surfaced in production, not CI. Fixing that first makes the actual cutover safe rather than hopeful.

## Changes

- **CI**: the careagents suite now runs against real Postgres in the `postgres-tests` lane (`CARE_TEST_DATABASE_URL`). The `cfg` fixture drops the schema per test when the DB is server-side, so a shared database can't make ordering flaky.
- **Boot warning**: production on SQLite now logs a loud warning naming the risk and the fix.
- **Docs**: `docs/development.md` gets the cutover steps, including that passkeys are binary columns and need a real client rather than a CSV round-trip.

## Why a warning and not a hard failure

The project's posture is fail-closed, and this *should* end as a `_require`. But the live deployment is on SQLite right now — making it fail closed today would take careagents.cloud **down** rather than migrate it. So: warn now, and the doc records flipping it to `_require` immediately after cutover, so the end state is fail-closed rather than a permanently softened gate.

## Verification

1509 tests pass; ruff clean. The real proof for Postgres is this PR's `postgres-tests` lane — that's the first time these tables have been exercised on Postgres, so it's worth watching that job specifically.

## Not included

Provisioning Postgres on the careagents.cloud host and migrating existing rows is a production change on the shared VPS and needs explicit authorization — happy to do it on your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)