### PR TITLE
test(e2e): first browser coverage for CareAgents (#233)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,6 +4,18 @@ import { defineConfig, devices } from '@playwright/test';
 // Receiver binds it by default). CI keeps the default.
 const PORT = process.env.E2E_PORT || '5000';
 
+// CareAgents — a second, separate Flask app under test (issue #233). Own
+// port + own SQLite; the spec (tests/careagents.spec.ts) overrides baseURL
+// with CARE_BASE_URL. Its dev-mode mail stub (careagents/mail.py) logs each
+// sign-in code to stderr instead of sending email, so the server's stderr is
+// captured to CARE_LOG and the spec reads the code back from there — the
+// whole auth journey runs with no email provider, no LLM key and no
+// HealthClaw.
+export const CARE_PORT = process.env.CARE_E2E_PORT || '5101';
+export const CARE_BASE_URL = `http://localhost:${CARE_PORT}`;
+export const CARE_LOG = '/tmp/e2e-careagents.log';
+const CARE_DB = '/tmp/e2e-careagents.db';
+
 export default defineConfig({
   testDir: './tests',
   // Serial execution — shared SQLite instance, tests create resources
@@ -31,21 +43,49 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    // The app factory no longer creates tables at boot (schema is managed by
-    // explicit Alembic migrations). Initialize the DB, then serve — both
-    // processes share one absolute SQLite path so the server sees the tables.
-    command: 'cd .. && uv run flask --app main init-db && uv run python main.py',
-    url: `http://localhost:${PORT}/r6/fhir/health`,
-    reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
-    env: {
-      // Explicit testing env keeps the app off the fail-closed production path.
-      APP_ENV: 'testing',
-      STEP_UP_SECRET: 'e2e-test-secret-not-for-production',
-      SQLALCHEMY_DATABASE_URI: 'sqlite:////tmp/e2e-healthclaw.db',
-      FLASK_ENV: 'testing',
-      PORT,
+  webServer: [
+    {
+      // The app factory no longer creates tables at boot (schema is managed by
+      // explicit Alembic migrations). Initialize the DB, then serve — both
+      // processes share one absolute SQLite path so the server sees the tables.
+      command: 'cd .. && uv run flask --app main init-db && uv run python main.py',
+      url: `http://localhost:${PORT}/r6/fhir/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        // Explicit testing env keeps the app off the fail-closed production path.
+        APP_ENV: 'testing',
+        STEP_UP_SECRET: 'e2e-test-secret-not-for-production',
+        SQLALCHEMY_DATABASE_URI: 'sqlite:////tmp/e2e-healthclaw.db',
+        FLASK_ENV: 'testing',
+        PORT,
+      },
     },
-  },
+    {
+      // CareAgents (issue #233). No init step: careagents.models.make_engine
+      // runs create_all() at boot. Fresh DB + log each boot; stderr goes to
+      // CARE_LOG so the spec can read the dev-mode sign-in codes.
+      command:
+        `rm -f ${CARE_DB} ${CARE_LOG} && cd .. && ` +
+        `uv run flask --app careagents.wsgi run --port ${CARE_PORT} 2>> ${CARE_LOG}`,
+      url: `${CARE_BASE_URL}/healthz`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        // Development mode: fail-closed production checks off, dev session
+        // secret, mail stub active. Mirrors tests/test_careagents.py.
+        CARE_ENV: 'development',
+        CARE_DATABASE_URL: `sqlite:///${CARE_DB}`,
+        // A dead local port: the browser journey under test never touches
+        // HealthClaw, and anything that accidentally tries must fail fast
+        // rather than reach the real records service.
+        HEALTHCLAW_BASE: 'http://127.0.0.1:9',
+        CARE_ORIGIN: CARE_BASE_URL,
+        CARE_RP_ID: 'localhost',
+        // Explicitly blank so a developer shell with a real Resend key still
+        // gets the stderr mail stub — codes must never leave the machine.
+        RESEND_API_KEY: '',
+      },
+    },
+  ],
 });

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import { CARE_BASE_URL, CARE_LOG } from '../playwright.config';
+
+/**
+ * CareAgents core journey (issue #233) — the first browser-level coverage of
+ * the consumer app. Deliberately small: a pre-webinar safety net, not full
+ * coverage.
+ *
+ * Covers:  landing renders with its CTA · auth card renders · a wrong email
+ *          code is rejected without crashing · email-code sign-in reaches
+ *          the hub (via the dev-mode mail stub that logs codes to stderr).
+ * Not covered here (on purpose): chat/LLM turns, any HealthClaw call,
+ *          passkeys/WebAuthn, and the connect/wearable/Telegram/iMessage
+ *          dialogs (#224 is rebuilding those — do not assert on them).
+ *
+ * The app is booted by the second webServer entry in playwright.config.ts
+ * with HEALTHCLAW_BASE pointed at a dead local port, so nothing in this file
+ * can reach a real records service.
+ */
+
+// CareAgents runs on its own port; every test in this file targets it.
+test.use({ baseURL: CARE_BASE_URL });
+
+/** Unique per test so RESEND_COOLDOWN (30s per email) never bites. */
+const uniqueEmail = () =>
+  `e2e-${Date.now()}-${Math.floor(Math.random() * 1e4)}@example.test`;
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * The dev-mode mail stub (careagents/mail.py) logs
+ *   "DEV email — <verb> for <email>: <8 digits>"
+ * to stderr, which the webServer command redirects into CARE_LOG. Poll for
+ * the newest code addressed to this email.
+ */
+async function codeFromLog(email: string): Promise<string> {
+  let code = '';
+  await expect
+    .poll(
+      () => {
+        const log = fs.existsSync(CARE_LOG)
+          ? fs.readFileSync(CARE_LOG, 'utf8')
+          : '';
+        const re = new RegExp(
+          `DEV email — .* for ${escapeRe(email)}: (\\d{8})`, 'g');
+        for (let m = re.exec(log); m !== null; m = re.exec(log)) code = m[1];
+        return code;
+      },
+      // The stub logs before /api/auth/email even responds, so this is
+      // generous; if it expires, the server was not booted through the
+      // harness (or a real RESEND_API_KEY leaked into its env).
+      { timeout: 10_000, message: `no DEV email code logged for ${email}` },
+    )
+    .toMatch(/^\d{8}$/);
+  return code;
+}
+
+/** Walk the auth UI up to the code-entry step for a fresh email. */
+async function requestCode(page: Page, email: string): Promise<void> {
+  await page.goto('/auth');
+  await page.locator('#email').fill(email);
+  await page.locator('#email-btn').click();
+  await expect(page.locator('#step-code')).toBeVisible();
+  await expect(page.locator('#code-email')).toHaveText(email);
+}
+
+test.describe('CareAgents landing', () => {
+  test('renders the hero with its CTA', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/CareAgents/);
+    await expect(page.locator('main.hero h1')).toContainText(
+      'knows your health');
+    // Signed out, the primary CTA is "Get started" into /auth.
+    const cta = page.getByRole('link', { name: 'Get started' });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', '/auth');
+    // NOT asserted: the live trust-badge chip — it needs a reachable
+    // HealthClaw, which this harness deliberately does not provide.
+  });
+});
+
+test.describe('CareAgents auth', () => {
+  test('auth page renders passkey-first with the email fallback', async ({
+    page,
+  }) => {
+    await page.goto('/auth');
+    await expect(page.locator('#auth-card h1')).toHaveText(
+      'Your health, your keys');
+    await expect(page.locator('#passkey-btn')).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#email-btn')).toBeVisible();
+  });
+
+  test('a wrong code is rejected without crashing', async ({ page }) => {
+    const email = uniqueEmail();
+    await requestCode(page, email);
+    // Derive a guaranteed-wrong code from the real one (flip the last
+    // digit) — deterministic, unlike typing a fixed 8-digit guess.
+    const real = await codeFromLog(email);
+    const wrong =
+      real.slice(0, 7) + ((parseInt(real[7], 10) + 1) % 10).toString();
+    await page.locator('#code').fill(wrong);
+    await page.locator('#verify-btn').click();
+
+    const err = page.locator('#err');
+    await expect(err).toBeVisible();
+    await expect(err).toContainText('That code is wrong or expired.');
+    // Still on the code step, still interactive — no crash, no redirect.
+    await expect(page.locator('#step-code')).toBeVisible();
+    await expect(page.locator('#code')).toBeEditable();
+    // And no session was minted: the hub still bounces to /auth.
+    await page.goto('/home');
+    await expect(page).toHaveURL(/\/auth$/);
+  });
+
+  test('email-code sign-in reaches the hub', async ({ page }) => {
+    const email = uniqueEmail();
+    await requestCode(page, email);
+    const code = await codeFromLog(email);
+    await page.locator('#code').fill(code);
+    await page.locator('#verify-btn').click();
+
+    // First verified sign-in on a WebAuthn-capable browser offers passkey
+    // enrolment; passkeys are out of scope for browser tests, so skip.
+    await expect(page.locator('#step-passkey')).toBeVisible();
+    await page.locator('#skip-passkey-btn').click();
+
+    await expect(page).toHaveURL(/\/home$/);
+    await expect(page).toHaveTitle(/Your hub — CareAgents/);
+    await expect(page.locator('main.hub h1')).toHaveText('Welcome back');
+    await expect(page.locator('.hub-sub')).toContainText(email);
+    // NOT asserted: connection/agent/surface dialogs (#224 rebuild).
+  });
+});
+
+test.describe('CareAgents health', () => {
+  test('healthz reports the account store reachable', async ({ request }) => {
+    const res = await request.get('/healthz');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+    expect(body.accounts).toBe(true);
+  });
+});

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -7,32 +7,64 @@ import { CARE_BASE_URL, CARE_LOG } from '../playwright.config';
  * the consumer app. Deliberately small: a pre-webinar safety net, not full
  * coverage.
  *
