### PR TITLE
fix(careagents): bound the agent loop, harden the pool, stop reporting false success

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -40,6 +40,16 @@ class AuthError(RuntimeError):
     pass
 
 
+class MailError(RuntimeError):
+    """The one-time code could not be sent.
+
+    Distinct from AuthError: nothing is wrong with what the person typed, so
+    this is our failure to report (502), not theirs to correct (400). Login is
+    the front door — a silent failure here leaves them staring at an empty
+    inbox with no idea whether to wait or retry.
+    """
+
+
 class AccountService:
     def __init__(self, cfg):
         self.cfg = cfg
@@ -87,7 +97,15 @@ class AccountService:
             code = f"{secrets.randbelow(CODE_MAX):08d}"
             s.add(EmailToken(email=email, code_hash=self._hash(code),
                              purpose=purpose, exp=now() + CODE_TTL))
-        mail.send_code(self.cfg, email, code, purpose)
+        if not mail.send_code(self.cfg, email, code, purpose):
+            # Burn the code we just minted. It was never delivered, and leaving
+            # it live would make the resend cooldown above swallow the person's
+            # retry — reporting "sent" without sending anything.
+            with self.session() as s:
+                s.query(EmailToken).filter_by(
+                    email=email, used=False).update({"used": True})
+            raise MailError(
+                "We couldn't send your code just now. Please try again.")
 
     def verify_email_code(self, email: str, code: str) -> Account:
         email = email.strip().lower()

--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -23,6 +23,32 @@ from careagents.healthclaw import HealthClawClient, HealthClawError
 
 MAX_TOOL_ROUNDS = 6
 
