### PR TITLE
ci(prod-watch): keep dependency noise out of the alarm issue

### DIFF
--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -37,6 +37,15 @@ jobs:
         with:
           enable-cache: true
 
+      # Resolve dependencies before the checked step, so uv's download progress
+      # cannot end up in the issue body. The watch step merges stderr into
+      # result.txt on purpose — a traceback belongs in the alarm — but on a
+      # cold cache uv writes ~30 lines of "Downloading …" to the same stream,
+      # and the first real run pushed every check result below the fold of the
+      # issue somebody reads at 03:00.
+      - name: Warm the environment
+        run: uv run --with requests python -c ""
+
       - name: Check production
         id: watch
         run: |


### PR DESCRIPTION
## What the first real run told us

The prod-watch alarm path had **never executed on GitHub Actions** — every result across four QA rounds came from driving the real script body against a fake octokit. I flagged that as the headline caveat when #271 merged. Production is genuinely degraded right now (#273), so I triggered a manual `workflow_dispatch` — the honest first proof.

**It worked.** Run [30755829922](https://github.com/aks129/HealthClawGuardrails/actions/runs/30755829922) opened [#274](https://github.com/aks129/HealthClawGuardrails/issues/274):

- the **outage** alarm fired and the **stale** alarm correctly stayed silent — the two-alarm split, confirmed on real infrastructure rather than in a simulator
- `steps.watch.outputs.exit` populated as assumed; the `Sync the alert issues` step ran and the badge went red
- ANSI stripped, remedy sentence and run link present
- and `careagents: running the current build — f71d46ef9205` **passed against a real deployment**, closing the "no deployed build carries a marker" caveat

## The defect it also revealed

The issue body led with ~30 lines of `uv` `Downloading pygments…`, `Downloading mypy…` before reaching a single check result. The failing-check summary was below the fold.

The watch step merges stderr into `result.txt` deliberately — a traceback belongs in the alarm — and on a cold cache `uv` writes its progress to that same stream.

## Fix

Resolve dependencies in a preceding step, so the two streams are separated without weakening what the alarm captures. Three lines, no change to the check logic or the alarm predicates.

This is the channel a solo maintainer actually reads, which is the entire argument for the cron over dashboards (`Simplifications` table in the delivery plan). An alarm that buries its finding is one someone learns to skim.

## Verification

YAML parses; `uv run ruff check .` clean. The real proof is the next dispatch after merge — the body should open on `OK healthclaw: alive`. Worth one more manual run then, since this changes only workflow YAML and CI does not execute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)