### PR TITLE
CareAgents: execute durable runs in shared workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@
 # ── Flask core ───────────────────────────────────────────────────────────────
 SESSION_SECRET=change-me-in-prod
 STEP_UP_SECRET=change-me-hmac-secret
+INTERNAL_TOKEN_MINT_SECRET=change-me-internal-worker-secret
+AGENT_RUN_RECONCILE_SECRET=change-me-separate-operator-secret
 SQLALCHEMY_DATABASE_URI=sqlite:///mcp_server.db
 LOG_LEVEL=DEBUG
 # LOG_FORMAT=json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
           curl -sf -X POST http://localhost:5000/r6/fhir/internal/seed \
             -H "Content-Type: application/json" \
             -H "X-Tenant-ID: compliance-test" \
+            -H "X-Internal-Secret: $INTERNAL_TOKEN_MINT_SECRET" \
             -H "X-Step-Up-Token: $TOKEN" \
             -d '{"tenant_id":"compliance-test"}' > /dev/null
           # Read something

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,7 @@ jobs:
     env:
       STEP_UP_SECRET: ci-compliance-secret
       TENANT_ID: compliance-test
+      INTERNAL_TOKEN_MINT_SECRET: ci-compliance-internal-secret
       # Required compose variable (MCP transports are auth-gated).
       MCP_AUTH_TOKEN: ci-compliance-token
     steps:
@@ -336,6 +337,7 @@ jobs:
           TOKEN=$(curl -sf -X POST http://localhost:5000/r6/fhir/internal/step-up-token \
             -H "Content-Type: application/json" \
             -H "X-Tenant-ID: compliance-test" \
+            -H "X-Internal-Secret: $INTERNAL_TOKEN_MINT_SECRET" \
             -d '{}' | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))")
           curl -sf -X POST http://localhost:5000/r6/fhir/internal/seed \
             -H "Content-Type: application/json" \
@@ -416,6 +418,7 @@ jobs:
           TOKEN=$(curl -sf -X POST http://localhost:5000/r6/fhir/internal/step-up-token \
             -H "Content-Type: application/json" \
             -H "X-Tenant-ID: compliance-test" \
+            -H "X-Internal-Secret: $INTERNAL_TOKEN_MINT_SECRET" \
             -d '{}' | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))")
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -X POST http://localhost:5000/r6/fhir/Condition \

--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -357,6 +357,24 @@ class AccountService:
                 return None
             return {"agent": _agent_dict(a), "tenant": conn.tenant_id}
 
+    def get_worker_agent_context(self, agent_id: str) -> dict | None:
+        """Resolve an agent for the trusted run worker.
+
+        Browser routes must always use :meth:`get_agent_context`, which binds
+        the lookup to the signed-in account. The worker has no browser account
+        session; it instead verifies this result's tenant against the tenant on
+        the claimed HealthClaw run before it handles any data.
+        """
+        with self.session() as s:
+            a = s.query(Agent).filter_by(id=agent_id).first()
+            if not a:
+                return None
+            conn = s.get(Connection, a.connection_id)
+            if not conn:
+                return None
+            return {"agent": _agent_dict(a), "tenant": conn.tenant_id,
+                    "account_id": a.account_id}
+
     def add_surface(self, account_id: str, agent_id: str, kind: str,
                     handle: str | None, status: str = "pending") -> str:
         with self.session() as s:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -4,10 +4,9 @@ Identity model: a signed cookie holds `account_id` after passkey/email login.
 Everything (connections, agents, surfaces) is account-scoped; a foreign id
 reads as 404.
 
