### PR TITLE
fix(careagents): replace browser dialogs with in-page surfaces, rendered where the user is looking (#224)

### DIFF
--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -419,7 +419,17 @@ button.linkish { background: none; border: 0; color: var(--clay-deep);
 .conn-refresh-msg { margin-top: 10px; font-size: 12.5px; color: var(--ink-soft); }
 
 /* --- inline messages (replace blocking alerts) ---------------------------- */
-.inline-msg { margin-top: 12px; font-size: 13.5px; color: var(--clay-deep); }
+.inline-msg { margin-top: 12px; font-size: 13.5px; color: var(--clay-deep);
+  /* Honoured by the scrollIntoView nudge, so a message pulled into view never
+     sits flush against the edge of the screen. */
+  scroll-margin: 20px; }
+/* The message is moved next to whatever the user touched, so inside these
+   grids it becomes a grid item: span the row, or it sits in one narrow column
+   beside the tile instead of under it. */
+.marketplace > .inline-msg, .surface-row > .inline-msg {
+  grid-column: 1 / -1; margin-top: 2px;
+  background: #FBE9E2; border-radius: 12px; padding: 10px 14px;
+}
 
 /* --- picker / code / delete dialogs --------------------------------------- */
 .modal.sheet { align-items: flex-end; }

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -362,7 +362,10 @@ h1 em { font-style: italic; color: var(--clay); }
 .empty .linkish { font-weight: 600; }
 button.linkish { background: none; border: 0; color: var(--clay-deep);
   cursor: pointer; font: inherit; padding: 0; text-decoration: underline; }
-#connect-section.flash { animation: flashPulse 1.4s ease; border-radius: var(--radius); }
+/* Keyed by class, not by id: the same cue points at the connect step and at
+   the agents grid ("create an agent first"). */
+.hub-section.flash, #agents.flash { animation: flashPulse 1.4s ease;
+  border-radius: var(--radius); }
 @keyframes flashPulse {
   0%, 100% { box-shadow: 0 0 0 0 rgba(194,83,46,0); }
   30% { box-shadow: 0 0 0 4px rgba(194,83,46,.35); }
@@ -390,3 +393,63 @@ button.linkish { background: none; border: 0; color: var(--clay-deep);
 .auth-fine { font-size: 12.5px; color: var(--ink-soft); margin-top: 14px;
   text-align: center; }
 .auth-fine a, .consent-fine a { color: var(--clay-deep); }
+
+/* --- connection actions --------------------------------------------------- */
+.conn-refresh, .conn-disconnect, .conn-delete {
+  align-self: flex-start; margin-top: 8px; min-height: 44px;
+  font: inherit; font-size: 13.5px; cursor: pointer;
+  border-radius: 999px; padding: 10px 18px;
+}
+.conn-refresh, .conn-disconnect {
+  font-weight: 600; color: var(--ink-soft);
+  background: var(--card); border: 1px solid var(--hairline);
+}
+.conn-refresh:hover, .conn-disconnect:hover {
+  border-color: var(--clay); color: var(--clay-deep);
+}
+/* Delete is irreversible, so it reads as danger — but with no fill and a
+   lighter weight it stays quieter than Refresh. Destructive should be
+   findable, not inviting. */
+.conn-delete {
+  font-weight: 500; color: var(--clay-deep);
+  background: none; border: 1px dashed #E8C3B4;
+}
+.conn-delete:hover { border-style: solid; border-color: var(--clay-deep);
+  background: #FBEDE6; }
+.conn-refresh-msg { margin-top: 10px; font-size: 12.5px; color: var(--ink-soft); }
+
+/* --- inline messages (replace blocking alerts) ---------------------------- */
+.inline-msg { margin-top: 12px; font-size: 13.5px; color: var(--clay-deep); }
+
+/* --- picker / code / delete dialogs --------------------------------------- */
+.modal.sheet { align-items: flex-end; }
+.picker-row {
+  display: block; width: 100%; min-height: 44px; margin-top: 10px;
+  font: inherit; font-size: 16px; font-weight: 600; text-align: left;
+  color: var(--ink); background: var(--cream); cursor: pointer;
+  border: 1.5px solid var(--hairline); border-radius: 14px; padding: 13px 16px;
+}
+.picker-row:hover { border-color: var(--clay); }
+#pair-code {
+  -webkit-user-select: text; user-select: text;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 25px; letter-spacing: .04em; text-align: center;
+  overflow-wrap: anywhere; margin: 12px 0;
+  background: var(--cream); border: 1.5px dashed var(--hairline);
+  border-radius: 14px; padding: 16px 12px;
+}
+#code-instructions { font-size: 14.5px; color: var(--ink-soft); }
+#copy-code { min-height: 44px; margin-top: 0; }
+.delete-warn { font-size: 14.5px; color: var(--ink-soft); margin-top: 10px; }
+#delete-confirm { background: var(--clay-deep); box-shadow: none; }
+#delete-confirm[disabled] { opacity: .45; cursor: not-allowed; }
+#delete-confirm[disabled]:hover { background: var(--clay-deep); transform: none; }
+#picker-cancel, #code-done, #delete-cancel { min-height: 44px; }
+
+/* Phone: the picker becomes a sheet the thumb can reach. */
+@media (max-width: 640px) {
+  .modal.sheet { padding: 0; }
+  .sheet .modal-card { max-width: none; border-radius: 20px 20px 0 0;
+    animation: sheetUp .22s ease-out; }
+}
+@keyframes sheetUp { from { transform: translateY(24px); } }

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -20,13 +20,11 @@
         return;
       }
       let body = {};
+      $("connect-msg").hidden = true;
       if (tile.dataset.providers) {
-        const provs = JSON.parse(tile.dataset.providers);
-        const pick = prompt("Which do you use?\n" +
-          provs.map((p, i) => `${i + 1}. ${p.label}`).join("\n"), "1");
-        const idx = parseInt(pick, 10) - 1;
-        if (isNaN(idx) || !provs[idx]) return;
-        body.provider = provs[idx].id;
+        const provider = await pickProvider(JSON.parse(tile.dataset.providers));
+        if (!provider) return;
+        body.provider = provider;
       }
       // Real-record sources: informed consent before anything happens. The
       // server refuses (428) without it, so this card is UX, not the gate.
@@ -38,7 +36,11 @@
       tile.disabled = true;
       const res = await post("/api/connections/" + id, body);
       tile.disabled = false;
-      if (!res.ok) return alert(res.d.error || "Couldn't connect that source.");
+      if (!res.ok) {
+        // Inline, next to the tile that was tapped: never blocks, never needs
+        // dismissing, and the page stays usable.
+        return say($("connect-msg"), res.d.error || "Couldn't connect that source.");
+      }
       if (res.d.soon) { tile.querySelector(".connector-tag").textContent = "we'll let you know"; return; }
       if (res.d.connect_url) window.open(res.d.connect_url, "_blank", "noopener");
       location.reload();
@@ -56,6 +58,106 @@
       cancel.onclick = () => done(false);
       modal.hidden = false;
     });
