### PR TITLE
architecture: add durable agent run control plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
             tests/test_fasten_verify_signature.py \
             tests/test_fasten_job_recovery.py \
             tests/test_database_migrations.py \
+            tests/test_agent_runs.py \
             -v --tb=short
 
   node-tests:

--- a/docs/runbooks/agent-run-control-plane.md
+++ b/docs/runbooks/agent-run-control-plane.md
@@ -1,0 +1,86 @@
+# Agent run control plane
+
+The durable run API is the substrate for moving CareAgents work out of Flask
+request threads. This first slice does not switch CareAgents execution yet;
+issue #254 performs that cutover after the queue contract is deployed.
+
+## Durable records
+
+- `agent_runs` correlates one inbound conversation message with one run. Its
+  tenant/message unique constraint makes creation idempotent.
+- `agent_tool_calls` correlates a provider tool-call ID with a canonical input
+  hash. Re-registering the same call returns its existing state and result;
+  reusing the ID with different input fails closed.
+- `agent_run_events` is append-only outside tenant purge. Its integer ID is the
+  durable replay cursor used by a future SSE projection.
+
+Run states are `queued`, `running`, `waiting_for_human`, `completed`, `failed`,
+and `cancelled`. Invalid transitions are rejected in code and invalid stored
+states are rejected by database constraints.
+
+## Authentication boundaries
+
+Tenant sessions or tenant-bound step-up credentials may create, inspect,
+replay, and cancel their own runs. Worker operations span tenant queues and
+therefore require `X-Internal-Secret` matching `INTERNAL_TOKEN_MINT_SECRET`.
+The worker secret must never be sent to a browser or messaging client.
+
+Claim responses are the only worker endpoint that returns inbound message
+text. Tenant-facing run detail omits message text and tool arguments/results.
+Operational logs must use run IDs, status, attempts, hashes, references, and
+error classes only—never event payloads, message text, or tool results.
+
+## Worker contract
+
+1. Create a run after the inbound message is durably claimed.
+2. Claim with a stable worker ID and a 10–600 second lease.
+3. Heartbeat before the lease expires; stop if `cancel_requested` is true.
+4. Append UI/progress events before publishing them to a transport.
+5. Register each provider tool call before execution. If it replays as
+   `completed`, reuse the stored result instead of executing again.
+6. Transition the run to a terminal state or `waiting_for_human`.
+7. An approval surface resumes a waiting run through the internal resume API.
+
+Expired running leases are appended as `run.lease_expired`, requeued, and then
+claimed with an incremented attempt. Queued runs past their deadline fail as
+`RunDeadlineExceeded` rather than running late.
+
+## HTTP endpoints
+
+All paths are under `/command-center/api/runs`:
+
+- `POST /` — idempotently create from `{tenant_id, message_id}`.
+- `GET /<id>` — PHI-redacted run/tool projection.
+- `GET /<id>/events?after=<cursor>` — ordered durable replay.
+- `POST /<id>/cancel` — durable cancellation request.
+- `POST /claim` — atomically claim the next queued run (internal).
+- `POST /<id>/heartbeat` — renew the owning worker lease (internal).
+- `POST /<id>/transition` — state transition by the owning worker.
+- `POST /<id>/events` — append a bounded event before publishing it.
+- `POST /<id>/tool-calls` and `/tool-calls/<call>/transition` — durable,
+  idempotent tool lifecycle.
+- `POST /<id>/resume` — approval surface requeues a human-waiting run.
+
+Event and tool payloads are capped at 256 KiB. Error fields accept a class name,
+not raw exception text, to keep secrets and health content out of operations.
+
+## Deployment verification
+
+Run migrations before web or worker processes:
+
+```bash
+uv run flask --app main init-db
+```
+
+Then verify the three new tables exist and no stale run is silently stranded:
+
+```sql
+SELECT status, COUNT(*) FROM agent_runs GROUP BY status;
+
+SELECT id, worker_id, lease_expires_at
+FROM agent_runs
+WHERE status = 'running' AND lease_expires_at < CURRENT_TIMESTAMP;
+```
+
+The second query may briefly show an expired lease; the next claim records its
+recovery event and requeues it. Repeated expirations indicate a worker incident.

--- a/main.py
+++ b/main.py
@@ -91,6 +91,7 @@ def register_model_metadata() -> None:
     import r6.actions.confirmations  # noqa: F401
     import r6.actions.events  # noqa: F401
     import r6.actions.models  # noqa: F401
+    import r6.agent_runs.models  # noqa: F401
     import r6.command_center.models  # noqa: F401
     import r6.fasten.models  # noqa: F401
     import r6.smbp.models  # noqa: F401
@@ -216,6 +217,10 @@ def _register_blueprints(flask_app: Flask) -> None:
         "Actions Blueprint registered at /r6/actions (rails: %s)",
         ", ".join(action_kinds()),
     )
+
+    from r6.agent_runs.routes import agent_runs_blueprint
+
+    flask_app.register_blueprint(agent_runs_blueprint)
 
     from r6.ops.routes import ops_blueprint
 