-Chat history is DURABLE and lives in HealthClaw, per conversation (#222/#247).
-What sits in process memory here is only a per-turn working copy refreshed by
-load_history(). Redis serializes turns in one conversation across workers; the database
-idempotency key is the final defense against duplicate inbound delivery.
+Chat history and run state are DURABLE in HealthClaw (#222/#247/#248). Web
+requests enqueue work and replay its event log; inference and tools run only in
+the dedicated ``careagents.worker`` process.
 
 No PHI is stored here — health data lives in HealthClaw tenants behind the
 guardrail layer; careagents holds identity + pointers only.
@@ -21,7 +20,6 @@ import time
 import uuid
 from collections import defaultdict, deque
 from functools import wraps
-from threading import Lock
 
 from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
@@ -29,11 +27,9 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
 from careagents.accounts import (AccountService, AuthError, MailError,
                                  new_binding_code)
 from careagents import advisors, connectors
-from careagents.agent import run_turn, run_turn_to_message
 from careagents.config import Config
-from careagents.conversation_locks import ConversationLockError, ConversationTurnLocks
 from careagents.healthclaw import HealthClawClient, HealthClawError
-from careagents.personas import DEFAULT_PERSONA, PERSONAS, system_prompt
+from careagents.personas import DEFAULT_PERSONA, PERSONAS
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +40,6 @@ logger = logging.getLogger(__name__)
 # Disconnect and Delete sat on the same page (#203). Understating our own
 # strongest privacy control in the one place people read carefully.
 CONSENT_VERSION = "2026-08-01"
-
-# In-memory conversation bounds. Each worker caches the chats it serves, so
-# these cap memory and keep a long-running process from degrading (#218).
-MAX_LIVE_CONVERSATIONS = 200
-CONVERSATION_IDLE_SECONDS = 6 * 3600
-
 
 def create_app(config: Config | None = None,
                client: HealthClawClient | None = None,
@@ -63,54 +53,13 @@ def create_app(config: Config | None = None,
                       PERMANENT_SESSION_LIFETIME=90 * 24 * 3600)
     hc = client or HealthClawClient(cfg.healthclaw_base, cfg.mint_secret)
     svc = accounts or AccountService(cfg)
+    # Exposed for deterministic integration tests and process diagnostics.
+    # Production Gunicorn never executes this worker object; the systemd/OCI
+    # worker service constructs its own clients and calls careagents.worker.
+    app.extensions["careagents_runtime"] = {
+        "config": cfg, "client": hc, "accounts": svc}
 
-    histories: dict[str, list] = defaultdict(list)
-    hist_lock = Lock()
-    turn_locks = ConversationTurnLocks(
-        cfg.redis_url, production=cfg.app_env == "production")
     turns: dict[str, deque] = defaultdict(deque)
-    # Last time each conversation was touched, so idle ones can be released.
-    # Without this every tenant that ever chatted keeps its full transcript in
-    # memory for the life of the process.
-    hist_seen: dict[str, float] = {}
-
-    def conversation_key(tenant: str, conversation_id: str) -> str:
-        return f"{tenant}:{conversation_id}"
-
-    def load_history(tenant: str, conversation_id: str,
-                     agent_id: str) -> list:
-        """Refresh the per-turn working history from durable HealthClaw state.
-
-        A worker may have served this thread earlier and then gone stale while
-        another worker handled a turn. Reloading after the shared turn lock is
-        acquired prevents that stale cache from dropping cross-worker or
-        cross-surface messages.
-        """
-        key = conversation_key(tenant, conversation_id)
-        loaded = hc.recent_messages(
-            tenant, conversation_id=conversation_id, agent_id=agent_id)
-        with hist_lock:
-            history = histories[key]
-            history[:] = loaded
-        touch_history(key)
-        return history
-
-    def touch_history(key: str) -> None:
-        """Mark a conversation live; release idle ones once we're holding many.
-
-        Deliberately simple: only sweeps when the map is already large, so the
-        common path is a single dict write. Evicting is now safe rather than
-        lossy — a dropped conversation reloads from HealthClaw on next use.
-        """
-        seen_at = time.time()
-        with hist_lock:
-            hist_seen[key] = seen_at
-            if len(histories) <= MAX_LIVE_CONVERSATIONS:
-                return
-            for other, last in list(hist_seen.items()):
-                if other != key and seen_at - last > CONVERSATION_IDLE_SECONDS:
-                    histories.pop(other, None)
-                    hist_seen.pop(other, None)
 
     # --- auth plumbing -------------------------------------------------------
 
@@ -461,6 +410,66 @@ def create_app(config: Config | None = None,
         window.append(now)
         return True
 
+    def _event_for_browser(event: dict) -> dict | None:
+        kind = event.get("type")
+        payload = dict(event.get("payload") or {})
+        if kind == "agent.tool":
+            return {"type": "tool", "name": payload.get("name"),
+                    "label": payload.get("label")}
+        if kind == "agent.card":
+            payload.pop("provider_call_id", None)
+            payload.pop("event_key", None)
+            return payload
+        if kind == "agent.text":
+            return {"type": "text", "text": payload.get("text") or ""}
+        if kind == "agent.error":
+            return {"type": "error", "text": payload.get("text") or (
+                "Something went wrong on our side.")}
+        return None
+
+    def _run_belongs_to(run: dict, tenant: str, agent_id: str) -> bool:
+        return run.get("tenant_id") == tenant and run.get("agent_id") == agent_id
+
+    def _stream_run(tenant: str, agent_id: str, run_id: str, after: int = 0):
+        """Replay durable UI events. Disconnecting only stops this projection."""
+        cursor = max(0, after)
+        started = time.monotonic()
+        yield "data: " + json.dumps({
+            "type": "accepted", "run_id": run_id,
+            "next_cursor": cursor}) + "\n\n"
+        while time.monotonic() - started < cfg.run_sse_timeout_seconds:
+            page = hc.agent_run_events(tenant, run_id, after=cursor, limit=100)
+            events = page.get("events") or []
+            for event in events:
+                cursor = max(cursor, int(event.get("id") or 0))
+                projected = _event_for_browser(event)
+                if projected is not None:
+                    yield (f"id: {cursor}\n"
+                           f"data: {json.dumps(projected)}\n\n")
+            # A terminal run can have more than one page of durable events.
+            # Drain full pages before emitting done, otherwise reconnecting at
+            # the returned cursor would be the only way to see the tail.
+            if len(events) >= 100:
+                continue
+            status = page.get("status")
+            if status in ("completed", "failed", "cancelled",
+                          "waiting_for_human"):
+                done = {"type": "done", "status": status,
+                        "next_cursor": cursor}
+                yield (f"id: {cursor}\n"
+                       f"data: {json.dumps(done)}\n\n")
+                return
+            time.sleep(cfg.run_sse_poll_seconds)
+        yield "data: " + json.dumps({
+            "type": "reconnect", "run_id": run_id,
+            "next_cursor": cursor}) + "\n\n"
+
+    def _parse_cursor(value) -> int:
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
     @app.post("/api/chat")
     @login_required
     def api_chat():
@@ -496,60 +505,42 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "invalid conversation_id"}), 400
         if not 1 <= len(request_id) <= 128:
             return jsonify({"error": "invalid request_id"}), 400
-        sysprompt = system_prompt(agent["name"], agent["persona"],
-                                  agent.get("advisor"))
+        created, user_message_id = hc.claim_inbound_message(
+            tenant, text, agent["id"], conversation_id, "web", request_id)
+        if created is None or not user_message_id:
+            return jsonify({"error": "message store unavailable"}), 503
+        try:
+            run = hc.create_agent_run(
+                tenant, user_message_id, cfg.run_deadline_seconds)
+        except HealthClawError:
+            return jsonify({"error": "run queue unavailable"}), 503
+        after = _parse_cursor(body.get("after") or
+                              request.headers.get("Last-Event-ID"))
+        return Response(_stream_run(
+            tenant, agent["id"], run["id"], after),
+                        mimetype="text/event-stream",
+                        headers={"Cache-Control": "no-cache",
+                                 "X-Accel-Buffering": "no",
+                                 "X-CareAgents-Run-ID": run["id"]})
 
-        def remember(role, message, reply_to=None):
-            """Best-effort persist. Losing the transcript is bad; failing the
-            conversation in front of the person is worse."""
-            try:
-                hc.log_message(
-                    tenant, role, message, agent["id"], conversation_id,
-                    surface="web", reply_to=reply_to)
-            except Exception:  # noqa: BLE001
-                logger.warning("chat turn not persisted for %s", tenant)
-
-        def stream():
-            try:
-                key = conversation_key(tenant, conversation_id)
-                with turn_locks.hold(key):
-                    # Rehydrate BEFORE claiming the inbound row. run_turn()
-                    # appends the current prompt exactly once to this list.
-                    history = load_history(
-                        tenant, conversation_id, agent["id"])
-                    created, user_message_id = hc.claim_inbound_message(
-                        tenant, text, agent["id"], conversation_id,
-                        "web", request_id)
-                    if created is None:
-                        yield ('data: {"type": "error", "text": '
-                               '"I could not save this message safely. '
-                               'Please retry."}\n\n')
-                        yield 'data: {"type": "done"}\n\n'
-                        return
-                    if not created:
-                        yield ('data: {"type": "duplicate", "request_id": '
-                               f'{json.dumps(request_id)}}}\n\n')
-                        yield 'data: {"type": "done"}\n\n'
-                        return
-
-                    reply = []
-                    for event in run_turn(cfg, hc, tenant, sysprompt,
-                                          history, text):
-                        if event.get("type") == "text" and event.get("text"):
-                            reply.append(event["text"])
-                        yield f"data: {json.dumps(event)}\n\n"
-                    if reply:
-                        remember("assistant", "\n\n".join(reply),
-                                 reply_to=user_message_id)
-            except ConversationLockError:
-                yield ('data: {"type": "error", "text": '
-                       '"This conversation is busy. Please retry shortly."}\n\n')
-            except Exception:  # noqa: BLE001
-                yield ('data: {"type": "error", "text": '
-                       '"Something went wrong on our side."}\n\n')
-            yield 'data: {"type": "done"}\n\n'
-
-        return Response(stream(), mimetype="text/event-stream",
+    @app.get("/api/chat/runs/<run_id>/events")
+    @login_required
+    def api_chat_events(run_id):
+        acct = current_account()
+        agent_id = request.args.get("agent_id", "")
+        ctx = svc.get_agent_context(acct.id, agent_id)
+        if not ctx:
+            return jsonify({"error": "unknown agent"}), 404
+        try:
+            run = hc.get_agent_run(ctx["tenant"], run_id)
+        except HealthClawError:
+            return jsonify({"error": "unknown run"}), 404
+        if not _run_belongs_to(run, ctx["tenant"], agent_id):
+            return jsonify({"error": "unknown run"}), 404
+        after = _parse_cursor(request.args.get("after") or
+                              request.headers.get("Last-Event-ID"))
+        return Response(_stream_run(ctx["tenant"], agent_id, run_id, after),
+                        mimetype="text/event-stream",
                         headers={"Cache-Control": "no-cache",
                                  "X-Accel-Buffering": "no"})
 
@@ -734,31 +725,69 @@ def create_app(config: Config | None = None,
         conversation_id = (body.get("conversation_id")
                            or hc.conversation_id(agent["id"]))
         request_id = str(body.get("request_id") or uuid.uuid4())
-        sysprompt = system_prompt(agent["name"], agent["persona"],
-                                  agent.get("advisor"))
         try:
-            key = conversation_key(tenant, conversation_id)
-            with turn_locks.hold(key):
-                history = load_history(
-                    tenant, conversation_id, agent["id"])
-                created, user_message_id = hc.claim_inbound_message(
-                    tenant, text, agent["id"], conversation_id,
-                    "imessage", request_id)
-                if created is None:
-                    return jsonify({"error": "message store unavailable"}), 503
-                if not created:
-                    return jsonify({"duplicate": True, "reply": ""}), 200
-                reply = run_turn_to_message(
-                    cfg, hc, tenant, sysprompt, history, text,
-                    origin=cfg.origin, agent_id=agent["id"])
-                hc.log_message(
-                    tenant, "assistant", reply, agent["id"], conversation_id,
-                    surface="imessage", reply_to=user_message_id)
-        except ConversationLockError:
-            return jsonify({"error": "conversation busy"}), 409
-        except Exception:  # noqa: BLE001
-            reply = "Something went wrong on our side. Please try again."
-        return jsonify({"reply": reply})
+            created, user_message_id = hc.claim_inbound_message(
+                tenant, text, agent["id"], conversation_id,
+                "imessage", request_id)
+            if created is None or not user_message_id:
+                return jsonify({"error": "message store unavailable"}), 503
+            run = hc.create_agent_run(
+                tenant, user_message_id, cfg.run_deadline_seconds)
+        except HealthClawError:
+            return jsonify({"error": "run queue unavailable"}), 503
+        return jsonify({"run_id": run["id"], "status": run["status"],
+                        "duplicate": not created}), 202
+
+    @app.get("/api/surfaces/imessage/runs/<run_id>")
+    def imessage_run_result(run_id):
+        """Mint-secret-gated projection polled by the Mac relay."""
+        if request.headers.get("X-Internal-Secret") != cfg.mint_secret:
+            return jsonify({"error": "forbidden"}), 403
+        handle = str(request.args.get("handle") or "").strip()
+        surface = svc.find_surface_by_handle(handle, kind="imessage")
+        if not surface:
+            return jsonify({"error": "unbound handle"}), 404
+        ctx = svc.get_agent_context(surface["account_id"], surface["agent_id"])
+        if not ctx:
+            return jsonify({"error": "unknown agent"}), 404
+        try:
+            run = hc.get_agent_run(ctx["tenant"], run_id)
+            if not _run_belongs_to(run, ctx["tenant"], surface["agent_id"]):
+                return jsonify({"error": "unknown run"}), 404
+            page = hc.agent_run_events(
+                ctx["tenant"], run_id, after=0, limit=500)
+        except HealthClawError:
+            return jsonify({"error": "unknown run"}), 404
+        if page.get("status") not in (
+                "completed", "failed", "cancelled", "waiting_for_human"):
+            return jsonify({"run_id": run_id,
+                            "status": page.get("status")}), 202
+
+        parts: list[str] = []
+        extras: list[str] = []
+        for raw in page.get("events") or []:
+            event = _event_for_browser(raw)
+            if not event:
+                continue
+            if event.get("type") == "text" and event.get("text"):
+                parts.append(event["text"])
+            elif event.get("type") == "card" and (
+                    event.get("kind") == "review"):
+                extras.append(
+                    "I've prepared a form for your review — approve each "
+                    f"item here: {cfg.origin}/review/{surface['agent_id']}/"
+                    f"{event.get('action_id', '')}")
+            elif event.get("type") == "card" and (
+                    event.get("kind") == "pdf" and event.get("url")):
+                extras.append(
+                    f"Your signed document is ready: {event['url']}")
+            elif event.get("type") == "error":
+                parts.append(event.get("text") or (
+                    "Something went wrong on our side."))
+        reply = "\n\n".join([*parts, *extras]).strip() or (
+            "Something went wrong on our side. Please try again.")
+        return jsonify({"run_id": run_id, "status": page.get("status"),
+                        "reply": reply})
 
     # --- trust + ops ---------------------------------------------------------
 

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -430,6 +430,13 @@ def create_app(config: Config | None = None,
     def _run_belongs_to(run: dict, tenant: str, agent_id: str) -> bool:
         return run.get("tenant_id") == tenant and run.get("agent_id") == agent_id
 
+    def _workers_available() -> bool:
+        try:
+            status = hc.agent_worker_health(cfg.run_worker_stale_seconds)
+        except HealthClawError:
+            return False
+        return bool(status.get("available"))
+
     def _stream_run(tenant: str, agent_id: str, run_id: str, after: int = 0):
         """Replay durable UI events. Disconnecting only stops this projection."""
         cursor = max(0, after)
@@ -482,6 +489,11 @@ def create_app(config: Config | None = None,
         text = (body.get("message") or "").strip()
         if not text or len(text) > 2000:
             return jsonify({"error": "message must be 1-2000 characters"}), 400
+        if not _workers_available():
+            return jsonify({
+                "error": "run_workers_unavailable",
+                "message": "Chat is temporarily unavailable. Try again soon.",
+            }), 503
         if not _allow_turn(acct.id):
             return jsonify({"error": "rate_limited"}), 429
         # Durable daily ceiling — survives restarts and is shared across
@@ -717,6 +729,11 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "unknown agent"}), 404
         if not text or len(text) > 2000:
             return jsonify({"error": "message must be 1-2000 characters"}), 400
+        if not _workers_available():
+            return jsonify({
+                "error": "run_workers_unavailable",
+                "message": "Chat is temporarily unavailable. Try again soon.",
+            }), 503
         if not _allow_turn(surface["account_id"]):
             return jsonify({"reply": "One moment — too many messages just now. "
                                      "Try again in a bit."}), 200
@@ -816,8 +833,11 @@ def create_app(config: Config | None = None,
         round-trips a trivial query so the answer reflects reality.
         """
         accounts_ok = svc.ping()
-        body = {"status": "ok" if accounts_ok else "degraded",
-                "provider": cfg.provider, "accounts": accounts_ok}
-        return jsonify(body), (200 if accounts_ok else 503)
+        workers_ok = _workers_available()
+        ready = accounts_ok and workers_ok
+        body = {"status": "ok" if ready else "degraded",
+                "provider": cfg.provider, "accounts": accounts_ok,
+                "run_workers": workers_ok}
+        return jsonify(body), (200 if ready else 503)
 
     return app

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -84,15 +84,38 @@ class Config:
         # public, unauthenticated site).
         self.chat_turns_per_window = int(e.get("CARE_CHAT_TURNS", "20"))
         self.chat_window_seconds = int(e.get("CARE_CHAT_WINDOW", "600"))
-        # Shared serialization for turns in the same durable conversation.
-        # A single development worker can fall back to a local lock; production
-        # deployments should provide Redis before increasing worker count.
+        # Retained for other deployment integrations. Conversation execution
+        # itself is serialized by HealthClaw's database-backed run claims, so
+        # CareAgents no longer depends on Redis for correctness.
         self.redis_url = e.get("REDIS_URL", "")
         # Durable daily ceiling per account. The burst limiter above is
         # in-process, so it resets on restart and multiplies by gunicorn
         # worker count; this one is DB-backed and is what actually bounds
         # what a single account can cost the operator in a day.
         self.chat_turns_per_day = int(e.get("CARE_CHAT_TURNS_PER_DAY", "200"))
+
+        # Durable run execution. Web requests enqueue and replay; this fixed
+        # worker pool performs inference outside Gunicorn request threads.
+        self.run_deadline_seconds = int(e.get("CARE_RUN_DEADLINE_SECONDS", "120"))
+        self.run_lease_seconds = int(e.get("CARE_RUN_LEASE_SECONDS", "60"))
+        self.run_worker_concurrency = int(e.get("CARE_RUN_WORKERS", "4"))
+        self.run_poll_seconds = float(e.get("CARE_RUN_POLL_SECONDS", "0.5"))
+        self.run_sse_poll_seconds = float(e.get(
+            "CARE_RUN_SSE_POLL_SECONDS", "0.25"))
+        self.run_sse_timeout_seconds = int(e.get(
+            "CARE_RUN_SSE_TIMEOUT_SECONDS", "150"))
+        if not 5 <= self.run_deadline_seconds <= 3600:
+            raise ConfigError("CARE_RUN_DEADLINE_SECONDS must be 5-3600")
+        if not 10 <= self.run_lease_seconds <= 600:
+            raise ConfigError("CARE_RUN_LEASE_SECONDS must be 10-600")
+        if not 1 <= self.run_worker_concurrency <= 32:
+            raise ConfigError("CARE_RUN_WORKERS must be 1-32")
+        if not 0.05 <= self.run_poll_seconds <= 30:
+            raise ConfigError("CARE_RUN_POLL_SECONDS must be 0.05-30")
+        if not 0.05 <= self.run_sse_poll_seconds <= 10:
+            raise ConfigError("CARE_RUN_SSE_POLL_SECONDS must be 0.05-10")
+        if not 10 <= self.run_sse_timeout_seconds <= 3600:
+            raise ConfigError("CARE_RUN_SSE_TIMEOUT_SECONDS must be 10-3600")
 
         if prod:
             _require("CARE_SESSION_SECRET", self.session_secret,
@@ -109,8 +132,6 @@ class Config:
                     "ANTHROPIC_OAUTH_TOKEN preferred, OPENAI_API_KEY fallback)")
             _require("RESEND_API_KEY", self.resend_api_key,
                      "email verification codes require a transactional sender")
-            _require("REDIS_URL", self.redis_url,
-                     "conversation turns must serialize across workers")
             # SQLite is single-writer and file-local: it does not survive a
             # host rebuild, cannot be backed up consistently while running,
             # and serialises concurrent users. Fine for one tester, wrong for

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -100,6 +100,8 @@ class Config:
         self.run_lease_seconds = int(e.get("CARE_RUN_LEASE_SECONDS", "60"))
         self.run_worker_concurrency = int(e.get("CARE_RUN_WORKERS", "4"))
         self.run_poll_seconds = float(e.get("CARE_RUN_POLL_SECONDS", "0.5"))
+        self.run_worker_stale_seconds = int(e.get(
+            "CARE_RUN_WORKER_STALE_SECONDS", "30"))
         self.run_sse_poll_seconds = float(e.get(
             "CARE_RUN_SSE_POLL_SECONDS", "0.25"))
         self.run_sse_timeout_seconds = int(e.get(
@@ -112,6 +114,9 @@ class Config:
             raise ConfigError("CARE_RUN_WORKERS must be 1-32")
         if not 0.05 <= self.run_poll_seconds <= 30:
             raise ConfigError("CARE_RUN_POLL_SECONDS must be 0.05-30")
+        if not 5 <= self.run_worker_stale_seconds <= 300:
+            raise ConfigError(
+                "CARE_RUN_WORKER_STALE_SECONDS must be 5-300")
         if not 0.05 <= self.run_sse_poll_seconds <= 10:
             raise ConfigError("CARE_RUN_SSE_POLL_SECONDS must be 0.05-10")
         if not 10 <= self.run_sse_timeout_seconds <= 3600:

--- a/careagents/healthcheck.py
+++ b/careagents/healthcheck.py
@@ -1,0 +1,41 @@
+"""OCI health probe for the CareAgents web and durable-worker roles."""
+
+from __future__ import annotations
+
+import os
+import urllib.parse
+import urllib.request
+
+
+def healthy(env=None) -> bool:
+    env = env or os.environ
+    role = env.get("CARE_ROLE", "web")
+    timeout = 4
+    if role == "worker":
+        base = (env.get("HEALTHCLAW_BASE") or "").rstrip("/")
+        secret = env.get("HEALTHCLAW_MINT_SECRET") or ""
+        stale = env.get("CARE_RUN_WORKER_STALE_SECONDS", "30")
+        if not base or not secret:
+            return False
+        query = urllib.parse.urlencode({"max_age_seconds": stale})
+        request = urllib.request.Request(
+            f"{base}/command-center/api/runs/workers/health?{query}",
+            headers={"X-Internal-Secret": secret},
+        )
+    else:
+        port = env.get("PORT", "8600")
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/healthz")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status == 200
+    except Exception:  # noqa: BLE001 - a health probe must return unhealthy
+        return False
+
+
+def main() -> None:
+    raise SystemExit(0 if healthy() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -436,6 +436,31 @@ class HealthClawClient:
                 f"run claim failed ({r.status_code})", r.status_code)
         return r.json()
 
+    def agent_worker_health(self, max_age_seconds: int = 30) -> dict:
+        """Return queue-backed worker readiness, including unavailable/503."""
+        try:
+            r = self.http.get(
+                f"{self.base}/command-center/api/runs/workers/health",
+                params={"max_age_seconds": max_age_seconds},
+                headers=self._internal_headers(), timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run worker health failed", 0) from exc
+        if r.status_code not in (200, 503):
+            raise HealthClawError(
+                f"run worker health failed ({r.status_code})", r.status_code)
+        try:
+            result = r.json()
+        except ValueError as exc:
+            raise HealthClawError(
+                "run worker health returned invalid data", r.status_code
+            ) from exc
+        if not isinstance(result, dict):
+            raise HealthClawError(
+                "run worker health returned invalid data", r.status_code)
+        result["available"] = r.status_code == 200 and bool(
+            result.get("available"))
+        return result
+
     def heartbeat_agent_run(self, run_id: str, worker_id: str,
                             lease_seconds: int = 60) -> dict:
         return self._run_internal_post(
@@ -456,6 +481,15 @@ class HealthClawClient:
         if error_class is not None:
             body["error_class"] = error_class
         return self._run_internal_post(f"/{run_id}/transition", body)
+
+    def finalize_agent_run(self, run_id: str, worker_id: str, text: str,
+                           checkpoint_id: str) -> dict:
+        """Atomically persist the assistant answer and run completion."""
+        return self._run_internal_post(
+            f"/{run_id}/finalize",
+            {"worker_id": worker_id, "text": text,
+             "checkpoint_id": checkpoint_id},
+        )
 
     def append_agent_run_event(self, run_id: str, worker_id: str,
                                event_type: str, payload=None) -> dict:

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -78,6 +78,10 @@ class HealthClawClient:
                 "X-Step-Up-Token": self.mint_token(tenant),
                 "X-Agent-Id": "careagents"}
 
+    def _internal_headers(self) -> dict:
+        return {"X-Internal-Secret": self.mint_secret,
+                "X-Agent-Id": "careagents-worker"}
+
     # --- reads (redacted + audited by the layer) -----------------------------
 
     def search(self, tenant: str, resource_type: str,
@@ -327,7 +331,8 @@ class HealthClawClient:
                     agent_id: str | None = None,
                     conversation_id: str | None = None,
                     surface: str = "web",
-                    reply_to: str | None = None) -> bool:
+                    reply_to: str | None = None,
+                    request_id: str | None = None) -> bool:
         """Append one turn. Returns False on failure rather than raising:
         losing a transcript must never break the conversation in progress.
 
@@ -336,7 +341,7 @@ class HealthClawClient:
         """
         status, _body = self._post_message(
             tenant, role, text, agent_id, conversation_id, surface,
-            reply_to=reply_to)
+            request_id=request_id, reply_to=reply_to)
         if status not in (200, 201):
             if status is not None:
                 logger.warning("chat turn rejected for %s: HTTP %s",
@@ -346,14 +351,16 @@ class HealthClawClient:
 
     def recent_messages(self, tenant: str, limit: int = 20,
                         conversation_id: str | None = None,
-                        agent_id: str | None = None) -> list[dict]:
+                        agent_id: str | None = None,
+                        through_message_id: str | None = None) -> list[dict]:
         """Oldest-first [{role, text}] for rehydrating a conversation."""
         try:
             r = self.http.get(
                 f"{self.base}/command-center/api/conversations",
                 params={"limit": limit, "full": "1", "tenant": tenant,
                         "conversation_id": conversation_id,
-                        "agent_id": agent_id},
+                        "agent_id": agent_id,
+                        "through_message_id": through_message_id},
                 headers={"X-Tenant-Id": tenant,
                          "X-Step-Up-Token": self.mint_token(tenant)},
                 timeout=self.timeout)
@@ -367,6 +374,135 @@ class HealthClawClient:
                for m in reversed(rows)          # endpoint returns newest-first
                if m.get("role") in ("user", "assistant")]
         return out
+
+    # --- durable agent runs --------------------------------------------------
+
+    def create_agent_run(self, tenant: str, message_id: str,
+                         deadline_seconds: int = 120) -> dict:
+        """Create (or retrieve) the one durable run for an inbound message."""
+        try:
+            r = self.http.post(
+                f"{self.base}/command-center/api/runs",
+                json={"tenant_id": tenant, "message_id": message_id,
+                      "deadline_seconds": deadline_seconds},
+                headers=self._headers(tenant), timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run enqueue failed", 0) from exc
+        if r.status_code not in (200, 201):
+            raise HealthClawError(
+                f"run enqueue failed ({r.status_code})", r.status_code)
+        return r.json()
+
+    def get_agent_run(self, tenant: str, run_id: str) -> dict:
+        try:
+            r = self.http.get(
+                f"{self.base}/command-center/api/runs/{run_id}",
+                headers=self._headers(tenant), timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run lookup failed", 0) from exc
+        if r.status_code != 200:
+            raise HealthClawError(
+                f"run lookup failed ({r.status_code})", r.status_code)
+        return r.json()
+
+    def agent_run_events(self, tenant: str, run_id: str, after: int = 0,
+                         limit: int = 100) -> dict:
+        try:
+            r = self.http.get(
+                f"{self.base}/command-center/api/runs/{run_id}/events",
+                params={"after": max(0, int(after)), "limit": limit},
+                headers=self._headers(tenant), timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run event replay failed", 0) from exc
+        if r.status_code != 200:
+            raise HealthClawError(
+                f"run event replay failed ({r.status_code})", r.status_code)
+        return r.json()
+
+    def claim_agent_run(self, worker_id: str,
+                        lease_seconds: int = 60) -> dict | None:
+        try:
+            r = self.http.post(
+                f"{self.base}/command-center/api/runs/claim",
+                json={"worker_id": worker_id,
+                      "lease_seconds": lease_seconds},
+                headers=self._internal_headers(), timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run claim failed", 0) from exc
+        if r.status_code == 204:
+            return None
+        if r.status_code != 200:
+            raise HealthClawError(
+                f"run claim failed ({r.status_code})", r.status_code)
+        return r.json()
+
+    def heartbeat_agent_run(self, run_id: str, worker_id: str,
+                            lease_seconds: int = 60) -> dict:
+        return self._run_internal_post(
+            f"/{run_id}/heartbeat",
+            {"worker_id": worker_id, "lease_seconds": lease_seconds})
+
+    def transition_agent_run(self, run_id: str, worker_id: str, status: str,
+                             *, event_type: str | None = None,
+                             payload=None,
+                             error_class: str | None = None,
+                             available_in_seconds: int = 0) -> dict:
+        body = {"worker_id": worker_id, "status": status,
+                "available_in_seconds": available_in_seconds}
+        if event_type is not None:
+            body["event_type"] = event_type
+        if payload is not None:
+            body["payload"] = payload
+        if error_class is not None:
+            body["error_class"] = error_class
+        return self._run_internal_post(f"/{run_id}/transition", body)
+
+    def append_agent_run_event(self, run_id: str, worker_id: str,
+                               event_type: str, payload=None) -> dict:
+        body = {"worker_id": worker_id, "type": event_type}
+        if payload is not None:
+            body["payload"] = payload
+        return self._run_internal_post(f"/{run_id}/events", body,
+                                       expected=(201,))
+
+    def register_agent_tool_call(self, run_id: str, worker_id: str,
+                                 provider_call_id: str, tool_name: str,
+                                 arguments: dict) -> dict:
+        return self._run_internal_post(
+            f"/{run_id}/tool-calls",
+            {"worker_id": worker_id,
+             "provider_call_id": provider_call_id,
+             "tool_name": tool_name,
+             "arguments": arguments},
+            expected=(200, 201))
+
+    def transition_agent_tool_call(self, run_id: str, call_id: str,
+                                   worker_id: str, status: str, *,
+                                   result=None, outcome_ref: str | None = None,
+                                   error_class: str | None = None) -> dict:
+        body = {"worker_id": worker_id, "status": status}
+        if result is not None:
+            body["result"] = result
+        if outcome_ref is not None:
+            body["outcome_ref"] = outcome_ref
+        if error_class is not None:
+            body["error_class"] = error_class
+        return self._run_internal_post(
+            f"/{run_id}/tool-calls/{call_id}/transition", body)
+
+    def _run_internal_post(self, path: str, body: dict,
+                           expected: tuple[int, ...] = (200,)) -> dict:
+        try:
+            r = self.http.post(
+                f"{self.base}/command-center/api/runs{path}",
+                json=body, headers=self._internal_headers(),
+                timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise HealthClawError("run worker request failed", 0) from exc
+        if r.status_code not in expected:
+            raise HealthClawError(
+                f"run worker request failed ({r.status_code})", r.status_code)
+        return r.json()
 
     # --- surfaces: Telegram binding ------------------------------------------
 

--- a/careagents/static/chat.js
+++ b/careagents/static/chat.js
@@ -101,6 +101,46 @@
     }, 4000);
   }
 
+  function pause(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+  async function consumeEvents(resp, state, typing) {
+    const reader = resp.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let idx;
+      while ((idx = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, idx); buf = buf.slice(idx + 2);
+        const lines = frame.split("\n");
+        const idLine = lines.find((line) => line.startsWith("id: "));
+        const dataLine = lines.find((line) => line.startsWith("data: "));
+        if (idLine) state.cursor = Math.max(
+          state.cursor, parseInt(idLine.slice(4), 10) || 0);
+        if (!dataLine) continue;
+        let ev;
+        try { ev = JSON.parse(dataLine.slice(6)); } catch (e) { continue; }
+        if (ev.type === "accepted") {
+          state.runId = ev.run_id;
+          state.cursor = Math.max(state.cursor, ev.next_cursor || 0);
+        } else if (ev.type === "tool") addChip(ev.label);
+        else if (ev.type === "card" && ev.kind === "review")
+          addReviewCard(ev.action_id, ev.review_url);
+        else if (ev.type === "card" && ev.kind === "pdf")
+          addPdfCard(ev.url);
+        else if (ev.type === "text") {
+          typing.remove(); addAgentText(ev.text);
+        } else if (ev.type === "error") {
+          typing.remove(); addAgentText("⚠️ " + ev.text);
+        } else if (ev.type === "done") {
+          state.done = true;
+        }
+      }
+    }
+  }
+
   async function send(text) {
     if (busy || !text.trim()) return;
     busy = true; sendBtn.disabled = true;
@@ -113,45 +153,48 @@
       : Date.now().toString(36) + "-" + Math.random().toString(36).slice(2);
 
     try {
-      const resp = await fetch("/api/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text, agent_id: AGENT,
-                               conversation_id: CONVERSATION,
-                               request_id: requestId }),
-      });
-      if (resp.status === 429) {
-        typing.remove();
-        addAgentText("You’ve hit the pace limit for now — give it a few minutes.");
-        return;
-      }
-      if (!resp.ok || !resp.body) {
-        typing.remove();
-        addAgentText("I couldn’t reach my tools just now. Try again in a moment.");
-        return;
-      }
-      const reader = resp.body.getReader();
-      const dec = new TextDecoder();
-      let buf = "";
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buf += dec.decode(value, { stream: true });
-        let idx;
-        while ((idx = buf.indexOf("\n\n")) >= 0) {
-          const frame = buf.slice(0, idx); buf = buf.slice(idx + 2);
-          if (!frame.startsWith("data: ")) continue;
-          let ev;
-          try { ev = JSON.parse(frame.slice(6)); } catch (e) { continue; }
-          if (ev.type === "tool") addChip(ev.label);
-          else if (ev.type === "card" && ev.kind === "review")
-            addReviewCard(ev.action_id, ev.review_url);
-          else if (ev.type === "card" && ev.kind === "pdf")
-            addPdfCard(ev.url);
-          else if (ev.type === "text") { typing.remove(); addAgentText(ev.text); }
-          else if (ev.type === "duplicate") { typing.remove(); }
-          else if (ev.type === "error") { typing.remove(); addAgentText("⚠️ " + ev.text); }
+      const state = { runId: null, cursor: 0, done: false };
+      let initial = true;
+      let reconnectFailures = 0;
+      while (!state.done) {
+        try {
+          let resp;
+          if (initial || !state.runId) {
+            resp = await fetch("/api/chat", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ message: text, agent_id: AGENT,
+                                     conversation_id: CONVERSATION,
+                                     request_id: requestId,
+                                     after: state.cursor }),
+            });
+          } else {
+            const query = new URLSearchParams({
+              agent_id: AGENT, after: String(state.cursor),
+            });
+            resp = await fetch("/api/chat/runs/" +
+              encodeURIComponent(state.runId) + "/events?" + query.toString());
+          }
+          initial = false;
+          if (resp.status === 429) {
+            typing.remove();
+            addAgentText("You’ve hit the pace limit for now — give it a few minutes.");
+            return;
+          }
+          if (!resp.ok || !resp.body) throw new Error("event stream unavailable");
+          const responseRunId = resp.headers.get("X-CareAgents-Run-ID");
+          if (responseRunId) state.runId = responseRunId;
+          await consumeEvents(resp, state, typing);
+          reconnectFailures = 0;
+        } catch (streamError) {
+          reconnectFailures += 1;
+          // If the POST reached the server but its response was lost before
+          // the accepted event/header arrived, retrying with the same durable
+          // request ID retrieves the same message/run instead of inferring
+          // twice. Once the run ID is known, reconnect with GET only.
+          if (reconnectFailures > 5) throw streamError;
         }
+        if (!state.done) await pause(400);
       }
       if (typing.parentNode) typing.remove();
     } catch (e) {

--- a/careagents/worker.py
+++ b/careagents/worker.py
@@ -1,0 +1,438 @@
+"""Dedicated durable-run worker for CareAgents.
+
+The web app only persists an inbound message, creates its AgentRun, and replays
+events. This process owns model inference and tool execution. A lease heartbeat
+keeps a live claim from being recovered; after a crash, checkpoints and durable
+tool results let another worker continue without repeating completed tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import socket
+import threading
+from datetime import datetime, timezone
+
+from careagents import llm
+from careagents.accounts import AccountService
+from careagents.agent import (MAX_TOOL_ROUNDS, TOOL_LABELS, TOOLS,
+                              _execute_tool, _trim_history)
+from careagents.config import Config
+from careagents.healthclaw import HealthClawClient, HealthClawError
+from careagents.personas import system_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class RunCancelled(RuntimeError):
+    pass
+
+
+class RunDeadlineExceeded(RuntimeError):
+    pass
+
+
+class AmbiguousToolOutcome(RuntimeError):
+    pass
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _error_class(exc: Exception) -> str:
+    name = type(exc).__name__
+    return name if name and name[0].isalpha() else "WorkerError"
+
+
+class LeaseHeartbeat:
+    """Refresh one run lease independently of blocking provider calls."""
+
+    def __init__(self, hc: HealthClawClient, run_id: str, worker_id: str,
+                 lease_seconds: int):
+        self.hc = hc
+        self.run_id = run_id
+        self.worker_id = worker_id
+        self.lease_seconds = lease_seconds
+        self.cancel_requested = False
+        self.lost = False
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._loop, name=f"lease-{run_id[:8]}", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+    def check(self) -> None:
+        if self.cancel_requested:
+            raise RunCancelled("run cancellation requested")
+        if self.lost:
+            raise HealthClawError("worker lease was lost", 409)
+
+    def _loop(self) -> None:
+        interval = max(2.0, self.lease_seconds / 3)
+        while not self._stop.wait(interval):
+            try:
+                result = self.hc.heartbeat_agent_run(
+                    self.run_id, self.worker_id, self.lease_seconds)
+                self.cancel_requested = bool(result.get("cancel_requested"))
+            except HealthClawError as exc:
+                logger.error("heartbeat failed for run %s: %s",
+                             self.run_id, exc)
+                self.lost = True
+                return
+
+
+class RunWorker:
+    def __init__(self, cfg: Config, hc: HealthClawClient,
+                 accounts: AccountService, worker_id: str):
+        self.cfg = cfg
+        self.hc = hc
+        self.accounts = accounts
+        self.worker_id = worker_id
+
+    def run_once(self) -> bool:
+        run = self.hc.claim_agent_run(
+            self.worker_id, self.cfg.run_lease_seconds)
+        if run is None:
+            return False
+        self.process(run)
+        return True
+
+    def process(self, run: dict) -> None:
+        run_id = str(run["id"])
+        heartbeat = LeaseHeartbeat(
+            self.hc, run_id, self.worker_id, self.cfg.run_lease_seconds)
+        heartbeat.start()
+        try:
+            self._execute(run, heartbeat)
+        except RunCancelled:
+            heartbeat.stop()
+            self.hc.transition_agent_run(
+                run_id, self.worker_id, "cancelled",
+                event_type="run.cancelled",
+                payload={"status": "cancelled"})
+        except AmbiguousToolOutcome:
+            heartbeat.stop()
+            self.hc.append_agent_run_event(
+                run_id, self.worker_id, "agent.error", {
+                    "text": ("A tool may have completed before the worker "
+                             "stopped. It will not be repeated until its "
+                             "outcome is reconciled.")})
+            self.hc.transition_agent_run(
+                run_id, self.worker_id, "waiting_for_human",
+                event_type="run.needs_reconciliation",
+                payload={"status": "waiting_for_human"},
+                error_class="AmbiguousToolOutcome")
+        except Exception as exc:  # noqa: BLE001 - boundary records safe class
+            heartbeat.stop()
+            logger.exception("CareAgents run %s failed", run_id)
+            try:
+                self.hc.append_agent_run_event(
+                    run_id, self.worker_id, "agent.error",
+                    {"text": "Something went wrong on our side."})
+                self.hc.transition_agent_run(
+                    run_id, self.worker_id, "failed",
+                    event_type="run.failed",
+                    payload={"status": "failed"},
+                    error_class=_error_class(exc))
+            except HealthClawError:
+                logger.exception("could not record failure for run %s", run_id)
+        else:
+            heartbeat.stop()
+
+    def _execute(self, run: dict, heartbeat: LeaseHeartbeat) -> None:
+        run_id = str(run["id"])
+        tenant = str(run["tenant_id"])
+        agent_id = str(run.get("agent_id") or "")
+        message = run.get("message") or {}
+        user_text = str(message.get("text") or "")
+        if not agent_id or not user_text:
+            raise ValueError("claimed run has no CareAgents agent or message")
+
+        context = self.accounts.get_worker_agent_context(agent_id)
+        if context is None or context["tenant"] != tenant:
+            raise ValueError("claimed run does not match a CareAgents tenant")
+        agent = context["agent"]
+        prompt = system_prompt(
+            agent["name"], agent["persona"], agent.get("advisor"))
+
+        history = self.hc.recent_messages(
+            tenant, limit=40, conversation_id=run["conversation_id"],
+            agent_id=agent_id, through_message_id=run["message_id"])
+        _trim_history(history)
+        if not history or history[-1].get("role") != "user" or (
+                history[-1].get("content") != user_text):
+            # The claimed message is authoritative. This fallback covers a
+            # projection lag without ever appending it twice on the normal path.
+            history.append({"role": "user", "content": user_text})
+
+        replay = self.hc.agent_run_events(tenant, run_id, after=0, limit=500)
+        events = list(replay.get("events") or [])
+        checkpoints = [event for event in events
+                       if event.get("type") == "agent.checkpoint"]
+        tool_results = {
+            str((event.get("payload") or {}).get("provider_call_id")): (
+                event.get("payload") or {})
+            for event in events if event.get("type") == "agent.tool_result"
+        }
+        emitted = {
+            (event.get("type"), str((event.get("payload") or {}).get(
+                "event_key") or (event.get("payload") or {}).get(
+                    "checkpoint_id") or (event.get("payload") or {}).get(
+                    "provider_call_id") or ""))
+            for event in events
+        }
+
+        round_number = 0
+        final_checkpoint = None
+        for checkpoint in checkpoints:
+            payload = checkpoint.get("payload") or {}
+            round_number = max(round_number, int(payload.get("round") or 0))
+            calls = payload.get("tool_calls") or []
+            history.append({
+                "role": "assistant",
+                "content": payload.get("text") or "",
+                "tool_calls": calls,
+                "_openai_tool_calls": payload.get("raw_tool_calls") or [],
+            })
+            for call in calls:
+                result = tool_results.get(str(call.get("id")))
+                if result is None:
+                    # Only the newest checkpoint may be incomplete. Older
+                    # missing results indicate corrupted recovery state.
+                    if checkpoint is not checkpoints[-1]:
+                        raise ValueError("incomplete historical checkpoint")
+                    break
+                self._emit_ui_events(
+                    run["id"], str(call["id"]),
+                    result.get("ui_events") or [], emitted)
+                history.append({"role": "tool",
+                                "tool_call_id": call["id"],
+                                "content": result.get("content") or "{}"})
+            if not calls:
+                final_checkpoint = payload
+
+        if final_checkpoint is not None:
+            self._finish(run, final_checkpoint, emitted, heartbeat)
+            return
+
+        while True:
+            heartbeat.check()
+            self._check_deadline(run)
+
+            pending_checkpoint = checkpoints[-1].get("payload") if (
+                checkpoints and any(
+                    str(call.get("id")) not in tool_results
+                    for call in ((checkpoints[-1].get("payload") or {}).get(
+                        "tool_calls") or []))) else None
+            if pending_checkpoint is None:
+                tools = TOOLS if round_number < MAX_TOOL_ROUNDS else []
+                turn = llm.complete(self.cfg, prompt, history, tools)
+                round_number += 1
+                checkpoint_id = f"round-{round_number}"
+                pending_checkpoint = {
+                    "checkpoint_id": checkpoint_id,
+                    "round": round_number,
+                    "text": turn.text,
+                    "tool_calls": [
+                        {"id": call.id, "name": call.name,
+                         "arguments": call.arguments}
+                        for call in turn.tool_calls],
+                    "raw_tool_calls": turn.raw_tool_calls,
+                }
+                self.hc.append_agent_run_event(
+                    run_id, self.worker_id, "agent.checkpoint",
+                    pending_checkpoint)
+                checkpoints.append({"type": "agent.checkpoint",
+                                    "payload": pending_checkpoint})
+                history.append({
+                    "role": "assistant", "content": turn.text,
+                    "tool_calls": pending_checkpoint["tool_calls"],
+                    "_openai_tool_calls": turn.raw_tool_calls,
+                })
+
+            calls = pending_checkpoint.get("tool_calls") or []
+            if not calls:
+                self._finish(run, pending_checkpoint, emitted, heartbeat)
+                return
+
+            for call in calls:
+                heartbeat.check()
+                self._check_deadline(run)
+                call_id = str(call["id"])
+                result_event = tool_results.get(call_id)
+                if result_event is None:
+                    result_event = self._execute_durable_tool(
+                        run, call, emitted)
+                    tool_results[call_id] = result_event
+                history.append({"role": "tool", "tool_call_id": call_id,
+                                "content": result_event.get("content") or "{}"})
+            # The checkpoint is now complete. A following iteration performs
+            # the next model call; the completed tools remain replayable.
+
+    def _execute_durable_tool(self, run: dict, call: dict,
+                              emitted: set[tuple[str, str]]) -> dict:
+        run_id = str(run["id"])
+        tenant = str(run["tenant_id"])
+        provider_call_id = str(call["id"])
+        tool_name = str(call["name"])
+        arguments = call.get("arguments") or {}
+
+        durable = self.hc.register_agent_tool_call(
+            run_id, self.worker_id, provider_call_id, tool_name, arguments)
+        marker = ("agent.tool", provider_call_id)
+        if marker not in emitted:
+            self.hc.append_agent_run_event(
+                run_id, self.worker_id, "agent.tool",
+                {"provider_call_id": provider_call_id,
+                 "name": tool_name,
+                 "label": TOOL_LABELS.get(tool_name, tool_name)})
+            emitted.add(marker)
+
+        if durable.get("status") == "completed":
+            envelope = durable.get("result") or {}
+        else:
+            if durable.get("status") == "running":
+                self.hc.transition_agent_tool_call(
+                    run_id, durable["id"], self.worker_id,
+                    "needs_reconciliation",
+                    error_class="WorkerLeaseExpired")
+                raise AmbiguousToolOutcome(
+                    "tool was running when its worker lease expired")
+            if durable.get("status") == "needs_reconciliation":
+                raise AmbiguousToolOutcome(
+                    "tool outcome still requires reconciliation")
+            self.hc.transition_agent_tool_call(
+                run_id, durable["id"], self.worker_id, "running")
+            side_events: list[dict] = []
+            try:
+                content = _execute_tool(
+                    self.hc, tenant, tool_name, arguments, side_events)
+            except HealthClawError as exc:
+                content = json.dumps({"error": str(exc)})
+            envelope = {"content": content, "ui_events": side_events}
+            outcome_ref = next((
+                str(event.get("action_id"))
+                for event in side_events if event.get("action_id")), None)
+            self.hc.transition_agent_tool_call(
+                run_id, durable["id"], self.worker_id, "completed",
+                result=envelope, outcome_ref=outcome_ref)
+
+        result_payload = {
+            "provider_call_id": provider_call_id,
+            "content": envelope.get("content") or "{}",
+            "ui_events": envelope.get("ui_events") or [],
+        }
+        result_marker = ("agent.tool_result", provider_call_id)
+        if result_marker not in emitted:
+            self.hc.append_agent_run_event(
+                run_id, self.worker_id, "agent.tool_result", result_payload)
+            emitted.add(result_marker)
+        self._emit_ui_events(
+            run_id, provider_call_id, result_payload["ui_events"], emitted)
+        return result_payload
+
+    def _emit_ui_events(self, run_id: str, provider_call_id: str,
+                        ui_events: list[dict],
+                        emitted: set[tuple[str, str]]) -> None:
+        for index, ui_event in enumerate(ui_events):
+            event_key = f"{provider_call_id}:{index}"
+            marker = ("agent.card", event_key)
+            if marker in emitted:
+                continue
+            payload = dict(ui_event)
+            payload["provider_call_id"] = provider_call_id
+            payload["event_key"] = event_key
+            self.hc.append_agent_run_event(
+                run_id, self.worker_id, "agent.card", payload)
+            emitted.add(marker)
+
+    def _finish(self, run: dict, checkpoint: dict,
+                emitted: set[tuple[str, str]], heartbeat: LeaseHeartbeat) -> None:
+        heartbeat.check()
+        self._check_deadline(run)
+        run_id = str(run["id"])
+        text = str(checkpoint.get("text") or "").strip() or "…"
+        checkpoint_id = str(checkpoint.get("checkpoint_id") or "final")
+        marker = ("agent.text", checkpoint_id)
+        if marker not in emitted:
+            saved = self.hc.log_message(
+                run["tenant_id"], "assistant", text, run.get("agent_id"),
+                run["conversation_id"], surface=run.get("surface") or "web",
+                reply_to=run.get("message_id"),
+                request_id=f"run:{run_id}:assistant")
+            if not saved:
+                raise HealthClawError("assistant outcome was not persisted", 0)
+            self.hc.append_agent_run_event(
+                run_id, self.worker_id, "agent.text",
+                {"checkpoint_id": checkpoint_id, "text": text})
+        self.hc.transition_agent_run(
+            run_id, self.worker_id, "completed",
+            event_type="run.completed", payload={"status": "completed"})
+
+    @staticmethod
+    def _check_deadline(run: dict) -> None:
+        deadline = _parse_time(run.get("deadline_at"))
+        if deadline is not None and datetime.now(timezone.utc) >= deadline:
+            raise RunDeadlineExceeded("run deadline exceeded")
+
+
+def run_worker_pool(cfg: Config, stop: threading.Event | None = None) -> None:
+    """Run a fixed-size pool; each slot owns its HTTP session and lease id."""
+    stop = stop or threading.Event()
+    accounts = AccountService(cfg)
+    host = socket.gethostname().split(".")[0]
+    base_id = f"careagents-{host}-{os.getpid()}"
+
+    def loop(slot: int) -> None:
+        hc = HealthClawClient(cfg.healthclaw_base, cfg.mint_secret)
+        worker = RunWorker(cfg, hc, accounts, f"{base_id}-{slot}")
+        while not stop.is_set():
+            try:
+                worked = worker.run_once()
+            except HealthClawError as exc:
+                logger.error("run claim failed: %s", exc)
+                worked = False
+            if not worked:
+                stop.wait(cfg.run_poll_seconds)
+
+    threads = [threading.Thread(target=loop, args=(slot,), daemon=False,
+                                name=f"careagents-worker-{slot}")
+               for slot in range(cfg.run_worker_concurrency)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def main() -> None:
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    cfg = Config()
+    stop = threading.Event()
+
+    def request_stop(_signum, _frame) -> None:
+        stop.set()
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    run_worker_pool(cfg, stop)
+
+
+if __name__ == "__main__":
+    main()

--- a/careagents/worker.py
+++ b/careagents/worker.py
@@ -127,6 +127,18 @@ class RunWorker:
                 run_id, self.worker_id, "cancelled",
                 event_type="run.cancelled",
                 payload={"status": "cancelled"})
+        except RunDeadlineExceeded:
+            heartbeat.stop()
+            try:
+                self.hc.transition_agent_run(
+                    run_id, self.worker_id, "failed",
+                    event_type="run.deadline_exceeded",
+                    payload={"status": "failed"},
+                    error_class="RunDeadlineExceeded")
+            except HealthClawError:
+                # The authoritative heartbeat may already have committed the
+                # same terminal deadline transition and revoked this lease.
+                logger.info("run %s was already terminal at deadline", run_id)
         except AmbiguousToolOutcome:
             heartbeat.stop()
             self.hc.append_agent_run_event(
@@ -244,6 +256,11 @@ class RunWorker:
             if pending_checkpoint is None:
                 tools = TOOLS if round_number < MAX_TOOL_ROUNDS else []
                 turn = llm.complete(self.cfg, prompt, history, tools)
+                # The provider call may outlive the lease or hard deadline.
+                # Never checkpoint or persist a late result after the
+                # authoritative heartbeat transaction revoked ownership.
+                heartbeat.check()
+                self._check_deadline(run)
                 round_number += 1
                 checkpoint_id = f"round-{round_number}"
                 pending_checkpoint = {
@@ -371,20 +388,12 @@ class RunWorker:
         text = str(checkpoint.get("text") or "").strip() or "…"
         checkpoint_id = str(checkpoint.get("checkpoint_id") or "final")
         marker = ("agent.text", checkpoint_id)
-        if marker not in emitted:
-            saved = self.hc.log_message(
-                run["tenant_id"], "assistant", text, run.get("agent_id"),
-                run["conversation_id"], surface=run.get("surface") or "web",
-                reply_to=run.get("message_id"),
-                request_id=f"run:{run_id}:assistant")
-            if not saved:
-                raise HealthClawError("assistant outcome was not persisted", 0)
-            self.hc.append_agent_run_event(
-                run_id, self.worker_id, "agent.text",
-                {"checkpoint_id": checkpoint_id, "text": text})
-        self.hc.transition_agent_run(
-            run_id, self.worker_id, "completed",
-            event_type="run.completed", payload={"status": "completed"})
+        # HealthClaw owns the final fencing transaction. A client-side
+        # heartbeat check cannot atomically order transcript persistence
+        # against a concurrent deadline sweep or lease recovery.
+        self.hc.finalize_agent_run(
+            run_id, self.worker_id, text, checkpoint_id)
+        emitted.add(marker)
 
     @staticmethod
     def _check_deadline(run: dict) -> None:

--- a/careagents/wsgi.py
+++ b/careagents/wsgi.py
@@ -1,7 +1,7 @@
 """WSGI entry point: gunicorn 'careagents.wsgi:app'.
 
-Conversation turns use a Redis-backed distributed lock when ``REDIS_URL`` is
-configured, with a process-local fallback for single-worker development.
+The WSGI process only authenticates, enqueues, and replays durable run events.
+Inference and tools execute in ``python -m careagents.worker``.
 """
 
 from careagents.app import create_app

--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -4,10 +4,8 @@
 # so deploy with:  railway up  from a staging dir, or set the service's
 # Dockerfile path to deploy/careagents/Dockerfile with root as context.
 #
-# One worker on purpose: chat history is process-local (careagents/wsgi.py),
-# so a second worker would serve half the turns from an empty history.
-# Threads give concurrency without splitting that state. Scaling past one
-# process requires moving history to shared storage first.
+# The image supports two process roles: the default web command below, and
+# ``python -m careagents.worker`` for the durable inference/tool worker.
 
 FROM python:3.11-slim
 
@@ -26,6 +24,7 @@ RUN uv sync --frozen --no-dev
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
+ENV CARE_ROLE=web
 
 COPY careagents/ ./careagents/
 
@@ -33,13 +32,14 @@ COPY careagents/ ./careagents/
 ENV PORT=8600
 EXPOSE 8600
 
-# Health check hits the app's own readiness endpoint, so a container that
-# boots but can't reach its database is reported unhealthy rather than "up".
+# The web role probes its readiness endpoint. The worker has no HTTP listener;
+# its role-specific health check is process liveness, which the container
+# runtime already enforces by restarting an exited process.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD python -c "import os,urllib.request,sys; \
-sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PORT','8600')+'/healthz', timeout=4).status==200 else 1)"
+sys.exit(0 if os.environ.get('CARE_ROLE')=='worker' else (0 if urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PORT','8600')+'/healthz', timeout=4).status==200 else 1))"
 
 CMD ["sh", "-c", "gunicorn careagents.wsgi:app \
-  --bind 0.0.0.0:${PORT:-8600} --workers 1 --threads 8 --timeout 120 \
+  --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 4 --timeout 180 \
   --access-logfile - --error-logfile - \
   --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms'"]

--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -32,12 +32,10 @@ COPY careagents/ ./careagents/
 ENV PORT=8600
 EXPOSE 8600
 
-# The web role probes its readiness endpoint. The worker has no HTTP listener;
-# its role-specific health check is process liveness, which the container
-# runtime already enforces by restarting an exited process.
+# The web role probes its readiness endpoint. The worker role checks durable
+# queue presence, so a live-but-hung process cannot advertise itself healthy.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD python -c "import os,urllib.request,sys; \
-sys.exit(0 if os.environ.get('CARE_ROLE')=='worker' else (0 if urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('PORT','8600')+'/healthz', timeout=4).status==200 else 1))"
+  CMD python -m careagents.healthcheck
 
 CMD ["sh", "-c", "gunicorn careagents.wsgi:app \
   --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 4 --timeout 180 \

--- a/deploy/careagents/careagents-worker.service
+++ b/deploy/careagents/careagents-worker.service
@@ -1,0 +1,25 @@
+# CareAgents durable-run worker (careagents.cloud VPS)
+# Install: /etc/systemd/system/careagents-worker.service
+[Unit]
+Description=CareAgents durable inference and tool worker
+After=network.target
+
+[Service]
+Type=simple
+User=careagents
+Group=careagents
+WorkingDirectory=/opt/careagents/app
+EnvironmentFile=/etc/careagents/careagents.env
+ExecStart=/opt/careagents/venv/bin/python -m careagents.worker
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=150
+KillSignal=SIGTERM
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/opt/careagents
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/careagents/careagents.service
+++ b/deploy/careagents/careagents.service
@@ -1,6 +1,6 @@
 # CareAgents — systemd unit (careagents.cloud VPS)
 # Install: /etc/systemd/system/careagents.service
-# ONE worker by design: chat history is process-local (see careagents/app.py).
+# Web processes enqueue + replay only; inference runs in careagents-worker.
 [Unit]
 Description=CareAgents hosted experience (careagents.cloud)
 After=network.target
@@ -12,7 +12,7 @@ Group=careagents
 WorkingDirectory=/opt/careagents/app
 EnvironmentFile=/etc/careagents/careagents.env
 ExecStart=/opt/careagents/venv/bin/gunicorn careagents.wsgi:app \
-  --bind 127.0.0.1:8600 --workers 1 --threads 8 --timeout 120 \
+  --bind 127.0.0.1:8600 --workers 2 --threads 4 --timeout 180 \
   --access-logfile - --error-logfile - \
   --access-logformat '%%(h)s "%%(r)s" %%(s)s %%(M)sms'
 Restart=on-failure

--- a/deploy/careagents/deploy.sh
+++ b/deploy/careagents/deploy.sh
@@ -82,6 +82,7 @@ CARE_MODEL=claude-sonnet-5
 CARE_RUN_WORKERS=4
 CARE_RUN_DEADLINE_SECONDS=120
 CARE_RUN_LEASE_SECONDS=60
+CARE_RUN_WORKER_STALE_SECONDS=30
 ENV
   chmod 600 /etc/careagents/careagents.env
   echo "!! populate /etc/careagents/careagents.env before the service will boot"
@@ -128,6 +129,12 @@ systemctl restart careagents careagents-worker nginx
 sleep 2
 systemctl is-active careagents
 systemctl is-active careagents-worker
+for _attempt in {1..30}; do
+  if curl -sf http://127.0.0.1:8600/healthz >/dev/null; then
+    break
+  fi
+  sleep 1
+done
 curl -sf http://127.0.0.1:8600/healthz && echo
 REMOTE
 

--- a/deploy/careagents/deploy.sh
+++ b/deploy/careagents/deploy.sh
@@ -77,6 +77,11 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=
 CARE_OPENAI_MODEL=
 CARE_MODEL=claude-sonnet-5
+
+# --- durable worker pool ---
+CARE_RUN_WORKERS=4
+CARE_RUN_DEADLINE_SECONDS=120
+CARE_RUN_LEASE_SECONDS=60
 ENV
   chmod 600 /etc/careagents/careagents.env
   echo "!! populate /etc/careagents/careagents.env before the service will boot"
@@ -87,6 +92,7 @@ REMOTE
 
 echo "→ install unit + nginx"
 scp -q "$REPO_ROOT/deploy/careagents/careagents.service" "$HOST:/etc/systemd/system/careagents.service"
+scp -q "$REPO_ROOT/deploy/careagents/careagents-worker.service" "$HOST:/etc/systemd/system/careagents-worker.service"
 ssh "$HOST" bash -s <<'REMOTE'
 set -euo pipefail
 # Point nginx's `location /` at the app (both :80 and :443 servers), once.
@@ -117,10 +123,11 @@ PY
 fi
 nginx -t
 systemctl daemon-reload
-systemctl enable --now careagents
-systemctl restart careagents nginx
+systemctl enable --now careagents careagents-worker
+systemctl restart careagents careagents-worker nginx
 sleep 2
 systemctl is-active careagents
+systemctl is-active careagents-worker
 curl -sf http://127.0.0.1:8600/healthz && echo
 REMOTE
 

--- a/deploy/careagents/imessage_relay.py
+++ b/deploy/careagents/imessage_relay.py
@@ -4,12 +4,14 @@ CareAgents.
 
 It is a *transport only*: it carries no PHI logic and holds no credentials
 beyond the shared mint secret. Every inbound text is forwarded to CareAgents,
-which resolves the sender's handle to a bound agent, runs the guardrailed turn
-server-side, and returns the reply for this script to send back.
+which resolves the sender's handle to a bound agent and durably queues the
+turn. This relay polls the run projection; inference never runs in the web
+request that accepted the message.
 
 Flow per inbound message:
   - "care <code>"  → POST /api/surfaces/imessage/bind   {code, handle}
-  - anything else  → POST /api/surfaces/imessage/inbound {handle, text} → reply
+  - anything else  → POST /api/surfaces/imessage/inbound {handle, text}
+                   → GET /api/surfaces/imessage/runs/<id> → reply
 
 Requires macOS **Full Disk Access** for the interpreter (to read
 ~/Library/Messages/chat.db) and Automation permission for Messages.
@@ -32,7 +34,9 @@ import sqlite3
 import subprocess
 import sys
 import time
+import urllib.error
 import urllib.request
+import urllib.parse
 from pathlib import Path
 
 BASE = os.environ.get("CAREAGENTS_BASE", "https://careagents.cloud").rstrip("/")
@@ -42,7 +46,8 @@ STATE_FILE = Path(os.environ.get(
     "IMESSAGE_STATE_FILE",
     str(Path.home() / ".careagents-imessage-relay.json")))
 CHAT_DB = Path.home() / "Library" / "Messages" / "chat.db"
-HTTP_TIMEOUT = 60  # a turn can take a while (LLM + tools)
+HTTP_TIMEOUT = 20
+RUN_TIMEOUT = 180
 
 
 def _post(path: str, payload: dict) -> dict:
@@ -60,6 +65,22 @@ def _post(path: str, payload: dict) -> dict:
     except Exception as exc:  # network, timeout, JSON
         print(f"[relay] {path} failed: {type(exc).__name__}", file=sys.stderr)
     return {}
+
+
+def _get(path: str, params: dict) -> tuple[int, dict]:
+    query = urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        f"{BASE}{path}?{query}", method="GET",
+        headers={"X-Internal-Secret": SECRET})
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:200]
+        print(f"[relay] {path} HTTP {exc.code}: {body}", file=sys.stderr)
+    except Exception as exc:
+        print(f"[relay] {path} failed: {type(exc).__name__}", file=sys.stderr)
+    return 0, {}
 
 
 def _send_imessage(handle: str, text: str) -> None:
@@ -133,9 +154,21 @@ def _handle_message(handle: str, text: str) -> None:
         return
     res = _post("/api/surfaces/imessage/inbound",
                 {"handle": handle, "text": stripped})
-    reply = res.get("reply")
-    if reply:
-        _send_imessage(handle, reply)
+    run_id = res.get("run_id")
+    if run_id:
+        deadline = time.monotonic() + RUN_TIMEOUT
+        while time.monotonic() < deadline:
+            status, result = _get(
+                f"/api/surfaces/imessage/runs/{run_id}", {"handle": handle})
+            if status == 200:
+                reply = result.get("reply")
+                if reply:
+                    _send_imessage(handle, reply)
+                return
+            if status not in (0, 202):
+                return
+            time.sleep(1)
+        print(f"[relay] run {run_id} timed out", file=sys.stderr)
     # No reply + no error → handle isn't bound; stay silent (don't spam
     # strangers who text the number).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - FHIR_VALIDATOR_URL=${FHIR_VALIDATOR_URL:-http://localhost:8080}
       - REDIS_URL=redis://redis:6379/0
       - STEP_UP_SECRET=${STEP_UP_SECRET:-dev-step-up-secret-change-in-production}
+      - INTERNAL_TOKEN_MINT_SECRET=${INTERNAL_TOKEN_MINT_SECRET:-dev-internal-secret-change-in-production}
       # Read authorization (hardening): when enabled, non-public tenants
       # require a tenant-bound step-up token / OAuth read scope on reads.
       # PUBLIC_TENANTS is the explicit allowlist that may be read anonymously.
@@ -109,6 +110,57 @@ services:
     command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru
     networks:
       - fhir-net
+
+  careagents:
+    build:
+      context: .
+      dockerfile: deploy/careagents/Dockerfile
+    ports:
+      - "127.0.0.1:${CAREAGENTS_PORT:-8600}:8600"
+    environment:
+      - CARE_ENV=development
+      - CARE_DATABASE_URL=sqlite:////data/careagents.db
+      - HEALTHCLAW_BASE=http://fhir-mcp-guardrails:5000
+      - HEALTHCLAW_MINT_SECRET=${INTERNAL_TOKEN_MINT_SECRET:-dev-internal-secret-change-in-production}
+      - CARE_ORIGIN=http://localhost:${CAREAGENTS_PORT:-8600}
+      - CARE_RP_ID=localhost
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+    depends_on:
+      fhir-mcp-guardrails:
+        condition: service_started
+    volumes:
+      - careagents-data:/data
+    networks:
+      - fhir-net
+    profiles:
+      - careagents
+
+  careagents-worker:
+    build:
+      context: .
+      dockerfile: deploy/careagents/Dockerfile
+    command: ["python", "-m", "careagents.worker"]
+    environment:
+      - CARE_ROLE=worker
+      - CARE_ENV=development
+      - CARE_DATABASE_URL=sqlite:////data/careagents.db
+      - HEALTHCLAW_BASE=http://fhir-mcp-guardrails:5000
+      - HEALTHCLAW_MINT_SECRET=${INTERNAL_TOKEN_MINT_SECRET:-dev-internal-secret-change-in-production}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - CARE_RUN_WORKERS=${CARE_RUN_WORKERS:-2}
+    depends_on:
+      fhir-mcp-guardrails:
+        condition: service_started
+      careagents:
+        condition: service_started
+    volumes:
+      - careagents-data:/data
+    networks:
+      - fhir-net
+    profiles:
+      - careagents
 
   agent-orchestrator:
     build:
@@ -265,3 +317,4 @@ networks:
 volumes:
   wearables-pg-data:
   shl-data:
+  careagents-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - STEP_UP_SECRET=${STEP_UP_SECRET:-dev-step-up-secret-change-in-production}
       - INTERNAL_TOKEN_MINT_SECRET=${INTERNAL_TOKEN_MINT_SECRET:-dev-internal-secret-change-in-production}
+      - AGENT_RUN_RECONCILE_SECRET=${AGENT_RUN_RECONCILE_SECRET:-dev-reconcile-secret-change-in-production}
       # Read authorization (hardening): when enabled, non-public tenants
       # require a tenant-bound step-up token / OAuth read scope on reads.
       # PUBLIC_TENANTS is the explicit allowlist that may be read anonymously.
@@ -126,6 +127,7 @@ services:
       - CARE_RP_ID=localhost
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - CARE_RUN_WORKER_STALE_SECONDS=${CARE_RUN_WORKER_STALE_SECONDS:-30}
     depends_on:
       fhir-mcp-guardrails:
         condition: service_started
@@ -150,6 +152,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - CARE_RUN_WORKERS=${CARE_RUN_WORKERS:-2}
+      - CARE_RUN_WORKER_STALE_SECONDS=${CARE_RUN_WORKER_STALE_SECONDS:-30}
     depends_on:
       fhir-mcp-guardrails:
         condition: service_started

--- a/docs/runbooks/agent-run-control-plane.md
+++ b/docs/runbooks/agent-run-control-plane.md
@@ -1,8 +1,8 @@
 # Agent run control plane
 
-The durable run API is the substrate for moving CareAgents work out of Flask
-request threads. This first slice does not switch CareAgents execution yet;
-issue #254 performs that cutover after the queue contract is deployed.
+The durable run API backs CareAgents' dedicated worker and replayable SSE
+projection. Flask web processes enqueue work but never execute inference or
+tools inline.
 
 ## Durable records
 

--- a/docs/runbooks/agent-run-control-plane.md
+++ b/docs/runbooks/agent-run-control-plane.md
@@ -13,6 +13,8 @@ tools inline.
   reusing the ID with different input fails closed.
 - `agent_run_events` is append-only outside tenant purge. Its integer ID is the
   durable replay cursor used by a future SSE projection.
+- `agent_worker_presence` records the last successful queue transaction for
+  each worker slot. Process liveness alone never satisfies readiness.
 
 Run states are `queued`, `running`, `waiting_for_human`, `completed`, `failed`,
 and `cancelled`. Invalid transitions are rejected in code and invalid stored
@@ -24,6 +26,11 @@ Tenant sessions or tenant-bound step-up credentials may create, inspect,
 replay, and cancel their own runs. Worker operations span tenant queues and
 therefore require `X-Internal-Secret` matching `INTERNAL_TOKEN_MINT_SECRET`.
 The worker secret must never be sent to a browser or messaging client.
+Ambiguous side-effect reconciliation is a separate operator boundary. It
+requires `X-Reconciliation-Secret` matching `AGENT_RUN_RECONCILE_SECRET`;
+tenant credentials and the worker secret cannot assert provider truth. The
+request accepts only an opaque evidence reference, not provider or patient
+content.
 
 Claim responses are the only worker endpoint that returns inbound message
 text. Tenant-facing run detail omits message text and tool arguments/results.
@@ -34,16 +41,23 @@ error classes only—never event payloads, message text, or tool results.
 
 1. Create a run after the inbound message is durably claimed.
 2. Claim with a stable worker ID and a 10–600 second lease.
-3. Heartbeat before the lease expires; stop if `cancel_requested` is true.
+3. Heartbeat before the lease expires; stop if `cancel_requested` is true or
+   the server rejects the lease at the hard run deadline.
 4. Append UI/progress events before publishing them to a transport.
 5. Register each provider tool call before execution. If it replays as
    `completed`, reuse the stored result instead of executing again.
-6. Transition the run to a terminal state or `waiting_for_human`.
+6. Atomically finalize the assistant message and completed run. The generic
+   transition endpoint cannot create `completed` runs.
 7. An approval surface resumes a waiting run through the internal resume API.
 
 Expired running leases are appended as `run.lease_expired`, requeued, and then
-claimed with an incremented attempt. Queued runs past their deadline fail as
-`RunDeadlineExceeded` rather than running late.
+claimed with an incremented attempt. If an expired worker owned a running tool,
+the tool instead becomes `needs_reconciliation` and the run waits for verified
+provider truth; it is never re-executed automatically. Queued or running runs
+past their deadline fail as `RunDeadlineExceeded` rather than running late,
+unless an in-flight tool makes the outcome ambiguous. Readiness sweeps overdue
+runs even when no client is connected and no worker can claim. Heartbeats cap
+leases at `deadline_at` and atomically enforce the same deadline invariant.
 
 ## HTTP endpoints
 
@@ -54,11 +68,18 @@ All paths are under `/command-center/api/runs`:
 - `GET /<id>/events?after=<cursor>` — ordered durable replay.
 - `POST /<id>/cancel` — durable cancellation request.
 - `POST /claim` — atomically claim the next queued run (internal).
+- `GET /workers/health` — recent queue-backed worker readiness plus a bounded
+  overdue-run sweep (internal).
 - `POST /<id>/heartbeat` — renew the owning worker lease (internal).
 - `POST /<id>/transition` — state transition by the owning worker.
+- `POST /<id>/finalize` — atomically persist assistant text, its replay event,
+  and run completion behind the authoritative worker fence.
 - `POST /<id>/events` — append a bounded event before publishing it.
 - `POST /<id>/tool-calls` and `/tool-calls/<call>/transition` — durable,
   idempotent tool lifecycle.
+- `POST /<id>/tool-calls/<call>/reconcile` — operator-only, idempotently
+  records verified `completed|failed` provider truth by opaque evidence ID.
+  It cannot execute a tool or mark an abandoned run successfully completed.
 - `POST /<id>/resume` — approval surface requeues a human-waiting run.
 
 Event and tool payloads are capped at 256 KiB. Error fields accept a class name,
@@ -72,7 +93,7 @@ Run migrations before web or worker processes:
 uv run flask --app main init-db
 ```
 
-Then verify the three new tables exist and no stale run is silently stranded:
+Then verify the worker-presence table and that no stale run is stranded:
 
 ```sql
 SELECT status, COUNT(*) FROM agent_runs GROUP BY status;
@@ -80,6 +101,10 @@ SELECT status, COUNT(*) FROM agent_runs GROUP BY status;
 SELECT id, worker_id, lease_expires_at
 FROM agent_runs
 WHERE status = 'running' AND lease_expires_at < CURRENT_TIMESTAMP;
+
+SELECT worker_id, last_seen_at
+FROM agent_worker_presence
+ORDER BY last_seen_at DESC;
 ```
 
 The second query may briefly show an expired lease; the next claim records its

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -1,0 +1,84 @@
+# CareAgents durable worker and SSE replay
+
+CareAgents has two independent process roles:
+
+- **Web:** authenticates the account, durably claims the inbound message,
+  creates its queued `AgentRun`, and projects durable events over SSE.
+- **Worker:** claims queued runs, heartbeats a lease, performs model/tool work,
+  persists the assistant outcome, and marks the run terminal.
+
+The browser stream is not the lifecycle. Closing a tab or losing a connection
+only ends that projection. Reconnect with the run ID and the last event cursor:
+
+```text
+GET /api/chat/runs/<run_id>/events?agent_id=<agent_id>&after=<cursor>
+```
+
+## Ordering and recovery guarantees
+
+- A database lock on `cc_conversations` allows only one running turn per
+  conversation across all worker processes.
+- History is loaded through the claimed `message_id`, not from the live tail.
+  Later queued messages therefore cannot enter an earlier prompt.
+- Each model result is checkpointed before tools execute.
+- Tool identity is `(run_id, provider_call_id)`. Completed results are replayed
+  after recovery without calling the tool again.
+- A tool left `running` after lease expiry has an unknown provider outcome. It
+  moves to `needs_reconciliation`, and its run pauses in
+  `waiting_for_human`. Workers never retry that side effect blindly.
+- Assistant messages use `run:<run_id>:assistant` as their durable request key,
+  so recovery cannot append the final answer twice.
+
+## systemd
+
+Install and enable both units from `deploy/careagents/`:
+
+```bash
+sudo systemctl enable --now careagents careagents-worker
+sudo systemctl status careagents careagents-worker
+```
+
+The worker pool is bounded by `CARE_RUN_WORKERS` (default 4). Important knobs:
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `CARE_RUN_WORKERS` | 4 | Concurrent worker slots per process |
+| `CARE_RUN_DEADLINE_SECONDS` | 120 | End-to-end run deadline |
+| `CARE_RUN_LEASE_SECONDS` | 60 | Claim lease, heartbeated every third |
+| `CARE_RUN_POLL_SECONDS` | 0.5 | Empty-queue polling delay |
+| `CARE_RUN_SSE_TIMEOUT_SECONDS` | 150 | One browser projection window |
+
+Scale worker processes horizontally only when both HealthClaw and the
+CareAgents identity store use shared databases. The claim path is PostgreSQL
+safe (`FOR UPDATE SKIP LOCKED`); SQLite remains development-only for multiple
+hosts.
+
+## Compose
+
+Run the optional local profile:
+
+```bash
+docker compose --profile careagents up --build
+```
+
+This starts `careagents` and `careagents-worker` against the same HealthClaw
+service and CareAgents data volume.
+
+## Operations
+
+Queue and lease health live in HealthClaw:
+
+```sql
+SELECT status, COUNT(*) FROM agent_runs GROUP BY status;
+SELECT id, worker_id, lease_expires_at
+FROM agent_runs
+WHERE status = 'running'
+ORDER BY lease_expires_at;
+SELECT id, run_id, tool_name, error_class
+FROM agent_tool_calls
+WHERE status = 'needs_reconciliation';
+```
+
+An increasing `needs_reconciliation` count requires provider-specific truth
+lookup before an operator resolves a tool call. The reconciliation UI and
+alerts are tracked separately in issue #255.

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -27,7 +27,18 @@ GET /api/chat/runs/<run_id>/events?agent_id=<agent_id>&after=<cursor>
   moves to `needs_reconciliation`, and its run pauses in
   `waiting_for_human`. Workers never retry that side effect blindly.
 - Assistant messages use `run:<run_id>:assistant` as their durable request key,
-  so recovery cannot append the final answer twice.
+  and HealthClaw commits that message, its `agent.text` event, and run
+  completion in one fenced transaction. Recovery cannot append the final
+  answer twice, and a stale worker cannot publish after lease revocation.
+- Idle claims and owned-run heartbeats update durable worker presence only
+  after a successful queue transaction. Web readiness and chat admission fail
+  closed when no presence is fresh. The readiness poll also sweeps a bounded
+  batch of overdue queued or running runs, so expiry does not depend on a
+  client or worker.
+- A run heartbeat never extends a lease beyond the hard run deadline. Once the
+  deadline is reached, the authoritative heartbeat transaction revokes
+  ownership before a late provider result can be persisted. Pure model work
+  fails; an in-flight side effect instead enters reconciliation.
 
 ## systemd
 
@@ -46,6 +57,7 @@ The worker pool is bounded by `CARE_RUN_WORKERS` (default 4). Important knobs:
 | `CARE_RUN_DEADLINE_SECONDS` | 120 | End-to-end run deadline |
 | `CARE_RUN_LEASE_SECONDS` | 60 | Claim lease, heartbeated every third |
 | `CARE_RUN_POLL_SECONDS` | 0.5 | Empty-queue polling delay |
+| `CARE_RUN_WORKER_STALE_SECONDS` | 30 | Maximum age of successful queue access |
 | `CARE_RUN_SSE_TIMEOUT_SECONDS` | 150 | One browser projection window |
 
 Scale worker processes horizontally only when both HealthClaw and the
@@ -74,11 +86,16 @@ SELECT id, worker_id, lease_expires_at
 FROM agent_runs
 WHERE status = 'running'
 ORDER BY lease_expires_at;
+SELECT worker_id, last_seen_at
+FROM agent_worker_presence
+ORDER BY last_seen_at DESC;
 SELECT id, run_id, tool_name, error_class
 FROM agent_tool_calls
 WHERE status = 'needs_reconciliation';
 ```
 
 An increasing `needs_reconciliation` count requires provider-specific truth
-lookup before an operator resolves a tool call. The reconciliation UI and
+lookup before an operator resolves a tool call. Reconciliation requires the
+separate `AGENT_RUN_RECONCILE_SECRET`, records only an opaque evidence ID, and
+never turns an abandoned run into a silent success. The reconciliation UI and
 alerts are tracked separately in issue #255.

--- a/docs/runbooks/conversation-identity.md
+++ b/docs/runbooks/conversation-identity.md
@@ -37,10 +37,10 @@ Run the normal migration command before starting web processes:
 uv run flask --app main init-db
 ```
 
-CareAgents production also requires `REDIS_URL`. Redis serializes a conversation
-across workers while the database uniqueness constraint remains the final
-idempotency boundary. Development can run without Redis and uses a process-local
-lock.
+CareAgents workers serialize a conversation by locking its durable
+`cc_conversations` row while claiming the next run. Multiple web and worker
+processes are therefore safe without a process-local transcript or Redis lock;
+the database uniqueness constraint remains the inbound idempotency boundary.
 
 After deployment, verify that every message has a conversation and that no
 duplicate request keys exist:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,6 +15,7 @@ from models import db
 import r6.actions.confirmations  # noqa: F401
 import r6.actions.events  # noqa: F401
 import r6.actions.models  # noqa: F401
+import r6.agent_runs.models  # noqa: F401
 import r6.command_center.models  # noqa: F401
 import r6.fasten.models  # noqa: F401
 import r6.models  # noqa: F401

--- a/migrations/versions/0006_tool_reconciliation_state.py
+++ b/migrations/versions/0006_tool_reconciliation_state.py
@@ -1,0 +1,42 @@
+"""Add fail-closed reconciliation state for ambiguous tool outcomes.
+
+Revision ID: 0006_tool_reconciliation_state
+Revises: 0005_agent_run_control_plane
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0006_tool_reconciliation_state"
+down_revision = "0005_agent_run_control_plane"
+branch_labels = None
+depends_on = None
+
+
+def _replace_constraint(allowed: str) -> None:
+    with op.batch_alter_table("agent_tool_calls") as batch:
+        batch.drop_constraint("ck_agent_tool_call_status", type_="check")
+        batch.create_check_constraint(
+            "ck_agent_tool_call_status", f"status IN ({allowed})")
+
+
+def upgrade() -> None:
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    if "agent_tool_calls" not in tables:
+        raise RuntimeError(
+            "agent_tool_calls is missing; apply the 0005 foundation first")
+    _replace_constraint(
+        "'pending','running','completed','failed','needs_reconciliation'")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    unresolved = bind.execute(sa.text(
+        "SELECT COUNT(*) FROM agent_tool_calls "
+        "WHERE status = 'needs_reconciliation'"
+    )).scalar_one()
+    if unresolved:
+        raise RuntimeError(
+            "cannot downgrade while tool calls need reconciliation")
+    _replace_constraint("'pending','running','completed','failed'")

--- a/migrations/versions/0007_agent_worker_presence.py
+++ b/migrations/versions/0007_agent_worker_presence.py
@@ -1,0 +1,40 @@
+"""Add durable queue-access presence for agent workers.
+
+Revision ID: 0007_agent_worker_presence
+Revises: 0006_tool_reconciliation_state
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0007_agent_worker_presence"
+down_revision = "0006_tool_reconciliation_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    if "agent_worker_presence" in tables:
+        return
+    op.create_table(
+        "agent_worker_presence",
+        sa.Column("worker_id", sa.String(128), nullable=False),
+        sa.Column("first_seen_at", sa.DateTime(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("worker_id", name="pk_agent_worker_presence"),
+    )
+    op.create_index(
+        "ix_agent_worker_presence_last_seen_at",
+        "agent_worker_presence",
+        ["last_seen_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_agent_worker_presence_last_seen_at",
+        table_name="agent_worker_presence",
+    )
+    op.drop_table("agent_worker_presence")

--- a/r6/agent_runs/__init__.py
+++ b/r6/agent_runs/__init__.py
@@ -1,6 +1,15 @@
 """Durable agent-run control plane."""
 
-from r6.agent_runs.models import AgentRun, AgentRunEvent, AgentToolCall
+from r6.agent_runs.models import (
+    AgentRun,
+    AgentRunEvent,
+    AgentToolCall,
+    AgentWorkerPresence,
+)
 
-__all__ = ["AgentRun", "AgentRunEvent", "AgentToolCall"]
-
+__all__ = [
+    "AgentRun",
+    "AgentRunEvent",
+    "AgentToolCall",
+    "AgentWorkerPresence",
+]

--- a/r6/agent_runs/models.py
+++ b/r6/agent_runs/models.py
@@ -86,7 +86,8 @@ class AgentToolCall(db.Model):
         db.UniqueConstraint(
             "run_id", "provider_call_id", name="uq_agent_tool_call_provider"),
         db.CheckConstraint(
-            "status IN ('pending','running','completed','failed')",
+            "status IN ('pending','running','completed','failed',"
+            "'needs_reconciliation')",
             name="ck_agent_tool_call_status",
         ),
     )

--- a/r6/agent_runs/models.py
+++ b/r6/agent_runs/models.py
@@ -161,6 +161,24 @@ class AgentRunEvent(db.Model):
         return result
 
 
+class AgentWorkerPresence(db.Model):
+    """Last successful queue access for one durable-run worker slot."""
+
+    __tablename__ = "agent_worker_presence"
+
+    worker_id = db.Column(db.String(128), primary_key=True)
+    first_seen_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+    last_seen_at = db.Column(
+        db.DateTime, nullable=False, default=utcnow, index=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "worker_id": self.worker_id,
+            "first_seen_at": _iso(self.first_seen_at),
+            "last_seen_at": _iso(self.last_seen_at),
+        }
+
+
 def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
 

--- a/r6/agent_runs/routes.py
+++ b/r6/agent_runs/routes.py
@@ -7,6 +7,7 @@ import os
 import re
 
 from flask import Blueprint, jsonify, request, session
+from sqlalchemy.exc import SQLAlchemyError
 
 from models import db
 from r6.agent_runs.models import AgentRun, AgentRunEvent, AgentToolCall
@@ -14,11 +15,18 @@ from r6.agent_runs.service import (
     append_event,
     claim_next,
     create_run,
+    expire_overdue_runs,
+    expire_overdue_run,
+    finalize_run,
     heartbeat,
+    lock_owned_run,
+    reconcile_tool_call,
     register_tool_call,
     request_cancel,
-    transition_run,
+    resume_run,
+    transition_owned_run,
     transition_tool_call,
+    worker_availability,
 )
 from r6.agent_runs.state import InvalidTransition
 from r6.command_center.models import ConversationMessage
@@ -51,16 +59,14 @@ def _internal_authorized() -> bool:
     return bool(expected and hmac.compare_digest(provided, expected))
 
 
+def _reconciler_authorized() -> bool:
+    expected = os.environ.get("AGENT_RUN_RECONCILE_SECRET", "")
+    provided = request.headers.get("X-Reconciliation-Secret", "")
+    return bool(expected and hmac.compare_digest(provided, expected))
+
+
 def _run_or_404(run_id: str) -> AgentRun | None:
     return db.session.get(AgentRun, run_id)
-
-
-def _worker_owns(run: AgentRun, worker_id: str) -> bool:
-    return bool(
-        worker_id
-        and run.status == "running"
-        and run.worker_id == worker_id
-    )
 
 
 def _valid_payload_size(value) -> bool:
@@ -106,6 +112,7 @@ def get_agent_run(run_id: str):
         return jsonify({"error": "unknown run"}), 404
     if not _tenant_authorized(run.tenant_id):
         return jsonify({"error": "authentication required"}), 401
+    run = expire_overdue_run(run)
     result = run.to_dict()
     result["tool_calls"] = [
         call.to_dict()
@@ -122,6 +129,7 @@ def get_agent_run_events(run_id: str):
         return jsonify({"error": "unknown run"}), 404
     if not _tenant_authorized(run.tenant_id):
         return jsonify({"error": "authentication required"}), 401
+    run = expire_overdue_run(run)
     try:
         after = max(0, int(request.args.get("after", "0")))
         limit = min(500, max(1, int(request.args.get("limit", "100"))))
@@ -143,6 +151,34 @@ def get_agent_run_events(run_id: str):
     })
 
 
+@agent_runs_blueprint.get("/workers/health")
+def get_agent_worker_health():
+    """Internal readiness based on recent successful queue transactions."""
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    try:
+        max_age_seconds = int(request.args.get("max_age_seconds", "30"))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid max_age_seconds"}), 400
+    if not 5 <= max_age_seconds <= 300:
+        return jsonify({"error": "max_age_seconds must be 5-300"}), 400
+    try:
+        expired_runs = expire_overdue_runs(limit=100)
+        result = worker_availability(max_age_seconds)
+    except SQLAlchemyError:
+        db.session.rollback()
+        return jsonify({
+            "status": "unavailable",
+            "available": False,
+            "active_workers": 0,
+            "queue": "error",
+        }), 503
+    result["expired_runs"] = expired_runs
+    result["queue"] = "ok"
+    result["status"] = "healthy" if result["available"] else "unavailable"
+    return jsonify(result), (200 if result["available"] else 503)
+
+
 @agent_runs_blueprint.post("/<run_id>/cancel")
 def cancel_agent_run(run_id: str):
     run = _run_or_404(run_id)
@@ -158,13 +194,10 @@ def resume_agent_run(run_id: str):
     """Internal approval surface resumes one human-waiting run."""
     if not _internal_authorized():
         return jsonify({"error": "forbidden"}), 403
-    run = _run_or_404(run_id)
-    if run is None:
-        return jsonify({"error": "unknown run"}), 404
     try:
-        run = transition_run(
-            run, "queued", event_type="run.resumed",
-            payload={"status": "queued"})
+        run = resume_run(run_id)
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
     except InvalidTransition as exc:
         return jsonify({"error": str(exc)}), 409
     return jsonify(run.to_dict())
@@ -228,13 +261,8 @@ def heartbeat_agent_run(run_id: str):
 def transition_agent_run(run_id: str):
     if not _internal_authorized():
         return jsonify({"error": "forbidden"}), 403
-    run = _run_or_404(run_id)
-    if run is None:
-        return jsonify({"error": "unknown run"}), 404
     body = request.get_json(silent=True) or {}
     worker_id = str(body.get("worker_id") or "")
-    if not _worker_owns(run, worker_id):
-        return jsonify({"error": "worker does not own run"}), 409
     target = body.get("status")
     event_type = body.get("event_type") or None
     if event_type is not None and (
@@ -254,14 +282,17 @@ def transition_agent_run(run_id: str):
         if not 0 <= available_in_seconds <= 3600:
             return jsonify({
                 "error": "available_in_seconds must be 0-3600"}), 400
-        run = transition_run(
-            run,
+        run = transition_owned_run(
+            run_id,
+            worker_id,
             target,
             event_type=event_type,
             payload=payload,
             error_class=error_class,
             available_in_seconds=available_in_seconds,
         )
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
     except (TypeError, ValueError, InvalidTransition) as exc:
         return jsonify({"error": str(exc)}), 409
     return jsonify(run.to_dict())
@@ -271,19 +302,20 @@ def transition_agent_run(run_id: str):
 def append_agent_run_event(run_id: str):
     if not _internal_authorized():
         return jsonify({"error": "forbidden"}), 403
-    run = _run_or_404(run_id)
-    if run is None:
-        return jsonify({"error": "unknown run"}), 404
     body = request.get_json(silent=True) or {}
     worker_id = str(body.get("worker_id") or "")
-    if not _worker_owns(run, worker_id):
-        return jsonify({"error": "worker does not own run"}), 409
     event_type = body.get("type")
     if not isinstance(event_type, str) or not _EVENT_TYPE.fullmatch(event_type):
         return jsonify({"error": "invalid event type"}), 400
     payload = body.get("payload")
     if payload is not None and not _valid_payload_size(payload):
         return jsonify({"error": "event payload is invalid or too large"}), 413
+    try:
+        run = lock_owned_run(run_id, worker_id)
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except InvalidTransition as exc:
+        return jsonify({"error": str(exc)}), 409
     event = append_event(run, event_type, payload)
     db.session.commit()
     return jsonify(event.to_dict()), 201
@@ -293,13 +325,8 @@ def append_agent_run_event(run_id: str):
 def create_agent_tool_call(run_id: str):
     if not _internal_authorized():
         return jsonify({"error": "forbidden"}), 403
-    run = _run_or_404(run_id)
-    if run is None:
-        return jsonify({"error": "unknown run"}), 404
     body = request.get_json(silent=True) or {}
     worker_id = str(body.get("worker_id") or "")
-    if not _worker_owns(run, worker_id):
-        return jsonify({"error": "worker does not own run"}), 409
     provider_call_id = body.get("provider_call_id")
     tool_name = body.get("tool_name")
     arguments = body.get("arguments")
@@ -313,8 +340,14 @@ def create_agent_tool_call(run_id: str):
     if not _valid_payload_size(arguments):
         return jsonify({"error": "arguments are too large"}), 413
     try:
+        run = lock_owned_run(run_id, worker_id)
+        if run.cancel_requested:
+            raise InvalidTransition(
+                "run cancellation prevents new tool registration")
         call, created = register_tool_call(
             run, provider_call_id, tool_name, arguments)
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
     except InvalidTransition as exc:
         return jsonify({"error": str(exc)}), 409
     result = call.to_dict(include_payload=True)
@@ -332,8 +365,6 @@ def transition_agent_tool_call(run_id: str, call_id: str):
         return jsonify({"error": "unknown run or tool call"}), 404
     body = request.get_json(silent=True) or {}
     worker_id = str(body.get("worker_id") or "")
-    if not _worker_owns(run, worker_id):
-        return jsonify({"error": "worker does not own run"}), 409
     error_class = body.get("error_class")
     if error_class is not None and (
             not isinstance(error_class, str)
@@ -350,6 +381,7 @@ def transition_agent_tool_call(run_id: str, call_id: str):
         call = transition_tool_call(
             run,
             call,
+            worker_id,
             body.get("status"),
             result=body.get("result"),
             outcome_ref=outcome_ref,
@@ -358,3 +390,78 @@ def transition_agent_tool_call(run_id: str, call_id: str):
     except (LookupError, InvalidTransition) as exc:
         return jsonify({"error": str(exc)}), 409
     return jsonify(call.to_dict(include_payload=True))
+
+
+@agent_runs_blueprint.post("/<run_id>/finalize")
+def finalize_agent_run(run_id: str):
+    """Atomically persist a final assistant answer and complete its run."""
+    if not _internal_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    body = request.get_json(silent=True) or {}
+    worker_id = str(body.get("worker_id") or "")
+    text = body.get("text")
+    checkpoint_id = body.get("checkpoint_id")
+    if not isinstance(text, str) or not text.strip():
+        return jsonify({"error": "nonempty text is required"}), 400
+    if not isinstance(checkpoint_id, str) or not _ID.fullmatch(checkpoint_id):
+        return jsonify({"error": "valid checkpoint_id is required"}), 400
+    if not _valid_payload_size({"text": text, "checkpoint_id": checkpoint_id}):
+        return jsonify({"error": "assistant outcome is too large"}), 413
+    try:
+        run, message, changed = finalize_run(
+            run_id,
+            worker_id,
+            text=text,
+            checkpoint_id=checkpoint_id,
+        )
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except InvalidTransition as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify({
+        "run": run.to_dict(),
+        "message_id": message.id,
+        "idempotent_replay": not changed,
+    })
+
+
+@agent_runs_blueprint.post("/<run_id>/tool-calls/<call_id>/reconcile")
+def reconcile_agent_tool_call(run_id: str, call_id: str):
+    """Record operator-verified truth for an ambiguous side effect."""
+    if not _reconciler_authorized():
+        return jsonify({"error": "forbidden"}), 403
+    run = _run_or_404(run_id)
+    call = db.session.get(AgentToolCall, call_id)
+    if run is None or call is None or call.run_id != run_id:
+        return jsonify({"error": "unknown run or tool call"}), 404
+    body = request.get_json(silent=True) or {}
+    target = body.get("status")
+    if target not in ("completed", "failed"):
+        return jsonify({
+            "error": "status must be completed or failed",
+        }), 400
+    evidence_ref = body.get("evidence_ref")
+    if (not isinstance(evidence_ref, str)
+            or not _ID.fullmatch(evidence_ref)):
+        return jsonify({"error": "valid evidence_ref is required"}), 400
+    if body.get("result") is not None:
+        return jsonify({"error": "reconciliation does not accept result data"}), 400
+    error_class = body.get("error_class")
+    if error_class is not None and (
+            not isinstance(error_class, str)
+            or not _ERROR_CLASS.fullmatch(error_class)):
+        return jsonify({"error": "invalid error_class"}), 400
+    try:
+        call, run, changed = reconcile_tool_call(
+            run,
+            call,
+            target,
+            evidence_ref=evidence_ref,
+            error_class=error_class,
+        )
+    except (LookupError, InvalidTransition) as exc:
+        return jsonify({"error": str(exc)}), 409
+    response = call.to_dict()
+    response["run_status"] = run.status
+    response["idempotent_replay"] = not changed
+    return jsonify(response)

--- a/r6/agent_runs/service.py
+++ b/r6/agent_runs/service.py
@@ -21,7 +21,7 @@ from r6.agent_runs.state import (
     require_run_transition,
     require_tool_transition,
 )
-from r6.command_center.models import ConversationMessage
+from r6.command_center.models import Conversation, ConversationMessage
 
 
 def create_run(
@@ -124,13 +124,59 @@ def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
             commit=False,
         )
 
-    run = (
-        AgentRun.query
+    candidate_ids = [row[0] for row in (
+        db.session.query(AgentRun.id)
         .filter(AgentRun.status == "queued")
         .filter(AgentRun.available_at <= now)
         .filter(AgentRun.deadline_at > now)
         .order_by(AgentRun.available_at.asc(), AgentRun.created_at.asc())
-        .with_for_update(skip_locked=True)
+        .limit(50)
+        .all()
+    )]
+    run = None
+    for candidate_id in candidate_ids:
+        candidate = (
+            AgentRun.query
+            .filter(AgentRun.id == candidate_id)
+            .filter(AgentRun.status == "queued")
+            .with_for_update(skip_locked=True)
+            .first()
+        )
+        if candidate is None:
+            continue
+        # A conversation row is the cross-process mutex. Two workers may see
+        # different queued runs in one thread, but only one can lock this row;
+        # the loser leaves its run queued for the next claim cycle.
+        conversation = (
+            Conversation.query
+            .filter_by(tenant_id=candidate.tenant_id,
+                       id=candidate.conversation_id)
+            .with_for_update(skip_locked=True)
+            .first()
+        )
+        if conversation is None:
+            continue
+        already_running = (
+            AgentRun.query
+            .filter_by(tenant_id=candidate.tenant_id,
+                       conversation_id=candidate.conversation_id,
+                       status="running")
+            .first()
+        )
+        if already_running is not None:
+            continue
+        run = candidate
+        break
+
+    if run is None:
+        db.session.commit()
+        return None
+
+    # Re-check after the locks above; this is intentionally stricter than the
+    # candidate scan so stale queue snapshots cannot win a claim.
+    run = (
+        AgentRun.query
+        .filter(AgentRun.id == run.id, AgentRun.status == "queued")
         .first()
     )
     if run is None:
@@ -276,7 +322,7 @@ def transition_tool_call(
         call.started_at = now
         call.finished_at = None
         call.result_json = None
-    if target in ("completed", "failed"):
+    if target in ("completed", "failed", "needs_reconciliation"):
         call.finished_at = now
         call.result_json = _dump(result) if result is not None else None
     append_event(run, f"tool.{target}", {

--- a/r6/agent_runs/service.py
+++ b/r6/agent_runs/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import timedelta
+from datetime import timedelta, timezone
 
 from sqlalchemy.exc import IntegrityError
 
@@ -13,6 +13,7 @@ from r6.agent_runs.models import (
     AgentRun,
     AgentRunEvent,
     AgentToolCall,
+    AgentWorkerPresence,
     utcnow,
 )
 from r6.agent_runs.state import (
@@ -82,9 +83,234 @@ def append_event(
     return event
 
 
+def _preserve_ambiguous_tools(
+    run: AgentRun,
+    *,
+    reason: str,
+    commit: bool = True,
+) -> bool:
+    running_calls = (
+        AgentToolCall.query
+        .filter_by(run_id=run.id, tenant_id=run.tenant_id, status="running")
+        .with_for_update()
+        .all()
+    )
+    if not running_calls:
+        return False
+
+    # The external side effect may have completed even though its worker
+    # disappeared before persisting the outcome. Ambiguity wins over timeout,
+    # cancellation, and lease retry: never imply the action did not happen and
+    # never make it eligible for automatic execution.
+    now = utcnow()
+    tool_call_ids = []
+    for call in running_calls:
+        require_tool_transition(call.status, "needs_reconciliation")
+        call.status = "needs_reconciliation"
+        call.error_class = "AmbiguousToolOutcome"
+        call.finished_at = now
+        tool_call_ids.append(call.id)
+    require_run_transition(run.status, "waiting_for_human")
+    run.status = "waiting_for_human"
+    run.error_class = "AmbiguousToolOutcome"
+    run.worker_id = None
+    run.lease_expires_at = None
+    append_event(run, "run.needs_reconciliation", {
+        "status": "waiting_for_human",
+        "reason": reason,
+        "tool_call_ids": tool_call_ids,
+        "cancel_requested": bool(run.cancel_requested),
+    })
+    if commit:
+        db.session.commit()
+    return True
+
+
+def _terminalize_at_deadline(
+    run: AgentRun,
+    *,
+    commit: bool = True,
+) -> AgentRun:
+    if _preserve_ambiguous_tools(
+            run, reason="deadline_with_running_tool", commit=commit):
+        return run
+    if run.cancel_requested:
+        return transition_run(
+            run,
+            "cancelled",
+            event_type="run.cancelled_at_deadline",
+            commit=commit,
+        )
+    return transition_run(
+        run,
+        "failed",
+        event_type="run.deadline_exceeded",
+        error_class="RunDeadlineExceeded",
+        commit=commit,
+    )
+
+
+def _recover_expired_lease(
+    run: AgentRun,
+    now,
+    *,
+    commit: bool = True,
+) -> AgentRun:
+    if _preserve_ambiguous_tools(
+            run, reason="lease_expired_with_running_tool", commit=commit):
+        return run
+    if run.cancel_requested:
+        return transition_run(
+            run,
+            "cancelled",
+            event_type="run.cancelled_after_lease",
+            commit=commit,
+        )
+    require_run_transition(run.status, "queued")
+    run.status = "queued"
+    run.worker_id = None
+    run.lease_expires_at = None
+    run.available_at = now
+    append_event(run, "run.lease_expired", {
+        "attempt": run.attempt,
+        "error_class": "WorkerLeaseExpired",
+    })
+    if commit:
+        db.session.commit()
+    return run
+
+
+def _enforce_worker_fence(
+    run: AgentRun,
+    worker_id: str,
+    *,
+    now=None,
+) -> AgentRun:
+    """Validate ownership under lock and enforce deadline/lease fencing."""
+    if run.status != "running" or run.worker_id != worker_id:
+        raise InvalidTransition("worker does not own a running lease")
+    now = now or utcnow()
+    if _as_utc(run.deadline_at) <= now:
+        _terminalize_at_deadline(run)
+        raise InvalidTransition("run deadline exceeded")
+    if (run.lease_expires_at is None
+            or _as_utc(run.lease_expires_at) <= now):
+        _recover_expired_lease(run, now)
+        raise InvalidTransition("worker lease expired")
+    return run
+
+
+def lock_owned_run(run_id: str, worker_id: str) -> AgentRun:
+    """Lock and recheck the authoritative worker mutation fence."""
+    run = (
+        AgentRun.query
+        .filter(AgentRun.id == run_id)
+        .with_for_update()
+        .first()
+    )
+    if run is None:
+        raise LookupError("unknown run")
+    return _enforce_worker_fence(run, worker_id)
+
+
+def expire_overdue_run(run: AgentRun) -> AgentRun:
+    """Fail one overdue queued or running run without a worker claim.
+
+    Operator reads and SSE replay both call this path. The row lock makes it
+    race safely with claims and heartbeats: exactly one side can terminalize
+    the run at its hard deadline.
+    """
+    now = utcnow()
+    if run.status not in ("queued", "running"):
+        return run
+    locked = (
+        AgentRun.query
+        .filter(AgentRun.id == run.id)
+        .filter(AgentRun.status.in_(("queued", "running")))
+        .filter(AgentRun.deadline_at <= now)
+        .with_for_update()
+        .first()
+    )
+    if locked is None:
+        db.session.expire(run)
+        return db.session.get(AgentRun, run.id) or run
+    return _terminalize_at_deadline(locked)
+
+
+def expire_overdue_runs(limit: int = 100) -> int:
+    """Bounded control-plane sweep for runs stranded without a worker.
+
+    Readiness polls invoke this independently of clients and workers. Locks and
+    the nonterminal-state filter make repeated or concurrent sweeps idempotent.
+    """
+    now = utcnow()
+    candidate_ids = [row[0] for row in (
+        db.session.query(AgentRun.id)
+        .filter(AgentRun.status.in_(("queued", "running")))
+        .filter(AgentRun.deadline_at <= now)
+        .order_by(AgentRun.deadline_at.asc())
+        .limit(limit)
+        .all()
+    )]
+    expired = 0
+    for run_id in candidate_ids:
+        run = (
+            AgentRun.query
+            .filter(AgentRun.id == run_id)
+            .filter(AgentRun.status.in_(("queued", "running")))
+            .filter(AgentRun.deadline_at <= now)
+            .with_for_update(skip_locked=True)
+            .first()
+        )
+        if run is None:
+            continue
+        _terminalize_at_deadline(run, commit=False)
+        expired += 1
+    db.session.commit()
+    return expired
+
+
+def worker_availability(max_age_seconds: int = 30) -> dict:
+    """Summarize workers that recently completed a queue transaction."""
+    now = utcnow()
+    cutoff = now - timedelta(seconds=max_age_seconds)
+    active = AgentWorkerPresence.query.filter(
+        AgentWorkerPresence.last_seen_at >= cutoff).count()
+    latest = AgentWorkerPresence.query.order_by(
+        AgentWorkerPresence.last_seen_at.desc()).first()
+    return {
+        "available": active > 0,
+        "active_workers": active,
+        "max_age_seconds": max_age_seconds,
+        "latest_seen_at": (
+            latest.last_seen_at.isoformat() if latest is not None else None),
+    }
+
+
+def _record_worker_presence(worker_id: str, now) -> None:
+    presence = db.session.get(AgentWorkerPresence, worker_id)
+    if presence is None:
+        presence = AgentWorkerPresence(
+            worker_id=worker_id, first_seen_at=now, last_seen_at=now)
+        db.session.add(presence)
+    else:
+        presence.last_seen_at = now
+
+
+def _as_utc(value):
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
     """Recover expired leases and atomically claim the oldest queued run."""
     now = utcnow()
+
+    # This record is committed only if the queue transaction below succeeds.
+    # A live process that cannot reach or transact with the queue therefore
+    # cannot keep readiness green merely by existing.
+    _record_worker_presence(worker_id, now)
 
     expired = (
         AgentRun.query
@@ -94,19 +320,7 @@ def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
         .all()
     )
     for run in expired:
-        if run.cancel_requested:
-            transition_run(
-                run, "cancelled", event_type="run.cancelled_after_lease",
-                commit=False)
-        else:
-            run.status = "queued"
-            run.worker_id = None
-            run.lease_expires_at = None
-            run.available_at = now
-            append_event(run, "run.lease_expired", {
-                "attempt": run.attempt,
-                "error_class": "WorkerLeaseExpired",
-            })
+        _recover_expired_lease(run, now, commit=False)
 
     overdue = (
         AgentRun.query
@@ -189,7 +403,10 @@ def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
     run.attempt += 1
     run.started_at = run.started_at or now
     run.heartbeat_at = now
-    run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+    run.lease_expires_at = min(
+        now + timedelta(seconds=lease_seconds),
+        _as_utc(run.deadline_at),
+    )
     append_event(run, "run.started", {
         "status": "running",
         "attempt": run.attempt,
@@ -199,11 +416,22 @@ def claim_next(worker_id: str, lease_seconds: int = 60) -> AgentRun | None:
 
 
 def heartbeat(run: AgentRun, worker_id: str, lease_seconds: int = 60) -> None:
-    if run.status != "running" or run.worker_id != worker_id:
+    locked = (
+        AgentRun.query
+        .filter(AgentRun.id == run.id)
+        .with_for_update()
+        .first()
+    )
+    if locked is None:
         raise InvalidTransition("worker does not own a running lease")
     now = utcnow()
-    run.heartbeat_at = now
-    run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+    _enforce_worker_fence(locked, worker_id, now=now)
+    locked.heartbeat_at = now
+    locked.lease_expires_at = min(
+        now + timedelta(seconds=lease_seconds),
+        _as_utc(locked.deadline_at),
+    )
+    _record_worker_presence(worker_id, now)
     db.session.commit()
 
 
@@ -244,8 +472,57 @@ def transition_run(
     return run
 
 
+def transition_owned_run(
+    run_id: str,
+    worker_id: str,
+    target: str,
+    *,
+    event_type: str | None = None,
+    payload: dict | list | None = None,
+    error_class: str | None = None,
+    available_in_seconds: int = 0,
+) -> AgentRun:
+    """Apply a generic worker transition behind the authoritative fence."""
+    run = lock_owned_run(run_id, worker_id)
+    if target == "completed":
+        raise InvalidTransition(
+            "completed is only allowed through atomic finalization")
+    require_run_transition(run.status, target)
+    if _preserve_ambiguous_tools(
+            run, reason=f"worker_{target}_with_running_tool"):
+        return run
+    if run.cancel_requested and target != "cancelled":
+        return transition_run(
+            run, "cancelled", event_type="run.cancelled",
+            payload={"status": "cancelled"})
+    return transition_run(
+        run,
+        target,
+        event_type=event_type,
+        payload=payload,
+        error_class=error_class,
+        available_in_seconds=available_in_seconds,
+    )
+
+
 def request_cancel(run: AgentRun) -> AgentRun:
+    locked = (
+        AgentRun.query
+        .filter(AgentRun.id == run.id)
+        .with_for_update()
+        .first()
+    )
+    if locked is None:
+        raise LookupError("unknown run")
+    run = locked
     if run.status in TERMINAL_RUN_STATES:
+        return run
+    if run.status == "waiting_for_human" and AgentToolCall.query.filter_by(
+            run_id=run.id, status="needs_reconciliation").first() is not None:
+        if not run.cancel_requested:
+            run.cancel_requested = True
+            append_event(run, "run.cancel_requested", {"status": run.status})
+            db.session.commit()
         return run
     if run.status in ("queued", "waiting_for_human"):
         return transition_run(run, "cancelled")
@@ -253,6 +530,24 @@ def request_cancel(run: AgentRun) -> AgentRun:
     append_event(run, "run.cancel_requested", {"status": run.status})
     db.session.commit()
     return run
+
+
+def resume_run(run_id: str) -> AgentRun:
+    """Requeue a human-waiting run unless provider truth is unresolved."""
+    run = (
+        AgentRun.query
+        .filter(AgentRun.id == run_id)
+        .with_for_update()
+        .first()
+    )
+    if run is None:
+        raise LookupError("unknown run")
+    if AgentToolCall.query.filter_by(
+            run_id=run.id, status="needs_reconciliation").first() is not None:
+        raise InvalidTransition("run has a tool awaiting reconciliation")
+    return transition_run(
+        run, "queued", event_type="run.resumed",
+        payload={"status": "queued"})
 
 
 def register_tool_call(
@@ -304,14 +599,31 @@ def register_tool_call(
 def transition_tool_call(
     run: AgentRun,
     call: AgentToolCall,
+    worker_id: str,
     target: str,
     *,
     result: dict | list | str | None = None,
     outcome_ref: str | None = None,
     error_class: str | None = None,
 ) -> AgentToolCall:
+    # Lock in the same order as deadline enforcement so a late tool outcome
+    # cannot race past lease revocation and overwrite needs_reconciliation.
+    locked_run = lock_owned_run(run.id, worker_id)
+    locked_call = (
+        AgentToolCall.query
+        .filter(AgentToolCall.id == call.id)
+        .with_for_update()
+        .first()
+    )
+    if locked_call is None:
+        raise LookupError("unknown run or tool call")
+    run = locked_run
+    call = locked_call
     if call.run_id != run.id or call.tenant_id != run.tenant_id:
         raise LookupError("tool call does not belong to run")
+    if run.cancel_requested and target == "running":
+        raise InvalidTransition(
+            "run cancellation prevents starting a tool call")
     require_tool_transition(call.status, target)
     now = utcnow()
     call.status = target
@@ -337,5 +649,213 @@ def transition_tool_call(
     return call
 
 
+def finalize_run(
+    run_id: str,
+    worker_id: str,
+    *,
+    text: str,
+    checkpoint_id: str,
+) -> tuple[AgentRun, ConversationMessage, bool]:
+    """Atomically persist the assistant answer, event, and run completion."""
+    run = (
+        AgentRun.query
+        .filter(AgentRun.id == run_id)
+        .with_for_update()
+        .first()
+    )
+    if run is None:
+        raise LookupError("unknown run")
+
+    request_id = f"run:{run.id}:assistant"
+    prior = ConversationMessage.query.filter_by(
+        tenant_id=run.tenant_id,
+        conversation_id=run.conversation_id,
+        request_id=request_id,
+    ).first()
+    if run.status == "completed":
+        prior_text_events = AgentRunEvent.query.filter_by(
+            run_id=run.id, event_type="agent.text").all()
+        checkpoint_matches = any(
+            (_load(event.payload_json) or {}).get("checkpoint_id")
+            == checkpoint_id
+            for event in prior_text_events
+        )
+        if (prior is not None and prior.role == "assistant"
+                and prior.text == text and prior.agent_id == run.agent_id
+                and prior.reply_to == run.message_id and checkpoint_matches):
+            return run, prior, False
+        raise InvalidTransition("completed run has conflicting assistant outcome")
+
+    _enforce_worker_fence(run, worker_id)
+    unresolved = AgentToolCall.query.filter(
+        AgentToolCall.run_id == run.id,
+        AgentToolCall.status.in_((
+            "pending", "running", "needs_reconciliation")),
+    ).first()
+    if unresolved is not None:
+        raise InvalidTransition("run has an unresolved tool call")
+
+    if prior is not None:
+        if (prior.role != "assistant" or prior.text != text
+                or prior.agent_id != run.agent_id
+                or prior.reply_to != run.message_id):
+            raise InvalidTransition(
+                "assistant request ID conflicts with persisted outcome")
+        message = prior
+    else:
+        conversation = (
+            Conversation.query
+            .filter_by(tenant_id=run.tenant_id, id=run.conversation_id)
+            .with_for_update()
+            .first()
+        )
+        if conversation is None:
+            raise LookupError("run conversation is missing")
+        message = ConversationMessage(
+            tenant_id=run.tenant_id,
+            conversation_id=run.conversation_id,
+            agent_id=run.agent_id,
+            channel=run.surface,
+            role="assistant",
+            text=text,
+            request_id=request_id,
+            reply_to=run.message_id,
+            metadata_json=_dump({"careagents_agent_id": run.agent_id}),
+        )
+        db.session.add(message)
+        conversation.updated_at = utcnow()
+
+    prior_text_events = AgentRunEvent.query.filter_by(
+        run_id=run.id, event_type="agent.text").all()
+    already_emitted = any(
+        (_load(event.payload_json) or {}).get("checkpoint_id") == checkpoint_id
+        for event in prior_text_events
+    )
+    if not already_emitted:
+        append_event(run, "agent.text", {
+            "checkpoint_id": checkpoint_id,
+            "text": text,
+        })
+    transition_run(
+        run,
+        "completed",
+        event_type="run.completed",
+        payload={"status": "completed"},
+        commit=False,
+    )
+    db.session.commit()
+    return run, message, True
+
+
+def reconcile_tool_call(
+    run: AgentRun,
+    call: AgentToolCall,
+    target: str,
+    *,
+    evidence_ref: str,
+    error_class: str | None = None,
+) -> tuple[AgentToolCall, AgentRun, bool]:
+    """Record provider truth for one ambiguous side effect, idempotently.
+
+    This is intentionally separate from worker transitions: a reconciler may
+    resolve ambiguity but can never put the call back into an executable state.
+    """
+    if target not in ("completed", "failed"):
+        raise InvalidTransition(
+            "reconciliation may only complete or fail a tool call")
+
+    locked_run = (
+        AgentRun.query
+        .filter(AgentRun.id == run.id)
+        .with_for_update()
+        .first()
+    )
+    locked_call = (
+        AgentToolCall.query
+        .filter(AgentToolCall.id == call.id)
+        .with_for_update()
+        .first()
+    )
+    if locked_run is None or locked_call is None:
+        raise LookupError("unknown run or tool call")
+    run = locked_run
+    call = locked_call
+    if call.run_id != run.id or call.tenant_id != run.tenant_id:
+        raise LookupError("tool call does not belong to run")
+
+    prior_events = AgentRunEvent.query.filter_by(
+        run_id=run.id, event_type="tool.reconciled").all()
+    prior = next((
+        event for event in prior_events
+        if (_load(event.payload_json) or {}).get("tool_call_id") == call.id
+    ), None)
+    if prior is not None:
+        if call.status == target and call.outcome_ref == evidence_ref:
+            return call, run, False
+        raise InvalidTransition("tool reconciliation conflicts with prior truth")
+
+    if run.status != "waiting_for_human":
+        raise InvalidTransition("run is not awaiting reconciliation")
+    require_tool_transition(call.status, target)
+    now = utcnow()
+    call.status = target
+    call.outcome_ref = evidence_ref
+    call.error_class = (
+        None if target == "completed"
+        else (error_class or "ReconciledToolFailure")
+    )
+    # Reconciliation records only opaque, server-controlled evidence. It does
+    # not accept or manufacture a tool result envelope that a resumed model
+    # could mistake for the original provider response.
+    call.result_json = None
+    call.finished_at = now
+
+    remaining = (
+        AgentToolCall.query
+        .filter_by(run_id=run.id, status="needs_reconciliation")
+        .filter(AgentToolCall.id != call.id)
+        .count()
+    )
+    if remaining == 0:
+        if run.cancel_requested:
+            run_target = "cancelled"
+            run_error = None
+        else:
+            any_failed = AgentToolCall.query.filter_by(
+                run_id=run.id, status="failed").count() > 0
+            run_target = "failed"
+            run_error = (
+                "ReconciledToolFailure" if any_failed
+                else "ReconciledOutcomeNoAssistant"
+            )
+        require_run_transition(run.status, run_target)
+        run.status = run_target
+        run.error_class = run_error
+        run.finished_at = now
+        run.worker_id = None
+        run.lease_expires_at = None
+
+    append_event(run, "tool.reconciled", {
+        "tool_call_id": call.id,
+        "tool_name": call.tool_name,
+        "status": target,
+        "evidence_ref": evidence_ref,
+        "error_class": call.error_class,
+        "run_status": run.status,
+        "run_error_class": run.error_class,
+    })
+    db.session.commit()
+    return call, run, True
+
+
 def _dump(value) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _load(value: str | None):
+    if value is None:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return None

--- a/r6/agent_runs/state.py
+++ b/r6/agent_runs/state.py
@@ -21,12 +21,16 @@ RUN_TRANSITIONS = {
     "cancelled": frozenset(),
 }
 
-TOOL_STATES = frozenset({"pending", "running", "completed", "failed"})
+TOOL_STATES = frozenset({
+    "pending", "running", "completed", "failed", "needs_reconciliation"})
 TOOL_TRANSITIONS = {
     "pending": frozenset({"running", "failed"}),
-    "running": frozenset({"completed", "failed"}),
+    "running": frozenset({"completed", "failed", "needs_reconciliation"}),
     "completed": frozenset(),
     "failed": frozenset({"running"}),
+    # A human/reconciler must establish provider truth. Blind execution is
+    # intentionally absent: an unknown side effect is never retried.
+    "needs_reconciliation": frozenset({"completed", "failed"}),
 }
 
 

--- a/r6/command_center/projector.py
+++ b/r6/command_center/projector.py
@@ -11,7 +11,7 @@ import os
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from sqlalchemy import desc, func
+from sqlalchemy import desc, func, or_
 
 from models import db
 from r6.models import R6Resource, AuditEventRecord
@@ -649,7 +649,8 @@ def agents_status(tenant_id: str) -> list[dict]:
 def recent_conversations(tenant_id: str, limit: int = 15,
                          full: bool = False,
                          conversation_id: str | None = None,
-                         agent_id: str | None = None) -> list[dict]:
+                         agent_id: str | None = None,
+                         through_message_id: str | None = None) -> list[dict]:
     """Return the most recent chat turns across all agents + channels.
 
     `full` returns untruncated text. The dashboard wants the 500-char preview
@@ -661,6 +662,22 @@ def recent_conversations(tenant_id: str, limit: int = 15,
         query = query.filter_by(conversation_id=conversation_id)
     if agent_id:
         query = query.filter_by(agent_id=agent_id)
+    if through_message_id:
+        anchor = ConversationMessage.query.filter_by(
+            tenant_id=tenant_id, id=through_message_id).first()
+        if anchor is None:
+            return []
+        if conversation_id and anchor.conversation_id != conversation_id:
+            return []
+        if agent_id and anchor.agent_id != agent_id:
+            return []
+        # Strictly earlier timestamps plus the exact anchor. Excluding other
+        # same-timestamp rows is deliberately conservative: a later inbound
+        # message must never leak into an earlier queued run's prompt.
+        query = query.filter(or_(
+            ConversationMessage.created_at < anchor.created_at,
+            ConversationMessage.id == anchor.id,
+        ))
     msgs = query.order_by(
         desc(ConversationMessage.created_at),
         desc(ConversationMessage.id),

--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -223,10 +223,16 @@ def api_conversations_list():
         return err
     limit = min(int(request.args.get("limit", "15")), 100)
     full = request.args.get("full") in ("1", "true")
+    through_message_id = request.args.get("through_message_id") or None
+    if through_message_id is not None and (
+            not isinstance(through_message_id, str)
+            or not _REQUEST_ID.fullmatch(through_message_id)):
+        return jsonify({"error": "invalid through_message_id"}), 400
     return jsonify(projector.recent_conversations(
         _tenant(), limit=limit, full=full,
         conversation_id=request.args.get("conversation_id") or None,
         agent_id=request.args.get("agent_id") or None,
+        through_message_id=through_message_id,
     ))
 
 

--- a/r6/database_migrations.py
+++ b/r6/database_migrations.py
@@ -22,7 +22,7 @@ _ROOT = Path(__file__).resolve().parents[1]
 # never re-created — running the baseline migration against it dies with
 # "table ... already exists".
 _BASELINE_REVISION = "0001_v1_8_0"
-_CREATE_ALL_SCHEMA_REVISION = "0005_agent_run_control_plane"
+_CREATE_ALL_SCHEMA_REVISION = "0006_tool_reconciliation_state"
 
 # A table that has existed since long before v1.8.0 — its presence (without
 # alembic_version) is the legacy-database fingerprint.

--- a/r6/database_migrations.py
+++ b/r6/database_migrations.py
@@ -22,7 +22,7 @@ _ROOT = Path(__file__).resolve().parents[1]
 # never re-created — running the baseline migration against it dies with
 # "table ... already exists".
 _BASELINE_REVISION = "0001_v1_8_0"
-_CREATE_ALL_SCHEMA_REVISION = "0006_tool_reconciliation_state"
+_CREATE_ALL_SCHEMA_REVISION = "0007_agent_worker_presence"
 
 # A table that has existed since long before v1.8.0 — its presence (without
 # alembic_version) is the legacy-database fingerprint.
@@ -72,6 +72,7 @@ def _unstamped_adoption_revision(connection) -> str | None:
             and "agent_runs" in tables
             and "agent_tool_calls" in tables
             and "agent_run_events" in tables
+            and "agent_worker_presence" in tables
         ):
             return _CREATE_ALL_SCHEMA_REVISION
     return _BASELINE_REVISION

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -7,8 +7,15 @@ from datetime import timedelta
 import pytest
 
 from models import db
-from r6.agent_runs.models import AgentRun, AgentRunEvent, utcnow
+from r6.agent_runs.models import (
+    AgentRun,
+    AgentRunEvent,
+    AgentToolCall,
+    AgentWorkerPresence,
+    utcnow,
+)
 from r6.agent_runs.state import RUN_STATES
+from r6.command_center.models import ConversationMessage
 
 
 TENANT = "test-tenant"
@@ -18,6 +25,12 @@ TENANT = "test-tenant"
 def internal_headers(monkeypatch):
     monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "run-worker-secret")
     return {"X-Internal-Secret": "run-worker-secret"}
+
+
+@pytest.fixture
+def reconcile_headers(monkeypatch):
+    monkeypatch.setenv("AGENT_RUN_RECONCILE_SECRET", "operator-secret")
+    return {"X-Reconciliation-Secret": "operator-secret"}
 
 
 def _message(client, auth_headers, *, text="hello", request_id="request-1"):
@@ -105,6 +118,478 @@ def test_worker_claim_is_secret_gated_and_claims_once(
     assert body["message"] == {
         "id": message["id"], "role": "user", "text": "hello"}
     assert _claim(client, internal_headers, worker="worker-2").status_code == 204
+
+
+def test_worker_readiness_requires_recent_successful_queue_access(
+        app, client, internal_headers):
+    endpoint = "/command-center/api/runs/workers/health"
+    assert client.get(endpoint).status_code == 403
+    unavailable = client.get(endpoint, headers=internal_headers)
+    assert unavailable.status_code == 503
+    assert unavailable.get_json()["active_workers"] == 0
+
+    # A successful empty claim is still a real queue transaction and proves
+    # that an idle worker can reach the control plane.
+    assert _claim(client, internal_headers, worker="idle-worker").status_code == 204
+    healthy = client.get(endpoint, headers=internal_headers)
+    assert healthy.status_code == 200
+    assert healthy.get_json()["active_workers"] == 1
+
+    with app.app_context():
+        presence = db.session.get(AgentWorkerPresence, "idle-worker")
+        presence.last_seen_at = utcnow() - timedelta(seconds=31)
+        db.session.commit()
+    stale = client.get(endpoint, headers=internal_headers)
+    assert stale.status_code == 503
+    assert stale.get_json()["status"] == "unavailable"
+
+    assert _claim(client, internal_headers, worker="idle-worker").status_code == 204
+    assert client.get(endpoint, headers=internal_headers).status_code == 200
+
+
+def test_owned_run_heartbeat_refreshes_presence_but_wrong_worker_cannot(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="active-worker").status_code == 200
+    with app.app_context():
+        presence = db.session.get(AgentWorkerPresence, "active-worker")
+        presence.last_seen_at = utcnow() - timedelta(seconds=31)
+        db.session.commit()
+
+    wrong = client.post(
+        f"/command-center/api/runs/{run_id}/heartbeat",
+        headers=internal_headers,
+        json={"worker_id": "wrong-worker", "lease_seconds": 60},
+    )
+    assert wrong.status_code == 409
+    with app.app_context():
+        assert db.session.get(AgentWorkerPresence, "wrong-worker") is None
+    assert client.get(
+        "/command-center/api/runs/workers/health",
+        headers=internal_headers).status_code == 503
+
+    valid = client.post(
+        f"/command-center/api/runs/{run_id}/heartbeat",
+        headers=internal_headers,
+        json={"worker_id": "active-worker", "lease_seconds": 60},
+    )
+    assert valid.status_code == 200
+    health = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+    assert health.status_code == 200
+    assert health.get_json()["active_workers"] == 1
+
+
+def test_owned_heartbeat_terminalizes_run_at_hard_deadline_once(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="deadline-worker").status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    endpoint = f"/command-center/api/runs/{run_id}/heartbeat"
+    payload = {"worker_id": "deadline-worker", "lease_seconds": 60}
+    assert client.post(
+        endpoint, headers=internal_headers, json=payload).status_code == 409
+    assert client.post(
+        endpoint, headers=internal_headers, json=payload).status_code == 409
+
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        events = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "failed"
+        assert run.error_class == "RunDeadlineExceeded"
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert len(events) == 1
+
+
+def test_worker_readiness_sweeps_expired_runs_without_reading_them(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    # Exercise only independent readiness; neither a worker nor a run-specific
+    # GET is involved in the deadline transition.
+    first = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+    second = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+
+    assert first.status_code == second.status_code == 503
+    assert first.get_json()["expired_runs"] == 1
+    assert second.get_json()["expired_runs"] == 0
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        events = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "failed"
+        assert run.error_class == "RunDeadlineExceeded"
+        assert len(events) == 1
+
+
+def test_worker_readiness_sweeps_running_run_after_worker_crash(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="crashed-worker").status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    # No worker heartbeat, claim, or run-specific read participates. The
+    # independent readiness sweep owns hard-deadline enforcement here.
+    first = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+    second = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+
+    assert first.get_json()["expired_runs"] == 1
+    assert second.get_json()["expired_runs"] == 0
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        events = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "failed"
+        assert run.error_class == "RunDeadlineExceeded"
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert len(events) == 1
+
+
+def test_event_replay_expires_running_run_after_worker_crash(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="crashed-worker").status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    endpoint = f"/command-center/api/runs/{run_id}/events"
+    replay = client.get(endpoint, headers=auth_headers)
+    repeated = client.get(endpoint, headers=auth_headers)
+
+    assert replay.status_code == repeated.status_code == 200
+    assert replay.get_json()["status"] == "failed"
+    assert repeated.get_json()["status"] == "failed"
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        events = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "failed"
+        assert run.error_class == "RunDeadlineExceeded"
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert len(events) == 1
+
+
+def test_deadline_sweep_preserves_running_cancellation_request(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="crashed-worker").status_code == 200
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel",
+        headers=auth_headers,
+    ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        cancelled = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.cancelled_at_deadline").all()
+        deadline_failures = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "cancelled"
+        assert run.error_class is None
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert len(cancelled) == 1
+        assert deadline_failures == []
+
+
+@pytest.mark.parametrize("trigger", ["worker-health", "event-replay"])
+def test_deadline_preserves_ambiguous_running_tool_for_reconciliation(
+        trigger, app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="lost-worker").status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "lost-worker",
+            "provider_call_id": "possibly-completed-side-effect",
+            "tool_name": "book_appointment",
+            "arguments": {"slot": "slot-1"},
+        },
+    ).get_json()
+    call_id = created["id"]
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": "running"},
+    ).status_code == 200
+    if trigger == "worker-health":
+        # Cancellation cannot assert that an already-started side effect did
+        # not happen; ambiguity must take precedence at the deadline.
+        assert client.post(
+            f"/command-center/api/runs/{run_id}/cancel",
+            headers=auth_headers,
+        ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    if trigger == "worker-health":
+        endpoint = "/command-center/api/runs/workers/health"
+        first = client.get(endpoint, headers=internal_headers)
+        second = client.get(endpoint, headers=internal_headers)
+        assert first.get_json()["expired_runs"] == 1
+        assert second.get_json()["expired_runs"] == 0
+    else:
+        endpoint = f"/command-center/api/runs/{run_id}/events"
+        first = client.get(endpoint, headers=auth_headers)
+        second = client.get(endpoint, headers=auth_headers)
+        assert first.get_json()["status"] == "waiting_for_human"
+        assert second.get_json()["status"] == "waiting_for_human"
+        cancellation = client.post(
+            f"/command-center/api/runs/{run_id}/cancel",
+            headers=auth_headers,
+        ).get_json()
+        assert cancellation["status"] == "waiting_for_human"
+        assert cancellation["cancel_requested"] is True
+
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/resume",
+        headers=internal_headers,
+    ).status_code == 409
+
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        call = db.session.get(AgentToolCall, call_id)
+        reconciliation = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.needs_reconciliation").all()
+        deadline_failures = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.deadline_exceeded").all()
+        assert run.status == "waiting_for_human"
+        assert run.error_class == "AmbiguousToolOutcome"
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert call.status == "needs_reconciliation"
+        assert call.error_class == "AmbiguousToolOutcome"
+        assert call.attempt == 1
+        assert len(reconciliation) == 1
+        assert deadline_failures == []
+
+    # Recovery claims cannot rerun a call whose outcome is ambiguous.
+    assert _claim(
+        client, internal_headers, worker="replacement-worker").status_code == 204
+
+
+@pytest.mark.parametrize("race", ["cancel-requested", "deadline-passed"])
+def test_claim_recovery_preserves_ambiguous_tool_before_other_transitions(
+        race, app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="lost-worker").status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "lost-worker",
+            "provider_call_id": f"lease-race-{race}",
+            "tool_name": "book_appointment",
+            "arguments": {"slot": "slot-1"},
+        },
+    ).get_json()
+    call_id = created["id"]
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": "running"},
+    ).status_code == 200
+    if race == "cancel-requested":
+        assert client.post(
+            f"/command-center/api/runs/{run_id}/cancel",
+            headers=auth_headers,
+        ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.lease_expires_at = utcnow() - timedelta(seconds=1)
+        if race == "deadline-passed":
+            run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    assert _claim(
+        client, internal_headers, worker="replacement-worker").status_code == 204
+
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        call = db.session.get(AgentToolCall, call_id)
+        reconciliation = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.needs_reconciliation").all()
+        assert run.status == "waiting_for_human"
+        assert run.error_class == "AmbiguousToolOutcome"
+        assert run.worker_id is None and run.lease_expires_at is None
+        assert call.status == "needs_reconciliation"
+        assert call.attempt == 1
+        assert len(reconciliation) == 1
+        assert not AgentRunEvent.query.filter(
+            AgentRunEvent.run_id == run_id,
+            AgentRunEvent.event_type.in_((
+                "run.failed", "run.deadline_exceeded", "run.cancelled",
+                "run.cancelled_after_lease",
+            )),
+        ).all()
+
+
+@pytest.mark.parametrize("truth", ["completed", "failed"])
+def test_authorized_reconciler_resolves_ambiguous_tool_exactly_once(
+        truth, app, client, auth_headers, internal_headers,
+        reconcile_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(
+        client, internal_headers, worker="lost-worker").status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "lost-worker",
+            "provider_call_id": f"reconcile-{truth}",
+            "tool_name": "book_appointment",
+            "arguments": {"slot": "slot-1"},
+        },
+    ).get_json()
+    call_id = created["id"]
+    transition_endpoint = (
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition")
+    assert client.post(
+        transition_endpoint,
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": "running"},
+    ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+    assert client.get(
+        f"/command-center/api/runs/{run_id}/events",
+        headers=auth_headers,
+    ).get_json()["status"] == "waiting_for_human"
+
+    # The former worker cannot supply a late result after losing its lease.
+    assert client.post(
+        transition_endpoint,
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": truth},
+    ).status_code == 409
+
+    reconcile_endpoint = (
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/reconcile")
+    payload = {
+        "status": truth,
+        "evidence_ref": f"provider:truth:{truth}",
+    }
+    if truth == "failed":
+        payload["error_class"] = "ProviderRejected"
+    # Neither an unauthenticated caller nor an authenticated tenant can assert
+    # provider truth. Reconciliation uses a separate operator credential.
+    assert client.post(reconcile_endpoint, json=payload).status_code == 403
+    assert client.post(
+        reconcile_endpoint,
+        headers=auth_headers,
+        json=payload,
+    ).status_code == 403
+    assert client.post(
+        reconcile_endpoint,
+        headers=internal_headers,
+        json=payload,
+    ).status_code == 403
+    assert client.post(
+        reconcile_endpoint,
+        headers=reconcile_headers,
+        json={**payload, "status": "running"},
+    ).status_code == 400
+    assert client.post(
+        reconcile_endpoint,
+        headers=reconcile_headers,
+        json={**payload, "result": {"patient_name": "must-not-enter"}},
+    ).status_code == 400
+
+    resolved = client.post(
+        reconcile_endpoint, headers=reconcile_headers, json=payload)
+    replay = client.post(
+        reconcile_endpoint, headers=reconcile_headers, json=payload)
+    conflict = client.post(
+        reconcile_endpoint,
+        headers=reconcile_headers,
+        json={**payload, "evidence_ref": "provider:different:truth"},
+    )
+
+    assert resolved.status_code == replay.status_code == 200
+    assert resolved.get_json()["idempotent_replay"] is False
+    assert replay.get_json()["idempotent_replay"] is True
+    assert resolved.get_json()["run_status"] == "failed"
+    assert "input" not in resolved.get_json()
+    assert "result" not in resolved.get_json()
+    assert conflict.status_code == 409
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        call = db.session.get(AgentToolCall, call_id)
+        events = AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="tool.reconciled").all()
+        assert run.status == "failed"
+        assert run.error_class == (
+            "ReconciledToolFailure" if truth == "failed"
+            else "ReconciledOutcomeNoAssistant")
+        assert call.status == truth
+        assert call.outcome_ref == f"provider:truth:{truth}"
+        assert call.result_json is None
+        assert len(events) == 1
+
+
+def test_worker_readiness_fails_closed_on_queue_database_error(
+        client, internal_headers, monkeypatch):
+    from sqlalchemy.exc import SQLAlchemyError
+
+    def fail_sweep(*, limit):
+        raise SQLAlchemyError("queue unavailable")
+
+    monkeypatch.setattr(
+        "r6.agent_runs.routes.expire_overdue_runs", fail_sweep)
+    response = client.get(
+        "/command-center/api/runs/workers/health", headers=internal_headers)
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "status": "unavailable",
+        "available": False,
+        "active_workers": 0,
+        "queue": "error",
+    }
 
 
 def test_run_transition_and_cancel_state_machine(
@@ -376,6 +861,298 @@ def test_event_and_tool_payloads_are_bounded(
     ).status_code == 413
 
 
+def test_finalize_atomically_persists_assistant_message_and_completion(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    endpoint = f"/command-center/api/runs/{run_id}/finalize"
+    payload = {
+        "worker_id": "worker-1",
+        "checkpoint_id": "round-1",
+        "text": "Your appointment brief is ready.",
+    }
+
+    direct = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "completed"},
+    )
+    first = client.post(endpoint, headers=internal_headers, json=payload)
+    replay = client.post(endpoint, headers=internal_headers, json=payload)
+    conflict = client.post(
+        endpoint,
+        headers=internal_headers,
+        json={**payload, "text": "conflicting late answer"},
+    )
+    checkpoint_conflict = client.post(
+        endpoint,
+        headers=internal_headers,
+        json={**payload, "checkpoint_id": "different-final"},
+    )
+
+    assert direct.status_code == 409
+    assert first.status_code == replay.status_code == 200
+    assert first.get_json()["idempotent_replay"] is False
+    assert replay.get_json()["idempotent_replay"] is True
+    assert conflict.status_code == 409
+    assert checkpoint_conflict.status_code == 409
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        assistant = ConversationMessage.query.filter_by(
+            tenant_id=TENANT,
+            conversation_id=run.conversation_id,
+            request_id=f"run:{run_id}:assistant",
+        ).all()
+        assert run.status == "completed"
+        assert len(assistant) == 1
+        assert assistant[0].text == payload["text"]
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="agent.text").count() == 1
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.completed").count() == 1
+
+
+def test_generic_worker_failure_preserves_running_tool_ambiguity(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "exception-side-effect",
+            "tool_name": "book_appointment",
+            "arguments": {},
+        },
+    ).get_json()
+    call_id = created["id"]
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    ).status_code == 200
+
+    failed = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "failed",
+            "event_type": "run.failed",
+            "error_class": "UnexpectedWorkerError",
+        },
+    )
+
+    assert failed.status_code == 200
+    assert failed.get_json()["status"] == "waiting_for_human"
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        call = db.session.get(AgentToolCall, call_id)
+        assert run.status == "waiting_for_human"
+        assert run.error_class == "AmbiguousToolOutcome"
+        assert call.status == "needs_reconciliation"
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.failed").count() == 0
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.needs_reconciliation").count() == 1
+
+
+def test_cancellation_prevents_new_tool_registration(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel",
+        headers=auth_headers,
+    ).status_code == 200
+
+    response = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "cancelled-new-tool",
+            "tool_name": "book_appointment",
+            "arguments": {},
+        },
+    )
+
+    assert response.status_code == 409
+    with app.app_context():
+        assert AgentToolCall.query.filter_by(run_id=run_id).count() == 0
+
+
+def test_cancellation_prevents_pending_tool_from_starting(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "cancelled-pending-tool",
+            "tool_name": "book_appointment",
+            "arguments": {},
+        },
+    ).get_json()
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel",
+        headers=auth_headers,
+    ).status_code == 200
+
+    start = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{created['id']}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    )
+
+    assert start.status_code == 409
+    cancelled = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "failed",
+            "error_class": "ToolStartRejected",
+        },
+    )
+    assert cancelled.status_code == 200
+    assert cancelled.get_json()["status"] == "cancelled"
+    with app.app_context():
+        assert db.session.get(AgentToolCall, created["id"]).status == "pending"
+
+
+def test_cancellation_allows_started_tool_outcome_but_no_next_tool(
+        app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "already-started-tool",
+            "tool_name": "book_appointment",
+            "arguments": {},
+        },
+    ).get_json()
+    transition_endpoint = (
+        f"/command-center/api/runs/{run_id}/tool-calls/{created['id']}/transition")
+    assert client.post(
+        transition_endpoint,
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    ).status_code == 200
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/cancel",
+        headers=auth_headers,
+    ).status_code == 200
+
+    outcome = client.post(
+        transition_endpoint,
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "completed",
+            "outcome_ref": "provider:appointment:confirmed",
+            "result": {"content": "{}", "ui_events": []},
+        },
+    )
+    next_tool = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "must-not-start",
+            "tool_name": "send_message",
+            "arguments": {},
+        },
+    )
+    cancelled = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "cancelled"},
+    )
+
+    assert outcome.status_code == 200
+    assert outcome.get_json()["status"] == "completed"
+    assert next_tool.status_code == 409
+    assert cancelled.status_code == 200
+    assert cancelled.get_json()["status"] == "cancelled"
+
+
+@pytest.mark.parametrize("mutation", [
+    "completion", "event", "tool-registration", "finalization",
+])
+def test_worker_mutations_fail_after_authoritative_deadline(
+        mutation, app, client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    if mutation == "completion":
+        response = client.post(
+            f"/command-center/api/runs/{run_id}/transition",
+            headers=internal_headers,
+            json={"worker_id": "worker-1", "status": "completed"},
+        )
+    elif mutation == "event":
+        response = client.post(
+            f"/command-center/api/runs/{run_id}/events",
+            headers=internal_headers,
+            json={"worker_id": "worker-1", "type": "agent.late"},
+        )
+    elif mutation == "tool-registration":
+        response = client.post(
+            f"/command-center/api/runs/{run_id}/tool-calls",
+            headers=internal_headers,
+            json={
+                "worker_id": "worker-1",
+                "provider_call_id": "late-tool",
+                "tool_name": "book_appointment",
+                "arguments": {},
+            },
+        )
+    else:
+        response = client.post(
+            f"/command-center/api/runs/{run_id}/finalize",
+            headers=internal_headers,
+            json={
+                "worker_id": "worker-1",
+                "checkpoint_id": "late-final",
+                "text": "must not persist",
+            },
+        )
+
+    assert response.status_code == 409
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        assert run.status == "failed"
+        assert run.error_class == "RunDeadlineExceeded"
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.completed").count() == 0
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="agent.late").count() == 0
+        assert AgentToolCall.query.filter_by(
+            run_id=run_id, provider_call_id="late-tool").count() == 0
+        assert ConversationMessage.query.filter_by(
+            tenant_id=TENANT,
+            conversation_id=run.conversation_id,
+            request_id=f"run:{run_id}:assistant",
+        ).count() == 0
+
+
 def test_overdue_queued_run_fails_instead_of_starting(
         app, client, auth_headers, internal_headers):
     message = _message(client, auth_headers)
@@ -390,6 +1167,28 @@ def test_overdue_queued_run_fails_instead_of_starting(
         f"/command-center/api/runs/{run_id}", headers=auth_headers).get_json()
     assert detail["status"] == "failed"
     assert detail["error_class"] == "RunDeadlineExceeded"
+
+
+def test_event_replay_expires_queued_run_without_any_worker_claim(
+        app, client, auth_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    replay = client.get(
+        f"/command-center/api/runs/{run_id}/events", headers=auth_headers)
+
+    assert replay.status_code == 200
+    body = replay.get_json()
+    assert body["status"] == "failed"
+    assert [event["type"] for event in body["events"]] == [
+        "run.queued", "run.deadline_exceeded"]
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        assert run.error_class == "RunDeadlineExceeded"
 
 
 def test_postgres_workers_cannot_claim_one_run_twice(
@@ -442,11 +1241,118 @@ def test_postgres_workers_serialize_distinct_runs_in_one_conversation(
     assert winner["id"] in run_ids
 
     completed = client.post(
-        f"/command-center/api/runs/{winner['id']}/transition",
+        f"/command-center/api/runs/{winner['id']}/finalize",
         headers=internal_headers,
-        json={"worker_id": winner["worker_id"], "status": "completed"},
+        json={
+            "worker_id": winner["worker_id"],
+            "checkpoint_id": "concurrency-final",
+            "text": "first run complete",
+        },
     )
     assert completed.status_code == 200
     next_run = _claim(client, internal_headers, worker="worker-c")
     assert next_run.status_code == 200
     assert next_run.get_json()["id"] == (run_ids - {winner["id"]}).pop()
+
+
+@pytest.mark.parametrize("mutation", [
+    "finalization", "event", "tool-registration",
+])
+def test_postgres_deadline_fences_concurrent_stale_worker_mutation(
+        mutation, app, client, auth_headers, internal_headers, monkeypatch):
+    if db.engine.dialect.name != "postgresql":
+        pytest.skip("row-lock fencing contract requires PostgreSQL")
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    import r6.agent_runs.routes as run_routes
+    from r6.agent_runs.service import _terminalize_at_deadline
+
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    assert _claim(client, internal_headers).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    winner_locked = threading.Event()
+    release_winner = threading.Event()
+    mutation_started = threading.Event()
+    original_lock = run_routes.lock_owned_run
+    original_finalize = run_routes.finalize_run
+
+    def observed_lock(*args, **kwargs):
+        mutation_started.set()
+        return original_lock(*args, **kwargs)
+
+    def observed_finalize(*args, **kwargs):
+        mutation_started.set()
+        return original_finalize(*args, **kwargs)
+
+    monkeypatch.setattr(run_routes, "lock_owned_run", observed_lock)
+    monkeypatch.setattr(run_routes, "finalize_run", observed_finalize)
+
+    def deadline_winner():
+        with app.app_context():
+            run = (
+                AgentRun.query.filter_by(id=run_id)
+                .with_for_update().one()
+            )
+            _terminalize_at_deadline(run, commit=False)
+            winner_locked.set()
+            assert release_winner.wait(5)
+            db.session.commit()
+
+    def stale_mutation():
+        with app.test_client() as contender:
+            if mutation == "finalization":
+                return contender.post(
+                    f"/command-center/api/runs/{run_id}/finalize",
+                    headers=internal_headers,
+                    json={
+                        "worker_id": "worker-1",
+                        "checkpoint_id": "late-final",
+                        "text": "must not persist",
+                    },
+                ).status_code
+            if mutation == "event":
+                return contender.post(
+                    f"/command-center/api/runs/{run_id}/events",
+                    headers=internal_headers,
+                    json={"worker_id": "worker-1", "type": "agent.late"},
+                ).status_code
+            return contender.post(
+                f"/command-center/api/runs/{run_id}/tool-calls",
+                headers=internal_headers,
+                json={
+                    "worker_id": "worker-1",
+                    "provider_call_id": "late-tool",
+                    "tool_name": "book_appointment",
+                    "arguments": {},
+                },
+            ).status_code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        winner = pool.submit(deadline_winner)
+        assert winner_locked.wait(5)
+        stale = pool.submit(stale_mutation)
+        assert mutation_started.wait(5)
+        release_winner.set()
+        winner.result(timeout=5)
+        assert stale.result(timeout=5) == 409
+
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        assert run.status == "failed"
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="run.completed").count() == 0
+        assert AgentRunEvent.query.filter_by(
+            run_id=run_id, event_type="agent.late").count() == 0
+        assert AgentToolCall.query.filter_by(
+            run_id=run_id, provider_call_id="late-tool").count() == 0
+        assert ConversationMessage.query.filter_by(
+            tenant_id=TENANT,
+            conversation_id=run.conversation_id,
+            request_id=f"run:{run_id}:assistant",
+        ).count() == 0

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -232,6 +232,61 @@ def test_waiting_run_requeues_without_replaying_completed_tool(
     assert conflict.status_code == 409
 
 
+def test_ambiguous_running_tool_requires_reconciliation_before_resolution(
+        client, auth_headers, internal_headers):
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _claim(client, internal_headers)
+    created = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "provider_call_id": "side-effect-1",
+            "tool_name": "book_appointment",
+            "arguments": {"slot": "slot-1"},
+        },
+    ).get_json()
+    call_id = created["id"]
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    ).status_code == 200
+
+    ambiguous = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "needs_reconciliation",
+            "error_class": "AmbiguousToolOutcome",
+        },
+    )
+    assert ambiguous.status_code == 200
+    assert ambiguous.get_json()["status"] == "needs_reconciliation"
+
+    # Re-execution is intentionally not a legal transition. An operator or
+    # downstream reconciliation job must resolve the original side effect.
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    ).status_code == 409
+    resolved = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={
+            "worker_id": "worker-1",
+            "status": "completed",
+            "result": {"appointment_id": "appointment-1"},
+            "outcome_ref": "appointment-1",
+        },
+    )
+    assert resolved.status_code == 200
+    assert resolved.get_json()["status"] == "completed"
+
+
 def test_expired_worker_lease_is_recovered_for_another_worker(
         app, client, auth_headers, internal_headers):
     message = _message(client, auth_headers)
@@ -357,3 +412,41 @@ def test_postgres_workers_cannot_claim_one_run_twice(
     assert sorted(status for status, _body in results) == [200, 204]
     winner = next(body for status, body in results if status == 200)
     assert winner["id"] == run_id
+
+
+def test_postgres_workers_serialize_distinct_runs_in_one_conversation(
+        app, client, auth_headers, internal_headers):
+    if db.engine.dialect.name != "postgresql":
+        pytest.skip("conversation row-lock contract requires PostgreSQL")
+    from concurrent.futures import ThreadPoolExecutor
+
+    first_message = _message(
+        client, auth_headers, text="first", request_id="request-first")
+    second_message = _message(
+        client, auth_headers, text="second", request_id="request-second")
+    run_ids = {
+        _run(client, auth_headers, first_message["id"]).get_json()["id"],
+        _run(client, auth_headers, second_message["id"]).get_json()["id"],
+    }
+
+    def claim(worker):
+        with app.test_client() as contender:
+            response = _claim(contender, internal_headers, worker=worker)
+            return response.status_code, response.get_json(silent=True)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ("worker-a", "worker-b")))
+
+    assert sorted(status for status, _body in results) == [200, 204]
+    winner = next(body for status, body in results if status == 200)
+    assert winner["id"] in run_ids
+
+    completed = client.post(
+        f"/command-center/api/runs/{winner['id']}/transition",
+        headers=internal_headers,
+        json={"worker_id": winner["worker_id"], "status": "completed"},
+    )
+    assert completed.status_code == 200
+    next_run = _claim(client, internal_headers, worker="worker-c")
+    assert next_run.status_code == 200
+    assert next_run.get_json()["id"] == (run_ids - {winner["id"]}).pop()

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -269,6 +269,78 @@ def test_confirm_action_mints_action_bound_credential_then_uses_it():
     assert calls[1][2]['X-Step-Up-Token'] == 'action-bound-token'
 
 
+def test_worker_health_client_accepts_fail_closed_503_projection():
+    import careagents.healthclaw as hcmod
+
+    captured = {}
+
+    class _Resp:
+        status_code = 503
+
+        @staticmethod
+        def json():
+            return {"available": False, "active_workers": 0}
+
+    class _HTTP:
+        @staticmethod
+        def get(url, params=None, headers=None, timeout=None):
+            captured.update({"url": url, "params": params,
+                             "headers": headers, "timeout": timeout})
+            return _Resp()
+
+    client = hcmod.HealthClawClient("http://local", "mint-secret")
+    client.http = _HTTP()
+
+    result = client.agent_worker_health(45)
+
+    assert result["available"] is False
+    assert captured["url"].endswith(
+        "/command-center/api/runs/workers/health")
+    assert captured["params"] == {"max_age_seconds": 45}
+    assert captured["headers"] == {
+        "X-Internal-Secret": "mint-secret",
+        "X-Agent-Id": "careagents-worker",
+    }
+
+
+def test_worker_container_probe_uses_authenticated_queue_readiness(monkeypatch):
+    from careagents import healthcheck
+
+    captured = {}
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["secret"] = request.get_header("X-internal-secret")
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", urlopen)
+    env = {"CARE_ROLE": "worker", "HEALTHCLAW_BASE": "http://healthclaw",
+           "HEALTHCLAW_MINT_SECRET": "worker-secret",
+           "CARE_RUN_WORKER_STALE_SECONDS": "45"}
+
+    assert healthcheck.healthy(env) is True
+    assert captured["url"].endswith(
+        "/command-center/api/runs/workers/health?max_age_seconds=45")
+    assert captured["secret"] == "worker-secret"
+
+
+def test_worker_container_probe_fails_closed_without_secret():
+    from careagents.healthcheck import healthy
+
+    assert healthy({"CARE_ROLE": "worker",
+                    "HEALTHCLAW_BASE": "http://healthclaw"}) is False
+
+
 def test_a_chat_turn_is_persisted_to_healthclaw_not_careagents(
         cfg, svc, monkeypatch):
     # The transcript is PHI-adjacent, so it belongs behind the guardrails in
@@ -452,8 +524,67 @@ def test_worker_enforces_claimed_run_deadline_before_inference(
     RunWorker(cfg, fake, svc, "deadline-worker").run_once()
 
     assert fake.runs[run_id]["status"] == "failed"
-    assert any(event["type"] == "run.failed"
+    assert any(event["type"] == "run.deadline_exceeded"
                for event in fake.events[run_id])
+
+
+def test_sse_replay_terminates_expired_run_without_a_worker(
+        cfg, svc, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    response = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "worker disappears",
+        "request_id": "expire-without-worker"}, buffered=False)
+    stream = iter(response.response)
+    assert '"type": "accepted"' in next(stream).decode()
+    run_id = next(iter(fake.runs))
+    fake.runs[run_id]["deadline_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+
+    body = b"".join(stream).decode()
+
+    assert fake.runs[run_id]["status"] == "failed"
+    assert '"type": "done"' in body
+    assert '"status": "failed"' in body
+
+
+def test_late_provider_result_is_not_checkpointed_after_lease_loss(
+        cfg, svc, monkeypatch):
+    from careagents.worker import RunWorker
+
+    app, client, fake, agent_id, tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    accepted = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "provider may hang",
+        "request_id": "late-provider"}, buffered=False)
+    next(iter(accepted.response))
+    accepted.close()
+    run = fake.claim_agent_run("late-worker")
+
+    class _Turn:
+        text, tool_calls, raw_tool_calls = "late answer", [], []
+
+    monkeypatch.setattr(
+        "careagents.worker.llm.complete", lambda *_args: _Turn())
+
+    class _RevokedLease:
+        checks = 0
+
+        def check(self):
+            self.checks += 1
+            if self.checks > 1:
+                raise HealthClawError("worker lease was lost", 409)
+
+    with pytest.raises(HealthClawError):
+        RunWorker(cfg, fake, svc, "late-worker")._execute(
+            run, _RevokedLease())
+
+    assert [event["type"] for event in fake.events[run["id"]]] == [
+        "run.queued", "run.started"]
+    assert [message["role"] for message in fake.logged[
+        (tenant, fake.conversation_id(agent_id))]] == ["user"]
 
 
 def test_worker_pool_creates_only_the_configured_number_of_slots(
@@ -753,6 +884,7 @@ def test_healthz_reports_ok_when_the_account_store_answers(app):
     assert r.status_code == 200
     d = r.get_json()
     assert d["status"] == "ok" and d["accounts"] is True
+    assert d["run_workers"] is True
 
 
 def test_healthz_reports_503_when_the_account_store_is_unreachable(app, svc,
@@ -765,6 +897,58 @@ def test_healthz_reports_503_when_the_account_store_is_unreachable(app, svc,
     r = app.test_client().get("/healthz")
     assert r.status_code == 503
     assert r.get_json()["accounts"] is False
+
+
+def test_healthz_and_chat_fail_fast_when_worker_presence_is_stale(
+        cfg, svc, monkeypatch):
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    fake.worker_available = False
+
+    health = client.get("/healthz")
+    refused = client.post("/api/chat", json={
+        "agent_id": agent_id,
+        "message": "do not strand this",
+        "request_id": "worker-absent",
+    })
+
+    assert health.status_code == 503
+    assert health.get_json()["run_workers"] is False
+    assert refused.status_code == 503
+    assert refused.get_json()["error"] == "run_workers_unavailable"
+    assert fake.runs == {}
+
+
+def test_chat_recovers_after_worker_queue_access_returns(
+        cfg, svc, monkeypatch):
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    payload = {"agent_id": agent_id, "message": "try once healthy",
+               "request_id": "worker-recovery"}
+    fake.worker_available = False
+    assert client.post("/api/chat", json=payload).status_code == 503
+
+    fake.worker_available = True
+    accepted = client.post("/api/chat", json=payload, buffered=False)
+    first = next(iter(accepted.response)).decode()
+    accepted.close()
+
+    assert accepted.status_code == 200
+    assert '"type": "accepted"' in first
+    assert len(fake.runs) == 1
+
+
+def test_unreachable_worker_control_plane_degrades_readiness_and_admission(
+        cfg, svc, monkeypatch):
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    fake.worker_health_error = True
+
+    assert client.get("/healthz").status_code == 503
+    response = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "upstream is unreachable"})
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "run_workers_unavailable"
 
 
 def test_ping_returns_false_instead_of_raising(svc, monkeypatch):
@@ -833,6 +1017,8 @@ class FakeClient:
         self.events: dict[str, list[dict]] = {}
         self.tool_calls: dict[tuple[str, str], dict] = {}
         self._event_id = 0
+        self.worker_available = True
+        self.worker_health_error = False
 
     @staticmethod
     def conversation_id(agent_id):
@@ -920,11 +1106,26 @@ class FakeClient:
 
     def agent_run_events(self, tenant, run_id, after=0, limit=100):
         run = self.get_agent_run(tenant, run_id)
+        if run["status"] == "queued":
+            from datetime import datetime, timezone
+            deadline = datetime.fromisoformat(run["deadline_at"])
+            if datetime.now(timezone.utc) >= deadline:
+                self.runs[run_id]["status"] = "failed"
+                self._append_run_event(
+                    run_id, "run.deadline_exceeded", {"status": "failed"})
+                run = self.get_agent_run(tenant, run_id)
         events = [event for event in self.events.get(run_id, [])
                   if event["id"] > after][:limit]
         return {"run_id": run_id, "status": run["status"],
                 "events": events,
                 "next_cursor": events[-1]["id"] if events else after}
+
+    def agent_worker_health(self, max_age_seconds=30):
+        if self.worker_health_error:
+            raise HealthClawError("worker health unavailable", 0)
+        return {"available": self.worker_available,
+                "active_workers": 1 if self.worker_available else 0,
+                "max_age_seconds": max_age_seconds}
 
     def claim_agent_run(self, worker_id, lease_seconds=60):
         run = next((item for item in self.runs.values()
@@ -960,6 +1161,31 @@ class FakeClient:
             run_id, kwargs.get("event_type") or f"run.{status}",
             kwargs.get("payload") or {"status": status})
         return dict(run)
+
+    def finalize_agent_run(self, run_id, worker_id, text, checkpoint_id):
+        run = self.runs[run_id]
+        if run["status"] == "completed":
+            return {"run": dict(run), "idempotent_replay": True}
+        if run["status"] != "running" or run["worker_id"] != worker_id:
+            raise HealthClawError("worker does not own run", 409)
+        request_id = f"run:{run_id}:assistant"
+        rows = self.logged.setdefault(
+            (run["tenant_id"], run["conversation_id"]), [])
+        if not any(row.get("request_id") == request_id for row in rows):
+            rows.append({
+                "role": "assistant", "content": text,
+                "agent_id": run.get("agent_id"),
+                "surface": run.get("surface") or "web",
+                "reply_to": run.get("message_id"),
+                "request_id": request_id,
+            })
+        self._append_run_event(run_id, "agent.text", {
+            "checkpoint_id": checkpoint_id, "text": text})
+        run["status"] = "completed"
+        run["worker_id"] = None
+        self._append_run_event(run_id, "run.completed", {
+            "status": "completed"})
+        return {"run": dict(run), "idempotent_replay": False}
 
     def append_agent_run_event(self, run_id, worker_id, event_type,
                                payload=None):

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -139,9 +139,29 @@ def _turn(client, agent_id, message, request_id=None, conversation_id=None):
         payload["request_id"] = request_id
     if conversation_id:
         payload["conversation_id"] = conversation_id
-    r = client.post("/api/chat", json=payload)
+    r = client.post("/api/chat", json=payload, buffered=False)
+    runtime = client.application.extensions["careagents_runtime"]
+    from careagents.worker import RunWorker
+    RunWorker(runtime["config"], runtime["client"], runtime["accounts"],
+              "test-worker").run_once()
     r.get_data()
     return r
+
+
+def _enqueue_and_run_imessage(app, client, *, headers, json):
+    """Enqueue from the relay, execute separately, then poll its projection."""
+    from careagents.worker import RunWorker
+
+    runtime = app.extensions["careagents_runtime"]
+    queued = client.post(
+        "/api/surfaces/imessage/inbound", headers=headers, json=json)
+    assert queued.status_code == 202
+    run_id = queued.get_json()["run_id"]
+    RunWorker(runtime["config"], runtime["client"], runtime["accounts"],
+              "test-surface-worker").run_once()
+    return client.get(
+        f"/api/surfaces/imessage/runs/{run_id}", headers=headers,
+        query_string={"handle": json["handle"]})
 
 
 def _chat_app(cfg, svc, monkeypatch, reply="here you go"):
@@ -343,10 +363,233 @@ def test_duplicate_inbound_request_runs_the_model_once(cfg, svc, monkeypatch):
     replay = _turn(c, agent_id, "one delivery", request_id="delivery-1")
 
     assert calls["count"] == 1
-    assert '"type": "duplicate"' in replay.get_data(as_text=True)
+    assert '"type": "accepted"' in replay.get_data(as_text=True)
+    assert '"text": "once"' in replay.get_data(as_text=True)
     stored = fake.logged[(tenant, fake.conversation_id(agent_id))]
     assert [message["role"] for message in stored] == ["user", "assistant"]
     assert first.status_code == replay.status_code == 200
+
+
+def test_browser_disconnect_reconnect_replays_without_duplicate_inference(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch, reply="durable answer")
+    from careagents import agent as agent_mod
+    from careagents.worker import RunWorker
+
+    calls = {"count": 0}
+
+    class _Turn:
+        text, tool_calls, raw_tool_calls = "durable answer", [], []
+
+    def complete(*args, **kwargs):
+        calls["count"] += 1
+        return _Turn()
+
+    monkeypatch.setattr(agent_mod.llm, "complete", complete)
+    response = c.post("/api/chat", json={
+        "agent_id": agent_id, "message": "keep working",
+        "request_id": "disconnect-1"}, buffered=False)
+    assert response.headers["X-CareAgents-Run-ID"] in fake.runs
+    accepted = next(iter(response.response)).decode()
+    run_id = next(iter(fake.runs))
+    assert '"type": "accepted"' in accepted and run_id in accepted
+    response.close()  # disconnect is projection-only; it never cancels.
+
+    RunWorker(cfg, fake, svc, "worker-after-disconnect").run_once()
+    replay = c.get(
+        f"/api/chat/runs/{run_id}/events",
+        query_string={"agent_id": agent_id, "after": 0})
+    body = replay.get_data(as_text=True)
+
+    assert calls["count"] == 1
+    assert '"text": "durable answer"' in body
+    assert '"type": "done"' in body
+
+
+def test_terminal_sse_drains_every_event_page_before_done(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    created, message_id = fake.claim_inbound_message(
+        tenant, "many events", agent_id, fake.conversation_id(agent_id),
+        "web", "many-events")
+    assert created is True
+    run = fake.create_agent_run(tenant, message_id)
+    for index in range(101):
+        fake._append_run_event(
+            run["id"], "agent.text", {"text": f"part-{index}"})
+    fake.runs[run["id"]]["status"] = "completed"
+
+    response = c.get(
+        f"/api/chat/runs/{run['id']}/events",
+        query_string={"agent_id": agent_id, "after": 0})
+    body = response.get_data(as_text=True)
+
+    assert body.count('"type": "text"') == 101
+    assert body.index('"text": "part-100"') < body.index('"type": "done"')
+
+
+def test_worker_enforces_claimed_run_deadline_before_inference(
+        cfg, svc, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+    from careagents.worker import RunWorker
+
+    app, c, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    response = c.post("/api/chat", json={
+        "agent_id": agent_id, "message": "too late",
+        "request_id": "expired-before-inference"}, buffered=False)
+    next(iter(response.response))
+    response.close()
+    run_id = next(iter(fake.runs))
+    fake.runs[run_id]["deadline_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    monkeypatch.setattr(
+        "careagents.worker.llm.complete",
+        lambda *a, **k: pytest.fail("deadline allowed model inference"))
+
+    RunWorker(cfg, fake, svc, "deadline-worker").run_once()
+
+    assert fake.runs[run_id]["status"] == "failed"
+    assert any(event["type"] == "run.failed"
+               for event in fake.events[run_id])
+
+
+def test_worker_pool_creates_only_the_configured_number_of_slots(
+        cfg, monkeypatch):
+    import threading
+    from careagents import worker as worker_mod
+
+    cfg.run_worker_concurrency = 3
+    stop = threading.Event()
+    stop.set()
+    threads = []
+
+    class _Thread:
+        def __init__(self, target, args, daemon, name):
+            self.target, self.args = target, args
+            self.daemon, self.name = daemon, name
+            self.started = self.joined = False
+            threads.append(self)
+
+        def start(self):
+            self.started = True
+            self.target(*self.args)
+
+        def join(self):
+            self.joined = True
+
+    monkeypatch.setattr(worker_mod.threading, "Thread", _Thread)
+    monkeypatch.setattr(worker_mod, "AccountService", lambda _cfg: object())
+    monkeypatch.setattr(worker_mod, "HealthClawClient",
+                        lambda *_args: object())
+
+    worker_mod.run_worker_pool(cfg, stop)
+
+    assert [thread.name for thread in threads] == [
+        "careagents-worker-0", "careagents-worker-1",
+        "careagents-worker-2"]
+    assert all(thread.started and thread.joined for thread in threads)
+
+
+def test_queued_run_history_stops_at_its_claimed_message(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    from careagents.worker import RunWorker
+
+    seen = []
+
+    class _Turn:
+        text, tool_calls, raw_tool_calls = "ok", [], []
+
+    def complete(_cfg, _system, history, _tools):
+        seen.append([message.get("content") for message in history])
+        return _Turn()
+
+    monkeypatch.setattr("careagents.worker.llm.complete", complete)
+    first = c.post("/api/chat", json={
+        "agent_id": agent_id, "message": "earlier question",
+        "request_id": "queued-earlier"}, buffered=False)
+    next(iter(first.response))
+    first.close()
+    later = c.post("/api/chat", json={
+        "agent_id": agent_id, "message": "later private detail",
+        "request_id": "queued-later"}, buffered=False)
+    next(iter(later.response))
+    later.close()
+
+    RunWorker(cfg, fake, svc, "history-worker").run_once()
+
+    assert "earlier question" in seen[0]
+    assert "later private detail" not in seen[0]
+
+
+def test_recovery_reuses_completed_tool_and_fails_closed_on_ambiguous_tool(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    from careagents.worker import RunWorker
+
+    response = c.post("/api/chat", json={
+        "agent_id": agent_id, "message": "check my labs",
+        "request_id": "recovery-completed"}, buffered=False)
+    next(iter(response.response))
+    response.close()
+    run_id = next(run_id for run_id, run in fake.runs.items()
+                  if run["status"] == "queued")
+    run = fake.runs[run_id]
+    run["status"], run["worker_id"] = "running", "dead-worker"
+    fake._append_run_event(run_id, "agent.checkpoint", {
+        "checkpoint_id": "round-1", "round": 1, "text": "",
+        "tool_calls": [{"id": "provider-call-1", "name": "get_labs",
+                        "arguments": {}}], "raw_tool_calls": []})
+    fake.tool_calls[(run_id, "provider-call-1")] = {
+        "id": "call-1", "run_id": run_id,
+        "provider_call_id": "provider-call-1", "tool_name": "get_labs",
+        "input": {}, "status": "completed",
+        "result": {"content": '{"already":"done"}', "ui_events": []}}
+    run["status"], run["worker_id"] = "queued", None
+
+    executed = {"count": 0}
+    monkeypatch.setattr("careagents.worker._execute_tool",
+                        lambda *a, **k: executed.__setitem__(
+                            "count", executed["count"] + 1))
+
+    class _Final:
+        text, tool_calls, raw_tool_calls = "reused safely", [], []
+
+    monkeypatch.setattr("careagents.worker.llm.complete",
+                        lambda *a, **k: _Final())
+    RunWorker(cfg, fake, svc, "recovery-worker").run_once()
+    assert executed["count"] == 0
+    assert fake.runs[run_id]["status"] == "completed"
+
+    # A call left *running* has an unknown provider outcome. It must not be
+    # executed again; it moves to reconciliation and pauses the run.
+    second_message = fake.claim_inbound_message(
+        tenant, "prepare a form", agent_id, fake.conversation_id(agent_id),
+        "web", "recovery-ambiguous")[1]
+    ambiguous = fake.create_agent_run(tenant, second_message)
+    ambiguous_id = ambiguous["id"]
+    fake._append_run_event(ambiguous_id, "agent.checkpoint", {
+        "checkpoint_id": "round-1", "round": 1, "text": "",
+        "tool_calls": [{"id": "provider-call-2",
+                        "name": "start_intake_form", "arguments": {}}],
+        "raw_tool_calls": []})
+    fake.tool_calls[(ambiguous_id, "provider-call-2")] = {
+        "id": "call-2", "run_id": ambiguous_id,
+        "provider_call_id": "provider-call-2",
+        "tool_name": "start_intake_form", "input": {},
+        "status": "running", "result": None}
+
+    RunWorker(cfg, fake, svc, "reconcile-worker").run_once()
+
+    assert executed["count"] == 0
+    assert fake.tool_calls[(ambiguous_id, "provider-call-2")][
+        "status"] == "needs_reconciliation"
+    assert fake.runs[ambiguous_id]["status"] == "waiting_for_human"
 
 
 def test_web_and_imessage_resume_the_same_explicit_conversation(
@@ -367,13 +610,16 @@ def test_web_and_imessage_resume_the_same_explicit_conversation(
 
     seen = []
 
-    def reply(_cfg, _hc, _tenant, _system, history, text, **kwargs):
-        seen.extend(message["content"] for message in history)
-        return "continued on iMessage"
+    class _Turn:
+        text, tool_calls, raw_tool_calls = "continued on iMessage", [], []
 
-    monkeypatch.setattr("careagents.app.run_turn_to_message", reply)
-    response = relay.post(
-        "/api/surfaces/imessage/inbound",
+    def reply(_cfg, _system, history, _tools):
+        seen.extend(message["content"] for message in history)
+        return _Turn()
+
+    monkeypatch.setattr("careagents.worker.llm.complete", reply)
+    response = _enqueue_and_run_imessage(
+        app, relay,
         headers=headers,
         json={
             "handle": "+15551234567",
@@ -425,8 +671,8 @@ def test_a_storage_outage_does_not_break_the_chat(cfg, svc, monkeypatch):
     monkeypatch.setattr(fake, "claim_inbound_message",
                         lambda *a, **k: (None, None))
     r = _turn(c, agent_id, "still works?")
-    assert r.status_code == 200
-    assert "could not save this message safely" in r.get_data(as_text=True)
+    assert r.status_code == 503
+    assert r.get_json()["error"] == "message store unavailable"
 
 
 def test_history_is_trimmed_but_never_orphans_a_tool_call():
@@ -582,6 +828,11 @@ class FakeClient:
         # Conversation store, keyed by tenant + thread, matching HealthClaw.
         self.logged: dict[tuple[str, str], list] = {}
         self.claimed: dict[tuple[str, str, str], str] = {}
+        self.runs: dict[str, dict] = {}
+        self.run_by_message: dict[str, str] = {}
+        self.events: dict[str, list[dict]] = {}
+        self.tool_calls: dict[tuple[str, str], dict] = {}
+        self._event_id = 0
 
     @staticmethod
     def conversation_id(agent_id):
@@ -605,17 +856,139 @@ class FakeClient:
         return True, message_id
 
     def log_message(self, tenant, role, text, agent_id=None,
-                    conversation_id=None, surface="web", reply_to=None):
+                    conversation_id=None, surface="web", reply_to=None,
+                    request_id=None):
         conversation_id = conversation_id or self.conversation_id(agent_id)
+        if request_id and any(
+                item.get("request_id") == request_id
+                for item in self.logged.setdefault(
+                    (tenant, conversation_id), [])):
+            return True
         self.logged.setdefault((tenant, conversation_id), []).append(
             {"role": role, "content": text, "agent_id": agent_id,
-             "surface": surface, "reply_to": reply_to})
+             "surface": surface, "reply_to": reply_to,
+             "request_id": request_id})
         return True
 
     def recent_messages(self, tenant, limit=20, conversation_id=None,
-                        agent_id=None):
+                        agent_id=None, through_message_id=None):
         conversation_id = conversation_id or self.conversation_id(agent_id)
-        return list(self.logged.get((tenant, conversation_id), []))[-limit:]
+        rows = list(self.logged.get((tenant, conversation_id), []))
+        if through_message_id:
+            anchor = next((index for index, row in enumerate(rows)
+                           if row.get("id") == through_message_id), None)
+            rows = [] if anchor is None else rows[:anchor + 1]
+        return rows[-limit:]
+
+    def _append_run_event(self, run_id, kind, payload=None):
+        self._event_id += 1
+        event = {"id": self._event_id, "run_id": run_id, "type": kind,
+                 "payload": payload or {}}
+        self.events.setdefault(run_id, []).append(event)
+        return event
+
+    def create_agent_run(self, tenant, message_id, deadline_seconds=120):
+        existing = self.run_by_message.get(message_id)
+        if existing:
+            return {**self.runs[existing], "idempotent_replay": True}
+        message = next(
+            item for rows in self.logged.values() for item in rows
+            if item.get("id") == message_id)
+        run_id = f"run-{len(self.runs) + 1}"
+        from datetime import datetime, timedelta, timezone
+        run = {
+            "id": run_id, "tenant_id": tenant,
+            "conversation_id": next(
+                key[1] for key, rows in self.logged.items()
+                if message in rows),
+            "message_id": message_id, "agent_id": message["agent_id"],
+            "surface": message["surface"], "status": "queued",
+            "worker_id": None, "cancel_requested": False,
+            "deadline_at": (datetime.now(timezone.utc) + timedelta(
+                seconds=deadline_seconds)).isoformat(),
+        }
+        self.runs[run_id] = run
+        self.run_by_message[message_id] = run_id
+        self._append_run_event(run_id, "run.queued", {"status": "queued"})
+        return {**run, "idempotent_replay": False}
+
+    def get_agent_run(self, tenant, run_id):
+        run = self.runs.get(run_id)
+        if not run or run["tenant_id"] != tenant:
+            raise HealthClawError("unknown run", 404)
+        return dict(run)
+
+    def agent_run_events(self, tenant, run_id, after=0, limit=100):
+        run = self.get_agent_run(tenant, run_id)
+        events = [event for event in self.events.get(run_id, [])
+                  if event["id"] > after][:limit]
+        return {"run_id": run_id, "status": run["status"],
+                "events": events,
+                "next_cursor": events[-1]["id"] if events else after}
+
+    def claim_agent_run(self, worker_id, lease_seconds=60):
+        run = next((item for item in self.runs.values()
+                    if item["status"] == "queued"), None)
+        if run is None:
+            return None
+        run["status"] = "running"
+        run["worker_id"] = worker_id
+        self._append_run_event(run["id"], "run.started",
+                               {"status": "running"})
+        message = next(
+            item for rows in self.logged.values() for item in rows
+            if item.get("id") == run["message_id"])
+        return {**run, "message": {
+            "id": run["message_id"], "role": "user",
+            "text": message["content"]}}
+
+    def heartbeat_agent_run(self, run_id, worker_id, lease_seconds=60):
+        run = self.runs[run_id]
+        if run["status"] != "running" or run["worker_id"] != worker_id:
+            raise HealthClawError("worker does not own run", 409)
+        return {"ok": True,
+                "cancel_requested": run.get("cancel_requested", False)}
+
+    def transition_agent_run(self, run_id, worker_id, status, **kwargs):
+        run = self.runs[run_id]
+        if run["status"] != "running" or run["worker_id"] != worker_id:
+            raise HealthClawError("worker does not own run", 409)
+        run["status"] = status
+        if status != "running":
+            run["worker_id"] = None
+        self._append_run_event(
+            run_id, kwargs.get("event_type") or f"run.{status}",
+            kwargs.get("payload") or {"status": status})
+        return dict(run)
+
+    def append_agent_run_event(self, run_id, worker_id, event_type,
+                               payload=None):
+        run = self.runs[run_id]
+        if run["status"] != "running" or run["worker_id"] != worker_id:
+            raise HealthClawError("worker does not own run", 409)
+        return self._append_run_event(run_id, event_type, payload)
+
+    def register_agent_tool_call(self, run_id, worker_id, provider_call_id,
+                                 tool_name, arguments):
+        key = (run_id, provider_call_id)
+        existing = self.tool_calls.get(key)
+        if existing:
+            return {**existing, "idempotent_replay": True}
+        call = {"id": f"call-{len(self.tool_calls) + 1}",
+                "run_id": run_id, "provider_call_id": provider_call_id,
+                "tool_name": tool_name, "input": arguments,
+                "status": "pending", "result": None}
+        self.tool_calls[key] = call
+        return {**call, "idempotent_replay": False}
+
+    def transition_agent_tool_call(self, run_id, call_id, worker_id, status,
+                                   **kwargs):
+        call = next(item for item in self.tool_calls.values()
+                    if item["id"] == call_id and item["run_id"] == run_id)
+        call["status"] = status
+        if "result" in kwargs:
+            call["result"] = kwargs["result"]
+        return dict(call)
 
     def new_tenant_id(self):
         self.seeded.append(1)
@@ -1252,8 +1625,6 @@ def test_chat_refuses_once_the_daily_limit_is_reached(cfg, svc, monkeypatch):
     agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
                                         "connection_id": conn}).get_json()["id"]
 
-    monkeypatch.setattr("careagents.app.run_turn",
-                        lambda *a, **k: iter(["ok"]))
     first = c.post("/api/chat", json={"agent_id": agent, "message": "hi"})
     assert first.status_code == 200
 
@@ -1397,14 +1768,20 @@ def test_imessage_connect_bind_inbound_flow(app, svc, monkeypatch, cfg):
                       json={"code": "bogus", "handle": "+1"}
                       ).status_code == 404
 
-    # inbound: fake the agent turn, assert the reply is relayed back
-    monkeypatch.setattr("careagents.app.run_turn_to_message",
-                        lambda *a, **k: "Your last A1c was 6.1% — in range.")
+    # inbound: fake the worker's model turn, assert the reply is relayed back
+    class _Turn:
+        text = "Your last A1c was 6.1% — in range."
+        tool_calls = []
+        raw_tool_calls = []
+
+    monkeypatch.setattr("careagents.worker.llm.complete",
+                        lambda *a, **k: _Turn())
     assert relay.post("/api/surfaces/imessage/inbound",
                       json={"handle": "+15559998888", "text": "how's my a1c?"}
                       ).status_code == 403  # needs mint secret
-    ok = relay.post("/api/surfaces/imessage/inbound", headers=hdrs,
-                    json={"handle": "+15559998888", "text": "how's my a1c?"})
+    ok = _enqueue_and_run_imessage(
+        app, relay, headers=hdrs,
+        json={"handle": "+15559998888", "text": "how's my a1c?"})
     assert ok.status_code == 200
     assert "6.1%" in ok.get_json()["reply"]
     # an unbound handle is not routed (don't answer strangers)

--- a/tests/test_command_center.py
+++ b/tests/test_command_center.py
@@ -433,6 +433,44 @@ class TestRestEndpoints:
         )
         assert mismatch.status_code == 409
 
+    def test_conversation_replay_can_stop_at_an_exact_claimed_message(
+            self, app, client, step_up_token):
+        """A later queued inbound must not enter an earlier run's prompt."""
+        from datetime import datetime, timezone
+        from models import db
+        from r6.command_center.models import ConversationMessage
+
+        headers = {"X-Step-Up-Token": step_up_token}
+        base = {"tenant_id": TENANT,
+                "conversation_id": "careagents:bounded",
+                "agent_id": "bounded", "surface": "web", "role": "user"}
+        first = client.post(
+            "/command-center/api/conversations",
+            json={**base, "request_id": "bounded-1", "text": "first"},
+            headers=headers).get_json()
+        later = client.post(
+            "/command-center/api/conversations",
+            json={**base, "request_id": "bounded-2", "text": "later"},
+            headers=headers).get_json()
+        # Even a timestamp collision is fail-closed: only the exact anchor and
+        # strictly earlier timestamps are eligible.
+        with app.app_context():
+            same = datetime.now(timezone.utc)
+            db.session.get(ConversationMessage, first["id"]).created_at = same
+            db.session.get(ConversationMessage, later["id"]).created_at = same
+            db.session.commit()
+
+        rows = client.get(
+            "/command-center/api/conversations",
+            query_string={"tenant": TENANT,
+                          "conversation_id": "careagents:bounded",
+                          "agent_id": "bounded",
+                          "through_message_id": first["id"],
+                          "full": "1"},
+            headers=headers).get_json()
+
+        assert [row["text"] for row in rows] == ["first"]
+
     def test_same_external_conversation_id_is_tenant_scoped(self, client):
         from r6.stepup import generate_step_up_token
 

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -193,7 +193,7 @@ def test_initialize_database_runs_alembic_on_the_app_engine(monkeypatch):
         assert schema.get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]
-    assert revision == "0005_agent_run_control_plane"
+    assert revision == "0006_tool_reconciliation_state"
 
 
 def test_legacy_environment_flag_cannot_run_ddl_during_factory(monkeypatch):
@@ -224,6 +224,10 @@ def test_deploy_configs_run_migrations_before_web_processes():
     assert services["seed-demo"]["depends_on"]["migrate"] == {
         "condition": "service_completed_successfully"
     }
+    assert "careagents-worker" in services
+    assert "CARE_ROLE=worker" in services["careagents-worker"]["environment"]
+    assert services["careagents-worker"]["command"] == [
+        "python", "-m", "careagents.worker"]
 
     railway = (ROOT / "railway.toml").read_text()
     assert "preDeployCommand" in railway
@@ -346,11 +350,11 @@ def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
 
     revision = upgrade_database(engine)  # must NOT raise 'already exists'
 
-    assert revision == "0005_agent_run_control_plane"
+    assert revision == "0006_tool_reconciliation_state"
     inspector = inspect(engine)
     assert "alembic_version" in inspector.get_table_names()
     # And it must be repeatable (deploys run it every release).
-    assert upgrade_database(engine) == "0005_agent_run_control_plane"
+    assert upgrade_database(engine) == "0006_tool_reconciliation_state"
 
 
 def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
@@ -389,7 +393,7 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
         ))
 
     revision = upgrade_database(engine)
-    assert revision == "0005_agent_run_control_plane"
+    assert revision == "0006_tool_reconciliation_state"
 
     inspector = inspect(engine)
     pk = inspector.get_pk_constraint("r6_resources")
@@ -432,9 +436,9 @@ def test_legacy_create_all_upgrade_on_configured_database():
 
         revision = upgrade_database(engine)  # must not raise "already exists"
 
-        assert revision == "0005_agent_run_control_plane"
+        assert revision == "0006_tool_reconciliation_state"
         assert "alembic_version" in inspect(engine).get_table_names()
-        assert upgrade_database(engine) == "0005_agent_run_control_plane"  # idempotent
+        assert upgrade_database(engine) == "0006_tool_reconciliation_state"  # idempotent
         assert inspect(engine).get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -145,18 +145,21 @@ def test_agent_run_control_plane_migration_is_reversible(tmp_path):
 
     command.upgrade(config, "head")
     assert {
-        "agent_runs", "agent_tool_calls", "agent_run_events"
+        "agent_runs", "agent_tool_calls", "agent_run_events",
+        "agent_worker_presence",
     } <= set(inspect(engine).get_table_names())
 
     command.downgrade(config, "0004_conversation_identity")
     assert {
-        "agent_runs", "agent_tool_calls", "agent_run_events"
+        "agent_runs", "agent_tool_calls", "agent_run_events",
+        "agent_worker_presence",
     }.isdisjoint(inspect(engine).get_table_names())
     assert "cc_conversations" in inspect(engine).get_table_names()
 
     command.upgrade(config, "head")
     assert {
-        "agent_runs", "agent_tool_calls", "agent_run_events"
+        "agent_runs", "agent_tool_calls", "agent_run_events",
+        "agent_worker_presence",
     } <= set(inspect(engine).get_table_names())
     engine.dispose()
 
@@ -193,7 +196,7 @@ def test_initialize_database_runs_alembic_on_the_app_engine(monkeypatch):
         assert schema.get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]
-    assert revision == "0006_tool_reconciliation_state"
+    assert revision == "0007_agent_worker_presence"
 
 
 def test_legacy_environment_flag_cannot_run_ddl_during_factory(monkeypatch):
@@ -228,6 +231,12 @@ def test_deploy_configs_run_migrations_before_web_processes():
     assert "CARE_ROLE=worker" in services["careagents-worker"]["environment"]
     assert services["careagents-worker"]["command"] == [
         "python", "-m", "careagents.worker"]
+    assert any(
+        value.startswith("CARE_RUN_WORKER_STALE_SECONDS=")
+        for value in services["careagents-worker"]["environment"])
+    dockerfile = (ROOT / "deploy/careagents/Dockerfile").read_text()
+    assert "python -m careagents.healthcheck" in dockerfile
+    assert "CARE_ROLE')=='worker'" not in dockerfile
 
     railway = (ROOT / "railway.toml").read_text()
     assert "preDeployCommand" in railway
@@ -350,11 +359,11 @@ def test_legacy_create_all_database_is_adopted_not_recreated(tmp_path):
 
     revision = upgrade_database(engine)  # must NOT raise 'already exists'
 
-    assert revision == "0006_tool_reconciliation_state"
+    assert revision == "0007_agent_worker_presence"
     inspector = inspect(engine)
     assert "alembic_version" in inspector.get_table_names()
     # And it must be repeatable (deploys run it every release).
-    assert upgrade_database(engine) == "0006_tool_reconciliation_state"
+    assert upgrade_database(engine) == "0007_agent_worker_presence"
 
 
 def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
@@ -393,7 +402,7 @@ def test_pre_w0_sqlite_database_with_unnamed_pk_upgrades(tmp_path):
         ))
 
     revision = upgrade_database(engine)
-    assert revision == "0006_tool_reconciliation_state"
+    assert revision == "0007_agent_worker_presence"
 
     inspector = inspect(engine)
     pk = inspector.get_pk_constraint("r6_resources")
@@ -436,9 +445,9 @@ def test_legacy_create_all_upgrade_on_configured_database():
 
         revision = upgrade_database(engine)  # must not raise "already exists"
 
-        assert revision == "0006_tool_reconciliation_state"
+        assert revision == "0007_agent_worker_presence"
         assert "alembic_version" in inspect(engine).get_table_names()
-        assert upgrade_database(engine) == "0006_tool_reconciliation_state"  # idempotent
+        assert upgrade_database(engine) == "0007_agent_worker_presence"  # idempotent
         assert inspect(engine).get_pk_constraint("r6_resources")[
             "constrained_columns"
         ] == ["tenant_id", "resource_type", "id"]


### PR DESCRIPTION
## Summary

- move CareAgents inference and tool execution out of Gunicorn requests into a bounded, leased worker pool
- persist model checkpoints and tool results, then project the durable event log over cursor-based SSE and iMessage polling
- serialize runs per conversation and bound prompts at the exact claimed inbound message
- make queue-backed worker presence part of chat admission, web readiness, and worker health

## Recovery and side-effect safety

- enforce hard deadlines for queued and running work independently of any client or worker
- fence every worker mutation under an authoritative run lock with owner, lease, deadline, and cancellation checks
- move unknown in-flight side effects to `needs_reconciliation`; never retry them automatically or erase ambiguity through cancellation/failure
- expose a separate operator-only, evidence-referenced reconciliation boundary; tenant and worker credentials cannot assert provider truth
- atomically persist assistant text, its replay event, and run completion; generic transitions cannot create `completed` runs

## Validation at `4b1adb55780a49c63b779a9abf78ed43d651531c`

- 1,621 Python tests passed (6 skipped locally; PostgreSQL-only concurrency cases run in CI)
- 176 Node tests passed
- Ruff, configured mypy, TypeScript, Compose rendering, shell syntax, and diff checks passed
- focused regressions cover worker absence/staleness/recovery, hard deadlines, crash-after-claim, side-effect ambiguity, operator reconciliation, cancellation fencing, atomic finalization, SSE replay, and PostgreSQL row-lock races

Closes #254

Agent: Fizz
Runtime-Model: OpenAI Codex (GPT-5)
