### PR TITLE
careagents: add durable conversation identity and isolation

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -4,12 +4,10 @@ Identity model: a signed cookie holds `account_id` after passkey/email login.
 Everything (connections, agents, surfaces) is account-scoped; a foreign id
 reads as 404.
 
-Chat history is DURABLE and lives in HealthClaw, per tenant (#222). What sits
-in process memory here is only a cache of it, rebuilt by load_history() when
-cold — so a restart or an idle eviction costs a round trip, not the
-conversation. Deploy with ONE gunicorn worker (threads for concurrency): the
-cache is process-local, so a second worker would serve some turns from an
-empty one.
+Chat history is DURABLE and lives in HealthClaw, per conversation (#222/#247).
+What sits in process memory here is only a per-turn working copy refreshed by
+load_history(). Redis serializes turns in one conversation across workers; the database
+idempotency key is the final defense against duplicate inbound delivery.
 
 No PHI is stored here — health data lives in HealthClaw tenants behind the
 guardrail layer; careagents holds identity + pointers only.
@@ -20,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+import uuid
 from collections import defaultdict, deque
 from functools import wraps
 from threading import Lock
@@ -32,6 +31,7 @@ from careagents.accounts import (AccountService, AuthError, MailError,
 from careagents import advisors, connectors
 from careagents.agent import run_turn, run_turn_to_message
 from careagents.config import Config
+from careagents.conversation_locks import ConversationLockError, ConversationTurnLocks
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
 
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 # strongest privacy control in the one place people read carefully.
 CONSENT_VERSION = "2026-08-01"
 
-# In-memory conversation bounds. One worker holds every live chat, so these
-# cap memory and keep a long-running process from degrading (#218).
+# In-memory conversation bounds. Each worker caches the chats it serves, so
+# these cap memory and keep a long-running process from degrading (#218).
 MAX_LIVE_CONVERSATIONS = 200
 CONVERSATION_IDLE_SECONDS = 6 * 3600
 
@@ -66,27 +66,36 @@ def create_app(config: Config | None = None,
 
     histories: dict[str, list] = defaultdict(list)
     hist_lock = Lock()
+    turn_locks = ConversationTurnLocks(
+        cfg.redis_url, production=cfg.app_env == "production")
     turns: dict[str, deque] = defaultdict(deque)
     # Last time each conversation was touched, so idle ones can be released.
     # Without this every tenant that ever chatted keeps its full transcript in
     # memory for the life of the process.
     hist_seen: dict[str, float] = {}
 
-    def load_history(tenant: str) -> list:
-        """The in-memory conversation, rehydrated from HealthClaw if cold.
+    def conversation_key(tenant: str, conversation_id: str) -> str:
+        return f"{tenant}:{conversation_id}"
 
-        Process memory is a cache, not the record. Deploys, restarts and idle
-        eviction all empty it, and before this the agent simply forgot the
-        person — a strange trait for a product promising a *persistent* health
-        agent. Call under hist_lock.
+    def load_history(tenant: str, conversation_id: str,
+                     agent_id: str) -> list:
+        """Refresh the per-turn working history from durable HealthClaw state.
+
+        A worker may have served this thread earlier and then gone stale while
+        another worker handled a turn. Reloading after the shared turn lock is
+        acquired prevents that stale cache from dropping cross-worker or
+        cross-surface messages.
         """
-        history = histories[tenant]
-        if not history:
-            history.extend(hc.recent_messages(tenant))
-        touch_history(tenant)
+        key = conversation_key(tenant, conversation_id)
+        loaded = hc.recent_messages(
+            tenant, conversation_id=conversation_id, agent_id=agent_id)
+        with hist_lock:
+            history = histories[key]
+            history[:] = loaded
+        touch_history(key)
         return history
 
-    def touch_history(tenant: str) -> None:
+    def touch_history(key: str) -> None:
         """Mark a conversation live; release idle ones once we're holding many.
 
         Deliberately simple: only sweeps when the map is already large, so the
@@ -94,14 +103,14 @@ def create_app(config: Config | None = None,
         lossy — a dropped conversation reloads from HealthClaw on next use.
         """
         seen_at = time.time()
-        hist_seen[tenant] = seen_at
-        if len(histories) <= MAX_LIVE_CONVERSATIONS:
-            return
-        for other, last in list(hist_seen.items()):
-            if other != tenant and seen_at - last > CONVERSATION_IDLE_SECONDS:
-                histories.pop(other, None)
-                turns.pop(other, None)
-                hist_seen.pop(other, None)
+        with hist_lock:
+            hist_seen[key] = seen_at
+            if len(histories) <= MAX_LIVE_CONVERSATIONS:
+                return
+            for other, last in list(hist_seen.items()):
+                if other != key and seen_at - last > CONVERSATION_IDLE_SECONDS:
+                    histories.pop(other, None)
+                    hist_seen.pop(other, None)
 
     # --- auth plumbing -------------------------------------------------------
 
@@ -429,11 +438,16 @@ def create_app(config: Config | None = None,
         if not ctx:
             return redirect(url_for("home"))
         p = PERSONAS.get(ctx["agent"]["persona"], PERSONAS[DEFAULT_PERSONA])
+        conversation_id = hc.conversation_id(agent_id)
         # Show the conversation they actually had. Rendering only the canned
         # greeting made every return visit look like a first visit.
         return render_template("chat.html", me=ctx["agent"], persona=p,
                                agent_id=agent_id,
-                               past=hc.recent_messages(ctx["tenant"], limit=30))
+                               conversation_id=conversation_id,
+                               past=hc.recent_messages(
+                                   ctx["tenant"], limit=30,
+                                   conversation_id=conversation_id,
+                                   agent_id=agent_id))
 
     # --- chat API (SSE), scoped to the account's agent -----------------------
 
@@ -475,36 +489,64 @@ def create_app(config: Config | None = None,
 
         tenant = ctx["tenant"]
         agent = ctx["agent"]
+        conversation_id = (body.get("conversation_id")
+                           or hc.conversation_id(agent["id"]))
+        request_id = str(body.get("request_id") or uuid.uuid4())
+        if not 1 <= len(conversation_id) <= 128:
+            return jsonify({"error": "invalid conversation_id"}), 400
+        if not 1 <= len(request_id) <= 128:
+            return jsonify({"error": "invalid request_id"}), 400
         sysprompt = system_prompt(agent["name"], agent["persona"],
                                   agent.get("advisor"))
 
-        def remember(role, body):
+        def remember(role, message, reply_to=None):
             """Best-effort persist. Losing the transcript is bad; failing the
             conversation in front of the person is worse."""
             try:
-                hc.log_message(tenant, role, body, agent["id"])
+                hc.log_message(
+                    tenant, role, message, agent["id"], conversation_id,
+                    surface="web", reply_to=reply_to)
             except Exception:  # noqa: BLE001
                 logger.warning("chat turn not persisted for %s", tenant)
 
-        # Record the question before streaming the answer: they definitely
-        # asked it, even if they close the tab before the reply finishes.
-        remember("user", text)
-
         def stream():
-            with hist_lock:
-                history = load_history(tenant)
-            reply = []
             try:
-                for event in run_turn(cfg, hc, tenant, sysprompt,
-                                      history, text):
-                    if event.get("type") == "text" and event.get("text"):
-                        reply.append(event["text"])
-                    yield f"data: {json.dumps(event)}\n\n"
+                key = conversation_key(tenant, conversation_id)
+                with turn_locks.hold(key):
+                    # Rehydrate BEFORE claiming the inbound row. run_turn()
+                    # appends the current prompt exactly once to this list.
+                    history = load_history(
+                        tenant, conversation_id, agent["id"])
+                    created, user_message_id = hc.claim_inbound_message(
+                        tenant, text, agent["id"], conversation_id,
+                        "web", request_id)
+                    if created is None:
+                        yield ('data: {"type": "error", "text": '
+                               '"I could not save this message safely. '
+                               'Please retry."}\n\n')
+                        yield 'data: {"type": "done"}\n\n'
+                        return
+                    if not created:
+                        yield ('data: {"type": "duplicate", "request_id": '
+                               f'{json.dumps(request_id)}}}\n\n')
+                        yield 'data: {"type": "done"}\n\n'
+                        return
+
+                    reply = []
+                    for event in run_turn(cfg, hc, tenant, sysprompt,
+                                          history, text):
+                        if event.get("type") == "text" and event.get("text"):
+                            reply.append(event["text"])
+                        yield f"data: {json.dumps(event)}\n\n"
+                    if reply:
+                        remember("assistant", "\n\n".join(reply),
+                                 reply_to=user_message_id)
+            except ConversationLockError:
+                yield ('data: {"type": "error", "text": '
+                       '"This conversation is busy. Please retry shortly."}\n\n')
             except Exception:  # noqa: BLE001
                 yield ('data: {"type": "error", "text": '
                        '"Something went wrong on our side."}\n\n')
-            if reply:
-                remember("assistant", "\n\n".join(reply))
             yield 'data: {"type": "done"}\n\n'
 
         return Response(stream(), mimetype="text/event-stream",
@@ -689,21 +731,33 @@ def create_app(config: Config | None = None,
                                      "Try again in a bit."}), 200
         tenant = ctx["tenant"]
         agent = ctx["agent"]
+        conversation_id = (body.get("conversation_id")
+                           or hc.conversation_id(agent["id"]))
+        request_id = str(body.get("request_id") or uuid.uuid4())
         sysprompt = system_prompt(agent["name"], agent["persona"],
                                   agent.get("advisor"))
-        with hist_lock:
-            history = load_history(tenant)
         try:
-            reply = run_turn_to_message(cfg, hc, tenant, sysprompt, history,
-                                        text, origin=cfg.origin,
-                                        agent_id=agent["id"])
+            key = conversation_key(tenant, conversation_id)
+            with turn_locks.hold(key):
+                history = load_history(
+                    tenant, conversation_id, agent["id"])
+                created, user_message_id = hc.claim_inbound_message(
+                    tenant, text, agent["id"], conversation_id,
+                    "imessage", request_id)
+                if created is None:
+                    return jsonify({"error": "message store unavailable"}), 503
+                if not created:
+                    return jsonify({"duplicate": True, "reply": ""}), 200
+                reply = run_turn_to_message(
+                    cfg, hc, tenant, sysprompt, history, text,
+                    origin=cfg.origin, agent_id=agent["id"])
+                hc.log_message(
+                    tenant, "assistant", reply, agent["id"], conversation_id,
+                    surface="imessage", reply_to=user_message_id)
+        except ConversationLockError:
+            return jsonify({"error": "conversation busy"}), 409
         except Exception:  # noqa: BLE001
             reply = "Something went wrong on our side. Please try again."
-        else:
-            # Same store as the web surface, so a conversation started in
-            # Telegram continues on the web and vice versa.
-            hc.log_message(tenant, "user", text, agent["id"])
-            hc.log_message(tenant, "assistant", reply, agent["id"])
         return jsonify({"reply": reply})
 
     # --- trust + ops ---------------------------------------------------------

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -84,6 +84,10 @@ class Config:
         # public, unauthenticated site).
         self.chat_turns_per_window = int(e.get("CARE_CHAT_TURNS", "20"))
         self.chat_window_seconds = int(e.get("CARE_CHAT_WINDOW", "600"))
+        # Shared serialization for turns in the same durable conversation.
+        # A single development worker can fall back to a local lock; production
+        # deployments should provide Redis before increasing worker count.
+        self.redis_url = e.get("REDIS_URL", "")
         # Durable daily ceiling per account. The burst limiter above is
         # in-process, so it resets on restart and multiplies by gunicorn
         # worker count; this one is DB-backed and is what actually bounds
@@ -105,6 +109,8 @@ class Config:
                     "ANTHROPIC_OAUTH_TOKEN preferred, OPENAI_API_KEY fallback)")
             _require("RESEND_API_KEY", self.resend_api_key,
                      "email verification codes require a transactional sender")
+            _require("REDIS_URL", self.redis_url,
+                     "conversation turns must serialize across workers")
             # SQLite is single-writer and file-local: it does not survive a
             # host rebuild, cannot be backed up consistently while running,
             # and serialises concurrent users. Fine for one tester, wrong for

--- a/careagents/conversation_locks.py
+++ b/careagents/conversation_locks.py
@@ -1,0 +1,85 @@
+"""Per-conversation turn serialization.
+
+Redis is the cross-worker lock in production. A process-local lock remains the
+development/test fallback and also prevents duplicate work inside one worker.
+Lock keys contain only a SHA-256 digest, never tenant or conversation text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from contextlib import contextmanager
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationLockError(RuntimeError):
+    pass
+
+
+class ConversationTurnLocks:
+    def __init__(self, redis_url: str = "", production: bool = False):
+        self._guard = Lock()
+        self._local: dict[str, tuple[Lock, int]] = {}
+        self._production = production
+        self._redis = None
+        if redis_url:
+            import redis
+            self._redis = redis.Redis.from_url(redis_url, decode_responses=True)
+
+    def _local_lock(self, key: str) -> Lock:
+        with self._guard:
+            lock, users = self._local.get(key, (Lock(), 0))
+            self._local[key] = (lock, users + 1)
+            return lock
+
+    def _release_local(self, key: str, lock: Lock) -> None:
+        with self._guard:
+            current, users = self._local[key]
+            if current is lock and users == 1:
+                self._local.pop(key)
+            else:
+                self._local[key] = (current, users - 1)
+
+    @staticmethod
+    def _redis_key(key: str) -> str:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return f"healthclaw:careagents:conversation-lock:{digest}"
+
+    @contextmanager
+    def hold(self, key: str):
+        local = self._local_lock(key)
+        try:
+            with local:
+                distributed = None
+                if self._redis is not None:
+                    try:
+                        distributed = self._redis.lock(
+                            self._redis_key(key), timeout=600,
+                            blocking_timeout=30)
+                        if not distributed.acquire(blocking=True):
+                            raise ConversationLockError(
+                                "conversation is busy; retry shortly")
+                    except ConversationLockError:
+                        raise
+                    except Exception as exc:  # noqa: BLE001 - Redis errors vary
+                        if self._production:
+                            raise ConversationLockError(
+                                "shared conversation lock is unavailable") from exc
+                        logger.warning(
+                            "Redis conversation lock unavailable; using local lock")
+                        distributed = None
+                try:
+                    yield
+                finally:
+                    if distributed is not None:
+                        try:
+                            distributed.release()
+                        except Exception as exc:  # noqa: BLE001 - Redis errors vary
+                            logger.error(
+                                "could not release conversation lock: %s",
+                                type(exc).__name__)
+        finally:
+            self._release_local(key, local)

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -274,45 +274,86 @@ class HealthClawClient:
     # changed; replaying them as history would let a stale reading masquerade
     # as current truth. On a cold start the agent re-reads instead.
 
-    def log_message(self, tenant: str, role: str, text: str,
-                    agent_id: str | None = None) -> bool:
-        """Append one turn. Returns False on failure rather than raising:
-        losing a transcript must never break the conversation in progress.
+    @staticmethod
+    def conversation_id(agent_id: str) -> str:
+        """Stable default thread shared by every surface for one agent."""
+        return f"careagents:{agent_id}"
 
-        `agent_id` travels in metadata, NOT in the endpoint's own agent_id
-        field. Those are different namespaces: that field is validated against
-        HealthClaw's command-center agent registry, and a CareAgents agent id
-        is not in it, so sending one is rejected with 400 and — because this
-        method is best-effort — the turn is dropped silently. The conversation
-        is scoped by tenant anyway, which is how CareAgents keys its own
-        history.
-        """
+    def _post_message(self, tenant: str, role: str, text: str,
+                      agent_id: str | None = None,
+                      conversation_id: str | None = None,
+                      surface: str = "web",
+                      request_id: str | None = None,
+                      reply_to: str | None = None) -> tuple[int | None, dict | None]:
         try:
             r = self.http.post(
                 f"{self.base}/command-center/api/conversations",
                 json={"tenant_id": tenant, "role": role, "text": text,
-                      "channel": "web",
+                      "agent_id": agent_id,
+                      "conversation_id": conversation_id,
+                      "surface": surface,
+                      "request_id": request_id,
+                      "reply_to": reply_to,
                       "metadata": {"careagents_agent_id": agent_id}},
                 headers={"X-Tenant-Id": tenant,
                          "X-Step-Up-Token": self.mint_token(tenant)},
                 timeout=self.timeout)
-            if r.status_code != 201:
-                # Log it: a silent False is how the namespace mismatch above
-                # stayed invisible until acceptance testing.
-                logger.warning("chat turn rejected for %s: HTTP %s",
-                               tenant, r.status_code)
-                return False
-            return True
-        except (requests.RequestException, HealthClawError):
+            body = r.json() if r.status_code in (200, 201) else None
+            return r.status_code, body
+        except (requests.RequestException, HealthClawError, ValueError,
+                AttributeError):
             logger.warning("could not persist a chat turn for %s", tenant)
-            return False
+            return None, None
 
-    def recent_messages(self, tenant: str, limit: int = 20) -> list[dict]:
+    def claim_inbound_message(self, tenant: str, text: str, agent_id: str,
+                              conversation_id: str, surface: str,
+                              request_id: str) -> tuple[bool | None, str | None]:
+        """Create an inbound turn once.
+
+        Returns ``(True, id)`` when created, ``(False, id)`` on an idempotent
+        replay, and ``(None, None)`` when durable storage is unavailable.
+        """
+        status, body = self._post_message(
+            tenant, "user", text, agent_id, conversation_id, surface,
+            request_id=request_id)
+        if status not in (200, 201) or not body:
+            if status is not None:
+                logger.warning("chat turn rejected for %s: HTTP %s",
+                               tenant, status)
+            return None, None
+        return status == 201, body.get("id")
+
+    def log_message(self, tenant: str, role: str, text: str,
+                    agent_id: str | None = None,
+                    conversation_id: str | None = None,
+                    surface: str = "web",
+                    reply_to: str | None = None) -> bool:
+        """Append one turn. Returns False on failure rather than raising:
+        losing a transcript must never break the conversation in progress.
+
+        The command-center API treats ``agent_id`` as an opaque tenant-scoped
+        identity, so CareAgents can preserve its own agent UUID explicitly.
+        """
+        status, _body = self._post_message(
+            tenant, role, text, agent_id, conversation_id, surface,
+            reply_to=reply_to)
+        if status not in (200, 201):
+            if status is not None:
+                logger.warning("chat turn rejected for %s: HTTP %s",
+                               tenant, status)
+            return False
+        return True
+
+    def recent_messages(self, tenant: str, limit: int = 20,
+                        conversation_id: str | None = None,
+                        agent_id: str | None = None) -> list[dict]:
         """Oldest-first [{role, text}] for rehydrating a conversation."""
         try:
             r = self.http.get(
                 f"{self.base}/command-center/api/conversations",
-                params={"limit": limit, "full": "1", "tenant": tenant},
+                params={"limit": limit, "full": "1", "tenant": tenant,
+                        "conversation_id": conversation_id,
+                        "agent_id": agent_id},
                 headers={"X-Tenant-Id": tenant,
                          "X-Step-Up-Token": self.mint_token(tenant)},
                 timeout=self.timeout)

--- a/careagents/static/chat.js
+++ b/careagents/static/chat.js
@@ -2,6 +2,7 @@
    typewriter render. No frameworks. */
 (function () {
   const AGENT = window.CARE_AGENT || "";
+  const CONVERSATION = window.CARE_CONVERSATION || "";
   const log = document.getElementById("log");
   const box = document.getElementById("box");
   const composer = document.getElementById("composer");
@@ -107,12 +108,17 @@
     addUser(text);
     box.value = "";
     const typing = addTyping();
+    const requestId = (window.crypto && window.crypto.randomUUID)
+      ? window.crypto.randomUUID()
+      : Date.now().toString(36) + "-" + Math.random().toString(36).slice(2);
 
     try {
       const resp = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text, agent_id: AGENT }),
+        body: JSON.stringify({ message: text, agent_id: AGENT,
+                               conversation_id: CONVERSATION,
+                               request_id: requestId }),
       });
       if (resp.status === 429) {
         typing.remove();
@@ -143,6 +149,7 @@
           else if (ev.type === "card" && ev.kind === "pdf")
             addPdfCard(ev.url);
           else if (ev.type === "text") { typing.remove(); addAgentText(ev.text); }
+          else if (ev.type === "duplicate") { typing.remove(); }
           else if (ev.type === "error") { typing.remove(); addAgentText("⚠️ " + ev.text); }
         }
       }

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -50,6 +50,9 @@
     <button class="btn-primary" id="send" type="submit">Send</button>
   </form>
 </main>
-<script>window.CARE_AGENT = {{ agent_id|tojson }};</script>
+<script>
+window.CARE_AGENT = {{ agent_id|tojson }};
+window.CARE_CONVERSATION = {{ conversation_id|tojson }};
+</script>
 <script src="{{ url_for('static', filename='chat.js') }}"></script>
 {% endblock %}

--- a/careagents/wsgi.py
+++ b/careagents/wsgi.py
@@ -1,7 +1,7 @@
 """WSGI entry point: gunicorn 'careagents.wsgi:app'.
 
-Run with ONE worker (threads for concurrency) — chat history is
-process-local. See deploy/careagents/careagents.service.
+Conversation turns use a Redis-backed distributed lock when ``REDIS_URL`` is
+configured, with a process-local fallback for single-worker development.
 """
 
 from careagents.app import create_app

--- a/docs/runbooks/conversation-identity.md
+++ b/docs/runbooks/conversation-identity.md
@@ -1,0 +1,59 @@
+# Conversation identity and migration
+
+HealthClaw stores each chat turn under a durable, tenant-owned
+`conversation_id`. CareAgents uses `careagents:<agent_id>` as the stable default,
+so web, Telegram, and iMessage can resume the same thread for that agent without
+sharing history with another agent attached to the same record connection.
+
+## Caller contract
+
+- Send the same `conversation_id` on every turn that belongs to one thread.
+- Send the CareAgents agent UUID as `agent_id`. HealthClaw treats it as an opaque,
+  tenant-scoped identity rather than a command-center registry key.
+- Send a stable `request_id` for every inbound delivery. A retry returns HTTP 200
+  with `idempotent_replay: true` and the original message ID; a new claim returns
+  HTTP 201. Never run inference or a tool after an idempotent replay.
+- Set `surface` to `web`, `telegram`, `imessage`, `api`, or the originating
+  adapter. Set an assistant message's `reply_to` to the claimed inbound message
+  ID.
+- A conversation cannot change tenants or agents after creation. Attempts return
+  404 for a tenant mismatch and 409 for an agent mismatch.
+
+If an older caller omits `conversation_id`, HealthClaw uses
+`careagents:<agent_id>` when an agent is present, otherwise
+`legacy:<tenant_id>`. Explicit IDs are preferred.
+
+## Deployment and backfill
+
+Migration `0004_conversation_identity` creates `cc_conversations`, adds thread,
+request, and reply fields to messages, and adds a unique database constraint on
+`(tenant_id, conversation_id, request_id)`. Existing tenant-wide messages are
+preserved in one compatibility thread named `legacy:<tenant_id>`; no transcript
+rows are discarded.
+
+Run the normal migration command before starting web processes:
+
+```bash
+uv run flask --app main init-db
+```
+
+CareAgents production also requires `REDIS_URL`. Redis serializes a conversation
+across workers while the database uniqueness constraint remains the final
+idempotency boundary. Development can run without Redis and uses a process-local
+lock.
+
+After deployment, verify that every message has a conversation and that no
+duplicate request keys exist:
+
+```sql
+SELECT COUNT(*) FROM cc_conversation_messages WHERE conversation_id IS NULL;
+
+SELECT tenant_id, conversation_id, request_id, COUNT(*)
+FROM cc_conversation_messages
+WHERE request_id IS NOT NULL
+GROUP BY tenant_id, conversation_id, request_id
+HAVING COUNT(*) > 1;
+```
+
+Both queries should return zero rows/counts. Legacy threads remain readable and
+may be archived later only through an explicit retention decision.

--- a/migrations/versions/0004_conversation_identity.py
+++ b/migrations/versions/0004_conversation_identity.py
@@ -1,0 +1,113 @@
+"""Add durable conversation identity and idempotent message metadata.
+
+Revision ID: 0004_conversation_identity
+Revises: 0003_audit_outcome_detail
+
+Existing tenant-wide transcripts are preserved in one documented compatibility
+thread named ``legacy:<tenant_id>``. New callers should always provide an
+explicit conversation ID.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0004_conversation_identity"
+down_revision = "0003_audit_outcome_detail"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # A short-lived pre-Alembic boot path built metadata from the current
+    # checkout. Such a database can contain this complete schema while
+    # an older table still needs 0002's reconciliation. After 0002 repairs that
+    # table, treat the already-current conversation schema as adopted.
+    inspector = sa.inspect(op.get_bind())
+    tables = set(inspector.get_table_names())
+    if "cc_conversations" in tables:
+        message_columns = {
+            column["name"]
+            for column in inspector.get_columns("cc_conversation_messages")
+        }
+        if {"conversation_id", "request_id", "reply_to"} <= message_columns:
+            return
+
+    op.create_table(
+        "cc_conversations",
+        sa.Column("id", sa.String(128), nullable=False),
+        sa.Column("tenant_id", sa.String(64), nullable=False),
+        sa.Column("agent_id", sa.String(64), nullable=True),
+        sa.Column("created_by_surface", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(24), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint(
+            "tenant_id", "id", name="pk_cc_conversations"),
+    )
+    for column in ("agent_id", "created_at", "status", "tenant_id", "updated_at"):
+        op.create_index(
+            f"ix_cc_conversations_{column}", "cc_conversations", [column])
+
+    with op.batch_alter_table("cc_conversation_messages") as batch:
+        batch.add_column(sa.Column("conversation_id", sa.String(128), nullable=True))
+        batch.add_column(sa.Column("request_id", sa.String(128), nullable=True))
+        batch.add_column(sa.Column("reply_to", sa.String(64), nullable=True))
+
+    # One compatibility thread per tenant preserves every pre-migration row.
+    op.execute(sa.text("""
+        INSERT INTO cc_conversations
+            (id, tenant_id, agent_id, created_by_surface, status,
+             created_at, updated_at)
+        SELECT
+            'legacy:' || tenant_id,
+            tenant_id,
+            NULL,
+            'legacy',
+            'active',
+            COALESCE(MIN(created_at), CURRENT_TIMESTAMP),
+            COALESCE(MAX(created_at), CURRENT_TIMESTAMP)
+        FROM cc_conversation_messages
+        GROUP BY tenant_id
+    """))
+    op.execute(sa.text("""
+        UPDATE cc_conversation_messages
+        SET conversation_id = 'legacy:' || tenant_id
+        WHERE conversation_id IS NULL
+    """))
+
+    with op.batch_alter_table(
+            "cc_conversation_messages", recreate="always") as batch:
+        batch.alter_column(
+            "conversation_id", existing_type=sa.String(128), nullable=False)
+        batch.create_foreign_key(
+            "fk_cc_message_conversation", "cc_conversations",
+            ["tenant_id", "conversation_id"], ["tenant_id", "id"],
+            ondelete="CASCADE")
+        batch.create_unique_constraint(
+            "uq_cc_message_request",
+            ["tenant_id", "conversation_id", "request_id"])
+
+    for column in ("conversation_id", "reply_to", "request_id"):
+        op.create_index(
+            f"ix_cc_conversation_messages_{column}",
+            "cc_conversation_messages", [column])
+
+
+def downgrade() -> None:
+    for column in ("request_id", "reply_to", "conversation_id"):
+        op.drop_index(
+            f"ix_cc_conversation_messages_{column}",
+            table_name="cc_conversation_messages")
+    with op.batch_alter_table(
+            "cc_conversation_messages", recreate="always") as batch:
+        batch.drop_constraint("uq_cc_message_request", type_="unique")
+        batch.drop_constraint("fk_cc_message_conversation", type_="foreignkey")
+        batch.drop_column("reply_to")
+        batch.drop_column("request_id")
+        batch.drop_column("conversation_id")
+
+    for column in ("updated_at", "tenant_id", "status", "created_at", "agent_id"):
+        op.drop_index(
+            f"ix_cc_conversations_{column}", table_name="cc_conversations")
+    op.drop_table("cc_conversations")

--- a/r6/command_center/__init__.py
+++ b/r6/command_center/__init__.py
@@ -7,11 +7,12 @@ MCP server, Flask health). Defines a small agent registry so actions can be
 attributed to named health personas (Health Advisor, Fitness & Dietician, etc.).
 """
 
-from r6.command_center.models import ConversationMessage, AgentTask
+from r6.command_center.models import Conversation, ConversationMessage, AgentTask
 from r6.command_center.agents import load_agents, get_agent, agent_for_tool
 from r6.command_center.routes import command_center_blueprint
 
 __all__ = [
+    "Conversation",
     "ConversationMessage",
     "AgentTask",
     "load_agents",

--- a/r6/command_center/models.py
+++ b/r6/command_center/models.py
@@ -1,6 +1,8 @@
 """
 Command center DB models.
 
+Conversation — durable thread identity shared across messaging surfaces.
+
 ConversationMessage — persists chat turns from the Telegram bot (and any
 future channels) so the dashboard can show recent activity by agent.
 
@@ -16,6 +18,47 @@ from datetime import datetime, timezone
 from models import db
 
 
+def default_conversation_id(tenant_id: str, agent_id: str | None = None) -> str:
+    """Stable compatibility thread for callers that do not supply an ID."""
+    return "careagents:%s" % agent_id if agent_id else "legacy:%s" % tenant_id
+
+
+class Conversation(db.Model):
+    """A durable, tenant-owned thread that can span web and messaging surfaces."""
+
+    __tablename__ = "cc_conversations"
+    __table_args__ = (
+        db.PrimaryKeyConstraint(
+            "tenant_id", "id", name="pk_cc_conversations"),
+    )
+
+    id = db.Column(db.String(128), nullable=False)
+    tenant_id = db.Column(db.String(64), nullable=False, index=True)
+    # Opaque identity in the calling system's namespace (for example a
+    # CareAgents agent UUID). It is tenant-scoped, not a command-center FK.
+    agent_id = db.Column(db.String(64), nullable=True, index=True)
+    created_by_surface = db.Column(db.String(32), nullable=False,
+                                   default="unknown")
+    status = db.Column(db.String(24), nullable=False, default="active",
+                       index=True)
+    created_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+    updated_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc), index=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "agent_id": self.agent_id,
+            "created_by_surface": self.created_by_surface,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
 class ConversationMessage(db.Model):
     """
     One turn in an agent conversation. A "turn" is a single user message or
@@ -23,15 +66,30 @@ class ConversationMessage(db.Model):
     """
 
     __tablename__ = "cc_conversation_messages"
+    __table_args__ = (
+        db.ForeignKeyConstraint(
+            ["tenant_id", "conversation_id"],
+            ["cc_conversations.tenant_id", "cc_conversations.id"],
+            name="fk_cc_message_conversation",
+            ondelete="CASCADE",
+        ),
+        db.UniqueConstraint(
+            "tenant_id", "conversation_id", "request_id",
+            name="uq_cc_message_request",
+        ),
+    )
 
     id = db.Column(db.String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
     tenant_id = db.Column(db.String(64), nullable=False, index=True)
+    conversation_id = db.Column(db.String(128), nullable=False, index=True)
     agent_id = db.Column(db.String(64), nullable=True, index=True)
     channel = db.Column(db.String(32), nullable=False, default="unknown")  # telegram, mcp, api, web
     session_id = db.Column(db.String(128), nullable=True, index=True)  # telegram chat_id, mcp session, etc.
     user_id = db.Column(db.String(128), nullable=True)
     role = db.Column(db.String(16), nullable=False)  # user | assistant | system
     text = db.Column(db.Text, nullable=False)
+    request_id = db.Column(db.String(128), nullable=True, index=True)
+    reply_to = db.Column(db.String(64), nullable=True, index=True)
     metadata_json = db.Column(db.Text, nullable=True)  # tool calls, latency, token counts
     created_at = db.Column(
         db.DateTime,
@@ -43,12 +101,15 @@ class ConversationMessage(db.Model):
         return {
             "id": self.id,
             "tenant_id": self.tenant_id,
+            "conversation_id": self.conversation_id,
             "agent_id": self.agent_id,
             "channel": self.channel,
             "session_id": self.session_id,
             "user_id": self.user_id,
             "role": self.role,
             "text": self.text[:500] if self.text else "",
+            "request_id": self.request_id,
+            "reply_to": self.reply_to,
             "truncated": bool(self.text) and len(self.text) > 500,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }

--- a/r6/command_center/projector.py
+++ b/r6/command_center/projector.py
@@ -1,11 +1,8 @@
 """
 Command center projector.
 
-Pure functions that read existing tables + runtime signals and produce
-the JSON shapes the dashboard consumes. No new DB tables are invented —
-everything is derived from AuditEventRecord, R6Resource, FastenConnection,
-FastenJob, WearableConnection, ConversationMessage, AgentTask, plus live
-probes (OpenClaw gateway, MCP server, FHIR_UPSTREAM_URL).
+Pure functions that read durable control-plane tables + runtime signals and
+produce the JSON shapes the dashboard consumes.
 """
 
 from __future__ import annotations
@@ -650,20 +647,24 @@ def agents_status(tenant_id: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def recent_conversations(tenant_id: str, limit: int = 15,
-                         full: bool = False) -> list[dict]:
+                         full: bool = False,
+                         conversation_id: str | None = None,
+                         agent_id: str | None = None) -> list[dict]:
     """Return the most recent chat turns across all agents + channels.
 
     `full` returns untruncated text. The dashboard wants the 500-char preview
     `to_dict()` gives it, but a client rehydrating a conversation needs what
     was actually said — a truncated replay would quietly rewrite history.
     """
-    msgs = (
-        ConversationMessage.query
-        .filter_by(tenant_id=tenant_id)
-        .order_by(desc(ConversationMessage.created_at))
-        .limit(limit)
-        .all()
-    )
+    query = ConversationMessage.query.filter_by(tenant_id=tenant_id)
+    if conversation_id:
+        query = query.filter_by(conversation_id=conversation_id)
+    if agent_id:
+        query = query.filter_by(agent_id=agent_id)
+    msgs = query.order_by(
+        desc(ConversationMessage.created_at),
+        desc(ConversationMessage.id),
+    ).limit(limit).all()
     out = []
     for m in msgs:
         agent = get_agent(m.agent_id) if m.agent_id else None

--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -26,20 +26,30 @@ Routes:
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 
 from flask import (
     Blueprint, jsonify, redirect, render_template, request, session, url_for
 )
+from sqlalchemy.exc import IntegrityError
 
 from models import db
 from r6.command_center import projector, access, gateway
-from r6.command_center.models import ConversationMessage, AgentTask
+from r6.command_center.models import (
+    AgentTask,
+    Conversation,
+    ConversationMessage,
+    default_conversation_id,
+)
 from r6.command_center.agents import load_agents, load_agent_templates, get_agent
 from r6.read_auth import TENANT_SESSION_KEY, authorize_tenant_read
 from r6.stepup import validate_step_up_token
 
 logger = logging.getLogger(__name__)
+
+_CONVERSATION_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 
 command_center_blueprint = Blueprint(
     "command_center",
@@ -213,8 +223,11 @@ def api_conversations_list():
         return err
     limit = min(int(request.args.get("limit", "15")), 100)
     full = request.args.get("full") in ("1", "true")
-    return jsonify(projector.recent_conversations(_tenant(), limit=limit,
-                                                  full=full))
+    return jsonify(projector.recent_conversations(
+        _tenant(), limit=limit, full=full,
+        conversation_id=request.args.get("conversation_id") or None,
+        agent_id=request.args.get("agent_id") or None,
+    ))
 
 
 @command_center_blueprint.route("/api/tasks", methods=["GET"])
@@ -311,10 +324,13 @@ def api_conversations_create():
 
     Body:
         tenant_id: str (required)
-        agent_id: str (optional)
-        channel: str (telegram|mcp|api|web, default 'unknown')
+        conversation_id: str (optional; stable tenant default when omitted)
+        agent_id: str (optional, opaque tenant-scoped identity)
+        channel/surface: str (telegram|mcp|api|web|imessage)
         session_id: str (e.g. telegram chat_id)
         user_id: str
+        request_id: str (optional idempotency key for an inbound user message)
+        reply_to: str (optional parent message id)
         role: str (user|assistant|system, required)
         text: str (required)
         metadata: dict (optional)
@@ -331,8 +347,67 @@ def api_conversations_create():
         return err
 
     agent_id = body.get("agent_id")
-    if agent_id and not get_agent(agent_id):
-        return jsonify({"error": f"unknown agent_id: {agent_id}"}), 400
+    if agent_id is not None and (
+            not isinstance(agent_id, str) or not 1 <= len(agent_id) <= 64):
+        return jsonify({"error": "invalid agent_id"}), 400
+    conversation_id = body.get("conversation_id") or default_conversation_id(
+        tenant_id, agent_id)
+    request_id = body.get("request_id")
+    reply_to = body.get("reply_to")
+    channel = body.get("surface") or body.get("channel", "unknown")
+
+    if not isinstance(conversation_id, str) or not _CONVERSATION_ID.fullmatch(
+            conversation_id):
+        return jsonify({"error": "invalid conversation_id"}), 400
+    if request_id is not None and (
+            not isinstance(request_id, str)
+            or not _REQUEST_ID.fullmatch(request_id)):
+        return jsonify({"error": "invalid request_id"}), 400
+    if role not in ("user", "assistant", "system"):
+        return jsonify({"error": "role must be user, assistant, or system"}), 400
+    if not isinstance(text, str):
+        return jsonify({"error": "text must be a string"}), 400
+    if not isinstance(channel, str) or not 1 <= len(channel) <= 32:
+        return jsonify({"error": "invalid channel/surface"}), 400
+
+    conversation = Conversation.query.filter_by(
+        tenant_id=tenant_id, id=conversation_id).first()
+    if conversation is not None:
+        if conversation.agent_id != agent_id:
+            return jsonify({"error": "conversation belongs to another agent"}), 409
+    else:
+        conversation = Conversation(
+            id=conversation_id,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            created_by_surface=channel,
+        )
+        db.session.add(conversation)
+
+    if request_id:
+        prior = ConversationMessage.query.filter_by(
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+            request_id=request_id,
+        ).first()
+        if prior is not None:
+            if (prior.role != role or prior.text != text
+                    or prior.agent_id != agent_id):
+                return jsonify({
+                    "error": "request_id was already used for another message"
+                }), 409
+            replay = prior.to_dict()
+            replay["idempotent_replay"] = True
+            return jsonify(replay), 200
+
+    if reply_to:
+        parent = ConversationMessage.query.filter_by(
+            id=reply_to,
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+        ).first()
+        if parent is None:
+            return jsonify({"error": "reply_to is outside the conversation"}), 400
 
     import json as _json
     md = body.get("metadata")
@@ -340,17 +415,45 @@ def api_conversations_create():
 
     msg = ConversationMessage(
         tenant_id=tenant_id,
+        conversation_id=conversation_id,
         agent_id=agent_id,
-        channel=body.get("channel", "unknown"),
+        channel=channel,
         session_id=body.get("session_id"),
         user_id=body.get("user_id"),
         role=role,
         text=text,
+        request_id=request_id,
+        reply_to=reply_to,
         metadata_json=metadata_json,
     )
     db.session.add(msg)
-    db.session.commit()
-    return jsonify(msg.to_dict()), 201
+    conversation.updated_at = datetime.now(timezone.utc)
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        # Two workers may claim the same inbound request concurrently. The
+        # database uniqueness constraint is authoritative; return the winner
+        # instead of leaking a 500 or running the agent twice.
+        if request_id:
+            prior = ConversationMessage.query.filter_by(
+                tenant_id=tenant_id,
+                conversation_id=conversation_id,
+                request_id=request_id,
+            ).first()
+            if prior is not None:
+                if (prior.role != role or prior.text != text
+                        or prior.agent_id != agent_id):
+                    return jsonify({
+                        "error": "request_id was already used for another message"
+                    }), 409
+                replay = prior.to_dict()
+                replay["idempotent_replay"] = True
+                return jsonify(replay), 200
+        raise
+    created = msg.to_dict()
+    created["idempotent_replay"] = False
+    return jsonify(created), 201
 
 
 @command_center_blueprint.route("/api/tasks", methods=["POST"])

--- a/r6/database_migrations.py
+++ b/r6/database_migrations.py
@@ -22,6 +22,7 @@ _ROOT = Path(__file__).resolve().parents[1]
 # never re-created — running the baseline migration against it dies with
 # "table ... already exists".
 _BASELINE_REVISION = "0001_v1_8_0"
+_CREATE_ALL_SCHEMA_REVISION = "0004_conversation_identity"
 
 # A table that has existed since long before v1.8.0 — its presence (without
 # alembic_version) is the legacy-database fingerprint.
@@ -35,18 +36,42 @@ def alembic_config() -> Config:
     return config
 
 
-def _is_unstamped_legacy_database(connection) -> bool:
-    """True when the schema was built by pre-Alembic create_all: real tables
-    exist but Alembic has never recorded a revision.
+def _unstamped_adoption_revision(connection) -> str | None:
+    """Revision to stamp when ``create_all`` built an unstamped schema.
+
+    Older deployments have the v1.8 baseline shape. A current checkout can
+    also create a full present-day schema before the migration command runs;
+    stamping that at the old baseline would replay DDL for tables it already
+    contains. Distinguish the two shapes using the first table introduced
+    after the baseline.
 
     Checks the recorded REVISION, not mere table presence — an interrupted
     earlier run can leave an empty alembic_version table behind, and that
     state is still unstamped."""
     current = MigrationContext.configure(connection).get_current_revision()
     if current is not None:
-        return False
+        return None
     inspector = inspect(connection)
-    return _LEGACY_SENTINEL_TABLE in inspector.get_table_names()
+    tables = set(inspector.get_table_names())
+    if _LEGACY_SENTINEL_TABLE not in tables:
+        return None
+    if "cc_conversations" in tables:
+        message_columns = {
+            column["name"]
+            for column in inspector.get_columns("cc_conversation_messages")
+        }
+        resource_pk = inspector.get_pk_constraint("r6_resources").get(
+            "constrained_columns", [])
+        audit_columns = {
+            column["name"] for column in inspector.get_columns("audit_events")
+        }
+        if (
+            {"conversation_id", "request_id", "reply_to"} <= message_columns
+            and resource_pk == ["tenant_id", "resource_type", "id"]
+            and "outcome_detail_code" in audit_columns
+        ):
+            return _CREATE_ALL_SCHEMA_REVISION
+    return _BASELINE_REVISION
 
 
 def upgrade_database(engine: Engine, revision: str = "head") -> str:
@@ -61,12 +86,14 @@ def upgrade_database(engine: Engine, revision: str = "head") -> str:
     config = alembic_config()
     with engine.connect() as connection:
         config.attributes["connection"] = connection
-        if _is_unstamped_legacy_database(connection):
+        adoption_revision = _unstamped_adoption_revision(connection)
+        if adoption_revision:
             logger.info(
                 "Existing pre-Alembic schema detected (no alembic_version); "
-                "stamping baseline %s before upgrading", _BASELINE_REVISION,
+                "stamping matching revision %s before upgrading",
+                adoption_revision,
             )
-            command.stamp(config, _BASELINE_REVISION)
+            command.stamp(config, adoption_revision)
         command.upgrade(config, revision)
         current = MigrationContext.configure(connection).get_current_revision()
         # Alembic treats a SUPPLIED connection as externally managed and does

--- a/r6/purge.py
+++ b/r6/purge.py
@@ -59,6 +59,7 @@ def purge_tenant(tenant_id):
     for import_path, attr, label in (
             ("r6.actions.models", "ProposedAction", "proposed_actions"),
             ("r6.command_center.models", "ConversationMessage", "messages"),
+            ("r6.command_center.models", "Conversation", "conversations"),
             ("r6.command_center.models", "AgentTask", "agent_tasks"),
             ("r6.fasten.models", "FastenConnection", "fasten_connections"),
             ("r6.fasten.models", "FastenJob", "fasten_jobs"),

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -28,7 +28,8 @@ def test_production_config_requires_every_secret():
             Config(env={**base, **missing})
     ok = Config(env={**base, "CARE_SESSION_SECRET": "x" * 32,
                      "HEALTHCLAW_MINT_SECRET": "m", "OPENAI_API_KEY": "k",
-                     "RESEND_API_KEY": "r"})
+                     "RESEND_API_KEY": "r",
+                     "REDIS_URL": "redis://localhost:6379/1"})
     assert ok.provider == "openai" and ok.rp_id == "careagents.cloud"
 
 
@@ -41,6 +42,7 @@ def test_production_on_sqlite_warns_loudly(caplog):
         Config(env={"CARE_ENV": "production", "CARE_SESSION_SECRET": "x" * 32,
                     "HEALTHCLAW_MINT_SECRET": "m", "OPENAI_API_KEY": "k",
                     "RESEND_API_KEY": "r",
+                    "REDIS_URL": "redis://localhost:6379/1",
                     "CARE_DATABASE_URL": "sqlite:///careagents.db"})
     assert any("SQLite" in r.message and "Postgres" in r.message
                for r in caplog.records)
@@ -53,6 +55,7 @@ def test_production_on_postgres_does_not_warn(caplog):
                           "CARE_SESSION_SECRET": "x" * 32,
                           "HEALTHCLAW_MINT_SECRET": "m", "OPENAI_API_KEY": "k",
                           "RESEND_API_KEY": "r",
+                          "REDIS_URL": "redis://localhost:6379/1",
                           "CARE_DATABASE_URL":
                               "postgresql://u:p@db:5432/care"})
     assert cfg.database_url.startswith("postgresql")
@@ -125,14 +128,18 @@ def test_review_submit_reports_a_failed_confirmation(cfg, svc, monkeypatch):
 
 # --- chat persistence (#222) --------------------------------------------------
 
-def _turn(client, agent_id, message):
+def _turn(client, agent_id, message, request_id=None, conversation_id=None):
     """Post a chat turn AND drain the SSE stream, as a browser does.
 
     The response body is a generator; without reading it the turn never
     actually runs to completion.
     """
-    r = client.post("/api/chat",
-                    json={"agent_id": agent_id, "message": message})
+    payload = {"agent_id": agent_id, "message": message}
+    if request_id:
+        payload["request_id"] = request_id
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    r = client.post("/api/chat", json=payload)
     r.get_data()
     return r
 
@@ -157,29 +164,20 @@ def _chat_app(cfg, svc, monkeypatch, reply="here you go"):
     agent_id = c.post("/api/agents", json={
         "name": "Juniper", "persona": "calm",
         "connection_id": conn["id"]}).get_json()["id"]
-    return app, c, fake, agent_id, fake.tenants[-1]
+    return app, c, fake, agent_id, fake.tenants[-1], conn["id"]
 
 
-def test_log_message_does_not_send_a_careagents_agent_id_upstream():
-    """Caught in Phase 1 acceptance testing against a live stack, not by any
-    unit test.
-
-    HealthClaw's conversation endpoint validates `agent_id` against its own
-    command-center agent registry. CareAgents agent ids are a different
-    namespace, so sending one is rejected with 400 — and because persistence
-    is deliberately best-effort, every chat turn would have silently failed to
-    save in production while the feature looked shipped.
-
-    The other tests here use a FakeClient that accepts any agent_id, so they
-    prove the app CALLS log_message, not that log_message works. This one pins
-    the wire format where a fake cannot paper over it.
-    """
+def test_log_message_sends_explicit_agent_and_conversation_identity():
+    """The wire contract preserves CareAgents identity across surfaces."""
     import careagents.healthclaw as hcmod
 
     sent = {}
 
     class _Resp:
         status_code = 201
+
+        def json(self):
+            return {"id": "message-1"}
 
     class _HTTP:
         def post(self, url, json=None, headers=None, timeout=None):
@@ -190,9 +188,13 @@ def test_log_message_does_not_send_a_careagents_agent_id_upstream():
     client.http = _HTTP()
     client.mint_token = lambda tenant: "tok"
 
-    assert client.log_message("t-1", "user", "hi", "ag_care_123") is True
-    assert "agent_id" not in sent, (
-        "a CareAgents agent id in the endpoint's agent_id field is a 400")
+    assert client.log_message(
+        "t-1", "user", "hi", "ag_care_123",
+        "careagents:ag_care_123", surface="web",
+    ) is True
+    assert sent["agent_id"] == "ag_care_123"
+    assert sent["conversation_id"] == "careagents:ag_care_123"
+    assert sent["surface"] == "web"
     assert sent["metadata"]["careagents_agent_id"] == "ag_care_123"
     assert sent["tenant_id"] == "t-1" and sent["text"] == "hi"
 
@@ -251,10 +253,10 @@ def test_a_chat_turn_is_persisted_to_healthclaw_not_careagents(
         cfg, svc, monkeypatch):
     # The transcript is PHI-adjacent, so it belongs behind the guardrails in
     # the tenant — never in CareAgents' own tables.
-    app, c, fake, agent_id, tenant = _chat_app(cfg, svc, monkeypatch)
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
     _turn(c, agent_id, "hi there")
 
-    stored = fake.logged[tenant]
+    stored = fake.logged[(tenant, fake.conversation_id(agent_id))]
     assert [m["role"] for m in stored] == ["user", "assistant"]
     assert stored[0]["content"] == "hi there"
     assert stored[1]["content"] == "here you go"
@@ -264,7 +266,7 @@ def test_a_returning_person_sees_the_conversation_they_had(cfg, svc,
                                                            monkeypatch):
     # The core of #222: process memory is a cache, not the record. Wiping it
     # (a deploy, a restart, idle eviction) must not make the agent forget.
-    app, c, fake, agent_id, tenant = _chat_app(cfg, svc, monkeypatch)
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
     _turn(c, agent_id, "am I due for a flu shot?")
 
     page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
@@ -274,7 +276,7 @@ def test_a_returning_person_sees_the_conversation_they_had(cfg, svc,
 
 def test_a_cold_process_rehydrates_instead_of_starting_over(cfg, svc,
                                                             monkeypatch):
-    app, c, fake, agent_id, tenant = _chat_app(cfg, svc, monkeypatch)
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
     _turn(c, agent_id, "first question")
 
     # Simulate the restart: everything in memory is gone, the store is not.
@@ -298,17 +300,133 @@ def test_a_cold_process_rehydrates_instead_of_starting_over(cfg, svc,
     _turn(c2, agent_id, "second question")
 
     assert "first question" in seen[0], "the new process forgot the conversation"
+    assert seen[0].count("second question") == 1
+
+
+def test_two_agents_on_one_connection_have_isolated_transcripts(
+        cfg, svc, monkeypatch):
+    _app, c, fake, first_agent, tenant, conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    second_agent = c.post("/api/agents", json={
+        "name": "Cedar",
+        "persona": "calm",
+        "connection_id": conn_id,
+    }).get_json()["id"]
+
+    _turn(c, first_agent, "only Juniper should see this")
+    _turn(c, second_agent, "only Cedar should see this")
+
+    first = fake.logged[(tenant, fake.conversation_id(first_agent))]
+    second = fake.logged[(tenant, fake.conversation_id(second_agent))]
+    assert "Cedar" not in " ".join(m["content"] for m in first)
+    assert "Juniper" not in " ".join(m["content"] for m in second)
+    assert first[0]["content"] == "only Juniper should see this"
+    assert second[0]["content"] == "only Cedar should see this"
+
+
+def test_duplicate_inbound_request_runs_the_model_once(cfg, svc, monkeypatch):
+    _app, c, fake, agent_id, tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    from careagents import agent as agent_mod
+
+    calls = {"count": 0}
+
+    class _Turn:
+        text, tool_calls, raw_tool_calls = "once", [], []
+
+    def _complete(*args, **kwargs):
+        calls["count"] += 1
+        return _Turn()
+
+    monkeypatch.setattr(agent_mod.llm, "complete", _complete)
+    first = _turn(c, agent_id, "one delivery", request_id="delivery-1")
+    replay = _turn(c, agent_id, "one delivery", request_id="delivery-1")
+
+    assert calls["count"] == 1
+    assert '"type": "duplicate"' in replay.get_data(as_text=True)
+    stored = fake.logged[(tenant, fake.conversation_id(agent_id))]
+    assert [message["role"] for message in stored] == ["user", "assistant"]
+    assert first.status_code == replay.status_code == 200
+
+
+def test_web_and_imessage_resume_the_same_explicit_conversation(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    _turn(c, agent_id, "remember this from web", request_id="web-1")
+
+    surface = c.post(
+        "/api/surfaces/imessage", json={"agent_id": agent_id}).get_json()
+    relay = app.test_client()
+    headers = {"X-Internal-Secret": cfg.mint_secret}
+    assert relay.post(
+        "/api/surfaces/imessage/bind",
+        headers=headers,
+        json={"code": surface["code"], "handle": "+15551234567"},
+    ).status_code == 200
+
+    seen = []
+
+    def reply(_cfg, _hc, _tenant, _system, history, text, **kwargs):
+        seen.extend(message["content"] for message in history)
+        return "continued on iMessage"
+
+    monkeypatch.setattr("careagents.app.run_turn_to_message", reply)
+    response = relay.post(
+        "/api/surfaces/imessage/inbound",
+        headers=headers,
+        json={
+            "handle": "+15551234567",
+            "text": "continue here",
+            "request_id": "imessage-1",
+            "conversation_id": fake.conversation_id(agent_id),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "remember this from web" in seen
+    stored = fake.logged[(tenant, fake.conversation_id(agent_id))]
+    assert {message["surface"] for message in stored} == {"web", "imessage"}
+
+
+def test_conversation_lock_serializes_concurrent_turns():
+    import threading
+    import time
+
+    from careagents.conversation_locks import ConversationTurnLocks
+
+    locks = ConversationTurnLocks()
+    state = {"active": 0, "maximum": 0}
+    guard = threading.Lock()
+
+    def work():
+        with locks.hold("tenant:careagents:agent"):
+            with guard:
+                state["active"] += 1
+                state["maximum"] = max(state["maximum"], state["active"])
+            time.sleep(0.02)
+            with guard:
+                state["active"] -= 1
+
+    threads = [threading.Thread(target=work) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert state["maximum"] == 1
+    assert locks._local == {}, "idle conversation locks leaked forever"
 
 
 def test_a_storage_outage_does_not_break_the_chat(cfg, svc, monkeypatch):
-    # Losing the transcript is bad; failing the conversation in front of the
-    # person is worse. Persistence is best-effort by design.
-    app, c, fake, agent_id, tenant = _chat_app(cfg, svc, monkeypatch)
-    monkeypatch.setattr(fake, "log_message",
-                        lambda *a, **k: (_ for _ in ()).throw(
-                            HealthClawError("store down", 500)))
+    # A user turn must be durably claimed before inference. Otherwise a retry
+    # can execute the same health action twice.
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+    monkeypatch.setattr(fake, "claim_inbound_message",
+                        lambda *a, **k: (None, None))
     r = _turn(c, agent_id, "still works?")
     assert r.status_code == 200
+    assert "could not save this message safely" in r.get_data(as_text=True)
 
 
 def test_history_is_trimmed_but_never_orphans_a_tool_call():
@@ -420,6 +538,7 @@ def test_anthropic_oauth_token_selects_anthropic_provider():
     prod = Config(env={"CARE_ENV": "production",
                        "CARE_SESSION_SECRET": "x" * 32,
                        "HEALTHCLAW_MINT_SECRET": "m", "RESEND_API_KEY": "r",
+                       "REDIS_URL": "redis://localhost:6379/1",
                        "ANTHROPIC_OAUTH_TOKEN": "oat-abc"})
     assert prod.provider == "anthropic"  # satisfies the prod LLM-cred gate
 
@@ -460,17 +579,43 @@ class FakeClient:
         self.seeded = []
         # Tenants this client minted, so a test can name the one it just made.
         self.tenants: list[str] = []
-        # Conversation store, keyed by tenant — stands in for HealthClaw's
-        # ConversationMessage table.
-        self.logged: dict[str, list] = {}
+        # Conversation store, keyed by tenant + thread, matching HealthClaw.
+        self.logged: dict[tuple[str, str], list] = {}
+        self.claimed: dict[tuple[str, str, str], str] = {}
 
-    def log_message(self, tenant, role, text, agent_id=None):
-        self.logged.setdefault(tenant, []).append(
-            {"role": role, "content": text, "agent_id": agent_id})
+    @staticmethod
+    def conversation_id(agent_id):
+        return f"careagents:{agent_id}"
+
+    def claim_inbound_message(self, tenant, text, agent_id, conversation_id,
+                              surface, request_id):
+        claim = (tenant, conversation_id, request_id)
+        if claim in self.claimed:
+            return False, self.claimed[claim]
+        message_id = f"message-{len(self.claimed) + 1}"
+        self.claimed[claim] = message_id
+        self.logged.setdefault((tenant, conversation_id), []).append({
+            "id": message_id,
+            "role": "user",
+            "content": text,
+            "agent_id": agent_id,
+            "surface": surface,
+            "request_id": request_id,
+        })
+        return True, message_id
+
+    def log_message(self, tenant, role, text, agent_id=None,
+                    conversation_id=None, surface="web", reply_to=None):
+        conversation_id = conversation_id or self.conversation_id(agent_id)
+        self.logged.setdefault((tenant, conversation_id), []).append(
+            {"role": role, "content": text, "agent_id": agent_id,
+             "surface": surface, "reply_to": reply_to})
         return True
 
-    def recent_messages(self, tenant, limit=20):
-        return list(self.logged.get(tenant, []))[-limit:]
+    def recent_messages(self, tenant, limit=20, conversation_id=None,
+                        agent_id=None):
+        conversation_id = conversation_id or self.conversation_id(agent_id)
+        return list(self.logged.get((tenant, conversation_id), []))[-limit:]
 
     def new_tenant_id(self):
         self.seeded.append(1)

--- a/tests/test_command_center.py
+++ b/tests/test_command_center.py
@@ -15,7 +15,7 @@ import json
 from models import db
 from r6.models import R6Resource, AuditEventRecord
 from r6.command_center import agents, projector, gateway
-from r6.command_center.models import ConversationMessage
+from r6.command_center.models import Conversation, ConversationMessage
 
 TENANT = "test-tenant"
 
@@ -127,8 +127,15 @@ class TestActionsAndAgents:
 
     def test_agents_status_includes_conversation_count(self, app):
         with app.app_context():
+            db.session.add(Conversation(
+                id="careagents:sally",
+                tenant_id=TENANT,
+                agent_id="sally",
+                created_by_surface="telegram",
+            ))
             db.session.add(ConversationMessage(
                 tenant_id=TENANT,
+                conversation_id="careagents:sally",
                 agent_id="sally",
                 channel="telegram",
                 role="user",
@@ -321,6 +328,8 @@ class TestRestEndpoints:
     def test_api_conversations_post_and_get(self, client, step_up_token):
         payload = {
             "tenant_id": TENANT,
+            "conversation_id": "careagents:sally",
+            "request_id": "telegram-update-123",
             "agent_id": "sally",
             "channel": "telegram",
             "session_id": "chat-123",
@@ -337,6 +346,8 @@ class TestRestEndpoints:
         created = resp.get_json()
         assert created["tenant_id"] == TENANT
         assert created["agent_id"] == "sally"
+        assert created["conversation_id"] == "careagents:sally"
+        assert created["request_id"] == "telegram-update-123"
 
         resp = client.get(
             "/command-center/api/conversations",
@@ -348,6 +359,108 @@ class TestRestEndpoints:
         assert msgs[0]["text"] == "/health"
         assert msgs[0]["agent_emoji"] == "🩺"
 
+    def test_api_conversations_replays_duplicate_request_once(
+            self, client, step_up_token):
+        payload = {
+            "tenant_id": TENANT,
+            "conversation_id": "careagents:juniper",
+            "agent_id": "juniper",
+            "surface": "web",
+            "request_id": "browser-request-1",
+            "role": "user",
+            "text": "show my medications",
+        }
+        headers = {"X-Step-Up-Token": step_up_token}
+
+        first = client.post(
+            "/command-center/api/conversations", json=payload, headers=headers)
+        replay = client.post(
+            "/command-center/api/conversations", json=payload, headers=headers)
+
+        assert first.status_code == 201
+        assert replay.status_code == 200
+        assert replay.get_json()["id"] == first.get_json()["id"]
+        assert replay.get_json()["idempotent_replay"] is True
+        conflict = client.post(
+            "/command-center/api/conversations",
+            json={**payload, "text": "different payload"},
+            headers=headers,
+        )
+        assert conflict.status_code == 409
+        rows = client.get(
+            "/command-center/api/conversations",
+            query_string={"tenant": TENANT,
+                          "conversation_id": "careagents:juniper"},
+        ).get_json()
+        assert [row["text"] for row in rows] == ["show my medications"]
+
+    def test_api_conversations_are_isolated_by_thread_and_agent(
+            self, client, step_up_token):
+        headers = {"X-Step-Up-Token": step_up_token}
+        for agent_id, text in (("agent-a", "thread A"),
+                               ("agent-b", "thread B")):
+            response = client.post(
+                "/command-center/api/conversations",
+                json={
+                    "tenant_id": TENANT,
+                    "conversation_id": f"careagents:{agent_id}",
+                    "agent_id": agent_id,
+                    "role": "user",
+                    "text": text,
+                },
+                headers=headers,
+            )
+            assert response.status_code == 201
+
+        rows = client.get(
+            "/command-center/api/conversations",
+            query_string={"tenant": TENANT,
+                          "conversation_id": "careagents:agent-a",
+                          "agent_id": "agent-a"},
+        ).get_json()
+        assert [row["text"] for row in rows] == ["thread A"]
+
+        mismatch = client.post(
+            "/command-center/api/conversations",
+            json={
+                "tenant_id": TENANT,
+                "conversation_id": "careagents:agent-a",
+                "agent_id": "agent-b",
+                "role": "user",
+                "text": "wrong owner",
+            },
+            headers=headers,
+        )
+        assert mismatch.status_code == 409
+
+    def test_same_external_conversation_id_is_tenant_scoped(self, client):
+        from r6.stepup import generate_step_up_token
+
+        for tenant, text in (("tenant-a", "A only"),
+                             ("tenant-b", "B only")):
+            token = generate_step_up_token(tenant)
+            response = client.post(
+                "/command-center/api/conversations",
+                json={
+                    "tenant_id": tenant,
+                    "conversation_id": "external-thread-1",
+                    "agent_id": "external-agent",
+                    "role": "user",
+                    "text": text,
+                },
+                headers={"X-Step-Up-Token": token},
+            )
+            assert response.status_code == 201
+
+        token = generate_step_up_token("tenant-a")
+        rows = client.get(
+            "/command-center/api/conversations",
+            query_string={"tenant": "tenant-a",
+                          "conversation_id": "external-thread-1"},
+            headers={"X-Step-Up-Token": token},
+        ).get_json()
+        assert [row["text"] for row in rows] == ["A only"]
+
     def test_api_conversations_post_rejects_missing_fields(self, client):
         resp = client.post(
             "/command-center/api/conversations",
@@ -355,7 +468,8 @@ class TestRestEndpoints:
         )
         assert resp.status_code == 400
 
-    def test_api_conversations_post_rejects_unknown_agent(self, client, step_up_token):
+    def test_api_conversations_accepts_opaque_agent_identity(
+            self, client, step_up_token):
         resp = client.post(
             "/command-center/api/conversations",
             json={
@@ -366,7 +480,8 @@ class TestRestEndpoints:
             },
             headers={"X-Step-Up-Token": step_up_token},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 201
+        assert resp.get_json()["agent_id"] == "bogus"
 
     def test_api_conversations_post_rejects_without_auth(self, client):
         resp = client.post(

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -43,6 +43,7 @@ def test_fresh_install_builds_current_schema_without_flask_app(tmp_path):
         "action_events",
         "action_confirmations",
         "cc_conversation_messages",
+        "cc_conversations",
         "cc_agent_tasks",
         "wearable_connections",
         "smbp_sessions",
@@ -53,6 +54,9 @@ def test_fresh_install_builds_current_schema_without_flask_app(tmp_path):
         "resource_type",
         "id",
     ]
+    assert schema.get_pk_constraint("cc_conversations")[
+        "constrained_columns"
+    ] == ["tenant_id", "id"]
     resource_columns = {
         column["name"]: column for column in schema.get_columns("r6_resources")
     }
@@ -82,6 +86,52 @@ def test_audit_outcome_detail_migration_is_reversible(tmp_path):
     assert "outcome_detail_code" in {
         column["name"] for column in inspect(engine).get_columns("audit_events")
     }
+    engine.dispose()
+
+
+def test_conversation_migration_backfills_legacy_tenant_transcripts(tmp_path):
+    url = f"sqlite:///{tmp_path / 'conversation-backfill.db'}"
+    config = _config(url)
+    engine = create_engine(url)
+    command.upgrade(config, "0003_audit_outcome_detail")
+    with engine.begin() as connection:
+        connection.execute(text(
+            "INSERT INTO cc_conversation_messages "
+            "(id, tenant_id, agent_id, channel, role, text, created_at) "
+            "VALUES ('message-1', 'tenant-1', 'legacy-agent', 'telegram', "
+            "'user', 'preserve me', CURRENT_TIMESTAMP)"
+        ))
+
+    command.upgrade(config, "head")
+
+    with engine.connect() as connection:
+        conversation = connection.execute(text(
+            "SELECT id, tenant_id, created_by_surface FROM cc_conversations"
+        )).mappings().one()
+        message = connection.execute(text(
+            "SELECT conversation_id, text FROM cc_conversation_messages"
+        )).mappings().one()
+    assert dict(conversation) == {
+        "id": "legacy:tenant-1",
+        "tenant_id": "tenant-1",
+        "created_by_surface": "legacy",
+    }
+    assert dict(message) == {
+        "conversation_id": "legacy:tenant-1",
+        "text": "preserve me",
+    }
+
+    command.downgrade(config, "0003_audit_outcome_detail")
+    schema = inspect(engine)
+    assert "cc_conversations" not in schema.get_table_names()
+    assert {"conversation_id", "request_id", "reply_to"}.isdisjoint(
+        column["name"]
+        for column in schema.get_columns("cc_conversation_messages")
+    )
+    with engine.connect() as connection:
+        assert connection.execute(text(
+            "SELECT text FROM cc_conversation_messages WHERE id = 'message-1'"
+        )).scalar_one() == "preserve me"
     engine.dispose()
 
 
@@ -117,7 +167,7 @@ def test_initialize_database_runs_alembic_on_the_app_engine(monkeypatch):
         assert schema.get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]
-    assert revision == "0003_audit_outcome_detail"
+    assert revision == "0004_conversation_identity"
 
 
 def test_legacy_environment_flag_cannot_run_ddl_during_factory(monkeypatch):
@@ -270,11 +320,11 @@ def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
 
     revision = upgrade_database(engine)  # must NOT raise 'already exists'
 
-    assert revision == "0003_audit_outcome_detail"
+    assert revision == "0004_conversation_identity"
     inspector = inspect(engine)
     assert "alembic_version" in inspector.get_table_names()
     # And it must be repeatable (deploys run it every release).
-    assert upgrade_database(engine) == "0003_audit_outcome_detail"
+    assert upgrade_database(engine) == "0004_conversation_identity"
 
 
 def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
@@ -313,7 +363,7 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
         ))
 
     revision = upgrade_database(engine)
-    assert revision == "0003_audit_outcome_detail"
+    assert revision == "0004_conversation_identity"
 
     inspector = inspect(engine)
     pk = inspector.get_pk_constraint("r6_resources")
@@ -356,9 +406,9 @@ def test_legacy_create_all_upgrade_on_configured_database():
 
         revision = upgrade_database(engine)  # must not raise "already exists"
 
-        assert revision == "0003_audit_outcome_detail"
+        assert revision == "0004_conversation_identity"
         assert "alembic_version" in inspect(engine).get_table_names()
-        assert upgrade_database(engine) == "0003_audit_outcome_detail"  # idempotent
+        assert upgrade_database(engine) == "0004_conversation_identity"  # idempotent
         assert inspect(engine).get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]


### PR DESCRIPTION
## Summary

- add a durable, tenant-scoped `Conversation` primitive and isolate messages by conversation and opaque agent identity
- make inbound delivery idempotent with database-enforced request IDs and explicit replay/conflict responses
- serialize turns per conversation with Redis in production and a bounded local fallback in development
- refresh durable history after locking so multiple workers and web/iMessage share a coherent thread
- backfill existing tenant-wide transcripts into documented `legacy:<tenant_id>` conversations
- fix the cold-start double-prompt bug by loading history before claiming the current inbound message

## Safety and compatibility

- conversation primary keys include the tenant, preventing cross-tenant ID squatting or collisions
- production CareAgents now fails closed without `REDIS_URL`
- existing callers receive stable defaults: `careagents:<agent_id>` or `legacy:<tenant_id>`
- migration upgrade and downgrade both preserve legacy transcript rows
- tenant purge removes messages before their parent conversations

## Verification

At commit `901ee1f516130ca176b145ee628c14362c39753e`:

- `uv run python -m pytest tests/ -q --tb=short` — 1,571 passed, 1 skipped
- `uv run ruff check .` — passed
- `uv run mypy` — passed
- focused command-center, CareAgents, migration, and purge suite — 149 passed, 1 skipped

## Attribution

Agent: Fizz  
Runtime-Model: OpenAI Codex (GPT-5)

Closes #247