+  }
+
+  // One shared primitive for the dialogs below: unhide a static modal, resolve
+  // once when it closes. ESC and a backdrop tap both abandon it — every one of
+  // these is safe to walk away from. The consent card deliberately does NOT go
+  // through this: its gate is explicit buttons only.
+  function openDialog(modal) {
+    let resolve;
+    const result = new Promise((r) => { resolve = r; });
+    const invoker = document.activeElement;
+    let closed = false;
+    const onKey = (e) => { if (e.key === "Escape") close(null); };
+    const onBackdrop = (e) => { if (e.target === modal) close(null); };
+    function close(value) {
+      if (closed) return;
+      closed = true;
+      document.removeEventListener("keydown", onKey);
+      modal.removeEventListener("click", onBackdrop);
+      modal.hidden = true;
+      if (invoker && document.contains(invoker)) invoker.focus();
+      resolve(value);
+    }
+    document.addEventListener("keydown", onKey);
+    modal.addEventListener("click", onBackdrop);
+    modal.hidden = false;
+    return { close, result };
+  }
+
+  // Inline message: shown in the page beside what the user touched.
+  function say(el, text) { el.textContent = text; el.hidden = false; }
+
+  // Scroll a section into view and pulse it — the in-page way to point at the
+  // step that has to happen first.
+  function flashSection(el, msgEl, text) {
+    if (msgEl) say(msgEl, text);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("flash");
+    setTimeout(() => el.classList.remove("flash"), 1400);
+  }
+
+  // Provider picker: one large row per provider, one tap to choose.
+  function pickProvider(provs) {
+    const rows = $("picker-rows");
+    rows.textContent = "";
+    const dlg = openDialog($("provider-picker"));
+    provs.forEach((p) => {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "picker-row";
+      row.dataset.providerId = p.id;
+      row.textContent = p.label;   // server-supplied label: text, never markup
+      row.addEventListener("click", () => dlg.close(p.id));
+      rows.appendChild(row);
+    });
+    $("picker-cancel").onclick = () => dlg.close(null);
+    const first = rows.querySelector(".picker-row");
+    if (first) first.focus();
+    return dlg.result;
+  }
+
+  // Pairing-code card. The visible string and the clipboard string are the
+  // same string: if the clipboard is blocked the user copies the selection by
+  // hand, and that must not be a different code.
+  function showCodeCard(codeString, instructions) {
+    const codeEl = $("pair-code");
+    const state = $("copy-state");
+    codeEl.textContent = codeString;
+    $("code-instructions").textContent = instructions;
+    state.textContent = "Copy";
+    let revert = 0;
+    const dlg = openDialog($("code-card"));
+    $("copy-code").onclick = async () => {
+      // navigator.clipboard is missing or blocked in several in-app browsers
+      // (Telegram's among them). Falling back to a selection keeps the flow
+      // alive instead of dead-ending on a silent failure.
+      try {
+        await navigator.clipboard.writeText(codeString);
+        state.textContent = "Copied ✓";
+      } catch (err) {
+        selectContents(codeEl);
+        state.textContent = "Press and hold to copy";
+      }
+      clearTimeout(revert);
+      revert = setTimeout(() => { state.textContent = "Copy"; }, 1500);
+    };
+    $("code-done").onclick = () => dlg.close(null);
+    $("code-done").focus();  // never the code itself — that pops the keyboard
+    // A pairing code is a short-lived credential; don't leave it in the DOM
+    // after the card that needed it is gone.
+    dlg.result.then(() => { clearTimeout(revert); codeEl.textContent = ""; });
+  }
+
+  function selectContents(el) {
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    sel.removeAllRanges();
+    sel.addRange(range);
   }
 
   // Poll pending connection cards until active.
