### PR TITLE
fix(agent): never report a condition as absent when it can't be read (#207)

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -83,6 +83,16 @@ def _summarize_bundle(bundle: dict, limit: int = 12) -> list[dict]:
             c.get("display", "") for c in (code.get("coding") or [])[:1])
         if text:
             item["name"] = text.strip()
+        else:
+            # A record exists but carries no readable label. Say so explicitly
+            # and pass the raw code through: dropping the name key entirely
+            # made the record look like nothing, and the model then reported
+            # the condition as ABSENT (#207). Unreadable is not absent.
+            coding = (code.get("coding") or [{}])[0]
+            raw = coding.get("code")
+            item["name"] = (f"unlabeled record, code {raw}" if raw
+                            else "unlabeled record")
+            item["unreadable"] = True
         if res.get("status"):
             item["status"] = res["status"]
         vq = res.get("valueQuantity")

--- a/careagents/personas.py
+++ b/careagents/personas.py
@@ -23,6 +23,13 @@ Non-negotiable rules, regardless of your voice:
   themselves, out-of-band. Never imply an action is done before it is.
 - Never claim the person has "no known allergies" or invent any clinical fact.
   If the records don't show something, say the records don't show it.
+- Never answer a "do I have X?" question with a bare "no". You can only see
+  what a search returned, which is not the same as what the person has: a
+  record can be present but unreadable, and their records may be incomplete.
+  If a record comes back marked unreadable, or carries a code you cannot
+  name, SAY a record is there that you could not read — never treat it as
+  absence. "I don't see it in what I can read here" is honest; "No, you do
+  not have that" is not yours to say.
 - The person's records here may be clearly-labeled sample data. If asked,
   be straightforward about that.
 """

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -99,6 +99,28 @@ def test_anthropic_oauth_token_selects_anthropic_provider():
     assert prod.provider == "anthropic"  # satisfies the prod LLM-cred gate
 
 
+def test_unreadable_record_is_never_summarized_as_nothing():
+    # #207: when a record had no readable label the summarizer dropped the
+    # name key, the model saw an empty item, and answered "no, you do not
+    # have that". An unnamed record must still be visible AND flagged.
+    from careagents.agent import _summarize_bundle
+    bundle = {"entry": [{"resource": {
+        "resourceType": "Condition",
+        "code": {"coding": [{"system": "http://hl7.org/fhir/sid/icd-9-cm",
+                             "code": "250.00"}]},   # no display
+    }}]}
+    items = _summarize_bundle(bundle)
+    assert len(items) == 1
+    assert items[0]["unreadable"] is True
+    assert "250.00" in items[0]["name"]
+
+
+def test_safety_core_forbids_answering_absence_with_a_bare_no():
+    # The model must not convert "I couldn't read it" into "you don't have it".
+    assert "bare \"no\"" in SAFETY_CORE or "bare 'no'" in SAFETY_CORE
+    assert "unreadable" in SAFETY_CORE.lower()
+
+
 def test_every_persona_shares_the_safety_core():
     for key in PERSONAS:
         p = system_prompt("Juniper", key)


### PR DESCRIPTION
## Summary

Fixes the dangerous half of #207: the agent told a patient **"No, your records do not show a diagnosis of diabetes"** while an active ICD-9 250.00 Condition existed.

- `_summarize_bundle` now emits an explicit name for unlabeled records (`"unlabeled record, code 250.00"`) and flags `unreadable: true`, instead of dropping the name key so the record looked like nothing.
- `SAFETY_CORE` forbids answering "do I have X?" with a bare **no**. A search result is not the same as what the person has: a record can be present but unreadable, and their records may be incomplete. *"I don't see it in what I can read here"* is honest; *"No, you do not have that"* is not the agent's to say.

## What I tried first, and why it's not here

The obvious fix was to stop redaction stripping `Coding.display` — the label of a standardized code seemed safe, since the code itself survives anyway.

**`tests/test_recursive_redaction.py` caught that as a PHI leak.** Its fixture contains a real-world nasty:

```json
{"system": "http://loinc.org", "code": "2339-0",
 "display": "Glucose for Jane Secret"}
```

Upstream systems genuinely do write patient names into `display`. So the blanket rule is correct and stays exactly as it was — that test encodes hard-won knowledge and it was right.

Restoring readable labels safely needs **server-derived terminology** (HealthClaw supplying its own label for a recognized code) rather than trusting upstream free text. That's the remaining work on #207 and is a bigger piece than this PR.

## Effect

The agent still can't *name* the condition, but it can no longer deny it. It now says a record is present that it couldn't read — which is honest and safe — instead of confidently reporting absence.

## Verification

1526 tests pass (2 new: unreadable records stay visible and flagged; the safety core forbids the bare "no"). `uv run ruff check .` clean. The redaction PHI test that caught my first attempt passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)