### PR TITLE
feat(careagents): durable per-account daily turn cap — rebuilt on current main

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -25,7 +25,8 @@ from webauthn.helpers.structs import (AuthenticatorSelectionCriteria,
 
 from careagents import mail
 from careagents.models import (Account, Agent, Connection, EmailToken, Passkey,
-                               Surface, make_engine, make_session_factory, now)
+                               Surface, UsageDay, make_engine,
+                               make_session_factory, now)
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +253,28 @@ class AccountService:
             s.add(c)
             s.flush()
             return c.id
+
+    def claim_daily_turn(self, account_id: str, cap: int) -> tuple[bool, int]:
+        """Count one chat turn against today's cap. Returns (allowed, used).
+
+        Durable and shared, unlike the in-process burst limiter — a restart or
+        a second gunicorn worker must not hand the account a fresh allowance,
+        because every turn costs the operator real money.
+        """
+        from datetime import datetime, timezone
+        day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        with self.session() as s:
+            row = (s.query(UsageDay)
+                   .filter_by(account_id=account_id, day=day).first())
+            if row is None:
+                row = UsageDay(account_id=account_id, day=day, turns=0)
+                s.add(row)
+                s.flush()
+            used = int(row.turns or 0)
+            if used >= cap:
+                return False, used
+            row.turns = used + 1
+            return True, used + 1
 
     def set_connection_status(self, tenant_id: str, status: str) -> None:
         with self.session() as s:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -455,6 +455,17 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "message must be 1-2000 characters"}), 400
         if not _allow_turn(acct.id):
             return jsonify({"error": "rate_limited"}), 429
+        # Durable daily ceiling — survives restarts and is shared across
+        # workers, so it is the real bound on per-account inference spend.
+        allowed, used = svc.claim_daily_turn(acct.id, cfg.chat_turns_per_day)
+        if not allowed:
+            return jsonify({
+                "error": "daily_limit_reached",
+                "used": used,
+                "limit": cfg.chat_turns_per_day,
+                "message": ("You've reached today's message limit. It resets "
+                            "at midnight UTC."),
+            }), 429
 
         tenant = ctx["tenant"]
         agent = ctx["agent"]

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -84,6 +84,11 @@ class Config:
         # public, unauthenticated site).
         self.chat_turns_per_window = int(e.get("CARE_CHAT_TURNS", "20"))
         self.chat_window_seconds = int(e.get("CARE_CHAT_WINDOW", "600"))