--- a/migrations/versions/0005_agent_run_control_plane.py
+++ b/migrations/versions/0005_agent_run_control_plane.py
@@ -1,0 +1,145 @@
+"""Add durable agent-run queue, tool calls, and append-only events.
+
+Revision ID: 0005_agent_run_control_plane
+Revises: 0004_conversation_identity
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0005_agent_run_control_plane"
+down_revision = "0004_conversation_identity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    run_tables = {"agent_runs", "agent_tool_calls", "agent_run_events"}
+    if run_tables <= tables:
+        return
+    if run_tables & tables:
+        raise RuntimeError(
+            "partial agent-run schema detected; refusing an ambiguous upgrade")
+
+    op.create_table(
+        "agent_runs",
+        sa.Column("id", sa.String(64), nullable=False),
+        sa.Column("tenant_id", sa.String(64), nullable=False),
+        sa.Column("conversation_id", sa.String(128), nullable=False),
+        sa.Column("message_id", sa.String(64), nullable=False),
+        sa.Column("agent_id", sa.String(64), nullable=True),
+        sa.Column("surface", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(24), nullable=False),
+        sa.Column("attempt", sa.Integer(), nullable=False),
+        sa.Column("worker_id", sa.String(128), nullable=True),
+        sa.Column("available_at", sa.DateTime(), nullable=False),
+        sa.Column("deadline_at", sa.DateTime(), nullable=False),
+        sa.Column("lease_expires_at", sa.DateTime(), nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("error_class", sa.String(128), nullable=True),
+        sa.Column("cancel_requested", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_agent_runs"),
+        sa.ForeignKeyConstraint(
+            ["tenant_id", "conversation_id"],
+            ["cc_conversations.tenant_id", "cc_conversations.id"],
+            name="fk_agent_run_conversation",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["message_id"], ["cc_conversation_messages.id"],
+            name="fk_agent_run_message", ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "tenant_id", "message_id", name="uq_agent_run_message"),
+        sa.CheckConstraint(
+            "status IN ('queued','running','waiting_for_human',"
+            "'completed','failed','cancelled')",
+            name="ck_agent_run_status"),
+    )
+    for column in (
+        "agent_id", "available_at", "conversation_id", "created_at",
+        "deadline_at", "error_class", "lease_expires_at", "message_id",
+        "status", "tenant_id", "worker_id",
+    ):
+        op.create_index(f"ix_agent_runs_{column}", "agent_runs", [column])
+
+    op.create_table(
+        "agent_tool_calls",
+        sa.Column("id", sa.String(64), nullable=False),
+        sa.Column("tenant_id", sa.String(64), nullable=False),
+        sa.Column("run_id", sa.String(64), nullable=False),
+        sa.Column("provider_call_id", sa.String(128), nullable=False),
+        sa.Column("tool_name", sa.String(128), nullable=False),
+        sa.Column("input_hash", sa.String(64), nullable=False),
+        sa.Column("input_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(24), nullable=False),
+        sa.Column("attempt", sa.Integer(), nullable=False),
+        sa.Column("result_json", sa.Text(), nullable=True),
+        sa.Column("outcome_ref", sa.String(256), nullable=True),
+        sa.Column("error_class", sa.String(128), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_agent_tool_calls"),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"],
+            name="fk_agent_tool_call_run", ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "run_id", "provider_call_id",
+            name="uq_agent_tool_call_provider"),
+        sa.CheckConstraint(
+            "status IN ('pending','running','completed','failed')",
+            name="ck_agent_tool_call_status"),
+    )
+    for column in (
+        "created_at", "outcome_ref", "run_id", "status", "tenant_id",
+        "tool_name",
+    ):
+        op.create_index(
+            f"ix_agent_tool_calls_{column}", "agent_tool_calls", [column])
+
+    op.create_table(
+        "agent_run_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("tenant_id", sa.String(64), nullable=False),
+        sa.Column("run_id", sa.String(64), nullable=False),
+        sa.Column("event_type", sa.String(64), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_agent_run_events"),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"],
+            name="fk_agent_run_event_run", ondelete="CASCADE"),
+    )
+    for column in ("created_at", "event_type", "run_id", "tenant_id"):
+        op.create_index(
+            f"ix_agent_run_events_{column}", "agent_run_events", [column])
+
+
+def downgrade() -> None:
+    for column in ("tenant_id", "run_id", "event_type", "created_at"):
+        op.drop_index(
+            f"ix_agent_run_events_{column}", table_name="agent_run_events")
+    op.drop_table("agent_run_events")
+
+    for column in (
+        "tool_name", "tenant_id", "status", "run_id", "outcome_ref",
+        "created_at",
+    ):
+        op.drop_index(
+            f"ix_agent_tool_calls_{column}", table_name="agent_tool_calls")
+    op.drop_table("agent_tool_calls")
+
+    for column in (
+        "worker_id", "tenant_id", "status", "message_id",
+        "lease_expires_at", "error_class", "deadline_at", "created_at",
+        "conversation_id", "available_at", "agent_id",
+    ):
+        op.drop_index(f"ix_agent_runs_{column}", table_name="agent_runs")
+    op.drop_table("agent_runs")

--- a/r6/agent_runs/__init__.py
+++ b/r6/agent_runs/__init__.py
@@ -1,0 +1,6 @@
+"""Durable agent-run control plane."""
+
+from r6.agent_runs.models import AgentRun, AgentRunEvent, AgentToolCall
+
+__all__ = ["AgentRun", "AgentRunEvent", "AgentToolCall"]
+

--- a/r6/agent_runs/models.py
+++ b/r6/agent_runs/models.py
@@ -1,0 +1,173 @@
+"""Durable agent run, tool-call, and append-only event records."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+from models import db
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AgentRun(db.Model):
+    __tablename__ = "agent_runs"
+    __table_args__ = (
+        db.ForeignKeyConstraint(
+            ["tenant_id", "conversation_id"],
+            ["cc_conversations.tenant_id", "cc_conversations.id"],
+            name="fk_agent_run_conversation",
+            ondelete="CASCADE",
+        ),
+        db.UniqueConstraint(
+            "tenant_id", "message_id", name="uq_agent_run_message"),
+        db.CheckConstraint(
+            "status IN ('queued','running','waiting_for_human',"
+            "'completed','failed','cancelled')",
+            name="ck_agent_run_status",
+        ),
+    )
+
+    id = db.Column(
+        db.String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
+    tenant_id = db.Column(db.String(64), nullable=False, index=True)
+    conversation_id = db.Column(db.String(128), nullable=False, index=True)
+    message_id = db.Column(
+        db.String(64), db.ForeignKey(
+            "cc_conversation_messages.id", ondelete="CASCADE"),
+        nullable=False, index=True)
+    agent_id = db.Column(db.String(64), nullable=True, index=True)
+    surface = db.Column(db.String(32), nullable=False, default="unknown")
+    status = db.Column(db.String(24), nullable=False, default="queued", index=True)
+    attempt = db.Column(db.Integer, nullable=False, default=0)
+    worker_id = db.Column(db.String(128), nullable=True, index=True)
+    available_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+    deadline_at = db.Column(db.DateTime, nullable=False, index=True)
+    lease_expires_at = db.Column(db.DateTime, nullable=True, index=True)
+    heartbeat_at = db.Column(db.DateTime, nullable=True)
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    error_class = db.Column(db.String(128), nullable=True, index=True)
+    cancel_requested = db.Column(db.Boolean, nullable=False, default=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+    updated_at = db.Column(
+        db.DateTime, nullable=False, default=utcnow, onupdate=utcnow)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "conversation_id": self.conversation_id,
+            "message_id": self.message_id,
+            "agent_id": self.agent_id,
+            "surface": self.surface,
+            "status": self.status,
+            "attempt": self.attempt,
+            "worker_id": self.worker_id,
+            "available_at": _iso(self.available_at),
+            "deadline_at": _iso(self.deadline_at),
+            "lease_expires_at": _iso(self.lease_expires_at),
+            "heartbeat_at": _iso(self.heartbeat_at),
+            "started_at": _iso(self.started_at),
+            "finished_at": _iso(self.finished_at),
+            "error_class": self.error_class,
+            "cancel_requested": bool(self.cancel_requested),
+            "created_at": _iso(self.created_at),
+            "updated_at": _iso(self.updated_at),
+        }
+
+
+class AgentToolCall(db.Model):
+    __tablename__ = "agent_tool_calls"
+    __table_args__ = (
+        db.UniqueConstraint(
+            "run_id", "provider_call_id", name="uq_agent_tool_call_provider"),
+        db.CheckConstraint(
+            "status IN ('pending','running','completed','failed')",
+            name="ck_agent_tool_call_status",
+        ),
+    )
+
+    id = db.Column(
+        db.String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
+    tenant_id = db.Column(db.String(64), nullable=False, index=True)
+    run_id = db.Column(
+        db.String(64), db.ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False, index=True)
+    provider_call_id = db.Column(db.String(128), nullable=False)
+    tool_name = db.Column(db.String(128), nullable=False, index=True)
+    input_hash = db.Column(db.String(64), nullable=False)
+    input_json = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(24), nullable=False, default="pending", index=True)
+    attempt = db.Column(db.Integer, nullable=False, default=0)
+    result_json = db.Column(db.Text, nullable=True)
+    outcome_ref = db.Column(db.String(256), nullable=True, index=True)
+    error_class = db.Column(db.String(128), nullable=True)
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+    updated_at = db.Column(
+        db.DateTime, nullable=False, default=utcnow, onupdate=utcnow)
+
+    def to_dict(self, include_payload: bool = False) -> dict:
+        result = {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "run_id": self.run_id,
+            "provider_call_id": self.provider_call_id,
+            "tool_name": self.tool_name,
+            "input_hash": self.input_hash,
+            "status": self.status,
+            "attempt": self.attempt,
+            "outcome_ref": self.outcome_ref,
+            "error_class": self.error_class,
+            "started_at": _iso(self.started_at),
+            "finished_at": _iso(self.finished_at),
+            "created_at": _iso(self.created_at),
+            "updated_at": _iso(self.updated_at),
+        }
+        if include_payload:
+            result["input"] = _json(self.input_json)
+            result["result"] = _json(self.result_json)
+        return result
+
+
+class AgentRunEvent(db.Model):
+    __tablename__ = "agent_run_events"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    tenant_id = db.Column(db.String(64), nullable=False, index=True)
+    run_id = db.Column(
+        db.String(64), db.ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False, index=True)
+    event_type = db.Column(db.String(64), nullable=False, index=True)
+    payload_json = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+
+    def to_dict(self, include_payload: bool = True) -> dict:
+        result = {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "run_id": self.run_id,
+            "type": self.event_type,
+            "created_at": _iso(self.created_at),
+        }
+        if include_payload:
+            result["payload"] = _json(self.payload_json) or {}
+        return result
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _json(value: str | None):
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return None

--- a/r6/agent_runs/routes.py
+++ b/r6/agent_runs/routes.py
@@ -1,0 +1,360 @@
+"""Authenticated durable AgentRun queue-control API."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+
+from flask import Blueprint, jsonify, request, session
+
+from models import db
+from r6.agent_runs.models import AgentRun, AgentRunEvent, AgentToolCall
+from r6.agent_runs.service import (
+    append_event,
+    claim_next,
+    create_run,
+    heartbeat,
+    register_tool_call,
+    request_cancel,
+    transition_run,
+    transition_tool_call,
+)
+from r6.agent_runs.state import InvalidTransition
+from r6.command_center.models import ConversationMessage
+from r6.read_auth import TENANT_SESSION_KEY
+from r6.stepup import validate_step_up_token
+
+
+agent_runs_blueprint = Blueprint(
+    "agent_runs",
+    __name__,
+    url_prefix="/command-center/api/runs",
+)
+
+_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_ERROR_CLASS = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,127}$")
+_MAX_EVENT_PAYLOAD_BYTES = 256 * 1024
+
+
+def _tenant_authorized(tenant_id: str) -> bool:
+    if session.get(TENANT_SESSION_KEY) == tenant_id:
+        return True
+    token = request.headers.get("X-Step-Up-Token", "")
+    return bool(token and validate_step_up_token(token, tenant_id)[0])
+
+
+def _internal_authorized() -> bool:
+    expected = os.environ.get("INTERNAL_TOKEN_MINT_SECRET", "")
+    provided = request.headers.get("X-Internal-Secret", "")
+    return bool(expected and hmac.compare_digest(provided, expected))
+
+
+def _run_or_404(run_id: str) -> AgentRun | None:
+    return db.session.get(AgentRun, run_id)
+
+
+def _worker_owns(run: AgentRun, worker_id: str) -> bool:
+    return bool(
+        worker_id
+        and run.status == "running"
+        and run.worker_id == worker_id
+    )
+
+
+def _valid_payload_size(value) -> bool:
+    import json
+    try:
+        return len(json.dumps(value, separators=(",", ":")).encode()) <= (
+            _MAX_EVENT_PAYLOAD_BYTES)
+    except (TypeError, ValueError):
+        return False
+
+
+@agent_runs_blueprint.post("")
+def create_agent_run():
+    body = request.get_json(silent=True) or {}
+    tenant_id = body.get("tenant_id") or request.headers.get("X-Tenant-Id")
+    message_id = body.get("message_id")
+    if not isinstance(tenant_id, str) or not _ID.fullmatch(tenant_id):
+        return jsonify({"error": "invalid tenant_id"}), 400
+    if not isinstance(message_id, str) or not _ID.fullmatch(message_id):
+        return jsonify({"error": "invalid message_id"}), 400
+    if not _tenant_authorized(tenant_id):
+        return jsonify({"error": "authentication required"}), 401
+    try:
+        deadline_seconds = int(body.get("deadline_seconds", 120))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid deadline_seconds"}), 400
+    if not 5 <= deadline_seconds <= 3600:
+        return jsonify({"error": "deadline_seconds must be 5-3600"}), 400
+    try:
+        run, created = create_run(
+            tenant_id, message_id, deadline_seconds=deadline_seconds)
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
+    result = run.to_dict()
+    result["idempotent_replay"] = not created
+    return jsonify(result), 201 if created else 200
+
+
+@agent_runs_blueprint.get("/<run_id>")
+def get_agent_run(run_id: str):
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    if not _tenant_authorized(run.tenant_id):
+        return jsonify({"error": "authentication required"}), 401
+    result = run.to_dict()
+    result["tool_calls"] = [
+        call.to_dict()
+        for call in AgentToolCall.query.filter_by(run_id=run.id)
+        .order_by(AgentToolCall.created_at.asc()).all()
+    ]
+    return jsonify(result)
+
+
+@agent_runs_blueprint.get("/<run_id>/events")
+def get_agent_run_events(run_id: str):
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    if not _tenant_authorized(run.tenant_id):
+        return jsonify({"error": "authentication required"}), 401
+    try:
+        after = max(0, int(request.args.get("after", "0")))
+        limit = min(500, max(1, int(request.args.get("limit", "100"))))
+    except ValueError:
+        return jsonify({"error": "invalid cursor or limit"}), 400
+    events = (
+        AgentRunEvent.query
+        .filter_by(tenant_id=run.tenant_id, run_id=run.id)
+        .filter(AgentRunEvent.id > after)
+        .order_by(AgentRunEvent.id.asc())
+        .limit(limit)
+        .all()
+    )
+    return jsonify({
+        "run_id": run.id,
+        "status": run.status,
+        "events": [event.to_dict() for event in events],
+        "next_cursor": events[-1].id if events else after,
+    })
+
+
+@agent_runs_blueprint.post("/<run_id>/cancel")
+def cancel_agent_run(run_id: str):
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    if not _tenant_authorized(run.tenant_id):
+        return jsonify({"error": "authentication required"}), 401
+    return jsonify(request_cancel(run).to_dict())
+
+
+@agent_runs_blueprint.post("/<run_id>/resume")
+def resume_agent_run(run_id: str):
+    """Internal approval surface resumes one human-waiting run."""
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    try:
+        run = transition_run(
+            run, "queued", event_type="run.resumed",
+            payload={"status": "queued"})
+    except InvalidTransition as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify(run.to_dict())
+
+
+@agent_runs_blueprint.post("/claim")
+def claim_agent_run():
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    body = request.get_json(silent=True) or {}
+    worker_id = body.get("worker_id")
+    if not isinstance(worker_id, str) or not _ID.fullmatch(worker_id):
+        return jsonify({"error": "invalid worker_id"}), 400
+    try:
+        lease_seconds = int(body.get("lease_seconds", 60))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid lease_seconds"}), 400
+    if not 10 <= lease_seconds <= 600:
+        return jsonify({"error": "lease_seconds must be 10-600"}), 400
+    run = claim_next(worker_id, lease_seconds)
+    if run is None:
+        return "", 204
+    message = ConversationMessage.query.filter_by(
+        tenant_id=run.tenant_id, id=run.message_id).first()
+    result = run.to_dict()
+    result["message"] = {
+        "id": message.id,
+        "role": message.role,
+        "text": message.text,
+    } if message else None
+    return jsonify(result)
+
+
+@agent_runs_blueprint.post("/<run_id>/heartbeat")
+def heartbeat_agent_run(run_id: str):
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    try:
+        lease_seconds = int(body.get("lease_seconds", 60))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid lease_seconds"}), 400
+    if not 10 <= lease_seconds <= 600:
+        return jsonify({"error": "lease_seconds must be 10-600"}), 400
+    try:
+        heartbeat(run, worker_id, lease_seconds)
+    except InvalidTransition as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify({
+        "ok": True,
+        "cancel_requested": bool(run.cancel_requested),
+        "lease_expires_at": run.to_dict()["lease_expires_at"],
+    })
+
+
+@agent_runs_blueprint.post("/<run_id>/transition")
+def transition_agent_run(run_id: str):
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    if not _worker_owns(run, worker_id):
+        return jsonify({"error": "worker does not own run"}), 409
+    target = body.get("status")
+    event_type = body.get("event_type") or None
+    if event_type is not None and (
+            not isinstance(event_type, str)
+            or not _EVENT_TYPE.fullmatch(event_type)):
+        return jsonify({"error": "invalid event type"}), 400
+    payload = body.get("payload")
+    if payload is not None and not _valid_payload_size(payload):
+        return jsonify({"error": "event payload is invalid or too large"}), 413
+    error_class = body.get("error_class")
+    if error_class is not None and (
+            not isinstance(error_class, str)
+            or not _ERROR_CLASS.fullmatch(error_class)):
+        return jsonify({"error": "invalid error_class"}), 400
+    try:
+        available_in_seconds = int(body.get("available_in_seconds", 0))
+        if not 0 <= available_in_seconds <= 3600:
+            return jsonify({
+                "error": "available_in_seconds must be 0-3600"}), 400
+        run = transition_run(
+            run,
+            target,
+            event_type=event_type,
+            payload=payload,
+            error_class=error_class,
+            available_in_seconds=available_in_seconds,
+        )
+    except (TypeError, ValueError, InvalidTransition) as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify(run.to_dict())
+
+
+@agent_runs_blueprint.post("/<run_id>/events")
+def append_agent_run_event(run_id: str):
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    if not _worker_owns(run, worker_id):
+        return jsonify({"error": "worker does not own run"}), 409
+    event_type = body.get("type")
+    if not isinstance(event_type, str) or not _EVENT_TYPE.fullmatch(event_type):
+        return jsonify({"error": "invalid event type"}), 400
+    payload = body.get("payload")
+    if payload is not None and not _valid_payload_size(payload):
+        return jsonify({"error": "event payload is invalid or too large"}), 413
+    event = append_event(run, event_type, payload)
+    db.session.commit()
+    return jsonify(event.to_dict()), 201
+
+
+@agent_runs_blueprint.post("/<run_id>/tool-calls")
+def create_agent_tool_call(run_id: str):
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    if run is None:
+        return jsonify({"error": "unknown run"}), 404
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    if not _worker_owns(run, worker_id):
+        return jsonify({"error": "worker does not own run"}), 409
+    provider_call_id = body.get("provider_call_id")
+    tool_name = body.get("tool_name")
+    arguments = body.get("arguments")
+    if not isinstance(provider_call_id, str) or not _ID.fullmatch(
+            provider_call_id):
+        return jsonify({"error": "invalid provider_call_id"}), 400
+    if not isinstance(tool_name, str) or not _ID.fullmatch(tool_name):
+        return jsonify({"error": "invalid tool_name"}), 400
+    if not isinstance(arguments, dict):
+        return jsonify({"error": "arguments must be an object"}), 400
+    if not _valid_payload_size(arguments):
+        return jsonify({"error": "arguments are too large"}), 413
+    try:
+        call, created = register_tool_call(
+            run, provider_call_id, tool_name, arguments)
+    except InvalidTransition as exc:
+        return jsonify({"error": str(exc)}), 409
+    result = call.to_dict(include_payload=True)
+    result["idempotent_replay"] = not created
+    return jsonify(result), 201 if created else 200
+
+
+@agent_runs_blueprint.post("/<run_id>/tool-calls/<call_id>/transition")
+def transition_agent_tool_call(run_id: str, call_id: str):
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    call = db.session.get(AgentToolCall, call_id)
+    if run is None or call is None or call.run_id != run_id:
+        return jsonify({"error": "unknown run or tool call"}), 404
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    if not _worker_owns(run, worker_id):
+        return jsonify({"error": "worker does not own run"}), 409
+    error_class = body.get("error_class")
+    if error_class is not None and (
+            not isinstance(error_class, str)
+            or not _ERROR_CLASS.fullmatch(error_class)):
+        return jsonify({"error": "invalid error_class"}), 400
+    if body.get("result") is not None and not _valid_payload_size(
+            body.get("result")):
+        return jsonify({"error": "result is invalid or too large"}), 413
+    outcome_ref = body.get("outcome_ref")
+    if outcome_ref is not None and (
+            not isinstance(outcome_ref, str) or len(outcome_ref) > 256):
+        return jsonify({"error": "invalid outcome_ref"}), 400
+    try:
+        call = transition_tool_call(
+            run,
+            call,
+            body.get("status"),
+            result=body.get("result"),
+            outcome_ref=outcome_ref,
+            error_class=error_class,
+        )
+    except (LookupError, InvalidTransition) as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify(call.to_dict(include_payload=True))

--- a/r6/agent_runs/service.py
+++ b/r6/agent_runs/service.py
@@ -1,0 +1,295 @@
+"""Transactional AgentRun queue and event operations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import timedelta
+
+from sqlalchemy.exc import IntegrityError
+
+from models import db
+from r6.agent_runs.models import (
+    AgentRun,
+    AgentRunEvent,
+    AgentToolCall,
+    utcnow,
+)
+from r6.agent_runs.state import (
+    TERMINAL_RUN_STATES,
+    InvalidTransition,
+    require_run_transition,
+    require_tool_transition,
+)
+from r6.command_center.models import ConversationMessage
+
+
+def create_run(
+    tenant_id: str,
+    message_id: str,
+    *,
+    deadline_seconds: int = 120,
+) -> tuple[AgentRun, bool]:
+    """Create one queued run for an inbound message, idempotently."""
+    existing = AgentRun.query.filter_by(
+        tenant_id=tenant_id, message_id=message_id).first()
+    if existing is not None:
+        return existing, False
+
+    message = ConversationMessage.query.filter_by(
+        tenant_id=tenant_id, id=message_id).first()
+    if message is None or message.role != "user":
+        raise LookupError("unknown inbound user message")
+
+    now = utcnow()
+    run = AgentRun(
+        tenant_id=tenant_id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+        agent_id=message.agent_id,
+        surface=message.channel,
+        status="queued",
+        available_at=now,
+        deadline_at=now + timedelta(seconds=deadline_seconds),
+    )
+    db.session.add(run)
+    try:
+        db.session.flush()
+        append_event(run, "run.queued", {"status": "queued"})
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        winner = AgentRun.query.filter_by(
+            tenant_id=tenant_id, message_id=message_id).first()
+        if winner is not None:
+            return winner, False
+        raise
+    return run, True
+
+
+def append_event(
+    run: AgentRun,
+    event_type: str,
+    payload: dict | list | None = None,
+) -> AgentRunEvent:
+    event = AgentRunEvent(
+        tenant_id=run.tenant_id,
+        run_id=run.id,
+        event_type=event_type,
+        payload_json=_dump(payload) if payload is not None else None,
+    )
+    db.session.add(event)
+    return event
+
+
+def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
+    """Recover expired leases and atomically claim the oldest queued run."""
+    now = utcnow()
+
+    expired = (
+        AgentRun.query
+        .filter(AgentRun.status == "running")
+        .filter(AgentRun.lease_expires_at < now)
+        .with_for_update(skip_locked=True)
+        .all()
+    )
+    for run in expired:
+        if run.cancel_requested:
+            transition_run(
+                run, "cancelled", event_type="run.cancelled_after_lease",
+                commit=False)
+        else:
+            run.status = "queued"
+            run.worker_id = None
+            run.lease_expires_at = None
+            run.available_at = now
+            append_event(run, "run.lease_expired", {
+                "attempt": run.attempt,
+                "error_class": "WorkerLeaseExpired",
+            })
+
+    overdue = (
+        AgentRun.query
+        .filter(AgentRun.status == "queued")
+        .filter(AgentRun.deadline_at <= now)
+        .with_for_update(skip_locked=True)
+        .all()
+    )
+    for run in overdue:
+        transition_run(
+            run,
+            "failed",
+            event_type="run.deadline_exceeded",
+            error_class="RunDeadlineExceeded",
+            commit=False,
+        )
+
+    run = (
+        AgentRun.query
+        .filter(AgentRun.status == "queued")
+        .filter(AgentRun.available_at <= now)
+        .filter(AgentRun.deadline_at > now)
+        .order_by(AgentRun.available_at.asc(), AgentRun.created_at.asc())
+        .with_for_update(skip_locked=True)
+        .first()
+    )
+    if run is None:
+        db.session.commit()
+        return None
+
+    require_run_transition(run.status, "running")
+    run.status = "running"
+    run.worker_id = worker_id
+    run.attempt += 1
+    run.started_at = run.started_at or now
+    run.heartbeat_at = now
+    run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+    append_event(run, "run.started", {
+        "status": "running",
+        "attempt": run.attempt,
+    })
+    db.session.commit()
+    return run
+
+
+def heartbeat(run: AgentRun, worker_id: str, lease_seconds: int = 60) -> None:
+    if run.status != "running" or run.worker_id != worker_id:
+        raise InvalidTransition("worker does not own a running lease")
+    now = utcnow()
+    run.heartbeat_at = now
+    run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+    db.session.commit()
+
+
+def transition_run(
+    run: AgentRun,
+    target: str,
+    *,
+    event_type: str | None = None,
+    payload: dict | list | None = None,
+    error_class: str | None = None,
+    available_in_seconds: int = 0,
+    commit: bool = True,
+) -> AgentRun:
+    if run.cancel_requested and target != "cancelled":
+        raise InvalidTransition("run cancellation was requested")
+    require_run_transition(run.status, target)
+    now = utcnow()
+    run.status = target
+    run.error_class = error_class
+    if target == "queued":
+        run.worker_id = None
+        run.lease_expires_at = None
+        run.available_at = now + timedelta(seconds=available_in_seconds)
+    elif target in TERMINAL_RUN_STATES:
+        run.finished_at = now
+        run.lease_expires_at = None
+        run.worker_id = None
+    elif target == "waiting_for_human":
+        run.lease_expires_at = None
+        run.worker_id = None
+    append_event(
+        run,
+        event_type or f"run.{target}",
+        payload if payload is not None else {"status": target},
+    )
+    if commit:
+        db.session.commit()
+    return run
+
+
+def request_cancel(run: AgentRun) -> AgentRun:
+    if run.status in TERMINAL_RUN_STATES:
+        return run
+    if run.status in ("queued", "waiting_for_human"):
+        return transition_run(run, "cancelled")
+    run.cancel_requested = True
+    append_event(run, "run.cancel_requested", {"status": run.status})
+    db.session.commit()
+    return run
+
+
+def register_tool_call(
+    run: AgentRun,
+    provider_call_id: str,
+    tool_name: str,
+    arguments: dict,
+) -> tuple[AgentToolCall, bool]:
+    encoded = _dump(arguments)
+    input_hash = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    existing = AgentToolCall.query.filter_by(
+        run_id=run.id, provider_call_id=provider_call_id).first()
+    if existing is not None:
+        if existing.tool_name != tool_name or existing.input_hash != input_hash:
+            raise InvalidTransition(
+                "provider_call_id was reused with different tool input")
+        return existing, False
+    call = AgentToolCall(
+        tenant_id=run.tenant_id,
+        run_id=run.id,
+        provider_call_id=provider_call_id,
+        tool_name=tool_name,
+        input_hash=input_hash,
+        input_json=encoded,
+        status="pending",
+    )
+    db.session.add(call)
+    try:
+        db.session.flush()
+        append_event(run, "tool.registered", {
+            "tool_call_id": call.id,
+            "tool_name": tool_name,
+            "input_hash": input_hash,
+        })
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        winner = AgentToolCall.query.filter_by(
+            run_id=run.id, provider_call_id=provider_call_id).first()
+        if winner is None:
+            raise
+        if winner.tool_name != tool_name or winner.input_hash != input_hash:
+            raise InvalidTransition(
+                "provider_call_id was reused with different tool input")
+        return winner, False
+    return call, True
+
+
+def transition_tool_call(
+    run: AgentRun,
+    call: AgentToolCall,
+    target: str,
+    *,
+    result: dict | list | str | None = None,
+    outcome_ref: str | None = None,
+    error_class: str | None = None,
+) -> AgentToolCall:
+    if call.run_id != run.id or call.tenant_id != run.tenant_id:
+        raise LookupError("tool call does not belong to run")
+    require_tool_transition(call.status, target)
+    now = utcnow()
+    call.status = target
+    call.error_class = error_class
+    call.outcome_ref = outcome_ref
+    if target == "running":
+        call.attempt += 1
+        call.started_at = now
+        call.finished_at = None
+        call.result_json = None
+    if target in ("completed", "failed"):
+        call.finished_at = now
+        call.result_json = _dump(result) if result is not None else None
+    append_event(run, f"tool.{target}", {
+        "tool_call_id": call.id,
+        "tool_name": call.tool_name,
+        "status": target,
+        "attempt": call.attempt,
+        "outcome_ref": outcome_ref,
+        "error_class": error_class,
+    })
+    db.session.commit()
+    return call
+
+
+def _dump(value) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))

