### PR TITLE
security: bind action approval credentials

### DIFF
--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -152,8 +152,22 @@ class HealthClawClient:
         return r.json()
 
     def confirm_action(self, tenant: str, action_id: str) -> dict:
+        mint = self.http.post(
+            f"{self.actions}/{action_id}/approval-token",
+            headers={"X-Tenant-Id": tenant,
+                     "X-Internal-Secret": self.mint_secret},
+            timeout=self.timeout)
+        token = (mint.json() or {}).get("token") if mint.ok else None
+        if not token:
+            raise HealthClawError(
+                f"approval token mint failed ({mint.status_code})",
+                mint.status_code)
         r = self.http.post(f"{self.actions}/{action_id}/confirm",
-                           headers=self._headers(tenant), timeout=self.timeout)
+                           headers={"X-Tenant-Id": tenant,
+                                    "X-Step-Up-Token": token,
+                                    "X-Agent-Id": "careagents"},
+                           json={"approved_via": "review-page"},
+                           timeout=self.timeout)
         if not r.ok:
             raise HealthClawError(f"confirm failed ({r.status_code})",
                                   r.status_code)

--- a/r6/actions/confirmations.py
+++ b/r6/actions/confirmations.py
@@ -11,6 +11,7 @@ from models import db
 from r6.actions.models import _utcnow
 
 APPROVED_VIA_VALUES = ('telegram', 'dashboard', 'review-page')
+ACTION_APPROVAL_AUDIENCE = 'action-approval'
 
 
 class ActionConfirmation(db.Model):

--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -27,7 +27,8 @@ from flask import Blueprint, jsonify, request
 
 from models import db
 from r6.actions import errors