@@ -123,13 +225,8 @@
     btn.addEventListener("click", async () => {
       const card = btn.closest(".conn-card");
       const msg = card.querySelector(".conn-refresh-msg");
-      const label = btn.dataset.label || "these records";
-      const typed = prompt(
-        `This permanently deletes the records in "${label}".\n\n` +
-        "The PHI-free audit trail (who accessed what) is kept as the record " +
-        "of what happened, and this deletion is added to it.\n\n" +
-        'Type DELETE to confirm:');
-      if (typed !== "DELETE") return;
+      const agreed = await askToDelete(btn.dataset.label || "these records");
+      if (!agreed) return;
 
       btn.disabled = true;
       msg.textContent = "Deleting…";
@@ -146,6 +243,26 @@
       location.reload();
     });
   });
+
+  // Resolves true only after the patient types DELETE exactly. Two gates on
+  // purpose: the button ships disabled and is only enabled on an exact match,
+  // and the click handler checks the value again — so a future markup change
+  // that drops `disabled` still can't turn this into a one-tap delete.
+  function askToDelete(label) {
+    const input = $("delete-input");
+    const ok = $("delete-confirm");
+    $("delete-label").textContent = label;
+    input.value = "";
+    ok.disabled = true;
+    const dlg = openDialog($("delete-modal"));
+    input.oninput = () => { ok.disabled = input.value !== "DELETE"; };
+    ok.onclick = () => { if (input.value === "DELETE") dlg.close(true); };
+    // Enter goes through the same check; there is no form here to submit.
+    input.onkeydown = (e) => { if (e.key === "Enter") ok.onclick(); };
+    $("delete-cancel").onclick = () => dlg.close(false);
+    input.focus();
+    return dlg.result;
+  }
 
   // After a re-authorization, poll until the provider delivers, then report
   // the growth the server measured against the pre-refresh baseline.
@@ -171,14 +288,7 @@
 
   // With no records connected there's nothing to build an agent on — send the
   // user to the connect step (highlight it) instead of opening a dead modal.
