### PR TITLE
fix(security): gate /demo/agent-loop — anonymous cross-tenant write, live in prod (#210)

### DIFF
--- a/docs/2026-08-01-alignment-review.md
+++ b/docs/2026-08-01-alignment-review.md
@@ -1,0 +1,221 @@
+# Codebase ↔ Vision Alignment Review — 2026-08-01
+
+Seven parallel audits (guardrails, architecture, user layer, integrations, actions,
+market, dev system) against one anchor:
+
+> A patient spins up a persistent, guardrailed health agent in a minute; it connects
+> their real records, answers safely, and **accomplishes real-world actions on their
+> behalf** with human approval — delivered to actual real users, with HealthClaw as
+> the standard-setter for agent guardrails in healthcare.
+
+Every finding below was verified by reading code, not comments.
+
+---
+
+## 0. Stop-the-line finding
+
+**`POST /r6/fhir/demo/agent-loop` is an unauthenticated cross-tenant write and
+policy-delete primitive, live in production right now.**
+
+- `/demo/` is prefix-exempt from tenant enforcement (`r6/routes.py:180-186`) and from
+  human-in-the-loop (`r6/health_compliance.py:109`).
+- The handler validates **no step-up token**. The two `generate_step_up_token()` calls
+  (`r6/routes.py:2249`, `:2432`) discard their return values — they are theater.
+- It reads `X-Tenant-Id` from the header (default `demo-tenant`), then commits a
+  Patient, **soft-deletes every existing Permission resource for that tenant**
+  (`r6/routes.py:2318-2323`), and commits a Permission and an Observation.
+- Verified live: `POST https://app.healthclaw.io/r6/fhir/demo/agent-loop` with no
+  auth returns **200**.
+
+Any anonymous caller can write into — and disable the access-control policy of — any
+tenant they can name. This directly falsifies the project's flagship claim that a
+client cannot bypass the guardrails. **Fix before anything else on this page.**
+
+Fix: restrict to `is_public(tenant_id)` tenants **and** require `X-Internal-Secret`,
+or disable in production outright. One day of work.
+
+---
+
+## 1. Alignment scorecard
+
+| Dimension | Grade | Where code and story diverge |
+|---|---|---|
+| Guardrail framework | **C+** | Core primitives (audit fail-loud, step-up design, action state machine) are genuinely excellent. But the demo endpoint above, a self-confirmable human gate, and read-auth-off-by-default mean the *system* is weaker than its *parts*. Grade A is earnable with all four live. |
+| Architecture | **B−** | PHI boundary is clean and real. Fails first at ~1 heavy user (unbounded history) and ~10-30 concurrent (thread saturation → healthz timeout → restart → amnesia). |
+| User layer | **C** | Honesty is engineered in, delete flow is best-in-class. But the "persistent agent" is a goldfish, passkey enrollment is a dead loop, and the payoff moment underdelivers. |
+| Integrations | **C+** | Fasten covers ~50-60% of clinical data self-serve. Wearables, insurer, pharmacy, file import: **0% self-serve.** Documents ingest but no tool reads them. |
+| Actions | **D+** | Exactly **one** real-world action ships (intake-form PDF). This is the vision's core and its weakest column. |
+| Market position | **B** | The unoccupied ground is real and verified. The moat is narrow and closing. |
+| Dev system | **B−** | Strong CI. Zero production verification; the review bot enforces a stale invariant. |
+
+**The pattern across all seven:** the *engine* is stronger than the *product*. We built
+excellent guardrail primitives, then shipped a consumer app that can't yet use most of
+them — while the market's read-only incumbents got 300M users.
+
+---
+
+## 2. Where the story is ahead of the code
+
+These are places our own docs, copy, or claims currently overstate what ships. Each is
+a trust liability for a health product.
+
+| Claim | Reality | Where |
+|---|---|---|
+| "Client cannot bypass the guardrails" | Demo endpoint bypasses everything, unauthenticated, in prod | `r6/routes.py:2218` |
+| "The spoofable `X-Human-Confirmed` header is gone" | True on the action rail only. It is still the **entire** human gate for direct clinical FHIR writes — and the conformance probe **spoofs the header itself**, so Grade A certifies a gate the grader just bypassed | `r6/health_compliance.py:91-131`, `r6/conformance/probes.py:230-233` |
+| "No code path lets an agent approve its own action" | `/confirm` accepts the same token class as `/commit`, with no audience/operation binding. An agent holding a commit token can confirm its own action | `r6/actions/routes.py:460-470` |
+| "Persistent health agent" | History is process-local, never rendered on reload, wiped by every deploy | `careagents/app.py:49` |
+| "(sample data for now)" greeting | Shown to **every** agent, including real-record ones | `careagents/templates/chat.html:23` |
+| "Email support to delete your data" (consent card) | Self-serve Delete shipped in #203 and sits on the same page | `careagents/templates/home.html:135` |
+| "Add a passkey" link | `/auth` redirects logged-in users to `/home` — enrollment unreachable after signup | `careagents/app.py:82-84` |
+| SHL paste / file upload tiles | Return `{"soon": True}` | `careagents/connectors.py` |
+| `REVIEW_STANDARDS.md` item 4 | Describes the removed header — the AI reviewer's constitution is stale | `.github/REVIEW_STANDARDS.md` |
+
+---
+
+## 3. Unified gap register
+
+Ranked by one question: **does this block a real user from getting real value — or
+expose them?**
+
+### P0 — before any real user (days)
+
+| # | Gap | Source |
+|---|---|---|
+| 1 | `/demo/agent-loop` unauthenticated cross-tenant write/policy-delete **(live in prod)** | Guardrails |
+| 2 | Bind the confirm credential (`require_audience='action-approval'` + operation). Curatr already does this correctly — copy the pattern | Guardrails, Actions |
+| 3 | Unbounded chat history → runaway spend, then permanent context-overflow 400s for that tenant; tool loop has no hard stop | Architecture |
+| 4 | `pool_pre_ping` / `pool_recycle` missing on managed Postgres — intermittent 500s post-migration | Architecture |
+| 5 | Two silent lies: `mail.send_code` failure returns `{"sent": true}`; failed `confirm_action` swallowed after user approves | Architecture |
+| 6 | Track + CI-build `deploy/careagents/Dockerfile` (still untracked) | Architecture |
+| 7 | Fix stale `X-Human-Confirmed` in `REVIEW_STANDARDS.md` / `development.md` / `SECURITY.md` | Dev system |
+| 8 | Nonce store: require `REDIS_URL` in production multi-worker, fail loud | Guardrails, Actions |
+
+### P1 — makes the product worth returning to (1-3 weeks)
+
+| # | Gap | Source |
+|---|---|---|
+| 9 | **Persist chat history** — decide storage side first (HealthClaw per-tenant keeps the no-PHI promise intact) | Architecture, UX |
+| 10 | **Server-derived terminology labels** — kills the "unlabeled record, code X" cliff. Codes are PHI-free; this needs no redaction change | UX, Integrations, #207 |
+| 11 | **`get_documents` tool** — DocumentReferences already ingest and count; nothing can read them | Integrations |
+| 12 | **Tier-2 approve surface** — required for *every* future action, purely in our control, ~1 day | Actions |
+| 13 | Enforce `CONTACT_NOT_ALLOWLISTED` + `DAILY_CAP_REACHED` (codes reserved, referenced nowhere) | Actions |
+| 14 | Scheduled prod synthetic monitor — `scripts/careagents_smoke.py` already exists, just not on a cron | Dev system |
+| 15 | Real greeting from actual records; kill "(sample data for now)" for real connections | UX |
+| 16 | Passkey dead loop; replace `prompt()`/`alert()` flows; style conn-card buttons | UX |
+| 17 | Read-auth: default-off and ungraded — a wide-open deployment still scores Grade A | Guardrails |
+| 18 | Redaction misses on `SubscriptionTopic/$list`; `$share-bundle` intake exports identified records on a generic token | Guardrails |
+
+### P2 — the differentiated bet (3-8 weeks)
+
+| # | Gap | Source |
+|---|---|---|
+| 19 | **Pharmacy transfer/refill call end-to-end** — the flagship action. Unblock Bland (external, start now) | Actions, Market |
+| 20 | Grade what we claim: probes for read-auth, spoofed-confirmation, step-up negatives, action-rail separation, redaction on search | Guardrails |
+| 21 | Versioned guardrail spec + written threat model — a third party has nothing normative to conform *to* | Guardrails, Market |
+| 22 | One proactive loop (weekly care-note via Resend) — the only thing on any list that answers "why come back" | UX |
+| 23 | Real file-upload / SHL import — zero-integration path every patient can use | Integrations |
+| 24 | Productize the MEDENT SMART flow (DB-backed broker) — turns a proven connection into something patients can click | Integrations |
+| 25 | Retire `X-Human-Confirmed` for direct clinical writes; route through the propose→approve rail | Guardrails |
+| 26 | CareAgents Playwright spec (none exists — all e2e targets the HealthClaw site) | UX, Dev system |
+| 27 | Purge orphans: `ActionEvent` / `ActionConfirmation` (no `tenant_id` at all) | QA, Actions |
+
+---
+
+## 4. Sequenced roadmap
+
+**Week 1 — Close the exposure.** P0 items 1-8. Nothing here is user-visible; all of it
+is the difference between "we have guardrails" being true and being marketing.
+
+**Weeks 2-3 — Make the payoff land.** Items 9-12, 14-16. The through-line: a user who
+connects real records today gets amnesia, unreadable labels, and unreadable documents.
+Three fixes turn the same connection into a real product. Ship the approve surface in
+this window regardless of Bland — it's the gate for every future action.
+
+**Weeks 4-8 — Ship the differentiator.** Item 19 as the headline, 20-21 as the
+standard-setter proof, 22 as retention. Start Bland onboarding *now*, in week 1, since
+it's the external critical path.
+
+**Sequencing logic:** P0 protects users who don't exist yet — but the HIMSS webinar
+(Aug 18) and any design-partner demo make the demo endpoint a live exposure today. P1
+is what makes a first user return. P2 is the only thing that distinguishes us from
+ChatGPT Health, which shipped nationwide nine days ago.
+
+---
+
+## 5. Strategic frame
+
+Verified unoccupied ground:
+
+1. **The consumer action rail.** ChatGPT Health, Claude+HealthEx, Perplexity Health —
+   all read-only. Amazon acts, but only inside its own clinic. Provider-side voice AI
+   (Hippocratic, Talkie) acts for the practice. A patient-owned agent that executes at
+   *any* provider behind propose→human-approve→audit is genuinely unclaimed.
+2. **Verifiable safety substrate.** Innovaccer's HMCP is the only comparable artifact —
+   a spec plus a commercial gateway for health systems. Open-source engine + live
+   `$conformance` grading is a different, checkable claim. *Provided the grade is honest*
+   — see §2, which is why item 20 is strategic, not hygiene.
+3. **The regulated on-ramp.** CARIN-CFA → Medicare App Library (CMS-recognized Feb 2026)
+   is a distribution channel Big AI can't easily use.
+
+Not a moat: "agent in a minute" (incumbents do record-grounded chat for 300M weekly
+health users) and raw connectivity (b.well's 1.7M providers dwarfs ours).
+
+Threats, in order: OpenAI/Anthropic adding actions; Amazon widening past its clinic;
+HMCP becoming the standard while we remain a project. The third makes the Bo Holland
+agent-identity thread and HL7/CARIN engagement **existential, not optional**.
+
+**First-1000 playbook** (from Solace, Guava, PicnicHealth, Ada): pick one population
+(Medicare + small practices like Dr. Magan's), make it free where a practice or sponsor
+pays, and publish the trust artifact — **"X actions completed, 100% human-approved, 0
+safety incidents."** That counter is the consumer analogue of the "115M interactions"
+stat that raised Hippocratic $126M. It also converges exactly with item 19: the approve
+surface plus one real action is what makes the number exist.
+
+---
+
+## 6. Standing sub-agent roster
+
+Each is grounded in a defect this repo actually shipped.
+
+| Agent | Trigger | Non-negotiable checklist (abridged) |
+|---|---|---|
+| **Guardrail Sentinel** | Every PR touching redaction / audit / step-up / actions / MCP error paths | No PHI or token in any log, audit `detail`, or error body (`str(exc)` vs `type(exc).__name__`); `validate_step_up_token` destructured; every access audited; tenant from header never body; no path where an agent approves its own action |
+| **Conformance Warden** | Conformance code, the four invariant docs, weekly sweep | Grade A never weakened to pass; `REVIEW_STANDARDS.md` ≡ `CLAUDE.md` ≡ `development.md` ≡ code; honesty postures not softened by wording edits; **first task: the stale `X-Human-Confirmed` text** |
+| **Onboarding Shadow** | Weekly cron + post-deploy | Full `careagents_smoke.py` incl. one real LLM turn; signup under a minute; synthetic tenants only; P1 issue with repro on failure. *Would have caught the broken-login bug the day it shipped* |
+| **Patient Advocate** | Every PR touching user-facing copy or templates | Nothing advertised that isn't wired (#170); consent at the real-records moment (#172); delete reachable and honest (#203); errors tell a scared human what to do and leak nothing |
+| **Release Captain** | Release cut; monthly if main >4 weeks past tag | All 8 drift-guard locations bumped together; `demo_e2e.sh` gates; post-deploy metadata + `tools/list` + Grade A; **never deploys MCP or CareAgents prod without explicit go** |
+| **Dependency Quartermaster** | Weekly + on audit-gate failure | Grouped minor/patch auto-merge; majors summarized with risk; unfixed advisory → scoped override same day (#197 pattern); no incidental `uv.lock` churn |
+| **Market Scout** | Weekly light / monthly deep | Every finding becomes an issue or is dropped; regulatory findings flagged before any public claim changes; **drafts only, human-gated** |
+
+Wiring: Sentinel, Warden, and Advocate are path-triggered additions to
+`claude-pr-review.yml`. Captain, Shadow, Quartermaster, Scout are scheduled/on-demand.
+
+---
+
+## 7. Research calendar
+
+| Cadence | Loop | Why here specifically |
+|---|---|---|
+| Weekly | Dependabot triage + prod smoke | Audit gate has broken main twice; login broke silently once |
+| Weekly | MCP spec + Anthropic platform changes | The MCP server *is* a product surface; transport auth fail-closed prod once |
+| Biweekly | FHIR R6 ballot progress | CI asserts the `6.0.0-ballot3` string — a bump is a breaking event |
+| Monthly | FTC HBNR + OCR enforcement vs consumer health apps | CareAgents is a non-covered-entity consumer app; **decision on #168 still open** |
+| Monthly | CARIN Alliance + agent-identity standards | Standard-setter thesis; Bo Holland thread live |
+| Monthly | Connector drift: Open Wearables, Fasten, MEDENT/Epic | OW 0.6.3 already broke docs-vs-reality (#127) |
+| Monthly | Competitor scan | Feeds HIMSS Aug 18 and the ecosystem campaign |
+| Quarterly | Security posture; re-pin the security-baseline commit | Pinned to a July commit by design — someone must consciously re-pin |
+
+---
+
+## 8. Three process changes with the best velocity-per-risk
+
+1. **Scheduled prod synthetic monitor** (~1 hour). Every 6h: smoke script, `$conformance`
+   Grade A assertion, `/healthz`, MCP `tools/list`. Failure opens a pinned issue — the
+   alerting channel a solo maintainer will actually see.
+2. **Move the strict dependency audit off the PR critical path** — daily scheduled job
+   that opens an issue; PRs gate only on lockfile changes. Add the expiring-exception
+   policy file `ci.yml` already promises but doesn't have.
+3. **Make the Postgres lane self-selecting** (marker + auto-marking conftest rule) and
+   add a nightly full-suite-on-Postgres run. The hand-curated 9-path allowlist already
+   leaked once (#206).

--- a/docs/2026-08-01-webinar-delivery-plan.md
+++ b/docs/2026-08-01-webinar-delivery-plan.md
@@ -1,0 +1,153 @@
+# Delivery Plan — HIMSS (Aug 18) + ICP (late Aug)
+
+**Today:** Sat Aug 1, 2026 · **HIMSS webinar:** Tue Aug 18 (17 days) · **ICP webinar:** late Aug
+
+**Goal:** a product a famous patient advocate can use unsupervised, be impressed by, and
+tell people about. Not a demo that works when driven by its author.
+
+Companion analysis: [2026-08-01-alignment-review.md](2026-08-01-alignment-review.md)
+
+---
+
+## The bet
+
+**What we demo:** *"I connected my real records. My agent read them, told me something
+true I didn't know, filled my new-patient intake form from them, I reviewed every line,
+and here is the signed PDF — with an audit trail of every access."*
+
+Every read-only competitor (ChatGPT Health, Claude+HealthEx, Perplexity) stops one step
+before that PDF. That step is the whole story, and **it already works today**.
+
+**What we are NOT betting on:** the pharmacy voice call. It is the better story, but it
+sits behind Bland onboarding — an external dependency we do not control 17 days out.
+Start the onboarding now; treat the call as a fast-follow that, if it clears, becomes the
+ICP-webinar headline.
+
+---
+
+## Simplifications (chosen deliberately over the "proper" build)
+
+| Instead of | We ship | Why |
+|---|---|---|
+| A terminology service / FHIR ValueSet resolver | A **static Python dict** of the top-N codes, sized by measurement | Zero infra, zero latency, trivially troubleshootable. A dict lookup cannot fail in production. |
+| A new chat-history store + PHI-boundary renegotiation | **Reuse `ConversationMessage`** (`r6/command_center/models.py`) and the existing `GET`/`POST /command-center/api/conversations` | Already tenant-scoped, already on the HealthClaw side of the boundary, already covered by `purge_tenant`. Persistence becomes wiring, not architecture. |
+| A document-understanding pipeline | **Add `DocumentReference` to the search enum** + surface existing text through redaction | The read path is already proven in the MCP server. |
+| Sentry + metrics + dashboards | **One 6-hourly cron** running the existing `scripts/careagents_smoke.py`, opening a pinned issue on failure | The alerting channel a solo maintainer actually reads. |
+| Racing Bland for a live call | **Polish the intake form** that works today | Value per day-of-risk is far higher, and it is the same "real action" claim. |
+
+Rule for the next 17 days: **if a fix needs a new service, a new table, or a new
+dependency, it is the wrong fix for this window.**
+
+---
+
+## Value gates — measure before building
+
+Each Phase-1 item is gated on evidence. If the gate fails, we do not build it; we
+re-plan. This is the discipline that keeps the window honest.
+
+| Gate | Measurement | Build only if | If it fails |
+|---|---|---|---|
+| **G1 — Terminology** | On the real MEDENT tenant, count distinct codes and cumulative coverage (count-only query; no PHI values leave the engine) | A few hundred codes cover the clear majority of records | Long tail → labels won't fix the payoff; pivot to showing structured data (dates, values, status) instead of names |
+| **G2 — Documents** | Sample what `DocumentReference` rows actually contain | They carry readable text or an inline attachment | Only external URLs → the tool cannot help; drop it and say so |
+| **G3 — Persistence** | Confirm `recent_conversations` returns full text | Full text available | `to_dict` truncates at 500 chars — small fix, then proceed |
+| **G4 — Retention loop** | Do we have a user who returned twice? | Yes | **No → do not build the care-note loop.** Retention features before retention are theater |
+
+G4 is the one most likely to save us a week.
+
+---
+
+## Phase 0 — Close the exposure + measure (Aug 1-4)
+
+Nothing user-visible. This is the difference between "we have guardrails" being true and
+being marketing — and we are about to say it on a stage.
+
+- [ ] **Kill `/demo/agent-loop`** — restrict to `is_public()` tenants + `X-Internal-Secret`, or disable in prod. *Live, unauthenticated, cross-tenant write + policy-delete.*
+- [ ] **Bind the confirm credential** — `require_audience='action-approval'` + operation. Copy the Curatr pattern (`r6/routes.py:2613`).
+- [ ] **Bound the agent loop** — trim history before each call, hard `return` after `MAX_TOOL_ROUNDS`, evict idle entries.
+- [ ] **`pool_pre_ping=True` + `pool_recycle=300`** on the careagents engine.
+- [ ] **Fix the two silent lies** — propagate `mail.send_code` failure; stop swallowing `confirm_action` errors.
+- [ ] **Track + CI-build `deploy/careagents/Dockerfile`** (still untracked).
+- [ ] **Fix stale `X-Human-Confirmed`** in `REVIEW_STANDARDS.md` / `development.md` / `SECURITY.md` — the review bot's constitution is wrong.
+- [ ] **Run G1 + G2 + G3 measurements.**
+
+**Exit:** prod has no unauthenticated write path; suite green; Grade A; measurements in hand.
+
+---
+
+## Phase 1 — Make the payoff land (Aug 5-11)
+
+The through-line: a user who connects real records today gets amnesia, unreadable labels,
+and unreadable documents. Same connection, three fixes, real product.
+
+- [ ] **Terminology labels** (gated on G1) — static map, applied in `_summarize_bundle`. Unknown codes keep the honest `unreadable: True` fallback.
+- [ ] **Chat persistence** (gated on G3) — write each turn to `ConversationMessage` via the existing endpoint; rehydrate on load; render prior turns in `chat.html`.
+- [ ] **`get_documents` tool** (gated on G2).
+- [ ] **Real first greeting** — replace the hardcoded string with actual findings ("I can see 3 conditions, 7 medications, 12 labs from *Provider*"). Kill "(sample data for now)" for real connections.
+- [ ] **Copy honesty pass** — consent card says email-support-to-delete while Delete sits on the same page (needs `CONSENT_VERSION` bump).
+
+**Exit:** connect real records → first screen says something true and useful → close the
+tab → come back → the conversation is still there.
+
+---
+
+## Phase 2 — Demo-solid (Aug 12-16)
+
+The bugs that make a live demo or an unsupervised advocate hit a wall.
+
+- [ ] **Passkey dead loop** — `/auth` redirects logged-in users away; enrollment unreachable after signup.
+- [ ] **Replace `prompt()`/`alert()`** in wearable pick + Telegram/iMessage binding; style the conn-card buttons; differentiate destructive Delete.
+- [ ] **CareAgents Playwright spec** — signup → sample connect → agent create → one chat turn. None exists today; all e2e targets the HealthClaw site.
+- [ ] **Prod synthetic monitor** — 6-hourly cron: smoke script + `$conformance` Grade A + `/healthz` + MCP `tools/list` → pinned issue on failure.
+- [ ] **Intake-form polish** — the demo centerpiece: review card clarity, PDF quality, error states.
+
+**Exit:** a stranger completes the full journey on a phone without help.
+
+---
+
+## Phase 3 — Freeze + rehearse (Aug 17-18)
+
+- [ ] **Code freeze Aug 16 EOD.** Only demo-blocking fixes after.
+- [ ] Full dry run on the real deployment, on the actual demo device and network.
+- [ ] One advocate runs it unsupervised while we watch. Fix only what blocks them.
+- [ ] Fallback plan: recorded backup of the intake-form flow if live connect fails on stage.
+
+---
+
+## Phase 4 — Advocates + ICP (Aug 19-31)
+
+- [ ] Onboard 3-5 patient advocates on real records; instrument where they stall.
+- [ ] **Bland, if cleared:** approve surface → allowlist + daily cap → reaper cron → dogfood ladder (own number → real pharmacy IVR → advocate scenario). This is the ICP headline if it lands.
+- [ ] Publish the trust artifact: **"X actions completed, 100% human-approved, 0 safety incidents."**
+- [ ] Care-note retention loop — **only if G4 passes.**
+
+---
+
+## Deliberately NOT doing before Aug 18
+
+Naming these so they stop consuming attention:
+
+- Open Wearables auth gap (upstream dependency, unbounded)
+- Productizing the MEDENT SMART flow (weeks; Fasten already covers the demo)
+- Alembic migration chain for careagents
+- Multi-worker scale-out / shared history (blocked on a boundary decision; 1 worker × 16 threads covers 50 users)
+- Retiring `X-Human-Confirmed` for direct clinical writes (real, but not demo-path — issue it)
+- Full conformance probe expansion (strategic, not demo-critical — issue it)
+- Appointment booking (deliberately post-webinar per spec v3)
+
+---
+
+## Vision + market checkpoints
+
+Re-read before each webinar; these are the claims we can defend:
+
+- **We are the only patient-owned agent that executes actions at any provider behind
+  propose → human-approve → audit.** Read-only is the incumbent posture (ChatGPT Health
+  nationwide Jul 23; Claude+HealthEx; Perplexity). Amazon acts only inside its own clinic.
+- **We are the only open-source guardrail engine that grades live deployments.** Innovaccer
+  HMCP is the nearest artifact — a spec plus a commercial gateway for health systems.
+  *Our grade must be honest for this to hold* — hence Phase 0 and the probe-expansion issue.
+- **Do not claim** speed-to-agent or connectivity breadth as moats. Incumbents beat us on
+  both.
+- **Existential thread:** if HMCP becomes the standard while we remain a project, the
+  standard-setter thesis inverts. Keep the Bo Holland agent-identity collaboration and
+  CARIN engagement warm through August.

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2229,8 +2229,33 @@ def demo_agent_loop():
     6. Commit write with full audit trail — shows end-to-end
 
     Each step returns its result so the dashboard can render progressively.
+
+    IMPORTANT — this endpoint NARRATES the guardrail pattern for the demo
+    dashboard; it does not enforce it. The step descriptions below are scripted
+    copy, not the outcome of a live gate. Real enforcement lives on the actual
+    FHIR routes (redaction on read, step-up + human confirmation on write,
+    audit on everything) and is what `$conformance` grades.
+
+    Two step-up tokens used to be minted here and thrown away, which read like
+    authorization and was not. They are gone; the write authorization for this
+    endpoint is the `_internal_mint_authorized` gate below.
     """
     tenant_id = request.headers.get('X-Tenant-Id', 'demo-tenant')
+
+    # This endpoint WRITES (Patient, Permission, Observation) and soft-deletes
+    # every existing Permission for the tenant, and it lives under /demo/ —
+    # a prefix exempt from tenant enforcement and human-in-the-loop. Without a
+    # gate it is an anonymous cross-tenant write + access-policy-delete
+    # primitive against any tenant an attacker can name, which falsifies the
+    # whole "a client cannot bypass the guardrails" claim.
+    #
+    # Same fail-closed gate as seed/mint: public/synthetic tenants (what the
+    # demo is actually for) are allowed; anything else needs the internal
+    # secret. Deliberately reusing that helper rather than inventing a second
+    # authorization rule for a third kind of privileged write.
+    if not _internal_mint_authorized(tenant_id):
+        return jsonify({'error': 'forbidden'}), 403
+
     demo_id = str(uuid.uuid4())[:8]
     steps = []
 
@@ -2246,7 +2271,6 @@ def demo_agent_loop():
         'telecom': [{'system': 'phone', 'value': '617-555-0198', 'use': 'mobile'}],
     }
 
-    generate_step_up_token(tenant_id)
     resource_json = json.dumps(patient, separators=(',', ':'), sort_keys=True)
     pt_resource = R6Resource(
         resource_type='Patient',
@@ -2428,8 +2452,6 @@ def demo_agent_loop():
     record_audit_event('read', 'Observation', med_request['id'],
                        agent_id='demo-agent', tenant_id=tenant_id,
                        detail='Agent demo: step-up token issued, human confirmation required')
-
-    generate_step_up_token(tenant_id, agent_id='demo-agent')
 
     steps.append({
         'step': 5,

--- a/tests/test_r6_dashboard.py
+++ b/tests/test_r6_dashboard.py
@@ -743,6 +743,59 @@ class TestDemoAgentLoop:
                            content_type='application/json')
         assert resp.status_code == 200
 
+    def test_demo_loop_refuses_non_public_tenants_without_the_secret(
+            self, client, monkeypatch):
+        """The demo loop WRITES and soft-deletes every Permission for the
+        tenant it is pointed at, and it lives under /demo/ — a prefix exempt
+        from tenant enforcement and human-in-the-loop.
+
+        Ungated it was an anonymous cross-tenant write + access-policy-delete
+        primitive against any tenant an attacker could name, live in
+        production. It rides the same fail-closed gate as seed/mint.
+        """
+        monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "s3cret")
+
+        denied = client.post('/r6/fhir/demo/agent-loop',
+                             content_type='application/json',
+                             headers={'X-Tenant-Id': 'someones-real-tenant'})
+        assert denied.status_code == 403
+
+        allowed = client.post('/r6/fhir/demo/agent-loop',
+                              content_type='application/json',
+                              headers={'X-Tenant-Id': 'someones-real-tenant',
+                                       'X-Internal-Secret': 's3cret'})
+        assert allowed.status_code == 200
+
+    def test_demo_loop_does_not_delete_permissions_it_cannot_write(
+            self, client, monkeypatch):
+        """The destructive half specifically: a refused call must not have
+        soft-deleted the target tenant's access-control policy on its way out.
+
+        Uses a NON-public tenant on purpose — the conftest marks 'test-tenant'
+        public, which is exactly the case the gate is supposed to allow.
+        """
+        from models import db
+        from r6.models import R6Resource
+
+        victim = 'someone-elses-private-tenant'
+        db.session.add(R6Resource(
+            resource_type='Permission',
+            resource_json=json.dumps({'resourceType': 'Permission',
+                                      'id': 'keep-me'}),
+            resource_id='keep-me', tenant_id=victim))
+        db.session.commit()
+
+        monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "s3cret")
+        refused = client.post('/r6/fhir/demo/agent-loop',
+                              content_type='application/json',
+                              headers={'X-Tenant-Id': victim})
+        assert refused.status_code == 403
+
+        survivor = R6Resource.query.filter_by(
+            resource_type='Permission', tenant_id=victim,
+            id='keep-me', is_deleted=False).first()
+        assert survivor is not None, "refused call still wiped the policy"
+
     def test_demo_loop_redaction_applied(self, client):
         """Step 1 shows redacted patient data."""
         resp = client.post('/r6/fhir/demo/agent-loop',


### PR DESCRIPTION
Closes #210.

`POST /r6/fhir/demo/agent-loop` accepted any request with **no authentication** and wrote into whatever tenant the caller named in a header. Verified live in production: 200 unauthenticated.

`/demo/` is prefix-exempt from tenant enforcement (`routes.py:180-186`) and from human-in-the-loop (`health_compliance.py:109`), and the handler validated no step-up token. So an anonymous caller could commit a Patient, Permission and Observation into any tenant they could name — and **soft-delete every existing Permission for that tenant** (`routes.py:2318-2323`), disabling its access-control policy.

This falsifies the project's central claim that a client cannot bypass the guardrails — the claim we present at the HIMSS webinar on Aug 18.

## Changes

- Rides the **same fail-closed gate as seed/mint** (`_internal_mint_authorized`): public/synthetic tenants — what the demo is actually for — stay open; anything else needs `X-Internal-Secret`. Reused deliberately rather than inventing a second authorization rule for a third kind of privileged write. The healthclaw.io demo keeps working via `PUBLIC_TENANTS`.
- Removed two `generate_step_up_token()` calls whose return values were discarded — they read like authorization and were not. The docstring now states plainly that this endpoint *narrates* the guardrail pattern and does not enforce it.

## Tests

Two regression tests pin both halves: a non-public tenant is refused without the secret and accepted with it, and a refused call must not have wiped the target tenant's Permission resources on its way out.

Full suite: 1528 passed, 1 skipped. Ruff (CI-pinned 0.15.21): clean.

Found by the 2026-08-01 guardrail audit — see `docs/2026-08-01-alignment-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)