-from r6.actions.confirmations import (APPROVED_VIA_VALUES,
+from r6.actions.confirmations import (ACTION_APPROVAL_AUDIENCE,
+                                      APPROVED_VIA_VALUES,
                                       consume_confirmation,
                                       issue_confirmation)
 from r6.actions.models import ProposedAction, VALID_KINDS, _utcnow
@@ -38,7 +39,7 @@ from r6.actions.state import transition_action
 from r6.audit import record_audit_event
 from r6.rate_limit import rate_limit_middleware
 from r6.read_auth import authorize_tenant_read
-from r6.stepup import validate_step_up_token
+from r6.stepup import generate_step_up_token, validate_step_up_token
 from r6.telegram_push import notify_tenant
 
 logger = logging.getLogger(__name__)
@@ -428,8 +429,8 @@ def commit_action(action_id):
 @actions_blueprint.route('/<action_id>/confirm', methods=['POST'])
 def confirm_action(action_id):
     """The human's out-of-band Approve — the ONLY place an action executes.
-    Called by the dashboard/Telegram approve handler with the patient's own
-    tenant-bound step-up token. Body optional: {'approved_via': 'dashboard'
+    Called by the dashboard/Telegram approve handler with a single-use token
+    bound to this exact action. Body optional: {'approved_via': 'dashboard'
     | 'telegram'} (default 'dashboard').
 
     Ordering rationale (do not reorder):
@@ -460,12 +461,15 @@ def confirm_action(action_id):
     step_up_token = request.headers.get('X-Step-Up-Token')
     if not step_up_token:
         return _error(401, 'Action confirm requires X-Step-Up-Token header')
-    # consume_nonce: the confirm token is a SINGLE-USE execution credential
-    # (spec v3). Commit validates the same token multi-use (submitting is not
-    # an execution); only the human's Approve spends the nonce, so a captured
-    # token can never authorize a second real-world execution.
-    valid, err = validate_step_up_token(step_up_token, tenant_id,
-                                        consume_nonce=True)
+    # consume_nonce: the action-bound confirm token is a SINGLE-USE execution
+    # credential (spec v3). Commit uses a separate generic write token;
+    # only the human's Approve surface can mint this credential, and confirm
+    # spends it so a captured token cannot authorize another execution.
+    valid, err = validate_step_up_token(
+        step_up_token, tenant_id, consume_nonce=True,
+        require_audience=ACTION_APPROVAL_AUDIENCE,
+        require_operation=action_id,
+    )
     if not valid:
         return _error(401, 'Step-up token rejected: %s' % err)
 
@@ -578,6 +582,49 @@ def confirm_action(action_id):
     # mapping lives in ONE place: _resolve_from_executing().
     result = ex.execute(action)
     return _resolve_from_executing(action, result)
+
+
+@actions_blueprint.route('/<action_id>/approval-token', methods=['POST'])
+def issue_action_approval_token(action_id):
+    """Mint the least-privilege credential used by a human approval surface.
+
+    This endpoint is deliberately separate from the public/demo token mint.
+    Even public tenants must present the server-to-server internal secret, so
+    an agent that can obtain a normal tenant write token cannot mint its own
+    approval credential.
+    """
+    tenant_id = _tenant_or_none()
+    if not tenant_id:
+        return _error(400, 'X-Tenant-Id header is required')
+
+    expected = os.environ.get('INTERNAL_TOKEN_MINT_SECRET', '')
+    provided = request.headers.get('X-Internal-Secret', '')
+    if not expected or not hmac.compare_digest(provided, expected):
+        return _error(403, 'Forbidden')
+
+    action = ProposedAction.query.filter_by(
+        id=action_id, tenant_id=tenant_id).first()
+    if action is None:
+        return _error(404, 'Unknown action')
+    if action.status != 'awaiting_confirmation':
+        return _error(409, 'Action is %s, not awaiting_confirmation'
+                      % action.status)
+    if action.is_expired():
+        return _error(410, 'Approval window lapsed — propose the action again')
+
+    token = generate_step_up_token(
+        tenant_id,
+        agent_id='human-approval',
+        audience=ACTION_APPROVAL_AUDIENCE,
+        operation=action_id,
+    )
+    record_audit_event(
+        'update', resource_type='ProposedAction', resource_id=action.id,
+        agent_id='human-approval', tenant_id=tenant_id,
+        detail='action-bound approval credential issued',
+    )
+    return jsonify({'token': token, 'tenant_id': tenant_id,
+                    'action_id': action_id})
 
 
 @actions_blueprint.route('/<action_id>', methods=['GET'])

--- a/scripts/demo_smoke.py
+++ b/scripts/demo_smoke.py
@@ -17,6 +17,7 @@ and a CI/monitor probe.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 import requests
@@ -40,6 +41,9 @@ def main() -> int:
     ap.add_argument("--tenant", default="desktop-demo",
                     help="public demo tenant")
     ap.add_argument("--timeout", type=float, default=20.0)
+    ap.add_argument(
+        "--mint-secret", default=os.environ.get("INTERNAL_TOKEN_MINT_SECRET"),
+        help="server-to-server secret required to mint the human approval token")
     args = ap.parse_args()
     base, tenant = args.base.rstrip("/"), args.tenant
     s = requests.Session()
@@ -54,14 +58,15 @@ def main() -> int:
     version = r.json().get("version")
     _ok(f"health: {r.json().get('status')} (version {version})")
 
-    # 1. Mint a tenant-bound step-up credential (the human's approval key).
+    # 1. Mint the tenant-bound write credential used for commit/review. Human
+    #    approval gets a separate, action-bound token at step 7.
     r = s.post(f"{fhir}/internal/step-up-token", json={"tenant_id": tenant},
                headers={"X-Tenant-Id": tenant}, timeout=args.timeout)
     token = (r.json() or {}).get("token") if r.ok else None
     if not token:
         _fail(f"step-up token mint {r.status_code}: {r.text[:120]}")
     h = {"X-Tenant-Id": tenant, "X-Step-Up-Token": token}
-    _ok("minted step-up token")
+    _ok("minted tenant write token")
 
     # 2. The agent PROPOSES filling the intake — it does not submit it.
     body = {"kind": "form-fill", "payload": {
@@ -110,7 +115,21 @@ def main() -> int:
 
     # 7. Out-of-band confirm EXECUTES: reviewed answers → PDF →
     #    DocumentReference → signed link.
-    r = s.post(f"{actions}/{aid}/confirm", headers=h, timeout=args.timeout)
+    if not args.mint_secret:
+        _fail("--mint-secret (or INTERNAL_TOKEN_MINT_SECRET) is required "
+              "for the human approval step")
+    r = s.post(
+        f"{actions}/{aid}/approval-token",
+        headers={"X-Tenant-Id": tenant,
+                 "X-Internal-Secret": args.mint_secret},
+        timeout=args.timeout)
+    approval_token = (r.json() or {}).get("token") if r.ok else None
+    if not approval_token:
+        _fail(f"approval token mint {r.status_code}: {r.text[:120]}")
+    approval_headers = {"X-Tenant-Id": tenant,
+                        "X-Step-Up-Token": approval_token}
+    r = s.post(f"{actions}/{aid}/confirm", headers=approval_headers,
+               timeout=args.timeout)
     data = r.json() if r.ok else {}
     import json as _json
     outcome = _json.loads(data.get("outcome_summary") or "{}")

--- a/tests/actions/test_confirm_is_commit.py
+++ b/tests/actions/test_confirm_is_commit.py
@@ -10,7 +10,9 @@ from datetime import datetime, timedelta, timezone
 
 from models import db
 from r6.actions import errors
+from r6.actions.confirmations import ACTION_APPROVAL_AUDIENCE
 from r6.actions.models import ProposedAction
+from r6.stepup import generate_step_up_token
 
 
 PROPOSE_BODY = {
@@ -39,9 +41,19 @@ def _commit(client, auth_headers, action_id):
                        headers=auth_headers)
 
 
-def _confirm(client, auth_headers, action_id, body=None):
+def _approval_headers(auth_headers, action_id):
+    headers = dict(auth_headers)
+    headers['X-Step-Up-Token'] = generate_step_up_token(
+        headers['X-Tenant-Id'], audience=ACTION_APPROVAL_AUDIENCE,
+        operation=action_id)
+    return headers
+
+
+def _confirm(client, auth_headers, action_id, body=None, headers=None):
     return client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=auth_headers, json=body or {})
+                       headers=headers or _approval_headers(auth_headers,
+                                                            action_id),
+                       json=body or {})
 
 
 # ---------------------------------------------------------------------------
@@ -113,10 +125,7 @@ def test_confirm_executes_exactly_once(client, tenant_headers, auth_headers,
     # (the first token's nonce is consumed by the first confirm — see the
     # replay tests below): the claim is already spent -> 409, and crucially
     # the provider was NOT called again.
-    from r6.stepup import generate_step_up_token
-    fresh = dict(auth_headers)
-    fresh['X-Step-Up-Token'] = generate_step_up_token(
-        tenant_headers['X-Tenant-Id'])
+    fresh = _approval_headers(auth_headers, action_id)
     second = _confirm(client, fresh, action_id)
     assert second.status_code == 409
     assert len(fake_providers) == 1
@@ -130,10 +139,66 @@ def test_confirm_requires_step_up(client, tenant_headers, auth_headers):
     assert resp.status_code == 401
 
 
+def test_approval_token_mint_requires_internal_secret_even_for_public_tenant(
+        client, tenant_headers, auth_headers, monkeypatch):
+    monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', 'human-surface-secret')
+    action_id = _propose(client, tenant_headers)
+    assert _commit(client, auth_headers, action_id).status_code == 202
+
+    missing = client.post('/r6/actions/%s/approval-token' % action_id,
+                          headers=tenant_headers)
+    wrong = client.post(
+        '/r6/actions/%s/approval-token' % action_id,
+        headers={**tenant_headers, 'X-Internal-Secret': 'wrong'})
+    assert missing.status_code == 403
+    assert wrong.status_code == 403
+
+    monkeypatch.delenv('INTERNAL_TOKEN_MINT_SECRET')
+    unconfigured = client.post(
+        '/r6/actions/%s/approval-token' % action_id,
+        headers={**tenant_headers,
+                 'X-Internal-Secret': 'human-surface-secret'})
+    assert unconfigured.status_code == 403
+
+
+def test_human_surface_mints_bound_token_and_confirms(
+        client, tenant_headers, auth_headers, action_registry, fake_providers,
+        monkeypatch):
+    monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', 'human-surface-secret')
+    monkeypatch.setenv('BLAND_AI_API_KEY', 'test-key')
+    action_id = _propose(client, tenant_headers)
+    assert _commit(client, auth_headers, action_id).status_code == 202
+
+    mint = client.post(
+        '/r6/actions/%s/approval-token' % action_id,
+        headers={**tenant_headers,
+                 'X-Internal-Secret': 'human-surface-secret'})
+    assert mint.status_code == 200
+    token = mint.get_json()['token']
+    confirmed = client.post(
+        '/r6/actions/%s/confirm' % action_id,
+        headers={**tenant_headers, 'X-Step-Up-Token': token},
+        json={'approved_via': 'review-page'})
+    assert confirmed.status_code == 200
+    assert len(fake_providers) == 1
+
+
+def test_approval_token_mint_requires_pending_action(
+        client, tenant_headers, monkeypatch):
+    monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', 'human-surface-secret')
+    action_id = _propose(client, tenant_headers)
+    mint = client.post(
+        '/r6/actions/%s/approval-token' % action_id,
+        headers={**tenant_headers,
+                 'X-Internal-Secret': 'human-surface-secret'})
+    assert mint.status_code == 409
+
+
 def test_confirm_before_commit_conflicts(client, tenant_headers, auth_headers,
                                          action_registry, fake_providers):
     action_id = _propose(client, tenant_headers)
-    resp = _confirm(client, auth_headers, action_id)
+    resp = _confirm(client, auth_headers, action_id,
+                    headers=_approval_headers(auth_headers, action_id))
     assert resp.status_code == 409
     assert fake_providers == []
 
@@ -203,8 +268,9 @@ def test_confirm_tenant_isolation(client, tenant_headers, auth_headers,
                                   fake_providers):
     action_id = _propose(client, tenant_headers)
     _commit(client, auth_headers, action_id)
-    resp = client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=other_tenant_headers, json={})
+    resp = client.post(
+        '/r6/actions/%s/confirm' % action_id,
+        headers=_approval_headers(other_tenant_headers, action_id), json={})
     assert resp.status_code == 404
     assert fake_providers == []
 
@@ -236,8 +302,9 @@ def test_confirm_rejects_unknown_approval_channel(client, tenant_headers,
     monkeypatch.setenv('BLAND_AI_API_KEY', 'test-key')
     action_id = _propose(client, tenant_headers)
     _commit(client, auth_headers, action_id)
+    approval = _approval_headers(auth_headers, action_id)
     resp = _confirm(client, auth_headers, action_id,
-                    body={'approved_via': 'carrier-pigeon'})
+                    body={'approved_via': 'carrier-pigeon'}, headers=approval)
     assert resp.status_code == 400
     assert fake_providers == []
     with app.app_context():
@@ -247,7 +314,7 @@ def test_confirm_rejects_unknown_approval_channel(client, tenant_headers,
     # The credential was NOT consumed by the 400 — the SAME token now
     # confirms successfully.
     retry = _confirm(client, auth_headers, action_id,
-                     body={'approved_via': 'dashboard'})
+                     body={'approved_via': 'dashboard'}, headers=approval)
     assert retry.status_code == 200
     assert len(fake_providers) == 1
 
@@ -259,10 +326,7 @@ def test_confirm_rejects_unknown_approval_channel(client, tenant_headers,
 def test_same_token_cannot_confirm_twice(client, tenant_headers, auth_headers,
                                          app, action_registry, fake_providers,
                                          monkeypatch):
-    """Spec v3: /confirm consumes the step-up token's nonce. One token
-    authorizes at most ONE real-world execution — a captured token can't be
-    replayed against a second pending action. (Nonce cache is cleared by the
-    autouse fixture in tests/actions/conftest.py.)"""
+    """An action-bound token is single-use as well as action-specific."""
     monkeypatch.setenv('BLAND_AI_API_KEY', 'test-key')
 
     first_action = _propose(client, tenant_headers)
@@ -270,12 +334,14 @@ def test_same_token_cannot_confirm_twice(client, tenant_headers, auth_headers,
     assert _commit(client, auth_headers, first_action).status_code == 202
     assert _commit(client, auth_headers, second_action).status_code == 202
 
-    first = _confirm(client, auth_headers, first_action)
+    approval = _approval_headers(auth_headers, first_action)
+    first = _confirm(client, auth_headers, first_action, headers=approval)
     assert first.status_code == 200
     assert len(fake_providers) == 1
 
-    # Same token against the OTHER awaiting_confirmation action: replay.
-    second = _confirm(client, auth_headers, second_action)
+    # Same token against the SAME action is rejected as a nonce replay before
+    # the already-spent action state is considered.
+    second = _confirm(client, auth_headers, first_action, headers=approval)
     assert second.status_code == 401
     assert 'already used (replay)' in second.get_json()['error']
     assert len(fake_providers) == 1   # nothing executed
@@ -284,28 +350,41 @@ def test_same_token_cannot_confirm_twice(client, tenant_headers, auth_headers,
         assert row.status == 'awaiting_confirmation'  # still approvable
 
 
-def test_commit_does_not_consume_token_only_confirm_does(
+def test_generic_commit_token_cannot_confirm(
         client, tenant_headers, auth_headers, action_registry,
         fake_providers, monkeypatch):
-    """A token used for commit and then confirm is legitimate: commit
-    validates multi-use (submit is not an execution), confirm consumes."""
+    """An agent's normal write token can submit but cannot self-approve."""
     monkeypatch.setenv('BLAND_AI_API_KEY', 'test-key')
 
-    # propose -> commit (token X) -> confirm (token X): succeeds end-to-end.
     action_id = _propose(client, tenant_headers)
     assert _commit(client, auth_headers, action_id).status_code == 202
+    resp = _confirm(client, auth_headers, action_id, headers=auth_headers)
+    assert resp.status_code == 401
+    assert 'audience mismatch' in resp.get_json()['error']
+    assert fake_providers == []
+
+    # The rejected generic token was not consumed; the separately minted,
+    # action-bound approval credential authorizes exactly this confirmation.
     resp = _confirm(client, auth_headers, action_id)
     assert resp.status_code == 200
     assert len(fake_providers) == 1
 
-    # A NEW action: commit with token X still works (multi-use validation),
-    # but confirm with the now-spent token X is a replay -> 401.
-    new_action = _propose(client, tenant_headers)
-    assert _commit(client, auth_headers, new_action).status_code == 202
-    replay = _confirm(client, auth_headers, new_action)
-    assert replay.status_code == 401
-    assert 'already used (replay)' in replay.get_json()['error']
-    assert len(fake_providers) == 1
+
+def test_action_bound_token_cannot_confirm_a_different_action(
+        client, tenant_headers, auth_headers, action_registry,
+        fake_providers, monkeypatch):
+    monkeypatch.setenv('BLAND_AI_API_KEY', 'test-key')
+    first_action = _propose(client, tenant_headers)
+    second_action = _propose(client, tenant_headers)
+    assert _commit(client, auth_headers, first_action).status_code == 202
+    assert _commit(client, auth_headers, second_action).status_code == 202
+
+    approval = _approval_headers(auth_headers, first_action)
+    wrong_action = _confirm(client, auth_headers, second_action,
+                            headers=approval)
+    assert wrong_action.status_code == 401
+    assert 'operation mismatch' in wrong_action.get_json()['error']
+    assert fake_providers == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/actions/test_form_fill_execute.py
+++ b/tests/actions/test_form_fill_execute.py
@@ -139,10 +139,15 @@ def test_end_to_end_propose_review_confirm_download(client, app, tenant_headers,
     assert review.get_json()['reviewed_qr_id']
 
     # Out-of-band confirm — mirrors tests/actions/test_confirm_is_commit.py::
-    # _confirm (auth_headers carry a valid step-up token; commit/review are
-    # multi-use, confirm consumes the nonce).
+    # _confirm (commit/review use the normal write token; confirm requires a
+    # separately minted action-bound token).
+    from r6.actions.confirmations import ACTION_APPROVAL_AUDIENCE
+    from r6.stepup import generate_step_up_token
+    approval_headers = dict(auth_headers)
+    approval_headers['X-Step-Up-Token'] = generate_step_up_token(
+        tenant, audience=ACTION_APPROVAL_AUDIENCE, operation=action_id)
     confirm = client.post('/r6/actions/%s/confirm' % action_id,
-                         headers=auth_headers, json={})
+                          headers=approval_headers, json={})
     assert confirm.status_code == 200, confirm.get_data(as_text=True)
     assert confirm.get_json()['status'] == 'completed'
 

--- a/tests/test_actions_routes.py
+++ b/tests/test_actions_routes.py
@@ -11,6 +11,16 @@ import json
 from r6.actions.models import ProposedAction
 
 
+def _approval_headers(auth_headers, action_id):
+    from r6.actions.confirmations import ACTION_APPROVAL_AUDIENCE
+    from r6.stepup import generate_step_up_token
+    headers = dict(auth_headers)
+    headers['X-Step-Up-Token'] = generate_step_up_token(
+        headers['X-Tenant-Id'], audience=ACTION_APPROVAL_AUDIENCE,
+        operation=action_id)
+    return headers
+
+
 PROPOSE_BODY = {
     'kind': 'phone-call',
     'payload': {
@@ -152,7 +162,8 @@ def test_commit_then_confirm_executes(client, tenant_headers, auth_headers,
     assert resp.status_code == 202
     assert fake_providers == []
     resp = client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=auth_headers, json={})
+                       headers=_approval_headers(auth_headers, action_id),
+                       json={})
     assert resp.status_code == 200
     assert resp.get_json()['status'] == 'executing'
     assert len(fake_providers) == 1
@@ -216,7 +227,8 @@ def test_confirm_outcome_unknown_maps_to_unknown_status(
 
     monkeypatch.setattr('requests.request', timeout)
     resp = client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=auth_headers, json={})
+                       headers=_approval_headers(auth_headers, action_id),
+                       json={})
     assert resp.status_code == 502
     with app.app_context():
         from models import db
@@ -236,7 +248,8 @@ def test_confirm_4xx_provider_error_is_failed(client, tenant_headers,
 
     monkeypatch.setattr('requests.request', lambda method, url, **kw: _Resp())
     resp = client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=auth_headers, json={})
+                       headers=_approval_headers(auth_headers, action_id),
+                       json={})
     assert resp.status_code == 502
     with app.app_context():
         from models import db