+# Keep a conversation from growing without limit. Nothing trimmed these before,
+# so a heavy user's cost per turn climbed forever and eventually the request
+# exceeded the model's context window — at which point every further turn for
+# that person failed until the process restarted.
+MAX_HISTORY_MESSAGES = 40
+
+
+def _trim_history(history: list) -> None:
+    """Drop the oldest turns in place, cutting only at a safe boundary.
+
+    A tool call and its result must stay together: an assistant message with
+    tool_calls whose matching tool results were trimmed away is rejected
+    outright by the provider APIs. So rather than slicing at an arbitrary
+    index, cut forward to the next plain user message.
+    """
+    if len(history) <= MAX_HISTORY_MESSAGES:
+        return
+    start = len(history) - MAX_HISTORY_MESSAGES
+    while start < len(history):
+        msg = history[start]
+        if msg.get("role") == "user" and not msg.get("tool_call_id"):
+            break
+        start += 1
+    if start < len(history):
+        del history[:start]
+
 TOOLS = [
     {"name": "get_health_summary",
      "description": ("The person's current conditions, medications, and "
@@ -153,6 +179,7 @@ def _execute_tool(hc: HealthClawClient, tenant: str, name: str,
 def run_turn(cfg, hc: HealthClawClient, tenant: str, system: str,
              history: list[dict], user_text: str):
     """Generator of UI events for one user message. Mutates `history`."""
+    _trim_history(history)
     history.append({"role": "user", "content": user_text})
     rounds = 0
     while True:
@@ -190,9 +217,22 @@ def run_turn(cfg, hc: HealthClawClient, tenant: str, system: str,
                 yield ev
 
         if rounds >= MAX_TOOL_ROUNDS:
+            # Budget spent. This used to append the nudge and keep looping, so
+            # a model that kept calling tools was never actually stopped — it
+            # just collected another nudge each round and spent indefinitely.
+            # Ask once more with NO tools offered, so the only thing it can do
+            # is answer, then return regardless of what comes back.
             history.append({"role": "user", "content": (
                 "(system: tool budget reached — answer now with what you "
                 "have)")})
+            try:
+                final = llm.complete(cfg, system, history, [])
+            except llm.LLMError as exc:
+                yield {"type": "error", "text": str(exc)}
+                return
+            history.append({"role": "assistant", "content": final.text})
+            yield {"type": "text", "text": final.text}
+            return
 
 
 def run_turn_to_message(cfg, hc: HealthClawClient, tenant: str, system: str,

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -12,6 +12,7 @@ guardrail layer; careagents holds identity + pointers only.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections import defaultdict, deque
 from functools import wraps
@@ -20,17 +21,25 @@ from threading import Lock
 from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
 
-from careagents.accounts import (AccountService, AuthError, new_binding_code)
+from careagents.accounts import (AccountService, AuthError, MailError,
+                                 new_binding_code)
 from careagents import advisors, connectors
 from careagents.agent import run_turn, run_turn_to_message
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
 
+logger = logging.getLogger(__name__)
+
 # Bump when the consent-card copy or the terms/privacy content it points at
 # changes materially. Stored per connection so we always know which version a
 # person agreed to — a later change never silently claims earlier consent.
 CONSENT_VERSION = "2026-07-19"
+
+# In-memory conversation bounds. One worker holds every live chat, so these
+# cap memory and keep a long-running process from degrading (#218).
+MAX_LIVE_CONVERSATIONS = 200
+CONVERSATION_IDLE_SECONDS = 6 * 3600
 
 
 def create_app(config: Config | None = None,
@@ -49,6 +58,28 @@ def create_app(config: Config | None = None,
     histories: dict[str, list] = defaultdict(list)
     hist_lock = Lock()
     turns: dict[str, deque] = defaultdict(deque)
+    # Last time each conversation was touched, so idle ones can be released.
+    # Without this every tenant that ever chatted keeps its full transcript in
+    # memory for the life of the process.
+    hist_seen: dict[str, float] = {}
+
+    def touch_history(tenant: str) -> None:
+        """Mark a conversation live; release idle ones once we're holding many.
+
+        Deliberately simple: only sweeps when the map is already large, so the
+        common path is a single dict write. Chat history moves to durable
+        per-tenant storage in a follow-up (#222) — this is the bound that keeps
+        the process healthy until then.
+        """
+        seen_at = time.time()
+        hist_seen[tenant] = seen_at
+        if len(histories) <= MAX_LIVE_CONVERSATIONS:
+            return
+        for other, last in list(hist_seen.items()):
+            if other != tenant and seen_at - last > CONVERSATION_IDLE_SECONDS:
+                histories.pop(other, None)
+                turns.pop(other, None)
+                hist_seen.pop(other, None)
 
     # --- auth plumbing -------------------------------------------------------
 
@@ -117,6 +148,11 @@ def create_app(config: Config | None = None,
             svc.start_email_code(email, purpose)
         except AuthError as exc:
             return jsonify({"error": str(exc)}), 400
+        except MailError as exc:
+            # Never report "sent" when nothing was sent — this is the front
+            # door, and a silent failure leaves the person watching an empty
+            # inbox with no idea whether to wait or retry.
+            return jsonify({"error": str(exc), "sent": False}), 502
         return jsonify({"sent": True})
 
     @app.post("/api/auth/verify")
@@ -403,6 +439,7 @@ def create_app(config: Config | None = None,
         def stream():
             with hist_lock:
                 history = histories[tenant]
+                touch_history(tenant)
             try:
                 for event in run_turn(cfg, hc, tenant, sysprompt,
                                       history, text):
@@ -477,7 +514,22 @@ def create_app(config: Config | None = None,
             try:
                 hc.confirm_action(tenant, action_id)
             except HealthClawError:
-                pass
+                # The review was recorded but the confirmation didn't land, so
+                # the action is still sitting unexecuted. Swallowing this told
+                # the person they'd approved something that would never happen.
+                # Say so plainly and let them retry — same posture as the
+                # delete flow, which never claims an outcome it didn't get.
+                logger.exception("confirm failed after review for %s", action_id)
+                body = dict(body) if isinstance(body, dict) else {}
+                body.update({
+                    "confirmed": False,
+                    "message": ("Your review was saved, but we couldn't submit "
+                                "the approval. Nothing has been sent — please "
+                                "try approving again."),
+                })
+                return jsonify(body), 502
+            body = dict(body) if isinstance(body, dict) else {}
+            body["confirmed"] = True
         return jsonify(body), status
 
     # --- surfaces ------------------------------------------------------------
@@ -583,6 +635,7 @@ def create_app(config: Config | None = None,
                                   agent.get("advisor"))
         with hist_lock:
             history = histories[tenant]
+            touch_history(tenant)
         try:
             reply = run_turn_to_message(cfg, hc, tenant, sysprompt, history,
                                         text, origin=cfg.origin,

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -170,8 +170,17 @@ def _ensure_columns(engine) -> None:
 
 
 def make_engine(url: str):
-    connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
-    engine = create_engine(url, connect_args=connect_args, future=True)
+    is_sqlite = url.startswith("sqlite")
+    connect_args = {"check_same_thread": False} if is_sqlite else {}
+    pool_kwargs = {}
+    if not is_sqlite:
+        # Managed Postgres (Railway) drops idle connections. Without these a
+        # quiet period is followed by intermittent "server closed the
+        # connection" 500s on the next request — check the connection before
+        # handing it out, and retire it well before the server would.
+        pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 300}
+    engine = create_engine(url, connect_args=connect_args, future=True,
+                           **pool_kwargs)
     Base.metadata.create_all(engine)
     _ensure_columns(engine)
     return engine

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -59,6 +59,143 @@ def test_production_on_postgres_does_not_warn(caplog):
     assert not any("SQLite" in r.message for r in caplog.records)
 
 
+def test_auth_email_reports_failure_instead_of_claiming_it_sent(app, svc,
+                                                                monkeypatch):
+    # Login is the front door. This used to discard send_code's return value
+    # and answer {"sent": true} even when Resend was down, leaving the person
+    # watching an empty inbox with no idea whether to wait or retry.
+    import careagents.mail as mailmod
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: False)
+    r = app.test_client().post("/api/auth/email",
+                               json={"email": "gene@example.com"})
+    assert r.status_code == 502
+    assert r.get_json()["sent"] is False
+
+
+def test_a_failed_send_does_not_block_the_retry(app, svc, monkeypatch):
+    # The code row is committed before the send, so an undelivered code left
+    # live would make the resend cooldown swallow the retry and report success
+    # without sending anything.
+    import careagents.mail as mailmod
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: False)
+    c = app.test_client()
+    assert c.post("/api/auth/email",
+                  json={"email": "retry@example.com"}).status_code == 502
+
+    sent = {}
+    monkeypatch.setattr(mailmod, "send_code",
+                        lambda cfg, e, code, purpose: sent.setdefault("c", code)
+                        is not None)
+    r = c.post("/api/auth/email", json={"email": "retry@example.com"})
+    assert r.status_code == 200 and sent.get("c"), "retry never sent a code"
+
+
+def test_review_submit_reports_a_failed_confirmation(cfg, svc, monkeypatch):
+    # The person approved. If the confirmation doesn't land, the action sits
+    # unexecuted — telling them it succeeded is the worst possible answer.
+    from careagents.app import create_app
+
+    class _Fake(FakeClient):
+        def submit_review(self, tenant, action_id, decisions):
+            return 200, {"ok": True}
+
+        def confirm_action(self, tenant, action_id):
+            raise HealthClawError("upstream down", 500)
+
+    fake = _Fake()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/sample").get_json()
+    agent_id = c.post("/api/agents", json={
+        "name": "A", "persona": "calm",
+        "connection_id": created["id"]}).get_json()["id"]
+
+    monkeypatch.setattr(fake, "action_status",
+                        lambda t, a: {"status": "awaiting_confirmation"})
+    r = c.post(f"/review/{agent_id}/act-1/submit", json={"approved": []})
+    assert r.status_code == 502
+    body = r.get_json()
+    assert body["confirmed"] is False
+    assert "not" in body["message"].lower() or "couldn't" in body["message"]
+
+
+def test_history_is_trimmed_but_never_orphans_a_tool_call():
+    # Unbounded history meant cost grew every turn until the request blew past
+    # the context window, after which that person's chat failed permanently.
+    # The trim must not cut between an assistant tool_call and its tool result
+    # — the provider APIs reject that outright.
+    from careagents.agent import MAX_HISTORY_MESSAGES, _trim_history
+    history = []
+    for i in range(60):
+        history.append({"role": "user", "content": f"q{i}"})
+        history.append({"role": "assistant", "content": "",
+                        "tool_calls": [{"id": f"c{i}", "name": "get_labs",
+                                        "arguments": {}}]})
+        history.append({"role": "tool", "tool_call_id": f"c{i}",
+                        "content": "{}"})
+        history.append({"role": "assistant", "content": f"a{i}"})
+
+    _trim_history(history)
+
+    assert len(history) <= MAX_HISTORY_MESSAGES
+    assert history[0]["role"] == "user"           # cut at a safe boundary
+    # every surviving tool result still has its call in view
+    call_ids = {c["id"] for m in history for c in m.get("tool_calls", [])}
+    for msg in history:
+        if msg.get("role") == "tool":
+            assert msg["tool_call_id"] in call_ids
+
+
+def test_history_shorter_than_the_cap_is_left_alone():
+    from careagents.agent import _trim_history
+    history = [{"role": "user", "content": "hi"},
+               {"role": "assistant", "content": "hello"}]
+    _trim_history(history)
+    assert len(history) == 2
+
+
+def test_tool_loop_stops_at_the_budget_instead_of_spending_forever(
+        cfg, monkeypatch):
+    # The budget nudge used to be appended inside `while True` with no exit, so
+    # a model that kept calling tools was never stopped — it just collected
+    # another nudge each round.
+    from careagents import agent as agent_mod
+
+    calls = {"n": 0, "toolless": 0}
+
+    class _Call:
+        def __init__(self, i):
+            self.id, self.name, self.arguments = f"c{i}", "get_labs", {}
+
+    class _Turn:
+        def __init__(self, tool_calls):
+            self.text = "working" if tool_calls else "final answer"
+            self.tool_calls = tool_calls
+            self.raw_tool_calls = []
+
+    def fake_complete(cfg_, system, history, tools):
+        calls["n"] += 1
+        if not tools:                      # the forced final call
+            calls["toolless"] += 1
+            return _Turn([])
+        return _Turn([_Call(calls["n"])])  # never stops asking for tools
+
+    class _HC:
+        def interpret_labs(self, tenant):
+            return {"consumer": "ok", "disclaimer": "d"}
+
+    monkeypatch.setattr(agent_mod.llm, "complete", fake_complete)
+    events = list(agent_mod.run_turn(cfg, _HC(), "t-1", "sys", [], "hi"))
+
+    assert calls["toolless"] == 1, "must make one final tools-free call"
+    assert calls["n"] <= agent_mod.MAX_TOOL_ROUNDS + 1
+    assert events[-1] == {"type": "text", "text": "final answer"}
+
+
 def test_healthz_reports_ok_when_the_account_store_answers(app):
     r = app.test_client().get("/healthz")
     assert r.status_code == 200
@@ -264,6 +401,19 @@ def _make_account(svc, monkeypatch, email):
     return svc.verify_email_code(email, captured["c"])
 
 
+def _sink_code(sink):
+    """Stand-in for mail.send_code that records the code and reports success.
+
+    Returning True is load-bearing: a falsy return now means "the send failed"
+    and raises MailError (#220), so a fake that returns None — as bare
+    list.append and dict.__setitem__ do — reads as an outage.
+    """
+    def _send(cfg, email, code, purpose):
+        sink.append(code)
+        return True
+    return _send
+
+
 def _login(client, svc, monkeypatch, email="gene@example.com"):
     """Log a client in via the real email-code path (code captured from mail)."""
     captured = {}
@@ -305,7 +455,7 @@ def test_fresh_home_gates_agent_modal_and_shows_onboarding(app, svc, monkeypatch
 def test_wrong_email_code_rejected(app, svc, monkeypatch):
     c = app.test_client()
     import careagents.mail as mailmod
-    monkeypatch.setattr(mailmod, "send_code", lambda *a: None)
+    monkeypatch.setattr(mailmod, "send_code", lambda *a: True)
     c.post("/api/auth/email", json={"email": "x@y.com"})
     r = c.post("/api/auth/verify", json={"email": "x@y.com", "code": "000000"})
     assert r.status_code == 400
@@ -316,11 +466,10 @@ def test_email_code_burns_after_max_attempts(svc, monkeypatch):
     guesses — even the correct code no longer works afterwards."""
     from careagents.accounts import MAX_CODE_ATTEMPTS, AuthError
     import careagents.mail as mailmod
-    cap = {}
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: cap.__setitem__("c", code))
+    cap = []
+    monkeypatch.setattr(mailmod, "send_code", _sink_code(cap))
     svc.start_email_code("brute@example.com")
-    real = cap["c"]
+    real = cap[0]
     assert len(real) == 8  # higher entropy than 6 digits
     for _ in range(MAX_CODE_ATTEMPTS):
         with pytest.raises(AuthError):
@@ -335,8 +484,7 @@ def test_email_resend_invalidates_prior_code(svc, monkeypatch):
     from careagents.accounts import AuthError
     import careagents.mail as mailmod
     codes = []
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: codes.append(code))
+    monkeypatch.setattr(mailmod, "send_code", _sink_code(codes))
     monkeypatch.setattr("careagents.accounts.RESEND_COOLDOWN", 0)  # skip cooldown
     svc.start_email_code("rotate@example.com")
     first = codes[-1]
@@ -352,8 +500,7 @@ def test_email_resend_cooldown_suppresses_duplicate_send(svc, monkeypatch):
     """Within the cooldown a repeat request does not mint/send a new code."""
     import careagents.mail as mailmod
     codes = []
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: codes.append(code))
+    monkeypatch.setattr(mailmod, "send_code", _sink_code(codes))
     svc.start_email_code("cool@example.com")
     svc.start_email_code("cool@example.com")  # within cooldown → suppressed
     assert len(codes) == 1


### PR DESCRIPTION
Closes #218, #220, #221. Four production failure modes from the 2026-08-01 architecture audit — all bite before scale does, and two of them lie to the person using the app.

## Unbounded chat history (#218) — bites at one heavy user
Nothing trimmed a conversation, so cost per turn climbed forever and eventually the request exceeded the model's context window; every further turn for that person then failed until the process restarted.

`_trim_history` caps it and **cuts only at a plain user message** — a tool call and its result must stay together or the provider APIs reject the request outright. Idle conversations are released once many are held.

## The tool loop never actually stopped (#218)
At `MAX_TOOL_ROUNDS` the code appended an "answer now" nudge and kept looping, so a model that kept calling tools was never stopped — it just collected another nudge each round and spent indefinitely.

Now it makes one final call with **no tools offered**, so the only thing it can do is answer, and returns regardless.

## Postgres pool (#221) — bites within days
`create_engine` had no `pool_pre_ping` / `pool_recycle`. Managed Postgres drops idle connections, producing intermittent `server closed the connection` 500s after quiet periods. We migrated to Railway Postgres today.

## Two paths reported success after failing (#220)
- **`mail.send_code`'s return value was discarded** — the API answered `{"sent": true}` even when Resend was down. Login is the front door. Now 502 with a plain message, and the undelivered code is **burned first**: leaving it live would make the resend cooldown swallow the retry and claim success a second time.
- **A failed `confirm_action` after review submit was swallowed with `pass`** — the person believed they had approved something that would never execute. Now 502, saying plainly that nothing was sent, matching the delete flow's posture of never claiming an outcome it didn't get.

## Tests
New coverage for each fix, including that the trim never orphans a tool call and that the budget path makes exactly one tools-free call.

Three existing fakes returned `None` from `send_code` (bare `list.append` / `dict.__setitem__`), which now reads as an outage — `_sink_code` models a real send.

**1532 passed, 1 skipped.** Ruff (CI-pinned 0.15.21): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)