-  function needConnection() {
-    const sec = $("connect-section");
-    if (sec) {
-      sec.scrollIntoView({ behavior: "smooth", block: "center" });
-      sec.classList.add("flash");
-      setTimeout(() => sec.classList.remove("flash"), 1400);
-    }
-  }
+  function needConnection() { flashSection($("connect-section"), null, ""); }
   function openAgentModal() {
     if (!hasConn()) { needConnection(); return; }
     $("modal-err").hidden = true;
@@ -212,12 +322,17 @@
   const tg = $("tg-surface");
   if (tg) tg.addEventListener("click", async () => {
     const firstAgent = document.querySelector(".agent-card");
-    if (!firstAgent) { alert("Create an agent first, then connect Telegram."); return; }
+    $("surfaces-msg").hidden = true;
+    if (!firstAgent) {
+      return flashSection($("agents"), $("surfaces-msg"),
+        "Create an agent first, then connect Telegram.");
+    }
     const agentId = new URL(firstAgent.href).searchParams.get("agent");
     const res = await post("/api/surfaces/telegram", { agent_id: agentId });
-    if (!res.ok) return alert(res.d.error || "Failed");
+    if (!res.ok) return say($("surfaces-msg"), res.d.error || "Failed");
     if (res.d.deep_link) { $("tg-state").textContent = "opening…"; window.open(res.d.deep_link, "_blank", "noopener"); }
-    else prompt("Send this code to the CareAgents bot with /start:", res.d.code);
+    // Telegram pairs on the bare code, so that is what we show and copy.
+    else showCodeCard(res.d.code, "Send this code to the CareAgents bot with /start:");
     $("tg-state").textContent = "pending — finish in Telegram";
   });
 
@@ -225,11 +340,16 @@
   const im = $("im-surface");
   if (im) im.addEventListener("click", async () => {
     const firstAgent = document.querySelector(".agent-card");
-    if (!firstAgent) { alert("Create an agent first, then connect iMessage."); return; }
+    $("surfaces-msg").hidden = true;
+    if (!firstAgent) {
+      return flashSection($("agents"), $("surfaces-msg"),
+        "Create an agent first, then connect iMessage.");
+    }
     const agentId = new URL(firstAgent.href).searchParams.get("agent");
     const res = await post("/api/surfaces/imessage", { agent_id: agentId });
-    if (!res.ok) return alert(res.d.error || "Failed");
+    if (!res.ok) return say($("surfaces-msg"), res.d.error || "Failed");
     $("im-state").textContent = "pending — text to finish";
-    prompt(res.d.instructions || "Text this code to connect:", "care " + res.d.code);
+    // iMessage needs the whole "care <code>" line as the text body.
+    showCodeCard("care " + res.d.code, res.d.instructions || "Text this code to connect:");
   });
 })();

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -37,9 +37,10 @@
       const res = await post("/api/connections/" + id, body);
       tile.disabled = false;
       if (!res.ok) {
-        // Inline, next to the tile that was tapped: never blocks, never needs
-        // dismissing, and the page stays usable.
-        return say($("connect-msg"), res.d.error || "Couldn't connect that source.");
+        // Inline, directly under the tile that was tapped: never blocks, never
+        // needs dismissing, and the page stays usable.
+        return say(tile, $("connect-msg"),
+                   res.d.error || "Couldn't connect that source.");
       }
       if (res.d.soon) { tile.querySelector(".connector-tag").textContent = "we'll let you know"; return; }
       if (res.d.connect_url) window.open(res.d.connect_url, "_blank", "noopener");
@@ -87,13 +88,34 @@
   }
 
   // Inline message: shown in the page beside what the user touched.
-  function say(el, text) { el.textContent = text; el.hidden = false; }
+  //
+  // The element is MOVED next to `anchor` before it is shown. A message that
+  // renders in its template position can land hundreds of pixels below the
+  // fold on a phone — which looks exactly like the dead browser dialog this
+  // replaced, so the position is part of the fix, not decoration. Moving the
+  // one element keeps the id stable for anything addressing it.
+  function say(anchor, el, text) {
+    if (anchor && el.previousElementSibling !== anchor) {
+      anchor.insertAdjacentElement("afterend", el);
+    }
+    el.textContent = text;
+    el.hidden = false;
+    // Only scrolls if it isn't already fully visible, and only as far as it
+    // has to — no jump when the message is already under the user's thumb.
+    el.scrollIntoView({ block: "nearest" });
+  }
 
   // Scroll a section into view and pulse it — the in-page way to point at the
