### PR TITLE
fix(careagents): reachable passkey enrolment + copy that matches the product

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -30,7 +30,10 @@ from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
 # Bump when the consent-card copy or the terms/privacy content it points at
 # changes materially. Stored per connection so we always know which version a
 # person agreed to — a later change never silently claims earlier consent.
-CONSENT_VERSION = "2026-07-19"
+# 2026-08-01: the "leaving" clause said to email support, while self-serve
+# Disconnect and Delete sat on the same page (#203). Understating our own
+# strongest privacy control in the one place people read carefully.
+CONSENT_VERSION = "2026-08-01"
 
 
 def create_app(config: Config | None = None,
@@ -80,9 +83,15 @@ def create_app(config: Config | None = None,
 
     @app.get("/auth")
     def auth():
-        if session.get("account_id"):
+        # `?enroll=1` lets someone already signed in add a passkey. Without it
+        # the only enrolment moment was the single screen after first email
+        # verification: skip once and the "sign in with your face" promise
+        # quietly expired into email codes forever, because this route sent
+        # every logged-in visitor straight back to /home (#223).
+        enroll = request.args.get("enroll") == "1"
+        if session.get("account_id") and not enroll:
             return redirect(url_for("home"))
-        return render_template("auth.html", rp_id=cfg.rp_id,
+        return render_template("auth.html", rp_id=cfg.rp_id, enroll=enroll,
                                terms_url=f"{cfg.healthclaw_base}/terms",
                                privacy_url=f"{cfg.healthclaw_base}/privacy")
 

--- a/careagents/connectors.py
+++ b/careagents/connectors.py
@@ -42,13 +42,19 @@ _CATALOG = [
      "blurb": "Oura, Whoop, Garmin, Fitbit, Strava, and Apple Health — "
               "through Open Wearables.",
      "providers": WEARABLE_PROVIDERS},
-    {"id": "shl", "tier": "import", "icon": "🔗",
+    # These two are NOT live: start() returns {"soon": True} for both. They
+    # were advertised as an "import" tier whose blurbs told people to paste a
+    # link or drop in a file, neither of which did anything (#225). Presented
+    # as coming-soon until the flow actually exists (#227) — the house rule is
+    # ship the mechanism, then the copy.
+    {"id": "shl", "tier": "soon", "icon": "🔗",
      "label": "SMART Health Link",
-     "blurb": "Paste a SMART Health Link or scan its QR to import a shared "
-              "record."},
-    {"id": "direct", "tier": "import", "icon": "📄",
+     "blurb": "Import a record shared with you as a SMART Health Link. "
+              "Not open yet — we'll let you know."},
+    {"id": "direct", "tier": "soon", "icon": "📄",
      "label": "Upload records",
-     "blurb": "Drop in a FHIR bundle or a SMART Health Card file."},
+     "blurb": "Bring a FHIR bundle or SMART Health Card file yourself. "
+              "Not open yet — we'll let you know."},
     {"id": "healthex", "tier": "soon", "icon": "🧬",
      "label": "HealthEx",
      "blurb": "Connect your HealthEx account."},

--- a/careagents/templates/auth.html
+++ b/careagents/templates/auth.html
@@ -10,8 +10,8 @@
 
     <div id="err" class="form-error" hidden></div>
 
-    <!-- Step: passkey-first -->
-    <div id="step-start">
+    <!-- Step: passkey-first (skipped when an existing account is enrolling) -->
+    <div id="step-start" {% if enroll %}hidden{% endif %}>
       <button class="btn-primary btn-block" id="passkey-btn">
         Sign in with a passkey</button>
       <div class="or">or use your email</div>
@@ -36,14 +36,15 @@
       <button class="linkish" id="back-btn">← use a different email</button>
     </div>
 
-    <!-- Step: add passkey after first verify -->
-    <div id="step-passkey" hidden>
+    <!-- Step: add passkey — after first verify, or any time via ?enroll=1 -->
+    <div id="step-passkey" {% if not enroll %}hidden{% endif %}>
       <span class="persona-emoji">🔐</span>
       <h2 style="font-size:22px;margin:8px 0">Add a passkey</h2>
       <p class="setup-sub">Set up Face ID / Touch ID so next time is one tap.</p>
       <button class="btn-primary btn-block" id="add-passkey-btn">
         Create passkey</button>
-      <button class="linkish" id="skip-passkey-btn">Skip for now →</button>
+      <button class="linkish" id="skip-passkey-btn">
+        {% if enroll %}Back to your hub →{% else %}Skip for now →{% endif %}</button>
     </div>
   </div>
 </main>

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -8,7 +8,7 @@
     <div>
       <h1>Welcome back</h1>
       <p class="hub-sub">{{ me.email }}
-        {% if not has_passkey %}· <a href="/auth">add a passkey</a>{% endif %}
+        {% if not has_passkey %}· <a href="/auth?enroll=1">add a passkey</a>{% endif %}
       </p>
     </div>
     <form method="post" action="/logout"><button class="pill">Sign out</button></form>
@@ -132,9 +132,13 @@
       <li><b>The AI can be wrong</b> — and your connected records may be
         incomplete. Don't treat either as a substitute for your official
         records or for professional medical judgment.</li>
-      <li><b>Leaving:</b> email
-        <a href="mailto:support@healthclaw.io">support@healthclaw.io</a> and
-        we'll delete your data and confirm when it's done.</li>
+      <li><b>Leaving:</b> you can do it yourself, right here, whenever you
+        like. <b>Disconnect</b> stops new records arriving and keeps what's
+        already there; <b>Delete</b> permanently removes the records
+        themselves and tells you how many were deleted. The PHI-free audit
+        trail of who accessed what is kept — a deletion shouldn't be able to
+        erase the record of the access that came before it. Stuck? Email
+        <a href="mailto:support@healthclaw.io">support@healthclaw.io</a>.</li>
     </ul>
     <p class="consent-fine">Full detail:
       <a href="{{ terms_url }}" target="_blank" rel="noopener">Terms</a> ·

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -376,6 +376,66 @@ def test_webauthn_options_are_issued_when_authed(app, svc, monkeypatch):
     assert login.status_code == 200 and "challenge" in login.get_json()
 
 
+def test_no_connector_tile_advertises_a_flow_that_does_not_exist(cfg):
+    # The house rule (#166, #170): ship the mechanism, then the copy. A tile
+    # that isn't wired must present as coming-soon rather than instructing an
+    # action that silently does nothing (#225).
+    from careagents import connectors
+    for item in connectors.catalog(cfg):
+        plan = connectors.start(item["id"], None, cfg, FakeClient())
+        if plan.get("soon"):
+            assert item["tier"] == "soon", (
+                f"{item['id']} is advertised as '{item['tier']}' but its "
+                f"start() is not implemented")
+
+
+def test_the_consent_card_points_at_the_delete_button_it_ships_with(
+        app, svc, monkeypatch):
+    # It told people to email support to leave, while self-serve Disconnect
+    # and Delete sat on the same page — understating our strongest privacy
+    # control in the one place people read carefully.
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    body = c.get("/home").get_data(as_text=True)
+    assert "Disconnect" in body and "Delete" in body
+    leaving = body[body.index("<b>Leaving:</b>"):][:600]
+    assert "yourself" in leaving
+
+
+def test_a_signed_in_person_can_still_add_a_passkey(app, svc, monkeypatch):
+    # #223: /auth bounced every logged-in visitor to /home, so the only chance
+    # to enrol was the one screen after first email verification. Skip it once
+    # and "sign in with your face" silently became email codes forever.
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+
+    r = c.get("/auth?enroll=1")
+    assert r.status_code == 200, "enrolment is unreachable once signed in"
+    body = r.get_data(as_text=True)
+
+    def _tag(div_id):
+        start = body.index(f'<div id="{div_id}"')
+        return body[start:body.index(">", start)]
+
+    # The enrolment step must be the visible one, and the sign-in step hidden —
+    # landing on a hidden panel would look like a blank page.
+    assert "hidden" not in _tag("step-passkey")
+    assert "hidden" in _tag("step-start")
+
+
+def test_plain_auth_still_sends_a_signed_in_person_home(app, svc, monkeypatch):
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    r = c.get("/auth")
+    assert r.status_code == 302 and "/home" in r.headers["Location"]
+
+
+def test_the_hub_links_to_a_reachable_enrolment_page(app, svc, monkeypatch):
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    assert "/auth?enroll=1" in c.get("/home").get_data(as_text=True)
+
+
 def test_passkey_registration_and_login_via_faked_verification(app, svc, monkeypatch):
     """Exercise the route wiring with the WebAuthn crypto faked (no browser)."""
     c = app.test_client()


### PR DESCRIPTION
Closes #223, closes #225. Off main — independent of the other open PRs.

## Passkey enrolment was unreachable (#223)

The hub linked "add a passkey" to `/auth`, and `/auth` redirected every signed-in visitor straight to `/home`. So the **only** enrolment moment was the single screen right after first email verification — skip it once and "sign in with your face" quietly became email codes forever.

`/auth?enroll=1` now opens the enrolment step directly. The server side already worked and was `@login_required`; it simply had no door.

## The consent card contradicted the page it sits on (#225)

It said to email support to leave, while self-serve **Disconnect** and **Delete** — shipped in #203 — were on the same screen. We were understating our strongest privacy control in the one place people actually read carefully.

It now describes both, including what Delete keeps and why the PHI-free audit trail survives it. **`CONSENT_VERSION` bumped** so we never claim an earlier agreement covered this wording.

## Two tiles advertised flows that do nothing (#225)

The "import" tier told people to paste a SMART Health Link or drop in a FHIR bundle. `start()` returns `{"soon": True}` for both. They now present as coming-soon until the flow exists (#227).

**A test enforces the rule generally:** any catalog tile whose `start()` isn't implemented must be tiered `soon` — so the next unwired tile can't quietly advertise itself as live. That's the house rule from #166/#170 made mechanical.

**1533 passed, 1 skipped.** Ruff (CI-pinned): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)