### PR TITLE
feat(careagents): container image + real /healthz readiness for Railway

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import logging
 import secrets
 import time
 from contextlib import contextmanager
+
+from sqlalchemy import text
 
 import webauthn
 from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
@@ -23,6 +26,8 @@ from webauthn.helpers.structs import (AuthenticatorSelectionCriteria,
 from careagents import mail
 from careagents.models import (Account, Agent, Connection, EmailToken, Passkey,
                                Surface, make_engine, make_session_factory, now)
+
+logger = logging.getLogger(__name__)
 
 CODE_TTL = 600  # 10 minutes
 MAX_CODE_ATTEMPTS = 5   # burn a login code after this many wrong guesses
@@ -123,6 +128,16 @@ class AccountService:
         if error:
             raise AuthError(error)
         return result
+
+    def ping(self) -> bool:
+        """True if the account store answers. Used by /healthz readiness."""
+        try:
+            with self.session() as s:
+                s.execute(text("SELECT 1"))
+            return True
+        except Exception:
+            logger.exception("account store unreachable")
+            return False
 
     def get_account(self, account_id: str) -> Account | None:
         with self.session() as s:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -609,7 +609,17 @@ def create_app(config: Config | None = None,
 
     @app.get("/healthz")
     def healthz():
-        return jsonify({"status": "ok", "provider": cfg.provider,
-                        "accounts": True})
+        """Readiness, not liveness: reports 503 when the account store is
+        unreachable.
+
+        This used to hard-code accounts=True, which meant a container that
+        could not reach its database still advertised itself as healthy — a
+        load balancer would route real sign-ins straight into failure. It now
+        round-trips a trivial query so the answer reflects reality.
+        """
+        accounts_ok = svc.ping()
+        body = {"status": "ok" if accounts_ok else "degraded",
+                "provider": cfg.provider, "accounts": accounts_ok}
+        return jsonify(body), (200 if accounts_ok else 503)
 
     return app

--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -1,0 +1,45 @@
+# CareAgents container image (Railway / any OCI host).
+#
+# Build context is the REPO ROOT (careagents imports from the repo package),
+# so deploy with:  railway up  from a staging dir, or set the service's
+# Dockerfile path to deploy/careagents/Dockerfile with root as context.
+#
+# One worker on purpose: chat history is process-local (careagents/wsgi.py),
+# so a second worker would serve half the turns from an empty history.
+# Threads give concurrency without splitting that state. Scaling past one
+# process requires moving history to shared storage first.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+# Lockfile first for layer caching.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+COPY careagents/ ./careagents/
+
+# Railway injects PORT; default keeps local `docker run` working.
+ENV PORT=8600
+EXPOSE 8600
+
+# Health check hits the app's own readiness endpoint, so a container that
+# boots but can't reach its database is reported unhealthy rather than "up".
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD python -c "import os,urllib.request,sys; \
+sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PORT','8600')+'/healthz', timeout=4).status==200 else 1)"
+
+CMD ["sh", "-c", "gunicorn careagents.wsgi:app \
+  --bind 0.0.0.0:${PORT:-8600} --workers 1 --threads 8 --timeout 120 \
+  --access-logfile - --error-logfile - \
+  --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms'"]

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -59,6 +59,32 @@ def test_production_on_postgres_does_not_warn(caplog):
     assert not any("SQLite" in r.message for r in caplog.records)
 
 
+def test_healthz_reports_ok_when_the_account_store_answers(app):
+    r = app.test_client().get("/healthz")
+    assert r.status_code == 200
+    d = r.get_json()
+    assert d["status"] == "ok" and d["accounts"] is True
+
+
+def test_healthz_reports_503_when_the_account_store_is_unreachable(app, svc,
+                                                                   monkeypatch):
+    # The point of a readiness check: a container that cannot reach its
+    # database must NOT advertise itself as healthy, or a load balancer will
+    # route real sign-ins straight into failure. This used to be hard-coded
+    # true, which would have made the Postgres cutover silently dangerous.
+    monkeypatch.setattr(svc, "ping", lambda: False)
+    r = app.test_client().get("/healthz")
+    assert r.status_code == 503
+    assert r.get_json()["accounts"] is False
+
+
+def test_ping_returns_false_instead_of_raising(svc, monkeypatch):
+    def boom():
+        raise RuntimeError("connection refused")
+    monkeypatch.setattr(svc, "session", boom)
+    assert svc.ping() is False
+
+
 def test_anthropic_oauth_token_selects_anthropic_provider():
     # An OAuth token (Claude subscription / OpenClaw) is a valid LLM credential
     # and selects the Anthropic provider without an API key.


### PR DESCRIPTION
## Summary

Moves CareAgents to Railway — the "best case" option: the app sits in the same project as its database, reaching it over **private networking** (`postgres-bfs.railway.internal`, no public endpoint), with managed backups and auto-deploy replacing the hand-run VPS script.

## Changes

- **`deploy/careagents/Dockerfile`** — one gunicorn worker deliberately: chat history is process-local (`careagents/wsgi.py`), so a second worker would serve half the turns from an empty history. Threads provide concurrency without splitting that state.
- **`/healthz` is now a readiness check.** It previously returned `accounts: True` **hard-coded** — a container that couldn't reach its database still advertised itself as healthy. During a database migration that is precisely backwards: the load balancer would route real sign-ins into failure. It now round-trips `SELECT 1` and returns 503 when the store is unreachable.

## Verified end-to-end on the deployed service (real Postgres)

| Step | Result |
|---|---|
| `/healthz` | 200, `accounts: true` (proves private-network DB round-trip) |
| Anonymous `/home`, `/api/*`, `DELETE` | 302 / 401 / 401 — gates hold |
| Signup → Resend email → code → session | works |
| Connect sample records | tenant seeded, 7 resources |
| Create agent → streamed chat turn | guardrailed tools called, LLM replied |
| **Delete connection (#173)** | `rows_deleted: 7`, tenant verified **empty** afterwards |

That last row is #173's first production exercise, and it passed including the negative check.

## Found during QA — filed separately

**#207: the agent tells patients they do *not* have a condition they *do* have.** Redaction strips `Coding.display`, so the agent receives an unnamed Condition and reports diabetes as absent. Not caused by this migration (same code path on the VPS) but far more serious than it — see the issue.

Also noted: neither the current VPS nor Railway sets CSP / HSTS / X-Frame-Options. Pre-existing on both, so not a migration regression, but worth closing before real onboarding.

## Not done here

DNS cutover for `careagents.cloud`, which needs a data migration first — production has **4 accounts including one real external user** and a registered passkey. Details in the follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)