-  // step that has to happen first.
+  // step that has to happen first. The message rides along to the section
+  // being scrolled to, or the words explaining the flash end up off-screen in
+  // the section the user just left.
   function flashSection(el, msgEl, text) {
-    if (msgEl) say(msgEl, text);
-    if (!el) return;
+    if (!el) { if (msgEl) say(null, msgEl, text); return; }
+    if (msgEl) {
+      el.insertAdjacentElement("afterend", msgEl);
+      msgEl.textContent = text;
+      msgEl.hidden = false;
+    }
     el.scrollIntoView({ behavior: "smooth", block: "center" });
     el.classList.add("flash");
     setTimeout(() => el.classList.remove("flash"), 1400);
@@ -134,21 +156,29 @@
       // navigator.clipboard is missing or blocked in several in-app browsers
       // (Telegram's among them). Falling back to a selection keeps the flow
       // alive instead of dead-ending on a silent failure.
+      clearTimeout(revert);
       try {
         await navigator.clipboard.writeText(codeString);
+        // Confirmation is transient; the instruction it replaces is not.
         state.textContent = "Copied ✓";
+        revert = setTimeout(() => { state.textContent = "Copy"; }, 1500);
       } catch (err) {
+        // This IS the recovery instruction — it stays until the card closes,
+        // or it disappears while the user is still pressing and holding.
         selectContents(codeEl);
         state.textContent = "Press and hold to copy";
       }
-      clearTimeout(revert);
-      revert = setTimeout(() => { state.textContent = "Copy"; }, 1500);
     };
     $("code-done").onclick = () => dlg.close(null);
     $("code-done").focus();  // never the code itself — that pops the keyboard
     // A pairing code is a short-lived credential; don't leave it in the DOM
-    // after the card that needed it is gone.
-    dlg.result.then(() => { clearTimeout(revert); codeEl.textContent = ""; });
+    // after the card that needed it is gone. The iMessage instructions quote
+    // the code (and the handle), so they have to go with it.
+    dlg.result.then(() => {
+      clearTimeout(revert);
+      codeEl.textContent = "";
+      $("code-instructions").textContent = "";
+    });
   }
 
   function selectContents(el) {
@@ -179,9 +209,11 @@
     btn.addEventListener("click", async () => {
       const card = btn.closest(".conn-card");
       const msg = card.querySelector(".conn-refresh-msg");
-      const say = (t) => { msg.textContent = t; msg.hidden = false; };
+      // Named apart from the module-scope say(anchor, el, text): this one is
+      // card-local and takes only the text.
+      const report = (t) => { msg.textContent = t; msg.hidden = false; };
       btn.disabled = true;
-      say("Checking…");
+      report("Checking…");
       let res = await post(`/api/connections/${btn.dataset.conn}/refresh`);
       // 428 means this deployment wants consent re-affirmed for the re-pull.
       if (!res.ok && res.d.error === "consent_required") {
@@ -191,11 +223,11 @@
                          { consent: true });
       }
       btn.disabled = false;
-      if (!res.ok) return say(res.d.error || "Couldn't refresh right now.");
-      if (res.d.unsupported) return say(res.d.reason);
+      if (!res.ok) return report(res.d.error || "Couldn't refresh right now.");
+      if (res.d.unsupported) return report(res.d.reason);
       if (res.d.reauth_url) {
         window.open(res.d.reauth_url, "_blank", "noopener");
-        say("Finish signing in to your provider — new records appear here.");
+        report("Finish signing in to your provider — new records appear here.");
         watchForNewRecords(card, msg);
       }
     });
@@ -329,7 +361,7 @@
     }
     const agentId = new URL(firstAgent.href).searchParams.get("agent");
     const res = await post("/api/surfaces/telegram", { agent_id: agentId });
-    if (!res.ok) return say($("surfaces-msg"), res.d.error || "Failed");
+    if (!res.ok) return say(tg, $("surfaces-msg"), res.d.error || "Failed");
     if (res.d.deep_link) { $("tg-state").textContent = "opening…"; window.open(res.d.deep_link, "_blank", "noopener"); }
     // Telegram pairs on the bare code, so that is what we show and copy.
     else showCodeCard(res.d.code, "Send this code to the CareAgents bot with /start:");
@@ -347,7 +379,7 @@
     }
     const agentId = new URL(firstAgent.href).searchParams.get("agent");
     const res = await post("/api/surfaces/imessage", { agent_id: agentId });
-    if (!res.ok) return say($("surfaces-msg"), res.d.error || "Failed");
+    if (!res.ok) return say(im, $("surfaces-msg"), res.d.error || "Failed");
     $("im-state").textContent = "pending — text to finish";
     // iMessage needs the whole "care <code>" line as the text body.
     showCodeCard("care " + res.d.code, res.d.instructions || "Text this code to connect:");

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -87,6 +87,7 @@
       </button>
       {% endfor %}
     </div>
+    <p class="inline-msg" id="connect-msg" hidden></p>
     <p class="add-note">Verified provider &amp; wearable logins happen on the
       provider’s own site — we never see your password.</p>
   </section>