--- a/r6/agent_runs/state.py
+++ b/r6/agent_runs/state.py
@@ -1,0 +1,48 @@
+"""Fail-closed AgentRun and AgentToolCall state transitions."""
+
+RUN_STATES = frozenset({
+    "queued",
+    "running",
+    "waiting_for_human",
+    "completed",
+    "failed",
+    "cancelled",
+})
+
+TERMINAL_RUN_STATES = frozenset({"completed", "failed", "cancelled"})
+
+RUN_TRANSITIONS = {
+    "queued": frozenset({"running", "cancelled", "failed"}),
+    "running": frozenset({
+        "queued", "waiting_for_human", "completed", "failed", "cancelled"}),
+    "waiting_for_human": frozenset({"queued", "failed", "cancelled"}),
+    "completed": frozenset(),
+    "failed": frozenset(),
+    "cancelled": frozenset(),
+}
+
+TOOL_STATES = frozenset({"pending", "running", "completed", "failed"})
+TOOL_TRANSITIONS = {
+    "pending": frozenset({"running", "failed"}),
+    "running": frozenset({"completed", "failed"}),
+    "completed": frozenset(),
+    "failed": frozenset({"running"}),
+}
+
+
+class InvalidTransition(ValueError):
+    pass
+
+
+def require_run_transition(current: str, target: str) -> None:
+    if current not in RUN_STATES or target not in RUN_STATES:
+        raise InvalidTransition(f"unknown run state: {current} -> {target}")
+    if target not in RUN_TRANSITIONS[current]:
+        raise InvalidTransition(f"invalid run transition: {current} -> {target}")
+
+
+def require_tool_transition(current: str, target: str) -> None:
+    if current not in TOOL_STATES or target not in TOOL_STATES:
+        raise InvalidTransition(f"unknown tool state: {current} -> {target}")
+    if target not in TOOL_TRANSITIONS[current]:
+        raise InvalidTransition(f"invalid tool transition: {current} -> {target}")