@@ -260,7 +273,8 @@ def test_confirm_5xx_provider_error_is_unknown(client, tenant_headers,
 
     monkeypatch.setattr('requests.request', lambda method, url, **kw: _Resp())
     resp = client.post('/r6/actions/%s/confirm' % action_id,
-                       headers=auth_headers, json={})
+                       headers=_approval_headers(auth_headers, action_id),
+                       json={})
     assert resp.status_code == 502
     with app.app_context():
         from models import db

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -213,6 +213,40 @@ def test_log_message_reports_failure_on_a_non_201():
     assert client.log_message("t-1", "user", "hi") is False
 
 
+def test_confirm_action_mints_action_bound_credential_then_uses_it():
+    import careagents.healthclaw as hcmod
+
+    calls = []
+
+    class _Resp:
+        def __init__(self, body):
+            self.status_code = 200
+            self.ok = True
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    class _HTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            calls.append((url, json, headers))
+            if url.endswith('/approval-token'):
+                return _Resp({'token': 'action-bound-token'})
+            return _Resp({'status': 'completed'})
+
+    client = hcmod.HealthClawClient("http://local", "mint-secret")
+    client.http = _HTTP()
+
+    assert client.confirm_action("tenant-1", "action-1") == {
+        'status': 'completed'}
+    assert calls[0][0].endswith('/r6/actions/action-1/approval-token')
+    assert calls[0][2] == {
+        'X-Tenant-Id': 'tenant-1', 'X-Internal-Secret': 'mint-secret'}
+    assert calls[1][0].endswith('/r6/actions/action-1/confirm')
+    assert calls[1][1] == {'approved_via': 'review-page'}
+    assert calls[1][2]['X-Step-Up-Token'] == 'action-bound-token'
+
+
 def test_a_chat_turn_is_persisted_to_healthclaw_not_careagents(
         cfg, svc, monkeypatch):
     # The transcript is PHI-adjacent, so it belongs behind the guardrails in
@@ -1354,4 +1388,3 @@ def test_unavailable_advisor_refused_not_downgraded(app, svc, monkeypatch):
     r = c.post("/api/agents", json={"name": "Plain", "persona": "calm",
                                     "connection_id": conn})
     assert r.status_code == 200
-


### PR DESCRIPTION
## Summary

- require `aud=action-approval` and `op=<action_id>` on every action confirmation
- add a fail-closed, internal-secret-gated approval-token mint for human surfaces
- update CareAgents and the demo smoke path to mint a fresh bound token immediately before approval
- cover generic-token rejection, cross-action rejection, nonce replay, mint authorization, and the CareAgents wire flow

## Validation

- `uv run pytest -q` — 1,563 passed, 1 skipped
- `uv run ruff check .` — passed
- `uv run mypy` — passed

Closes #211.

Originating Buzz channel: `3272710c-5124-46aa-a1d0-021ccb32f9af`