@@ -106,6 +107,7 @@
       {% endif %}
       <div class="surface soon"><b>Phone app</b><span>install from browser</span></div>
     </div>
+    <p class="inline-msg" id="surfaces-msg" hidden></p>
   </section>
 </main>
 
@@ -181,6 +183,52 @@
     <div id="modal-err" class="form-error" hidden></div>
     <button type="button" class="btn-primary btn-block" id="create-agent">Create</button>
     <button type="button" class="linkish" id="close-modal">Cancel</button>
+  </div>
+</div>
+
+<!-- Provider picker: one large tappable row per provider, filled in by
+     home.js from the tile's data-providers. No numbers, no keyboard — the
+     browser prompt this replaces is dead on several in-app mobile browsers. -->
+<div class="modal sheet" id="provider-picker" role="dialog" aria-modal="true"
+     aria-labelledby="picker-title" hidden>
+  <div class="modal-card">
+    <h3 id="picker-title">Which do you use?</h3>
+    <div id="picker-rows"></div>
+    <button type="button" class="linkish" id="picker-cancel">Not now</button>
+  </div>
+</div>
+
+<!-- Pairing code card. What is shown in #pair-code is byte-identical to what
+     Copy writes, so the press-and-hold fallback can't copy the wrong string. -->
+<div class="modal" id="code-card" role="dialog" aria-modal="true"
+     aria-labelledby="code-title" hidden>
+  <div class="modal-card">
+    <h3 id="code-title">Your pairing code</h3>
+    <p id="code-instructions"></p>
+    <div id="pair-code"></div>
+    <button type="button" class="btn-secondary btn-block" id="copy-code">
+      <span id="copy-state">Copy</span></button>
+    <button type="button" class="btn-primary btn-block" id="code-done">Done</button>
+  </div>
+</div>
+
+<!-- Delete confirmation. Same copy and the same typed-DELETE requirement as
+     the prompt() it replaces — the friction is the point, only the container
+     changed. #delete-confirm ships disabled; home.js re-checks on click too. -->
+<div class="modal" id="delete-modal" role="dialog" aria-modal="true"
+     aria-labelledby="delete-title" hidden>
+  <div class="modal-card">
+    <h3 id="delete-title">Delete these records?</h3>
+    <p class="delete-warn">This permanently deletes the records in
+      "<span id="delete-label"></span>".</p>
+    <p class="delete-warn">The PHI-free audit trail (who accessed what) is kept
+      as the record of what happened, and this deletion is added to it.</p>
+    <label class="field-label" for="delete-input">Type DELETE to confirm:</label>
+    <input class="field" id="delete-input" autocomplete="off"
+           autocapitalize="characters" autocorrect="off" spellcheck="false">
+    <button type="button" class="btn-primary btn-block" id="delete-confirm"
+            disabled>Delete these records</button>
+    <button type="button" class="linkish" id="delete-cancel">Cancel</button>
   </div>
 </div>
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1355,3 +1355,99 @@ def test_unavailable_advisor_refused_not_downgraded(app, svc, monkeypatch):
                                     "connection_id": conn})
     assert r.status_code == 200
 