--- a/r6/database_migrations.py
+++ b/r6/database_migrations.py
@@ -22,7 +22,7 @@ _ROOT = Path(__file__).resolve().parents[1]
 # never re-created — running the baseline migration against it dies with
 # "table ... already exists".
 _BASELINE_REVISION = "0001_v1_8_0"
-_CREATE_ALL_SCHEMA_REVISION = "0004_conversation_identity"
+_CREATE_ALL_SCHEMA_REVISION = "0005_agent_run_control_plane"
 
 # A table that has existed since long before v1.8.0 — its presence (without
 # alembic_version) is the legacy-database fingerprint.
@@ -69,6 +69,9 @@ def _unstamped_adoption_revision(connection) -> str | None:
             {"conversation_id", "request_id", "reply_to"} <= message_columns
             and resource_pk == ["tenant_id", "resource_type", "id"]
             and "outcome_detail_code" in audit_columns
+            and "agent_runs" in tables
+            and "agent_tool_calls" in tables
+            and "agent_run_events" in tables
         ):
             return _CREATE_ALL_SCHEMA_REVISION
     return _BASELINE_REVISION

--- a/r6/purge.py
+++ b/r6/purge.py
@@ -58,6 +58,9 @@ def purge_tenant(tenant_id):
     # they are logged and re-raised.
     for import_path, attr, label in (
             ("r6.actions.models", "ProposedAction", "proposed_actions"),
+            ("r6.agent_runs.models", "AgentRunEvent", "agent_run_events"),
+            ("r6.agent_runs.models", "AgentToolCall", "agent_tool_calls"),
+            ("r6.agent_runs.models", "AgentRun", "agent_runs"),
             ("r6.command_center.models", "ConversationMessage", "messages"),
             ("r6.command_center.models", "Conversation", "conversations"),
             ("r6.command_center.models", "AgentTask", "agent_tasks"),

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -1,0 +1,359 @@
+"""Durable AgentRun queue, replay, state, lease, and tool idempotency."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from models import db
+from r6.agent_runs.models import AgentRun, AgentRunEvent, utcnow
+from r6.agent_runs.state import RUN_STATES
+
+
+TENANT = "test-tenant"
+
+
+@pytest.fixture
+def internal_headers(monkeypatch):
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "run-worker-secret")
+    return {"X-Internal-Secret": "run-worker-secret"}
+
+
+def _message(client, auth_headers, *, text="hello", request_id="request-1"):
+    response = client.post(
+        "/command-center/api/conversations",
+        headers=auth_headers,
+        json={
+            "tenant_id": TENANT,
+            "conversation_id": "careagents:juniper",
+            "agent_id": "juniper",
+            "surface": "web",
+            "request_id": request_id,
+            "role": "user",
+            "text": text,
+        },
+    )
+    assert response.status_code == 201
+    return response.get_json()
+
+
+def _run(client, auth_headers, message_id):
+    return client.post(
+        "/command-center/api/runs",
+        headers=auth_headers,
+        json={"tenant_id": TENANT, "message_id": message_id},
+    )
+
+
+def _claim(client, internal_headers, worker="worker-1", lease=60):
+    return client.post(
+        "/command-center/api/runs/claim",
+        headers=internal_headers,
+        json={"worker_id": worker, "lease_seconds": lease},
+    )
+
+
+def test_run_creation_is_idempotent_and_events_replay_from_cursor(
+        client, auth_headers):
+    assert RUN_STATES == {
+        "queued", "running", "waiting_for_human",
+        "completed", "failed", "cancelled",
+    }
+    message = _message(client, auth_headers)
+
+    first = _run(client, auth_headers, message["id"])
+    replay = _run(client, auth_headers, message["id"])
+
+    assert first.status_code == 201
+    assert replay.status_code == 200
+    assert replay.get_json()["id"] == first.get_json()["id"]
+    assert replay.get_json()["idempotent_replay"] is True
+
+    run_id = first.get_json()["id"]
+    page = client.get(
+        f"/command-center/api/runs/{run_id}/events",
+        headers=auth_headers,
+    ).get_json()
+    assert [event["type"] for event in page["events"]] == ["run.queued"]
+    cursor = page["next_cursor"]
+    empty = client.get(
+        f"/command-center/api/runs/{run_id}/events",
+        headers=auth_headers,
+        query_string={"after": cursor},
+    ).get_json()
+    assert empty == {
+        "run_id": run_id,
+        "status": "queued",
+        "events": [],
+        "next_cursor": cursor,
+    }
+
+
+def test_worker_claim_is_secret_gated_and_claims_once(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+
+    assert _claim(client, {}).status_code == 403
+    claimed = _claim(client, internal_headers)
+    assert claimed.status_code == 200
+    body = claimed.get_json()
+    assert body["id"] == run_id
+    assert body["status"] == "running"
+    assert body["attempt"] == 1
+    assert body["message"] == {
+        "id": message["id"], "role": "user", "text": "hello"}
+    assert _claim(client, internal_headers, worker="worker-2").status_code == 204
+
+
+def test_run_transition_and_cancel_state_machine(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+
+    invalid = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "queued"},
+    )
+    assert invalid.status_code == 200  # running -> queued is an explicit retry
+    impossible = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "completed"},
+    )
+    assert impossible.status_code == 409  # worker released its lease
+
+    _claim(client, internal_headers)
+    cancel = client.post(
+        f"/command-center/api/runs/{run_id}/cancel", headers=auth_headers)
+    assert cancel.status_code == 200
+    assert cancel.get_json()["cancel_requested"] is True
+    heartbeat = client.post(
+        f"/command-center/api/runs/{run_id}/heartbeat",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "lease_seconds": 60},
+    )
+    assert heartbeat.status_code == 200
+    assert heartbeat.get_json()["cancel_requested"] is True
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "completed"},
+    ).status_code == 409
+    cancelled = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "cancelled"},
+    )
+    assert cancelled.status_code == 200
+    assert cancelled.get_json()["status"] == "cancelled"
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel",
+        headers=auth_headers,
+    ).get_json()["status"] == "cancelled"
+
+
+def test_waiting_run_requeues_without_replaying_completed_tool(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+    call = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "tool-call-1",
+            "tool_name": "start_intake_form",
+            "arguments": {},
+        },
+    )
+    assert call.status_code == 201
+    call_id = call.get_json()["id"]
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    ).status_code == 200
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "completed",
+            "result": {"status": "awaiting_confirmation"},
+            "outcome_ref": "action-1",
+        },
+    ).status_code == 200
+
+    waiting = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "waiting_for_human"},
+    )
+    assert waiting.status_code == 200
+    resumed = client.post(
+        f"/command-center/api/runs/{run_id}/resume",
+        headers=internal_headers,
+    )
+    assert resumed.status_code == 200
+    assert resumed.get_json()["status"] == "queued"
+    claimed = _claim(client, internal_headers, worker="worker-2")
+    assert claimed.status_code == 200
+
+    replay = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-2",
+            "provider_call_id": "tool-call-1",
+            "tool_name": "start_intake_form",
+            "arguments": {},
+        },
+    )
+    assert replay.status_code == 200
+    assert replay.get_json()["id"] == call_id
+    assert replay.get_json()["status"] == "completed"
+    assert replay.get_json()["idempotent_replay"] is True
+
+    conflict = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-2",
+            "provider_call_id": "tool-call-1",
+            "tool_name": "start_intake_form",
+            "arguments": {"changed": True},
+        },
+    )
+    assert conflict.status_code == 409
+
+
+def test_expired_worker_lease_is_recovered_for_another_worker(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.lease_expires_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    recovered = _claim(client, internal_headers, worker="worker-2")
+
+    assert recovered.status_code == 200
+    assert recovered.get_json()["worker_id"] == "worker-2"
+    assert recovered.get_json()["attempt"] == 2
+    with app.app_context():
+        kinds = [event.event_type for event in AgentRunEvent.query.filter_by(
+            run_id=run_id).order_by(AgentRunEvent.id.asc()).all()]
+    assert kinds == [
+        "run.queued", "run.started", "run.lease_expired", "run.started"]
+
+
+def test_run_detail_redacts_tool_payloads_from_operator_projection(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers, text="private health question")
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "private-call",
+            "tool_name": "search_records",
+            "arguments": {"resource_type": "Condition"},
+        },
+    ).get_json()
+
+    detail = client.get(
+        f"/command-center/api/runs/{run_id}", headers=auth_headers).get_json()
+
+    assert "message" not in detail
+    assert "input" not in detail["tool_calls"][0]
+    assert "result" not in detail["tool_calls"][0]
+    assert detail["tool_calls"][0]["input_hash"] == created["input_hash"]
+
+
+def test_run_access_is_tenant_bound(client, auth_headers):
+    from r6.stepup import generate_step_up_token
+
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    foreign = {
+        "X-Tenant-Id": "other-tenant",
+        "X-Step-Up-Token": generate_step_up_token("other-tenant"),
+    }
+
+    assert client.get(
+        f"/command-center/api/runs/{run_id}", headers=foreign
+    ).status_code == 401
+    assert client.get(
+        f"/command-center/api/runs/{run_id}/events", headers=foreign
+    ).status_code == 401
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel", headers=foreign
+    ).status_code == 401
+
+
+def test_event_and_tool_payloads_are_bounded(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+    huge = "x" * (256 * 1024 + 1)
+
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/events",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "type": "agent.text",
+              "payload": {"text": huge}},
+    ).status_code == 413
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "provider_call_id": "call-large",
+              "tool_name": "search_records", "arguments": {"q": huge}},
+    ).status_code == 413
+
+
+def test_overdue_queued_run_fails_instead_of_starting(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    assert _claim(client, internal_headers).status_code == 204
+    detail = client.get(
+        f"/command-center/api/runs/{run_id}", headers=auth_headers).get_json()
+    assert detail["status"] == "failed"
+    assert detail["error_class"] == "RunDeadlineExceeded"
+
+
+def test_postgres_workers_cannot_claim_one_run_twice(
+        app, client, auth_headers, internal_headers):
+    if db.engine.dialect.name != "postgresql":
+        pytest.skip("row-lock concurrency contract requires PostgreSQL")
+    from concurrent.futures import ThreadPoolExecutor
+
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+
+    def claim(worker):
+        with app.test_client() as contender:
+            response = _claim(contender, internal_headers, worker=worker)
+            return response.status_code, response.get_json(silent=True)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ("worker-a", "worker-b")))
+
+    assert sorted(status for status, _body in results) == [200, 204]
+    winner = next(body for status, body in results if status == 200)
+    assert winner["id"] == run_id

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -45,6 +45,9 @@ def test_fresh_install_builds_current_schema_without_flask_app(tmp_path):
         "cc_conversation_messages",
         "cc_conversations",
         "cc_agent_tasks",
+        "agent_runs",
+        "agent_tool_calls",
+        "agent_run_events",
         "wearable_connections",
         "smbp_sessions",
         "telegram_bindings",
@@ -135,6 +138,29 @@ def test_conversation_migration_backfills_legacy_tenant_transcripts(tmp_path):
     engine.dispose()
 
 
+def test_agent_run_control_plane_migration_is_reversible(tmp_path):
+    url = f"sqlite:///{tmp_path / 'agent-runs.db'}"
+    config = _config(url)
+    engine = create_engine(url)
+
+    command.upgrade(config, "head")
+    assert {
+        "agent_runs", "agent_tool_calls", "agent_run_events"
+    } <= set(inspect(engine).get_table_names())
+
+    command.downgrade(config, "0004_conversation_identity")
+    assert {
+        "agent_runs", "agent_tool_calls", "agent_run_events"
+    }.isdisjoint(inspect(engine).get_table_names())
+    assert "cc_conversations" in inspect(engine).get_table_names()
+
+    command.upgrade(config, "head")
+    assert {
+        "agent_runs", "agent_tool_calls", "agent_run_events"
+    } <= set(inspect(engine).get_table_names())
+    engine.dispose()
+
+
 def test_migrations_are_explicit_and_never_delegate_to_create_all():
     migration_sources = "\n".join(
         path.read_text()
@@ -167,7 +193,7 @@ def test_initialize_database_runs_alembic_on_the_app_engine(monkeypatch):
         assert schema.get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]
-    assert revision == "0004_conversation_identity"
+    assert revision == "0005_agent_run_control_plane"
 
 
 def test_legacy_environment_flag_cannot_run_ddl_during_factory(monkeypatch):
@@ -320,11 +346,11 @@ def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
 
     revision = upgrade_database(engine)  # must NOT raise 'already exists'
 
-    assert revision == "0004_conversation_identity"
+    assert revision == "0005_agent_run_control_plane"
     inspector = inspect(engine)
     assert "alembic_version" in inspector.get_table_names()
     # And it must be repeatable (deploys run it every release).
-    assert upgrade_database(engine) == "0004_conversation_identity"
+    assert upgrade_database(engine) == "0005_agent_run_control_plane"
 
 
 def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
@@ -363,7 +389,7 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
         ))
 
     revision = upgrade_database(engine)
-    assert revision == "0004_conversation_identity"
+    assert revision == "0005_agent_run_control_plane"
 
     inspector = inspect(engine)
     pk = inspector.get_pk_constraint("r6_resources")
@@ -406,9 +432,9 @@ def test_legacy_create_all_upgrade_on_configured_database():
 
         revision = upgrade_database(engine)  # must not raise "already exists"
 
-        assert revision == "0004_conversation_identity"
+        assert revision == "0005_agent_run_control_plane"
         assert "alembic_version" in inspect(engine).get_table_names()
-        assert upgrade_database(engine) == "0004_conversation_identity"  # idempotent
+        assert upgrade_database(engine) == "0005_agent_run_control_plane"  # idempotent
         assert inspect(engine).get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]


### PR DESCRIPTION
## Summary

First reviewable slice of parent #248:

- add tenant-scoped `AgentRun`, `AgentToolCall`, and append-only `AgentRunEvent` persistence
- enforce queued/running/waiting-for-human/completed/failed/cancelled state transitions in code and database constraints
- add idempotent run creation and provider tool-call correlation
- add PostgreSQL `SKIP LOCKED` queue claims, worker leases, heartbeats, expired-lease recovery, deadlines, cancellation, and internal approval resume
- add authenticated cursor replay and PHI-redacted run/tool projections
- fail closed on missing worker secrets, cross-tenant access, altered tool inputs, invalid states, oversized payloads, and partial migrations
- add reversible Alembic migration, purge support, operator runbook, and a PostgreSQL concurrency CI lane

## Deliberate boundary

This PR builds the durable control-plane substrate but does **not** switch CareAgents inference out of HTTP threads. That cutover and durable SSE projection are tracked by #254; approval-triggered resume and operational dashboards are completed in #255. Parent #248 remains open until those ship.

## Verification

At commit `f76db764090173b0e00d3bf86466342518609124`:

- `uv run python -m pytest tests/ -q --tb=short` — 1,581 passed, 2 skipped
- `uv run ruff check .` — passed
- `uv run mypy` — passed
- focused AgentRun/migration/purge suite — 27 passed, 2 skipped (PostgreSQL-only claims run in CI)

## Attribution

Agent: Fizz  
Runtime-Model: OpenAI Codex (GPT-5)

Closes #253
Part of #248

