### PR TITLE
feat(ci): scheduled production watch, with its scope stated honestly (#230)

### DIFF
--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -1,0 +1,95 @@
+name: prod-watch
+
+# Scheduled verification that the live product works. There was none before:
+# the sign-in code input silently truncated 8-digit codes to 6 (#181) and UI
+# login was broken in production until a human noticed.
+#
+# On failure this opens (or updates) a single pinned issue rather than emailing
+# a red X into a folder nobody reads — that is the channel a solo maintainer
+# actually sees. On recovery it closes the issue with a note, so a stale alarm
+# never sits open pretending production is still down.
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"   # every 6h, off the hour to dodge runner crowds
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: prod-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Check production
+        id: watch
+        run: |
+          set +e
+          uv run --with requests python scripts/prod_watch.py > result.txt 2>&1
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          # Strip ANSI so the issue body is readable.
+          sed -i 's/\x1b\[[0-9;]*m//g' result.txt
+          cat result.txt
+
+      - name: Open or update the alert issue
+        if: steps.watch.outputs.exit != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('result.txt', 'utf8');
+            const title = 'prod-watch: production checks failing';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const text = [
+              'Scheduled production check failed.',
+              '', '```', body.trim(), '```', '',
+              `Run: ${run}`,
+              '',
+              'This issue closes automatically when the checks pass again.',
+            ].join('\n');
+
+            const { data: found } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+            });
+            if (found.total_count > 0) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: found.items[0].number, body: text,
+              });
+            } else {
+              await github.rest.issues.create({ ...context.repo, title, body: text });
+            }
+
+      - name: Close the alert issue on recovery
+        if: steps.watch.outputs.exit == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'prod-watch: production checks failing';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: found } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+            });
+            for (const issue of found.items) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Production checks are passing again. Closing.\n\nRun: ${run}`,
+              });
+              await github.rest.issues.update({
+                ...context.repo, issue_number: issue.number, state: 'closed',
+              });
+            }
+
+      - name: Fail the run so the badge reflects reality
+        if: steps.watch.outputs.exit != '0'
+        run: exit 1

--- a/scripts/careagents_smoke.py
+++ b/scripts/careagents_smoke.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """CareAgents live smoke — the product works, end to end, or this fails loud.
 
-    python scripts/careagents_smoke.py                        # careagents.cloud
     python scripts/careagents_smoke.py --base http://127.0.0.1:8600
 
 Drives: landing → create agent (fresh tenant, seeded) → one real chat turn
@@ -9,6 +8,26 @@ Drives: landing → create agent (fresh tenant, seeded) → one real chat turn
 allergy-attestation gate rejects a bare submit through the relay → honest
 submit → confirm/execute → signed PDF downloads. One LLM call is involved
 (the chat turn), so run against a configured deployment.
+
+STALE — DOES NOT RUN AGAINST PRODUCTION TODAY.
+----------------------------------------------
+This drives the pre-accounts API: an anonymous `POST /start` that created an
+agent, and `/api/chat` without an agent id. CareAgents now requires a signed-in
+account (email code or passkey) and scopes every agent to it, so these calls no
+longer exist and this script fails on its first check against the live site.
+
+Automating the signed-in journey needs the runner to read a real inbox for the
+one-time code, which is genuine work and a genuine decision — see #242. Until
+then:
+
+  * scripts/prod_watch.py checks production on a schedule, unauthenticated,
+    with its scope stated plainly (it does NOT cover the signed-in journey).
+  * This script is still useful against a LOCAL stack, where mail.send_code
+    logs the code instead of sending it.
+
+Left in place rather than deleted because the flow it encodes — including the
+allergy-attestation gate, which is a real safety property — is worth porting to
+the account-based API rather than rewriting from scratch.
 """
 from __future__ import annotations
 

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Production watch — is the live product actually working right now?
+
+    python scripts/prod_watch.py                  # all deployments
+    python scripts/prod_watch.py --json           # machine-readable
+
+Exits non-zero if any check fails, so a scheduled job can open an issue.
+
+Why this exists
+---------------
+There was no scheduled verification of production at all. The sign-in code
+input silently truncated 8-digit codes to 6 (#181) — UI login was broken for
+every user, in production, and it was found by hand rather than by any alarm.
+The MCP server fail-closed on a missing token and stayed down until someone
+noticed.
+
+Scope, stated honestly
+----------------------
+Every check here is UNAUTHENTICATED on purpose, so this can run from CI with no
+credentials and no synthetic account to keep alive. That buys the catastrophic
+cases — deploy broke, database unreachable, guardrails regressed, labels
+regressed, MCP down — and it does NOT cover the signed-in journey (signup →
+email code → connect → chat → intake form).
+
+Covering that needs an inbox the runner can read, which is a real piece of work
+and a real decision; it is tracked separately rather than faked here. A monitor
+that quietly checks less than it appears to is worse than one with a narrow,
+stated scope.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+
+G, R, Y, D, X = "\033[92m", "\033[91m", "\033[93m", "\033[2m", "\033[0m"
+
+HEALTHCLAW = "https://app.healthclaw.io"
+CAREAGENTS = "https://careagents-production.up.railway.app"
+# Two MCP deployments by design: the real one is token-locked, the demo one is
+# unauthenticated but hard-pinned to a synthetic tenant.
+MCP_LOCKED = "https://mcp-server-production-5112.up.railway.app"
+MCP_DEMO = "https://mcp-demo-production-ee2c.up.railway.app"
+DEMO_TENANT = "desktop-demo"
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    results.append((name, ok, detail))
+    mark = f"{G} OK {X}" if ok else f"{R}FAIL{X}"
+    print(f"{mark} {name}" + (f" {D}— {detail}{X}" if detail else ""))
+    return ok
+
+
+def get(url: str, timeout: float, **kw):
+    try:
+        return requests.get(url, timeout=timeout, **kw)
+    except requests.RequestException as exc:
+        return type(exc).__name__
+
+
+def run(timeout: float) -> int:
+    # --- the guardrail engine ------------------------------------------------
+    r = get(f"{HEALTHCLAW}/r6/fhir/health", timeout)
+    check("healthclaw: alive", getattr(r, "status_code", None) == 200,
+          str(getattr(r, "status_code", r)))
+
+    r = get(f"{HEALTHCLAW}/r6/fhir/$conformance", timeout)
+    grade = None
+    if getattr(r, "status_code", None) == 200:
+        try:
+            grade = (r.json() or {}).get("grade")
+        except ValueError:
+            pass
+    # The public claim is Grade A. If a deployment stops earning it we should
+    # hear it from a machine, not from someone reading the site.
+    check("healthclaw: guardrail grade A", grade == "A", f"grade={grade}")
+
+    # --- terminology labels (#207) -------------------------------------------
+    # Redaction strips every upstream display, so if server-derived labelling
+    # regresses, records silently become "unlabeled record, code X" again and
+    # the agent loses the ability to name anything it reads.
+    r = get(f"{HEALTHCLAW}/r6/fhir/Condition?_count=5", timeout,
+            headers={"X-Tenant-Id": DEMO_TENANT})
+    labelled = 0
+    total = 0
+    if getattr(r, "status_code", None) == 200:
+        try:
+            for entry in (r.json().get("entry") or []):
+                res = entry.get("resource") or {}
+                if res.get("resourceType") != "Condition":
+                    continue
+                total += 1
+                cc = res.get("code") or {}
+                if cc.get("text") or any(c.get("display")
+                                         for c in (cc.get("coding") or [])):
+                    labelled += 1
+        except ValueError:
+            pass
+    check("healthclaw: records are readable", total > 0 and labelled == total,
+          f"{labelled}/{total} labelled")
+
+    # --- the consumer app ----------------------------------------------------
+    r = get(f"{CAREAGENTS}/healthz", timeout)
+    body = {}
+    if getattr(r, "status_code", None) in (200, 503):
+        try:
+            body = r.json() or {}
+        except ValueError:
+            pass
+    # /healthz round-trips the database, so this catches an app that booted but
+    # cannot reach its store — the state a load balancer must not route into.
+    check("careagents: ready (db reachable)",
+          getattr(r, "status_code", None) == 200 and body.get("accounts") is True,
+          f"status={getattr(r, 'status_code', r)} accounts={body.get('accounts')}")
+
+    r = get(f"{CAREAGENTS}/", timeout)
+    html = getattr(r, "text", "") or ""
+    check("careagents: landing renders",
+          getattr(r, "status_code", None) == 200 and "/auth" in html,
+          str(getattr(r, "status_code", r)))
+
+    # The sign-in page is the front door; #181 broke exactly this and nothing
+    # noticed. Codes are 8 digits — an input that cannot hold 8 is a dead door.
+    r = get(f"{CAREAGENTS}/auth", timeout)
+    html = getattr(r, "text", "") or ""
+    ok_auth = getattr(r, "status_code", None) == 200 and 'maxlength="8"' in html
+    check("careagents: sign-in accepts an 8-digit code", ok_auth,
+          "maxlength=8 present" if ok_auth else "code input missing or too short")
+
+    # --- MCP servers ---------------------------------------------------------
+    r = get(f"{MCP_LOCKED}/health", timeout)
+    check("mcp (locked): alive", getattr(r, "status_code", None) == 200,
+          str(getattr(r, "status_code", r)))
+
+    # The one non-negotiable on this server: an unauthenticated caller must be
+    # REFUSED. 401/403 is the pass. Anything that looks like service — a 200,
+    # or a 405 meaning "wrong method, but you're welcome" — is a failure,
+    # because it would mean the real tool surface had been left open.
+    r = get(f"{MCP_LOCKED}/mcp", timeout)
+    code = getattr(r, "status_code", None)
+    check("mcp (locked): refuses unauthenticated callers", code in (401, 403),
+          f"unauthenticated /mcp -> {code}")
+
+    # The public demo is meant to answer without a token; it is pinned to a
+    # synthetic tenant server-side. Alive is all we assert here.
+    r = get(f"{MCP_DEMO}/health", timeout)
+    check("mcp (public demo): alive", getattr(r, "status_code", None) == 200,
+          str(getattr(r, "status_code", r)))
+
+    failed = [n for n, ok, _ in results if not ok]
+    print()
+    if failed:
+        print(f"{R}{len(failed)} check(s) failing:{X} " + ", ".join(failed))
+        return 1
+    print(f"{G}all {len(results)} checks passing{X}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--timeout", type=float, default=20.0)
+    ap.add_argument("--json", action="store_true",
+                    help="emit machine-readable results")
+    args = ap.parse_args()
+
+    code = run(args.timeout)
+    if args.json:
+        print(json.dumps({"ok": code == 0,
+                          "checks": [{"name": n, "ok": o, "detail": d}
+                                     for n, o, d in results]}, indent=2))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #230. First Phase 2 item.

## The problem

**There was no scheduled verification of production at all** — zero `schedule:` triggers in the repo. #181 (sign-in input truncating 8-digit codes to 6) broke UI login for every user and was found by hand. The MCP server fail-closed and stayed down until someone noticed.

## What it checks, every 6 hours

- HealthClaw alive, and **still earning Grade A** — the public claim, verified by a machine rather than by someone reading the site
- **Records are readable** — server-derived labels present, so a #207 regression alarms instead of the agent quietly losing the ability to name anything
- CareAgents ready (round-trips the DB, catching an app that booted but can't reach its store)
- Landing and sign-in render, and **the code input can hold 8 digits** — the exact #181 regression
- **The locked MCP refuses unauthenticated callers** — 401/403 passes, a 200 *fails*, since anything resembling service means the real tool surface was left open
- The public demo MCP is alive

Failures open or update **one pinned issue**, and close it on recovery — the channel a solo maintainer actually reads, and no stale alarm left sitting open.

## One correction to #230

The issue assumed `scripts/careagents_smoke.py` could simply be put on a cron. **It can't** — it drives the pre-accounts API (anonymous `POST /start`, chat without an agent id) and fails on its first check against the live site. Scheduling it as-is would have produced a permanently red monitor everyone learns to ignore. Its docstring now says so; it's kept rather than deleted because the journey it encodes — including the allergy-attestation gate — is worth porting.

## Stated scope, not implied

Every check is unauthenticated **on purpose**, so this needs no credentials and no synthetic account to keep alive. It therefore does **not** cover the signed-in journey; that needs the runner to read a one-time code from an inbox, which is real work and a real decision — tracked in **#243** rather than faked here.

A monitor that quietly checks less than it appears to is worse than one with a narrow, stated scope.

**Verified against live production: 9/9 passing.** Suite 1554 passed, ruff clean, workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)