+
+# --- hub UI source guards (#224) ---------------------------------------------
+# Honest scope: these are SOURCE-level guards on careagents/static/home.js,
+# careagents/static/careagents.css and careagents/templates/home.html. They
+# execute no JavaScript and prove no behaviour — the behaviour has to be driven
+# in a real browser. What they do buy is a cheap regression fence around the
+# properties that are invisible in review and expensive to get wrong: no
+# blocking browser dialogs, no markup built from server strings, and a delete
+# confirmation that cannot decay into one tap.
+
+import pathlib as _pathlib
+
+_CA = _pathlib.Path(__file__).resolve().parents[1] / "careagents"
+_HOME_JS = (_CA / "static" / "home.js").read_text()
+_HOME_HTML = (_CA / "templates" / "home.html").read_text()
+_CSS = (_CA / "static" / "careagents.css").read_text()
+
+
+def test_hub_js_uses_no_blocking_browser_dialogs():
+    """prompt/alert/confirm are silently dead in several in-app mobile browsers
+    (the whole point of #224): a flow built on them just stops with no error."""
+    import re
+    for fn in ("prompt", "alert", "confirm"):
+        assert not re.search(r"(?<![\w.])" + fn + r"\s*\(", _HOME_JS), fn
+
+
+def test_hub_js_never_builds_markup_from_strings():
+    """Connection labels, provider labels and server error strings all reach the
+    DOM here. One innerHTML on that path turns an upstream string into markup."""
+    for sink in ("innerHTML", "outerHTML", "insertAdjacentHTML", "document.write"):
+        assert sink not in _HOME_JS, sink
+
+
+def test_copy_has_no_execcommand_fallback():
+    """execCommand('copy') reports success in browsers where it did nothing, so
+    the user is told the pairing code is copied when it is not."""
+    assert "execCommand" not in _HOME_JS
+
+
+def test_pairing_code_is_never_logged():
+    """The pairing code binds a chat handle to an account: it must not survive
+    in a console buffer or a log."""
+    assert "console.log" not in _HOME_JS
+    assert "console.debug" not in _HOME_JS
+
+
+def test_typed_delete_stays_double_gated():
+    """Three layers, all load-bearing. Deleting records is irreversible, and a
+    markup tidy-up that drops `disabled` must not silently make it one tap."""
+    # (a) the button ships disabled in the static markup
+    confirm = _HOME_HTML.split('id="delete-confirm"')[1][:120]
+    assert "disabled" in confirm
+    # (b) enabled only on an exact, case-sensitive match
+    assert 'input.value !== "DELETE"' in _HOME_JS
+    # (c) the click handler re-checks the value itself
+    assert 'if (input.value === "DELETE")' in _HOME_JS
+    # and the comparison is never loosened, inside the confirmation helper
+    ask = _HOME_JS.split("function askToDelete(")[1].split("\n  }")[0]
+    for loosener in ("trim()", "toUpperCase()", "toLowerCase()"):
+        assert loosener not in ask, loosener
+
+
+def test_delete_confirmation_is_not_a_form_or_native_dialog():
+    """A <form> would let Enter submit past the JS check; <dialog>/showModal
+    brings a focus trap that breaks VoiceOver on iOS."""
+    assert "<form" not in _HOME_HTML.split('id="delete-modal"')[1].split("</div>\n\n")[0]
+    assert "<dialog" not in _HOME_HTML
+    assert "showModal" not in _HOME_JS
+
+
+def test_hub_dialog_selector_contract():
+    """home.js addresses these by id; a template rename would break the flow at
+    runtime only, with no server-side signal."""
+    for sel in ('id="provider-picker"', 'id="picker-cancel"', 'id="picker-rows"',
+                'id="connect-msg"', 'id="surfaces-msg"', 'id="agents"',
+                'id="code-card"', 'id="pair-code"', 'id="copy-code"',
+                'id="copy-state"', 'id="code-instructions"', 'id="code-done"',
+                'id="tg-state"', 'id="im-state"', 'id="delete-modal"',
+                'id="delete-label"', 'id="delete-input"', 'id="delete-confirm"',
+                'id="delete-cancel"'):
+        assert sel in _HOME_HTML, sel
+
+
+def test_flash_cue_is_class_keyed_with_a_single_keyframe():
+    assert "#connect-section.flash" not in _CSS   # de-keyed from the one id
+    assert ".hub-section.flash" in _CSS
+    assert _CSS.count("@keyframes flashPulse") == 1
+
+
+def test_connection_action_buttons_are_styled_and_thumb_sized():
+    """44px is the tap target floor; the shared rule is what supplies it."""
+    for sel in (".conn-refresh", ".conn-disconnect", ".conn-delete",
+                ".conn-refresh-msg"):
+        assert sel in _CSS, sel
+    shared = _CSS.split(".conn-refresh, .conn-disconnect, .conn-delete {")[1]
+    assert "min-height: 44px" in shared.split("}")[0]


### PR DESCRIPTION
Closes #224.

## The problem

Non-technical patients were asked to **type a number into a browser `prompt()`** to pick a wearable provider; Telegram/iMessage pairing codes arrived the same way; errors came via `alert()`. Those dialogs are suppressed in several in-app mobile browsers — Telegram's own among them, which is exactly where our links get opened. The flow didn't fail; it silently stopped. On the primary device for this audience.

The connection-card buttons (`.conn-refresh`, `.conn-disconnect`, `.conn-delete`, `.conn-refresh-msg`) also had **no CSS rules at all**, so they rendered as raw browser defaults inside the polished cards, with destructive Delete carrying identical visual weight to Refresh.

## What changed

Three files only — `careagents/templates/home.html`, `careagents/static/home.js`, `careagents/static/careagents.css`. No server change, no endpoint/payload change, no framework, no build step.

