### PR TITLE
docs: add a ship gate, and stop handing out the unpinned-ruff trap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] Tests added/updated and `uv run python -m pytest tests/ -q` passes
-- [ ] `pipx run ruff check .` passes
+- [ ] `uv run ruff check .` passes (not `uvx`/`pipx` — those fetch an unpinned ruff)
 - [ ] No PHI in code, tests, fixtures, or logs (synthetic data only)
 - [ ] Touches auth/audit/redaction/tenancy? Note it here so maintainers review against the compliance rules
 - [ ] Node changes: `npx tsc --noEmit && npm test` passes in `services/agent-orchestrator`

--- a/docs/2026-08-01-webinar-delivery-plan.md
+++ b/docs/2026-08-01-webinar-delivery-plan.md
@@ -94,13 +94,35 @@ tab → come back → the conversation is still there.
 
 The bugs that make a live demo or an unsupervised advocate hit a wall.
 
-- [ ] **Passkey dead loop** — `/auth` redirects logged-in users away; enrollment unreachable after signup.
-- [ ] **Replace `prompt()`/`alert()`** in wearable pick + Telegram/iMessage binding; style the conn-card buttons; differentiate destructive Delete.
-- [ ] **CareAgents Playwright spec** — signup → sample connect → agent create → one chat turn. None exists today; all e2e targets the HealthClaw site.
-- [ ] **Prod synthetic monitor** — 6-hourly cron: smoke script + `$conformance` Grade A + `/healthz` + MCP `tools/list` → pinned issue on failure.
+- [x] **Passkey dead loop** — `/auth` redirects logged-in users away; enrollment unreachable after signup. (#241)
+- [ ] **Replace `prompt()`/`alert()`** in wearable pick + Telegram/iMessage binding; style the conn-card buttons; differentiate destructive Delete. (#224)
+- [ ] **CareAgents Playwright spec** — signup → sample connect → agent create → one chat turn. None exists today; all e2e targets the HealthClaw site. (#233)
+- [x] **Prod synthetic monitor** — 6-hourly cron: smoke script + `$conformance` Grade A + `/healthz` + MCP `tools/list` → pinned issue on failure. (#244)
 - [ ] **Intake-form polish** — the demo centerpiece: review card clarity, PDF quality, error states.
+- [ ] **Ship what we merged** — see the ship gate below. (#258)
 
-**Exit:** a stranger completes the full journey on a phone without help.
+**Exit:** a stranger completes the full journey on a phone without help,
+**against the deployed build** — not against `main`.
+
+### The ship gate (added Aug 2, after we caught ourselves)
+
+Merged is not shipped. The Flask engine auto-deploys on push to `main`;
+**CareAgents and the MCP server do not.** On Aug 2 every CareAgents change
+from Phase 0 and Phase 1 — durable chat history, the passkey fix, the daily
+turn cap — was sitting on `main`, unshipped, while `prod_watch.py` reported
+9/9 green. It was green because liveness, readiness, grade, and readability
+are all satisfied by a months-old build. Nothing we monitor can see version
+drift (#258, and #155 for the same problem on the MCP server).
+
+So each phase now ends with a deploy, not a merge:
+
+- Phase 2 exits only when the journey works on `careagents.cloud`, on a
+  phone, on the build a stranger would actually reach.
+- Phase 3's dry run is meaningless before that deploy lands, and the passkey
+  cannot be exercised at all until DNS points at the deployed service —
+  WebAuthn is bound to `CARE_RP_ID=careagents.cloud`.
+- Any "it's done" claim in this plan means deployed and checked, or it is not
+  a claim.
 
 ---
 

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -111,7 +111,7 @@ STEP_UP_SECRET=dev-secret python main.py            # http://localhost:5000
 
 uv run python -m pytest tests/ -q                    # all Python tests
 uv run python -m pytest tests/test_r6_routes.py::test_name -v   # one test
-uvx ruff check .                                     # lint (CI-gated)
+uv run ruff check .                                  # lint (CI-gated) — not uvx/pipx
 
 cd services/agent-orchestrator && npm ci && npx tsc --noEmit && npm test
 ```
@@ -133,7 +133,7 @@ Revert incidental `uv.lock` churn before committing.
 An issue is done when all of these hold. State them explicitly in the PR.
 
 - [ ] `uv run python -m pytest tests/ -q` passes — quote the actual counts
-- [ ] `uvx ruff check .` clean
+- [ ] `uv run ruff check .` clean
 - [ ] Node changes: `npx tsc --noEmit` clean and `npm test` passes
 - [ ] Conformance still **Grade A** (`tests/test_guardrail_conformance.py`)
 - [ ] New behavior has tests — including a **negative** test (the guardrail

--- a/docs/extending-the-action-rail.md
+++ b/docs/extending-the-action-rail.md
@@ -112,7 +112,7 @@ request shape and executor-specific failure modes, as
 Useful local checks while developing a rail:
 
 ```bash
-uvx ruff check r6/actions/rails tests/actions
+uv run ruff check r6/actions/rails tests/actions
 uv run python -m pytest tests/actions/test_contract_generic.py \
   tests/actions/test_webhook_poster_executor.py -v
 ```


### PR DESCRIPTION
## Why

On Aug 2 I verified production and found that **every CareAgents change from Phase 0 and Phase 1 was undeployed** — durable chat history (#222/#239), the passkey fix (#241), the daily turn cap (#245) — while `scripts/prod_watch.py` reported **9/9 green**.

The monitor was not wrong; it was answering a different question. Liveness, readiness, guardrail grade, and record readability are all satisfied by a months-old build. Details and evidence in #258.

The root cause in *this* document is simpler: the plan had no deploy step. "Done" meant merged, so merged is where the work stopped.

## What changes

- Phase 2 gains a **ship gate**: each phase ends with a deploy, not a merge.
- Phase 2's exit criterion is scoped to the build a stranger would actually reach, rather than to `main`.
- Notes that Phase 3's dry run is meaningless before that deploy lands, and that the passkey cannot be exercised at all until DNS points at the deployed service (WebAuthn is bound to `CARE_RP_ID=careagents.cloud`).
- Checks off the two Phase 2 items that did land (#241, #244) and cross-references the two in flight (#224, #233).

Docs only — no code, no behaviour change. `uv run ruff check .` passes.

## Not included

This PR does not deploy anything. Deploying CareAgents needs explicit authorization and the DNS cutover is owner-owned; both are listed as decisions in #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)