- * Covers:  landing renders with its CTA · auth card renders · a wrong email
- *          code is rejected without crashing · email-code sign-in reaches
- *          the hub (via the dev-mode mail stub that logs codes to stderr).
- * Not covered here (on purpose): chat/LLM turns, any HealthClaw call,
- *          passkeys/WebAuthn, and the connect/wearable/Telegram/iMessage
- *          dialogs (#224 is rebuilding those — do not assert on them).
+ * Covers:  landing renders and its CTA navigates · auth card renders ·
+ *          a wrong email code is rejected without crashing and mints no
+ *          session · email-code sign-in reaches the hub · /healthz reports
+ *          the account store reachable.
+ *
+ * NOT covered, on purpose: chat/LLM turns, any HealthClaw call, passkey
+ *          registration or passkey sign-in (WebAuthn is not driven here —
+ *          only the enrolment *prompt* is asserted, then skipped), and the
+ *          connect/wearable/Telegram/iMessage dialogs (#224 is rebuilding
+ *          those, so assertions there would collide and rot).
  *
  * The app is booted by the second webServer entry in playwright.config.ts
- * with HEALTHCLAW_BASE pointed at a dead local port, so nothing in this file
- * can reach a real records service.
+ * with HEALTHCLAW_BASE pointed at a dead local port, so the server cannot
+ * reach a real records service; blockThirdParty() below closes the same door
+ * on the browser side.
  */
 
 // CareAgents runs on its own port; every test in this file targets it.
 test.use({ baseURL: CARE_BASE_URL });
 
-/** Unique per test so RESEND_COOLDOWN (30s per email) never bites. */
+/**
+ * Fail the journey shut at the network edge: only the app under test may be
+ * contacted. This is both a determinism fix — base.html pulls Google Fonts,
+ * and a slow or blocked CDN stalls the `load` event that page.goto waits on —
+ * and a standing check that the covered journey needs no third party.
+ */
+async function blockThirdParty(page: Page): Promise<void> {
+  await page.route('**/*', (route) => {
+    const url = route.request().url();
+    if (!url.startsWith('http')) return route.continue();
+    const host = new URL(url).hostname;
+    return host === 'localhost' || host === '127.0.0.1'
+      ? route.continue()
+      : route.abort();
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await blockThirdParty(page);
+});
+
+/**
+ * Unique per test. Reusing an address breaks reruns: within RESEND_COOLDOWN
+ * (30s, careagents/accounts.py:35) start_email_code returns early and mints
+ * nothing, while /api/auth/email still answers {"sent": true} — so no new
+ * code would ever reach the log.
+ */
 const uniqueEmail = () =>
   `e2e-${Date.now()}-${Math.floor(Math.random() * 1e4)}@example.test`;
 
 const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
- * The dev-mode mail stub (careagents/mail.py) logs
+ * With no RESEND_API_KEY the mail stub (careagents/mail.py:19) logs
  *   "DEV email — <verb> for <email>: <8 digits>"
- * to stderr, which the webServer command redirects into CARE_LOG. Poll for
- * the newest code addressed to this email.
+ * to stderr instead of sending, and the webServer command redirects that
+ * into CARE_LOG. Match on this test's own address so a code minted for
+ * another test can never satisfy this poll.
  */
 async function codeFromLog(email: string): Promise<string> {
   let code = '';
@@ -43,12 +75,12 @@ async function codeFromLog(email: string): Promise<string> {
           ? fs.readFileSync(CARE_LOG, 'utf8')
           : '';
         const re = new RegExp(
-          `DEV email — .* for ${escapeRe(email)}: (\\d{8})`, 'g');
+          `DEV email — [^\\n]* for ${escapeRe(email)}: (\\d{8})`, 'g');
         for (let m = re.exec(log); m !== null; m = re.exec(log)) code = m[1];
         return code;
       },
       // The stub logs before /api/auth/email even responds, so this is
-      // generous; if it expires, the server was not booted through the
+      // generous; if it expires, the server was not booted through this
       // harness (or a real RESEND_API_KEY leaked into its env).
       { timeout: 10_000, message: `no DEV email code logged for ${email}` },
     )
@@ -66,15 +98,17 @@ async function requestCode(page: Page, email: string): Promise<void> {
 }
 
 test.describe('CareAgents landing', () => {
-  test('renders the hero with its CTA', async ({ page }) => {
+  test('renders the hero and its CTA reaches sign-in', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/CareAgents/);
     await expect(page.locator('main.hero h1')).toContainText(
       'knows your health');
-    // Signed out, the primary CTA is "Get started" into /auth.
-    const cta = page.getByRole('link', { name: 'Get started' });
-    await expect(cta).toBeVisible();
-    await expect(cta).toHaveAttribute('href', '/auth');
+    // Signed out, the primary CTA is "Get started". Click it rather than
+    // assert its href — a link that renders but does not route is the
+    // failure a browser test exists to catch.
+    await page.getByRole('link', { name: 'Get started' }).click();
+    await expect(page).toHaveURL(/\/auth$/);
+    await expect(page.locator('#auth-card')).toBeVisible();
     // NOT asserted: the live trust-badge chip — it needs a reachable
     // HealthClaw, which this harness deliberately does not provide.
   });
@@ -96,7 +130,7 @@ test.describe('CareAgents auth', () => {
     const email = uniqueEmail();
     await requestCode(page, email);
     // Derive a guaranteed-wrong code from the real one (flip the last
-    // digit) — deterministic, unlike typing a fixed 8-digit guess.
+    // digit) — deterministic, unlike guessing a fixed 8-digit string.
     const real = await codeFromLog(email);
     const wrong =
       real.slice(0, 7) + ((parseInt(real[7], 10) + 1) % 10).toString();
@@ -121,10 +155,15 @@ test.describe('CareAgents auth', () => {
     await page.locator('#code').fill(code);
     await page.locator('#verify-btn').click();
 
-    // First verified sign-in on a WebAuthn-capable browser offers passkey
-    // enrolment; passkeys are out of scope for browser tests, so skip.
-    await expect(page.locator('#step-passkey')).toBeVisible();
-    await page.locator('#skip-passkey-btn').click();
+    // On a WebAuthn-capable browser the first verified sign-in offers passkey
+    // enrolment (auth.js:72); elsewhere it goes straight to the hub. Assert
+    // whichever this browser is, then skip — creating a passkey is out of
+    // scope and needs a virtual authenticator.
+    const canPasskey = await page.evaluate(() => !!window.PublicKeyCredential);
+    if (canPasskey) {
+      await expect(page.locator('#step-passkey')).toBeVisible();
+      await page.locator('#skip-passkey-btn').click();
+    }
 
     await expect(page).toHaveURL(/\/home$/);
     await expect(page).toHaveTitle(/Your hub — CareAgents/);


### PR DESCRIPTION
Closes #233.

CareAgents has had **zero browser-level coverage** — every Playwright spec in `e2e/` targets the HealthClaw site. This adds the first one, scoped deliberately small: a pre-webinar safety net, not full coverage.

## What it covers

- Landing renders and its CTA **navigates** to `/auth` (a link that renders but doesn't route is the specific failure a browser test exists to catch)
- Auth card renders passkey-first with the email fallback
- A wrong code shows `That code is wrong or expired.`, leaves the step interactive, and **mints no session** (`/home` still bounces to `/auth`)
- Email-code sign-in reaches the hub with the right title, heading, and email
- `/healthz` reports `accounts: true`

## What it deliberately does not cover

Chat/LLM turns; every HealthClaw call (the server points at a dead port); **passkey registration and sign-in** — WebAuthn is never driven, only the enrolment prompt is asserted and skipped, so `/webauthn/*` has zero browser coverage; and all connect/wearable/Telegram/iMessage dialogs, since #224 is rebuilding those and assertions there would rot on contact. Also uncovered: the trust-badge chip, `/chat`, logout, resend/back-button paths, code expiry, the 5-attempt lockout, and any non-Chromium browser.

## Results

```
RUN 1:  42 passed (18.7s)     # full e2e suite; CareAgents is 5 of the 42
RUN 2:  42 passed (18.4s)
        42 passed (18.3s)     # CI=1 — fresh servers, retries:2, html reporter
```

Rerunnability was tested past the two runs, since "passes only on a clean database" is the trap here: three further runs against an accumulating DB (`ca_accounts` 1 → 4) also passed. Unique per-test emails are what make that hold.

The spec was **mutation-tested rather than trusted green**: redirecting the code lookup to another address fails with `no DEV email code logged for …`, proving the log match is email-specific and can't be satisfied by a neighbouring test's code; corrupting the hero and hub copy turns exactly those two tests red.

## Three fixes on top of the draft

1. **Third-party requests are aborted in the browser.** `careagents/templates/base.html:10` pulls Google Fonts via `<link rel=stylesheet>`, which blocks the `load` event `page.goto` waits on — a latent CI hang. Blocking non-localhost hosts also makes "nothing reaches a real service" true on the browser side, not only the server side.
2. **Passkey enrolment is asserted only where `window.PublicKeyCredential` exists** (`careagents/static/auth.js:72` branches on it). Asserting it unconditionally bakes a browser-capability assumption into a CI gate. The hub is asserted on both paths.
3. **The landing CTA is clicked, not href-asserted.**

## CI

No workflow change was needed and none was made. The existing `playwright-tests` job (`.github/workflows/ci.yml:142-181`) runs `npm test` in `e2e/`, which now discovers `careagents.spec.ts` and starts the second `webServer` automatically; `uv sync` at the repo root already installs everything CareAgents imports (verified by a cold boot in a fresh venv). This is wired in, not deferred — but it has only run on macOS/Chromium so far, so **the first CI run is the real proof**.

Confirmed the harness env beats a hostile shell: a run with `RESEND_API_KEY=…  HEALTHCLAW_BASE=https://app.healthclaw.io CARE_ENV=production` still passed 5/5, created no stray DB, and used the mail stub — a developer holding real credentials cannot accidentally send codes or hit prod from this suite.

## Findings filed separately

No production code was touched. Two testability findings are filed as follow-ups rather than patched here (#262, #263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)