- **Picker**: a slide-up card, one large tappable row per provider. No typing, no keyboard.
- **Errors/info**: one in-page message node that **moves to whatever element the message is about**, then nudges into view only if not already visible. A failure on the Telegram tile now reports under the Telegram tile.
- **Pairing codes**: a card showing the code as large selectable text, with a Copy button and visible "Copied ✓". What is *displayed* is byte-identical to what Copy *writes* — if the clipboard is blocked (common in in-app browsers) the user selects the visible text and still gets the right string.
- **Typed-DELETE**: semantics unchanged. Same copy, same requirement to type `DELETE`, cancel sends nothing. This friction is deliberate and stays; only the container is styled.
- **CSS**: Refresh/Disconnect as quiet filled pills; Delete danger-coded but unfilled and dashed, so it reads as dangerous without pulling harder than Refresh.

## How it was verified

The pytest suite covers none of this UI and **a green suite proves nothing here** — it is a server no-regression signal only. Verification was a real browser at **390×844**, driven with raw `page.mouse.click()` at computed coordinates rather than `locator.click()`, because `locator.click()` scrolls the target into view first and would have masked precisely the clipped-anchor cases that matter.

**QA failed the first implementation.** Spec compliance passed 9/9 and every security requirement held, but the replacement messages rendered **648px and 1091px below the fold** — the user taps, an error occurs, nothing visibly happens. That is the same invisible failure this issue exists to eliminate, with different plumbing. The second worst was the zero-agent path: it wrote its explanation into one section and then scrolled the viewport to a *different* one, away from the words it had just written.

After the fix, re-verified at five anchor positions including two built specifically to break the `scrollIntoView({block:"nearest"})` nudge — anchor half-clipped at the top edge, anchor with 24px visible, and the last tile flush with the bottom edge (the only case that scrolls; lands with exactly the 20px `scroll-margin`). Node integrity checked across six alternating failures between anchors at different scroll depths: always exactly one `#connect-msg`, never orphaned, correct sibling, correct text.

Security re-checked live, not just by grep: provider and connection labels carrying `<img src=x onerror=…>` rendered escaped with the payload counter never firing; the delete gate survived a real bypass attempt (strip `disabled`, click with a wrong value → zero requests); the consent card still ignores ESC and backdrop tap, which is deliberate friction that must not be "fixed".

```
1598 passed, 2 skipped     # after merging main
ruff: All checks passed!
grep -E "prompt\(|alert\(|confirm\(" careagents/static/home.js  →  0 matches
```

## Known limits — please read before merging

- **Chromium only.** No iOS device or simulator, no Android Chrome, no Telegram/Instagram in-app webview — *the browsers whose broken `prompt()` motivated this issue*. Every measurement above is Chromium at 390×844.
- **The delete confirm button may sit under the iOS keyboard.** Measured at 390×844: the input is auto-focused and the buttons land at y 514–620, while an iPhone 14 keyboard occupies roughly y ≥ 508. Not fixed, because it was measured in Chromium and iOS visual-viewport panning may rescue it. **Worth 5 minutes on real hardware before this ships** — it is the primary action of an irreversible operation.
- **Focus does not return from the code card**, because `#tg-surface`/`#im-surface` are non-focusable `<div>`s. Pre-existing; those tiles are not keyboard-reachable at all.
- **New LOW regression:** the page can scroll ~656px behind an open modal, because `say()` calls `scrollIntoView` unconditionally. Cosmetic — the fixed card does not move and stays functional — but the user ends up displaced when they dismiss it. Filed separately.
- No VoiceOver pass. The Telegram deep-link branch was not driven. Real HealthClaw is faked per repo convention, so these flows prove a call is *made*, not accepted.

## Tests added

Nine source-level guards in `tests/test_careagents.py`, whose commit message states plainly that they execute no JavaScript and prove no behaviour. They fence the properties that are invisible in review and expensive to get wrong: no blocking dialogs, no markup built from server strings, no `execCommand` fallback, the pairing code never logged, and the delete triple-gate. Mutation-checked — replacing the click-handler re-check makes `test_typed_delete_stays_double_gated` fail.

One of those guards fired on a *comment* containing a literal `alert()`. The comment was reworded rather than the regex loosened: a guard that parses JS comments is a guard that can be talked around.

## Merge note

`tests/test_careagents.py` conflicted with #260 — both appended tests at the same place. Both kept; the conflict was positional, not semantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)