+        # Durable daily ceiling per account. The burst limiter above is
+        # in-process, so it resets on restart and multiplies by gunicorn
+        # worker count; this one is DB-backed and is what actually bounds
+        # what a single account can cost the operator in a day.
+        self.chat_turns_per_day = int(e.get("CARE_CHAT_TURNS_PER_DAY", "200"))
 
         if prod:
             _require("CARE_SESSION_SECRET", self.session_secret,

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -114,6 +114,23 @@ class Surface(Base):
     account = relationship("Account", back_populates="surfaces")
 
 
+class UsageDay(Base):
+    """Per-account daily LLM turn count — a durable spend ceiling.
+
+    The in-process burst limiter bounds bursts, but it resets on restart and
+    is per-worker, so under gunicorn it multiplies by worker count. Inference
+    is billed to the operator, so the daily cap has to live somewhere shared
+    and durable: one row per account per UTC day.
+
+    Counts only — no message content, nothing PHI-adjacent.
+    """
+    __tablename__ = "ca_usage_days"
+    id = Column(String(32), primary_key=True, default=lambda: _uid("use"))
+    account_id = Column(String(32), ForeignKey("ca_accounts.id"), index=True)
+    day = Column(String(10), nullable=False, index=True)   # UTC "YYYY-MM-DD"
+    turns = Column(Integer, default=0)
+
+
 class EmailToken(Base):
     """One-time email code (sign-up verify / new-device login)."""
     __tablename__ = "ca_email_tokens"

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1022,6 +1022,69 @@ def test_delete_requires_a_session(app):
     assert app.test_client().delete("/api/connections/x").status_code == 401
 
 
+# --- daily usage cap (inference spend control) -------------------------------
+
+def test_daily_turn_cap_counts_and_then_refuses(svc, monkeypatch):
+    acct = _make_account(svc, monkeypatch, "cap@example.com")
+    used = [svc.claim_daily_turn(acct.id, cap=3) for _ in range(3)]
+    assert used == [(True, 1), (True, 2), (True, 3)]
+    # Fourth is refused, and the count does not keep climbing past the cap.
+    assert svc.claim_daily_turn(acct.id, cap=3) == (False, 3)
+    assert svc.claim_daily_turn(acct.id, cap=3) == (False, 3)
+
+
+def test_daily_cap_is_per_account(svc, monkeypatch):
+    a = _make_account(svc, monkeypatch, "capa@example.com")
+    b = _make_account(svc, monkeypatch, "capb@example.com")
+    svc.claim_daily_turn(a.id, cap=1)
+    assert svc.claim_daily_turn(a.id, cap=1)[0] is False
+    # A different account is unaffected by the first one's spend.
+    assert svc.claim_daily_turn(b.id, cap=1)[0] is True
+
+
+def test_daily_cap_survives_a_service_restart(tmp_path, monkeypatch):
+    # The whole point of moving this out of process memory: a restart must not
+    # hand the account a fresh allowance. Needs a real file DB — an in-memory
+    # SQLite would be a brand-new database per service instance and would pass
+    # this test for the wrong reason.
+    from careagents.accounts import AccountService
+    db_cfg = Config(env={"CARE_DATABASE_URL": f"sqlite:///{tmp_path}/care.db",
+                         "CARE_RP_ID": "localhost",
+                         "CARE_ORIGIN": "http://localhost",
+                         "OPENAI_API_KEY": "k",
+                         "HEALTHCLAW_MINT_SECRET": "mint-secret"})
+    first = AccountService(db_cfg)
+    acct = _make_account(first, monkeypatch, "restart@example.com")
+    assert first.claim_daily_turn(acct.id, cap=2)[0] is True
+    assert first.claim_daily_turn(acct.id, cap=2)[0] is True
+
+    reborn = AccountService(db_cfg)       # same DB file, new service instance
+    assert reborn.claim_daily_turn(acct.id, cap=2) == (False, 2)
+
+
+def test_chat_refuses_once_the_daily_limit_is_reached(cfg, svc, monkeypatch):
+    from careagents.app import create_app
+    monkeypatch.setattr(cfg, "chat_turns_per_day", 1)
+    app = create_app(config=cfg, client=FakeClient(), accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    monkeypatch.setattr("careagents.app.run_turn",
+                        lambda *a, **k: iter(["ok"]))
+    first = c.post("/api/chat", json={"agent_id": agent, "message": "hi"})
+    assert first.status_code == 200
+
+    second = c.post("/api/chat", json={"agent_id": agent, "message": "again"})
+    assert second.status_code == 429
+    d = second.get_json()
+    assert d["error"] == "daily_limit_reached" and d["limit"] == 1
+    assert "resets" in d["message"].lower()   # tells the user when, not just no
+
+
 # --- consent gate (real records only) ----------------------------------------
 
 def test_real_record_connect_refused_without_consent(app, svc, monkeypatch):


### PR DESCRIPTION
Supersedes #204 (please close it). Same feature, rebuilt on top of Phase 1.

## Why a new PR rather than a merge

#204 was opened before any Phase 1 work and conflicted in `tests/test_careagents.py`. The conflict was nasty: both branches added tests around the same helpers, so git spliced the two test bodies together on shared context lines (`app.config["TESTING"] = True`, `_login(...)`, etc.). Resolving those markers by hand would have been guesswork.

Instead the source changes were reapplied as a patch onto current main — **all four files applied cleanly** — and the four cap tests appended.

## Still needed after Phase 1

#218 bounded the cost of a *single* turn (history trimming + a hard stop on the tool loop). **Nothing bounded how many turns an account can spend in a day.** With advocates about to test on real records, that's the ceiling that matters.

- `claim_daily_turn` is a durable per-account counter in the CareAgents DB — survives restarts, shared across workers. A test pins that using a **real file database**; an in-memory SQLite would be a fresh DB per service instance and would pass for the wrong reason.
- The refusal says *when* the allowance resets rather than only saying no.

## Interaction with Phase 1, checked

Phase 1 added `remember("user", text)` before the SSE stream, so I verified ordering: the cap returns **429 before the question is persisted**, so a refused turn never enters the conversation history.

**1558 passed, 1 skipped.** Ruff (CI-pinned): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)