### PR TITLE
fix(careagents): make the container honour CARE_ROLE, so Railway can run a worker (#273)

### DIFF
--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -47,11 +47,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 # started a second web server would report itself healthy while nothing ever
 # drained the run queue. `${CARE_ROLE-web}`, not `${CARE_ROLE:-web}`, because
 # only an unset variable means "default" — an empty one is a broken config.
+# `printf`, not `echo`: dash's echo expands backslash escapes, so a role value
+# containing one would truncate its own error message.
 CMD ["sh", "-c", "case \"${CARE_ROLE-web}\" in \
   web) exec gunicorn careagents.wsgi:app \
   --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 4 --timeout 180 \
   --access-logfile - --error-logfile - \
   --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms' ;; \
   worker) exec python -m careagents.worker ;; \
-  *) echo \"careagents: unknown CARE_ROLE '$CARE_ROLE' (expected web or worker)\" >&2; exit 2 ;; \
+  *) printf \"careagents: unknown CARE_ROLE '%s' (expected web or worker)\\n\" \"$CARE_ROLE\" >&2; exit 2 ;; \
 esac"]

--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -4,8 +4,10 @@
 # so deploy with:  railway up  from a staging dir, or set the service's
 # Dockerfile path to deploy/careagents/Dockerfile with root as context.
 #
-# The image supports two process roles: the default web command below, and
-# ``python -m careagents.worker`` for the durable inference/tool worker.
+# The image supports two process roles, selected at start-up by CARE_ROLE:
+# ``web`` (the default) serves the app, and ``worker`` runs the durable
+# inference/tool worker. Railway's `railway add` has no start-command option,
+# so the role has to be reachable through the environment alone (#273).
 
 FROM python:3.11-slim
 
@@ -37,7 +39,19 @@ EXPOSE 8600
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD python -m careagents.healthcheck
 
-CMD ["sh", "-c", "gunicorn careagents.wsgi:app \
+# One image, two roles. `exec` so the role process replaces the shell and
+# receives the platform's SIGTERM directly: gunicorn drains, and
+# careagents.worker stops its pool through the handler it installs — neither
+# happens if a shell sits between them as PID 1. An unrecognised role exits
+# rather than falling through to web: a typo'd worker service that quietly
+# started a second web server would report itself healthy while nothing ever
+# drained the run queue. `${CARE_ROLE-web}`, not `${CARE_ROLE:-web}`, because
+# only an unset variable means "default" — an empty one is a broken config.
+CMD ["sh", "-c", "case \"${CARE_ROLE-web}\" in \
+  web) exec gunicorn careagents.wsgi:app \
   --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 4 --timeout 180 \
   --access-logfile - --error-logfile - \
-  --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms'"]
+  --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms' ;; \
+  worker) exec python -m careagents.worker ;; \
+  *) echo \"careagents: unknown CARE_ROLE '$CARE_ROLE' (expected web or worker)\" >&2; exit 2 ;; \
+esac"]

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -131,17 +131,30 @@ So do not hand-pick variables. The rule is: **mirror every non-`RAILWAY_*`
 variable from the web service**, as a reference rather than a copied value.
 Enumerate them rather than trusting a list in a document — the set drifts:
 
+Run this from the repo root, already linked to the project (the web deploy
+leaves you linked; otherwise `railway link` first — see below).
+
 ```bash
 WEB=careagents                      # the existing web service
-# --kv prints raw values; keep the output in the pipe, do not paste it.
-NAMES=$(railway variables list --service "$WEB" --kv \
-  | sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' \
+
+# Names only. --json keeps every value inside the pipe: parsing --kv with sed
+# would put a multi-line value's continuation line into the name list, and from
+# there into an `railway add` argv and your shell history.
+NAMES=$(railway variables list --service "$WEB" --json \
+  | python3 -c 'import json,sys; [print(k) for k in json.load(sys.stdin)]' \
   | grep -Ev '^(RAILWAY_|PORT$|CARE_ROLE$)')
 
 args=(--service careagents-worker --variables "CARE_ROLE=worker")
-for name in $NAMES; do
-  args+=(--variables "$name=\${{$WEB.$name}}")
-done
+# `while read`, not `for name in $NAMES`: zsh does not word-split unquoted
+# expansions, so a for-loop runs ONCE over the whole list and collapses all 17
+# names into a single malformed --variables argument. The service then boots
+# without CARE_ENV, takes the development path where nothing is required, and
+# runs green while draining nothing — no ConfigError to find. This loop
+# behaves the same in bash and zsh.
+while IFS= read -r name; do
+  [ -n "$name" ] && args+=(--variables "$name=\${{$WEB.$name}}")
+done <<< "$NAMES"
+
 railway add "${args[@]}"
 ```
 
@@ -168,17 +181,26 @@ anyway (`careagents/healthcheck.py` checks queue presence for the worker).
 
 ### Deploy and confirm it worked
 
+**`cd` into the stage; do not pass it as an argument.** `railway up <path>`
+roots the archive at the *project directory* rather than at the path unless you
+add `--path-as-root`, and it applies `.gitignore` — which lists
+`careagents/BUILD_SHA`. Run from the repo root and the marker is dropped from
+the upload, leaving a deployment that reports `build: unknown` and alarms as
+stale forever. `cd`-then-`up` is the form that has actually been used to deploy
+this service.
+
 ```bash
 railway link --project <project-id> --service careagents-worker --environment production
-railway up "$STAGE" --service careagents-worker --detach
+cd "$STAGE" && railway up --service careagents-worker --detach
 ```
 
 One stage serves both roles. Upload it twice — once per service — and the two
 report the same `build`:
 
 ```bash
-railway up "$STAGE" --service careagents        --detach
-railway up "$STAGE" --service careagents-worker --detach
+cd "$STAGE"
+railway up --service careagents        --detach
+railway up --service careagents-worker --detach
 ```
 
 Then confirm from the **web** service, which is where the worker becomes

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -65,6 +65,65 @@ CareAgents identity store use shared databases. The claim path is PostgreSQL
 safe (`FOR UPDATE SKIP LOCKED`); SQLite remains development-only for multiple
 hosts.
 
+## Railway
+
+Two services, one image, differing only by `CARE_ROLE`. `railway add` has no
+start-command option, so the role has to travel in the environment:
+`deploy/careagents/Dockerfile` dispatches on it at start-up — `web` (the
+default) runs gunicorn, `worker` runs `python -m careagents.worker`, and any
+other value exits non-zero instead of quietly starting a second web server
+(#273).
+
+Create the worker service from the same repo and the same Dockerfile path as
+the web service, then set `CARE_ROLE=worker` on it. It performs the inference
+and the tool calls, so it needs the same configuration the web service has, not
+a subset — a worker pointed at a different HealthClaw, holding a different mint
+secret, or reading a different accounts database claims nothing and its
+presence never reaches the web role's readiness check. Railway variable
+*references* share that configuration without copying secret values anywhere:
+
+| Worker variable | Value |
+| --- | --- |
+| `CARE_ROLE` | `worker` |
+| `HEALTHCLAW_BASE` | `${{careagents.HEALTHCLAW_BASE}}` |
+| `HEALTHCLAW_MINT_SECRET` | `${{careagents.HEALTHCLAW_MINT_SECRET}}` |
+| `CARE_DATABASE_URL` | `${{careagents.CARE_DATABASE_URL}}` |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | `${{careagents.ANTHROPIC_API_KEY}}` |
+| `CARE_ENV` | `${{careagents.CARE_ENV}}` |
+
+Substitute the web service's own name for `careagents`. A reference resolves at
+deploy time, so rotating the web service's secret rotates the worker's with it
+and the value is never pasted into a second dashboard field.
+
+Stamp the build marker for **both** services. Each is its own upload, so run
+
+```bash
+./deploy/careagents/stamp_build.sh "$STAGE"
+```
+
+against the staging directory before every `railway up`, whichever service it
+targets. A worker deployed from an unstamped stage reports `build: unknown`
+while the web service reports the commit you meant to ship, which is precisely
+the pair of deployments #258 could not tell apart.
+
+### A deployment with only the web service
+
+It looks healthy in a browser — the landing page and `/auth` render — and fails
+everywhere that matters:
+
+```text
+GET /healthz -> 503
+{"accounts": true, "provider": "openai", "run_workers": false,
+ "status": "degraded"}
+
+POST /api/chat -> run_workers_unavailable
+```
+
+That is readiness failing closed because no durable worker presence is fresh,
+not a regression. The fix is to add the worker service. Never relax the check:
+a green `/healthz` with nothing draining the queue is the state the fail-closed
+design exists to make visible.
+
 ## Compose
 
 Run the optional local profile:

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -138,7 +138,13 @@ service, which does not exist yet:
 railway link --project <project-id> --environment production
 ```
 
+The whole block runs in a subshell. It exits on any failure, and `exit` in a
+shell you pasted into is your session — which would also lose `$STAGE`, since
+that is a `mktemp -d` path held only in a shell variable, forcing you to redo
+the staging. The parentheses keep the failure inside.
+
 ```bash
+(
 WEB=careagents                      # the existing web service
 
 # Names only: --json keeps every value inside the pipe. Parsing --kv with sed
@@ -156,15 +162,17 @@ d = json.load(sys.stdin)                       # empty/banner/error output -> di
 if not isinstance(d, dict):
     sys.exit("expected a JSON object of variables")
 
+names = [k for k in d if not re.match(r"RAILWAY_|PORT$|CARE_ROLE$", k)]
+
 # Reject unreferenceable names LOUDLY. Filtering them would be a silent drop,
-# and the count below could not tell that from a healthy read. The rule is
+# and nothing downstream could tell that from a healthy read. The rule is
 # Railway/POSIX, not Python: str.isidentifier() accepts "CAFÉ_KEY" and the
 # Cyrillic-Е homoglyph "CARE_ЕNV", neither of which ${{web.NAME}} resolves.
-bad = sorted(k for k in d if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", k))
+# Checked after the exclusion, so a name we were never going to forward cannot
+# block the run.
+bad = sorted(k for k in names if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", k))
 if bad:
     sys.exit("cannot build a reference for: " + ", ".join(bad))
-
-names = [k for k in d if not re.match(r"RAILWAY_|PORT$|CARE_ROLE$", k)]
 
 # What the worker cannot boot without, from careagents/config.py. Named, not
 # counted: a threshold blocks a legitimate cleanup and waves through fifteen
@@ -192,7 +200,16 @@ while IFS= read -r name; do
 done <<< "$NAMES"
 
 railway add "${args[@]}"
+)
 ```
+
+If it refuses, it names what it found and nothing was created. **`cannot build
+a reference for: MY-VAR`** — Railway holds a name that `${{web.NAME}}` cannot
+express. Either rename it on the web service, or, if the worker does not need
+it, add it to the exclusion pattern beside `PORT` and `CARE_ROLE`.
+**`enumeration is missing CARE_ENV`** — you are reading the wrong service or
+project; check `railway status` before retrying. In both cases `$STAGE` is
+intact and you can re-run the block as-is.
 
 A reference resolves at deploy time, so rotating the web service's secret
 rotates the worker's with it and no secret is ever pasted into a second field.

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -131,18 +131,54 @@ So do not hand-pick variables. The rule is: **mirror every non-`RAILWAY_*`
 variable from the web service**, as a reference rather than a copied value.
 Enumerate them rather than trusting a list in a document — the set drifts:
 
-Run this from the repo root, already linked to the project (the web deploy
-leaves you linked; otherwise `railway link` first — see below).
+Run this from the repo root. Link the **project** first — not the worker
+service, which does not exist yet:
+
+```bash
+railway link --project <project-id> --environment production
+```
 
 ```bash
 WEB=careagents                      # the existing web service
 
-# Names only. --json keeps every value inside the pipe: parsing --kv with sed
+# Names only: --json keeps every value inside the pipe. Parsing --kv with sed
 # would put a multi-line value's continuation line into the name list, and from
-# there into an `railway add` argv and your shell history.
-NAMES=$(railway variables list --service "$WEB" --json \
-  | python3 -c 'import json,sys; [print(k) for k in json.load(sys.stdin)]' \
-  | grep -Ev '^(RAILWAY_|PORT$|CARE_ROLE$)')
+# there into a `railway add` argv and your shell history.
+#
+# Everything that can go wrong here fails CLOSED, because the service this
+# creates boots GREEN when it is wrong: without CARE_ENV, Config() takes the
+# development path, requires nothing, and the container runs while claiming no
+# work. Railway shows it healthy, /healthz stays 503, and the ConfigError this
+# runbook tells you to look for was never raised.
+NAMES=$(railway variables list --service "$WEB" --json | python3 -c '
+import json, re, sys
+d = json.load(sys.stdin)                       # empty/banner/error output -> dies here
+if not isinstance(d, dict):
+    sys.exit("expected a JSON object of variables")
+
+# Reject unreferenceable names LOUDLY. Filtering them would be a silent drop,
+# and the count below could not tell that from a healthy read. The rule is
+# Railway/POSIX, not Python: str.isidentifier() accepts "CAFÉ_KEY" and the
+# Cyrillic-Е homoglyph "CARE_ЕNV", neither of which ${{web.NAME}} resolves.
+bad = sorted(k for k in d if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", k))
+if bad:
+    sys.exit("cannot build a reference for: " + ", ".join(bad))
+
+names = [k for k in d if not re.match(r"RAILWAY_|PORT$|CARE_ROLE$", k)]
+
+# What the worker cannot boot without, from careagents/config.py. Named, not
+# counted: a threshold blocks a legitimate cleanup and waves through fifteen
+# names that happen to omit CARE_ENV — the one whose absence turns a broken
+# worker green.
+missing = {"CARE_ENV", "CARE_SESSION_SECRET", "HEALTHCLAW_MINT_SECRET",
+           "RESEND_API_KEY"} - set(names)
+if missing:
+    sys.exit("enumeration is missing " + ", ".join(sorted(missing)))
+if not {"OPENAI_API_KEY", "ANTHROPIC_API_KEY"} & set(names):
+    sys.exit("enumeration has no LLM credential")
+
+print("\n".join(names))
+') || exit 1
 
 args=(--service careagents-worker --variables "CARE_ROLE=worker")
 # `while read`, not `for name in $NAMES`: zsh does not word-split unquoted
@@ -190,16 +226,18 @@ stale forever. `cd`-then-`up` is the form that has actually been used to deploy
 this service.
 
 ```bash
-railway link --project <project-id> --service careagents-worker --environment production
 cd "$STAGE" && railway up --service careagents-worker --detach
 ```
+
+You linked the project before creating the service, and `--service` on each
+`railway up` picks the target, so no second `railway link` is needed.
 
 One stage serves both roles. Upload it twice — once per service — and the two
 report the same `build`:
 
 ```bash
 cd "$STAGE"
-railway up --service careagents        --detach
+railway up --service careagents        --detach   # production web redeploy
 railway up --service careagents-worker --detach
 ```
 

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -67,44 +67,132 @@ hosts.
 
 ## Railway
 
-Two services, one image, differing only by `CARE_ROLE`. `railway add` has no
-start-command option, so the role has to travel in the environment:
+Two services built from one image. The only configuration that differs is
+`CARE_ROLE` — and the public domain, which only the web service needs.
+`railway add` has no start-command option, so the role has to travel in the
+environment:
 `deploy/careagents/Dockerfile` dispatches on it at start-up — `web` (the
 default) runs gunicorn, `worker` runs `python -m careagents.worker`, and any
 other value exits non-zero instead of quietly starting a second web server
 (#273).
 
-Create the worker service from the same repo and the same Dockerfile path as
-the web service, then set `CARE_ROLE=worker` on it. It performs the inference
-and the tool calls, so it needs the same configuration the web service has, not
-a subset — a worker pointed at a different HealthClaw, holding a different mint
-secret, or reading a different accounts database claims nothing and its
-presence never reaches the web role's readiness check. Railway variable
-*references* share that configuration without copying secret values anywhere:
+Two things own the role, and neither is the dashboard: the image, and
+`CARE_ROLE`. Leave `startCommand` unset on both services. A custom start
+command in the console silently overrides the dispatch, and `CARE_ROLE` then
+means nothing — the live web service runs on Railway defaults
+(`startCommand`, `builder`, `rootDirectory`, `restartPolicyType` all unset) for
+exactly that reason.
 
-| Worker variable | Value |
-| --- | --- |
-| `CARE_ROLE` | `worker` |
-| `HEALTHCLAW_BASE` | `${{careagents.HEALTHCLAW_BASE}}` |
-| `HEALTHCLAW_MINT_SECRET` | `${{careagents.HEALTHCLAW_MINT_SECRET}}` |
-| `CARE_DATABASE_URL` | `${{careagents.CARE_DATABASE_URL}}` |
-| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | `${{careagents.ANTHROPIC_API_KEY}}` |
-| `CARE_ENV` | `${{careagents.CARE_ENV}}` |
+### Stage the build
 
-Substitute the web service's own name for `careagents`. A reference resolves at
-deploy time, so rotating the web service's secret rotates the worker's with it
-and the value is never pasted into a second dashboard field.
+**Do not create the service from the GitHub repo.** A repo-connected build
+picks up the repo-root `railway.toml`, which points at the repo-root
+`Dockerfile` — the HealthClaw Flask app, not CareAgents. You would get a
+"worker" serving `gunicorn main:app`, running the Flask migrations and demo
+seeding in `preDeployCommand` against whatever database is bound. Deploy from a
+staging directory instead, the same way the web service is deployed and for the
+same reason `docs/development.md` gives for the MCP server.
 
-Stamp the build marker for **both** services. Each is its own upload, so run
+From the repo root, on the commit you intend to ship:
 
 ```bash
-./deploy/careagents/stamp_build.sh "$STAGE"
+STAGE="$(mktemp -d)"
+cp pyproject.toml uv.lock "$STAGE/"
+cp -R careagents "$STAGE/"
+cp deploy/careagents/Dockerfile "$STAGE/Dockerfile"
+./deploy/careagents/stamp_build.sh "$STAGE"    # prints e.g. build 4f2a91cbeef1
 ```
 
-against the staging directory before every `railway up`, whichever service it
-targets. A worker deployed from an unstamped stage reports `build: unknown`
-while the web service reports the commit you meant to ship, which is precisely
-the pair of deployments #258 could not tell apart.
+That is everything the image's build context needs. The Dockerfile goes to the
+stage root under its default name so Railway's builder finds it without a
+`dockerfilePath` — the same reason it must not be a repo-connected build.
+
+Stamp last: `cp -R careagents` may carry a stale `BUILD_SHA` in from your
+checkout, and the stamp overwrites it. Stamp for **both** services — each
+`railway up` is its own upload, so a worker deployed from an unstamped stage
+reports `build: unknown` while the web service reports the commit you meant to
+ship. That is the pair of deployments #258 could not tell apart.
+
+### Create the worker service
+
+The worker runs `Config()` (`careagents/worker.py`), the same unconditional
+constructor the web app runs. In production it `_require`s
+`CARE_SESSION_SECRET` (32 chars or more), `HEALTHCLAW_MINT_SECRET`,
+`RESEND_API_KEY`, and an LLM credential — **including the two the worker never
+uses**. It sends no email and has no sessions; it still refuses to boot without
+them, and a worker service missing either crash-loops on:
+
+```text
+careagents.config.ConfigError: CARE_SESSION_SECRET is required in production
+careagents.config.ConfigError: RESEND_API_KEY is required in production
+```
+
+So do not hand-pick variables. The rule is: **mirror every non-`RAILWAY_*`
+variable from the web service**, as a reference rather than a copied value.
+Enumerate them rather than trusting a list in a document — the set drifts:
+
+```bash
+WEB=careagents                      # the existing web service
+# --kv prints raw values; keep the output in the pipe, do not paste it.
+NAMES=$(railway variables list --service "$WEB" --kv \
+  | sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' \
+  | grep -Ev '^(RAILWAY_|PORT$|CARE_ROLE$)')
+
+args=(--service careagents-worker --variables "CARE_ROLE=worker")
+for name in $NAMES; do
+  args+=(--variables "$name=\${{$WEB.$name}}")
+done
+railway add "${args[@]}"
+```
+
+A reference resolves at deploy time, so rotating the web service's secret
+rotates the worker's with it and no secret is ever pasted into a second field.
+At the time of writing the web service carries 17 of them: `CARE_DATABASE_URL`,
+`CARE_EMAIL_FROM`, `CARE_ENV`, `CARE_IMESSAGE_HANDLE`, `CARE_MODEL`,
+`CARE_OPENAI_MODEL`, `CARE_ORIGIN`, `CARE_RP_ID`, `CARE_RP_NAME`,
+`CARE_SESSION_SECRET`, `CARE_TELEGRAM_BOT`, `FASTEN_PUBLIC_KEY`,
+`HEALTHCLAW_BASE`, `HEALTHCLAW_MINT_SECRET`, `OPENAI_API_KEY`,
+`OPENAI_BASE_URL`, `RESEND_API_KEY`. Note which LLM credential that is:
+`ANTHROPIC_API_KEY` is **not** set, which is why `/healthz` reports
+`provider: openai`. Referencing a variable the web service does not have gives
+you an empty value — a boot refusal if it was the only credential, or worse, a
+worker that claims runs and fails every one at inference while readiness reports
+green.
+
+Give the worker **no healthcheck path and no public domain**. It serves no
+HTTP, so Railway's default (no path configured, which is what the web service
+also runs with) is correct; a healthcheck path copied across from the web
+service leaves the deploy permanently un-healthy. The `HEALTHCHECK` in the
+Dockerfile is a different thing — Railway ignores it, and it is role-aware
+anyway (`careagents/healthcheck.py` checks queue presence for the worker).
+
+### Deploy and confirm it worked
+
+```bash
+railway link --project <project-id> --service careagents-worker --environment production
+railway up "$STAGE" --service careagents-worker --detach
+```
+
+One stage serves both roles. Upload it twice — once per service — and the two
+report the same `build`:
+
+```bash
+railway up "$STAGE" --service careagents        --detach
+railway up "$STAGE" --service careagents-worker --detach
+```
+
+Then confirm from the **web** service, which is where the worker becomes
+visible. Readiness flips only once a worker's presence is fresh:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://careagents.cloud/healthz   # 200
+curl -s https://careagents.cloud/healthz                                    # "run_workers": true
+```
+
+`200` with `"run_workers": true` and a `build` matching the commit you staged is
+the finish line. If it stays 503, the worker is not running: check its deploy
+logs for a `ConfigError`, and check presence directly with the
+`agent_worker_presence` query under [Operations](#operations).
 
 ### A deployment with only the web service
 

--- a/tests/test_careagents_container_roles.py
+++ b/tests/test_careagents_container_roles.py
@@ -1,0 +1,174 @@
+"""What one CareAgents image will actually start, per CARE_ROLE.
+
+The image has to carry both process roles, because `railway add` has no
+start-command option: on Railway the role is reachable through the environment
+alone. Before #273 the Dockerfile *said* it supported two roles while `CMD` was
+hardcoded to gunicorn, so the deployment ran web twice — `/healthz` answered
+503 with `run_workers: false` and chat answered `run_workers_unavailable`,
+because nothing ever claimed a queued run.
+
+These tests extract the `CMD` from the Dockerfile and run that dispatch under
+`/bin/sh` with stub `gunicorn` and `python` executables on PATH, so the branch
+each role takes is observed rather than pattern-matched, and the web argv is
+compared element by element rather than by substring.
+
+What they do not prove: no image is built and no container is run. Nothing here
+shows that gunicorn or careagents.worker exist in the image, that PATH resolves
+the same way inside it, that `exec` really makes the role process PID 1, or
+that the Railway services carry the environment the worker needs. The shell is
+the host's `/bin/sh`, not the image's dash. One property is pinned — which
+command each CARE_ROLE reaches, and that an unrecognised role reaches none.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DOCKERFILE = REPO / "deploy" / "careagents" / "Dockerfile"
+
+# The command the web role ran before #273, split as the shell splits it. Any
+# edit to a flag, a default, or the access-log format has to be made here too —
+# which is the point: the durable-run split must not quietly re-tune the web
+# process while it is adding a second role.
+WEB_ARGV = [
+    "gunicorn", "careagents.wsgi:app",
+    "--bind", "0.0.0.0:8600",
+    "--workers", "2",
+    "--threads", "4",
+    "--timeout", "180",
+    "--access-logfile", "-",
+    "--error-logfile", "-",
+    "--access-logformat", '%(h)s "%(r)s" %(s)s %(M)sms',
+]
+
+STUB = """#!/bin/sh
+: > "$RECORD"
+for arg in "$0" "$@"; do printf '%s\\n' "$arg" >> "$RECORD"; done
+"""
+
+
+def _cmd_script() -> str:
+    """The shell program in the Dockerfile's `CMD ["sh", "-c", ...]`."""
+    text = DOCKERFILE.read_text()
+    # Docker joins continued lines before parsing the JSON form.
+    text = text.replace("\\\n", "")
+    match = re.search(r"^CMD (\[.*\])\s*$", text, re.M)
+    assert match, "CMD is no longer a single JSON exec form"
+    argv = json.loads(match.group(1))
+    assert argv[:2] == ["sh", "-c"], argv[:2]
+    return argv[2]
+
+
+@pytest.fixture(scope="module")
+def stubs(tmp_path_factory):
+    """A PATH holding recording stand-ins for gunicorn and python."""
+    path = tmp_path_factory.mktemp("bin")
+    for name in ("gunicorn", "python"):
+        stub = path / name
+        stub.write_text(STUB)
+        stub.chmod(0o755)
+    return path
+
+
+def _start(stubs, role, shell="/bin/sh", **env):
+    """Run the real dispatch; return (exit code, argv it launched, stderr)."""
+    record = stubs / "record"
+    if record.exists():
+        record.unlink()
+    environ = {"PATH": str(stubs), "RECORD": str(record), **env}
+    if role is not None:
+        environ["CARE_ROLE"] = role
+    result = subprocess.run([shell, "-c", _cmd_script()], env=environ,
+                            capture_output=True, text=True)
+    argv = None
+    if record.exists():
+        argv = record.read_text().splitlines()
+        argv[0] = os.path.basename(argv[0])
+    return result.returncode, argv, result.stderr
+
+
+# --- the two roles the image claims to support -------------------------------
+
+@pytest.mark.parametrize("role", [None, "web"])
+def test_the_default_role_still_starts_the_web_server_unchanged(stubs, role):
+    code, argv, stderr = _start(stubs, role)
+    assert code == 0, stderr
+    assert argv == WEB_ARGV
+
+
+def test_the_web_role_still_honours_its_port_and_worker_overrides(stubs):
+    _, argv, _ = _start(stubs, "web", PORT="9999", CARE_WEB_WORKERS="7")
+    assert argv[argv.index("--bind") + 1] == "0.0.0.0:9999"
+    assert argv[argv.index("--workers") + 1] == "7"
+
+
+def test_the_worker_role_starts_the_durable_worker(stubs):
+    # The defect in #273: this branch did not exist, so a service configured as
+    # the worker started a web process and readiness stayed 503 forever.
+    code, argv, stderr = _start(stubs, "worker")
+    assert code == 0, stderr
+    assert argv == ["python", "-m", "careagents.worker"]
+
+
+# --- and the one it must refuse ----------------------------------------------
+
+@pytest.mark.parametrize("role", [
+    "wokrer",       # a plain typo on the service that matters
+    "Worker",       # case is not a synonym
+    "",             # a variable reference that resolved to nothing
+    "web worker",   # both, which is not a role
+    "worker ",      # a trailing space pasted from a dashboard field
+])
+def test_an_unknown_role_exits_instead_of_starting_a_second_web_server(stubs,
+                                                                      role):
+    # Falling through to web is the dangerous outcome, not the loud one: the
+    # container would pass its health check and look correct in the dashboard
+    # while no process ever claimed a run.
+    code, argv, stderr = _start(stubs, role)
+    assert code != 0
+    assert argv is None, f"started {argv} for CARE_ROLE={role!r}"
+    assert "CARE_ROLE" in stderr
+
+
+def test_the_refusal_names_the_roles_the_image_can_run(stubs):
+    _, _, stderr = _start(stubs, "wokrer")
+    assert "web" in stderr and "worker" in stderr
+
+
+@pytest.mark.skipif(not os.path.exists("/bin/dash"), reason="dash not present")
+@pytest.mark.parametrize("role,expected", [
+    ("web", WEB_ARGV),
+    ("worker", ["python", "-m", "careagents.worker"]),
+    ("wokrer", None),
+])
+def test_the_dispatch_behaves_the_same_under_the_images_shell(stubs, role,
+                                                              expected):
+    # python:3.11-slim is Debian, where /bin/sh is dash. The tests above run
+    # whatever the host provides, which on macOS is bash — a `case` that
+    # depended on a bashism would pass there and fail in the image.
+    _, argv, _ = _start(stubs, role, shell="/bin/dash")
+    assert argv == expected
+
+
+# --- source-level, for the parts a stub run cannot observe -------------------
+
+def test_the_worker_branch_execs_so_it_receives_the_platform_sigterm():
+    # careagents.worker installs SIGTERM/SIGINT handlers and joins non-daemon
+    # threads. A shell left in front of it as PID 1 would swallow the signal,
+    # and every redeploy would end in SIGKILL with leases still held.
+    script = _cmd_script()
+    assert "exec python -m careagents.worker" in script
+    assert "exec gunicorn" in script
+
+
+def test_the_dockerfile_documents_the_role_it_dispatches_on():
+    # The header claimed two roles for two releases while CMD supported one.
+    header = DOCKERFILE.read_text().split("FROM ")[0]
+    assert "CARE_ROLE" in header

--- a/tests/test_careagents_container_roles.py
+++ b/tests/test_careagents_container_roles.py
@@ -12,12 +12,19 @@ These tests extract the `CMD` from the Dockerfile and run that dispatch under
 each role takes is observed rather than pattern-matched, and the web argv is
 compared element by element rather than by substring.
 
+The shell is covered: the dispatch runs under the host's `/bin/sh` and, where
+present, under `/bin/dash` — which is `/bin/sh` on Debian, so it is the image's
+own shell and the one Linux CI uses.
+
 What they do not prove: no image is built and no container is run. Nothing here
 shows that gunicorn or careagents.worker exist in the image, that PATH resolves
 the same way inside it, that `exec` really makes the role process PID 1, or
-that the Railway services carry the environment the worker needs. The shell is
-the host's `/bin/sh`, not the image's dash. One property is pinned — which
-command each CARE_ROLE reaches, and that an unrecognised role reaches none.
+that the Railway services carry the environment the worker needs. One property
+is pinned — which command each CARE_ROLE reaches, and that an unrecognised role
+reaches none. (Reviewing #273, QA closed the container-level gaps against a
+real build: the stored CMD matches, `CARE_ROLE=worker` puts the worker at PID
+1, and `docker stop` returns in 0.2s with `exec` versus 30s and SIGKILL
+without.)
 """
 
 from __future__ import annotations
@@ -47,6 +54,9 @@ WEB_ARGV = [
     "--error-logfile", "-",
     "--access-logformat", '%(h)s "%(r)s" %(s)s %(M)sms',
 ]
+
+# /bin/dash is /bin/sh on Debian, so it is both the image's shell and CI's.
+SHELLS = [path for path in ("/bin/sh", "/bin/dash") if os.path.exists(path)]
 
 STUB = """#!/bin/sh
 : > "$RECORD"
@@ -140,6 +150,22 @@ def test_an_unknown_role_exits_instead_of_starting_a_second_web_server(stubs,
 def test_the_refusal_names_the_roles_the_image_can_run(stubs):
     _, _, stderr = _start(stubs, "wokrer")
     assert "web" in stderr and "worker" in stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+@pytest.mark.parametrize("role", [
+    r"a\cb",       # dash's echo expands \c, which ends output mid-message
+    r"a\nb",
+    "%s-%d",       # and a value must never be read as a printf format
+])
+def test_a_hostile_role_value_cannot_truncate_or_reformat_the_refusal(
+        stubs, role, shell):
+    # The operator reads this line to find out what they typed wrong. It has to
+    # survive whatever the dashboard field held, on the image's shell.
+    _, argv, stderr = _start(stubs, role, shell=shell)
+    assert argv is None
+    assert stderr.strip() == (
+        f"careagents: unknown CARE_ROLE '{role}' (expected web or worker)")
 
 
 @pytest.mark.skipif(not os.path.exists("/bin/dash"), reason="dash not present")

--- a/tests/test_careagents_container_roles_qa.py
+++ b/tests/test_careagents_container_roles_qa.py
@@ -1,0 +1,264 @@
+"""QA regressions for the CareAgents CARE_ROLE dispatch (#273).
+
+Complements ``tests/test_careagents_container_roles.py``. That file proves the
+three intended values reach the three intended outcomes. These tests attack the
+same dispatch from the operator's and the attacker's side instead:
+
+- ``CARE_ROLE`` arrives from a Railway service variable, i.e. a dashboard text
+  field. Treat its value as hostile: whitespace, shell metacharacters, command
+  substitution, globs, unicode look-alikes, and a 60 kB value must all reach the
+  refusal branch and launch nothing. Starting *anything* for a value that is not
+  exactly ``web`` or ``worker`` is the failure this dispatch exists to prevent.
+- The parser in the sibling file models Docker's line-continuation join as
+  ``replace("\\\\\\n", "")``. That model was checked once against a real
+  ``docker build`` (Docker 29.6.2 keeps the continuation line's leading indent,
+  so the model is exact). Docker is not available in CI, so instead of pinning
+  Docker's behaviour these tests pin the property that makes the model safe:
+  the dispatch behaves identically under every plausible join rule, because
+  every continued line ends in a space before its backslash.
+
+What these do NOT prove, same as the sibling file: no image is built and no
+container is run here. Nothing below shows that ``exec`` makes the role process
+PID 1, that ``gunicorn`` and ``careagents.worker`` resolve inside the image, or
+that a Railway worker service carries the environment ``careagents.config``
+requires. Those were checked by hand against a locally built image; only the
+shell-level properties are pinned as regressions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DOCKERFILE = REPO / "deploy" / "careagents" / "Dockerfile"
+
+WEB_ARGV = [
+    "gunicorn", "careagents.wsgi:app",
+    "--bind", "0.0.0.0:8600",
+    "--workers", "2",
+    "--threads", "4",
+    "--timeout", "180",
+    "--access-logfile", "-",
+    "--error-logfile", "-",
+    "--access-logformat", '%(h)s "%(r)s" %(s)s %(M)sms',
+]
+WORKER_ARGV = ["python", "-m", "careagents.worker"]
+
+# Records argv, and would create $CANARY if a value ever escaped the case
+# subject into an evaluated command position.
+STUB = """#!/bin/sh
+: > "$RECORD"
+for arg in "$0" "$@"; do printf '%s\\n' "$arg" >> "$RECORD"; done
+"""
+
+SHELLS = [s for s in ("/bin/sh", "/bin/dash") if os.path.exists(s)]
+
+
+def _cmd_block() -> str:
+    """The raw, still-continued CMD instruction."""
+    lines = DOCKERFILE.read_text().splitlines(keepends=True)
+    starts = [i for i, line in enumerate(lines) if line.startswith("CMD [")]
+    assert starts, "no CMD instruction in the Dockerfile"
+    return "".join(lines[starts[-1]:])
+
+
+def _script(join=lambda block: block.replace("\\\n", "")) -> str:
+    joined = join(_cmd_block())
+    match = re.search(r"^CMD (\[.*\])\s*$", joined, re.M)
+    assert match, "CMD is no longer a single JSON exec form"
+    argv = json.loads(match.group(1))
+    assert argv[:2] == ["sh", "-c"], argv[:2]
+    return argv[2]
+
+
+@pytest.fixture(scope="module")
+def sandbox(tmp_path_factory):
+    path = tmp_path_factory.mktemp("care-role-qa")
+    for name in ("gunicorn", "python"):
+        stub = path / name
+        stub.write_text(STUB)
+        stub.chmod(0o755)
+    return path
+
+
+def _start(sandbox, role, shell="/bin/sh", script=None, **env):
+    """Run the dispatch. Returns (rc, argv launched or None, stderr, canary)."""
+    record = sandbox / "record"
+    canary = sandbox / "canary"
+    for leftover in (record, canary):
+        if leftover.exists():
+            leftover.unlink()
+    environ = {"PATH": str(sandbox), "RECORD": str(record),
+               "CANARY": str(canary), **env}
+    if role is not None:
+        environ["CARE_ROLE"] = role
+    result = subprocess.run([shell, "-c", script or _script()], env=environ,
+                            capture_output=True, text=True)
+    argv = None
+    if record.exists():
+        argv = record.read_text().splitlines()
+        argv[0] = os.path.basename(argv[0])
+    return result.returncode, argv, result.stderr, canary.exists()
+
+
+# --- a hostile CARE_ROLE must never start a process ---------------------------
+
+# Every one of these is something a Railway variable field can hold. None of
+# them is `web` or `worker`, so every one must exit non-zero having launched
+# nothing. A value that starts a web server here is a worker service that
+# silently serves HTTP, passes its health check, and drains no runs — the exact
+# shape of #273, reintroduced through a typo instead of a missing branch.
+HOSTILE = [
+    pytest.param("", id="empty-a-reference-that-resolved-to-nothing"),
+    pytest.param(" ", id="one-space"),
+    pytest.param("   ", id="only-spaces"),
+    pytest.param("\t", id="tab"),
+    pytest.param("web ", id="web-trailing-space"),
+    pytest.param(" web", id="web-leading-space"),
+    pytest.param("web\t", id="web-trailing-tab"),
+    pytest.param("worker ", id="worker-trailing-space-pasted"),
+    pytest.param("web\n", id="web-trailing-newline"),
+    pytest.param("\nweb", id="web-leading-newline"),
+    pytest.param("web\r", id="web-trailing-cr-from-windows-paste"),
+    pytest.param("web\nworker", id="both-on-two-lines"),
+    pytest.param("web worker", id="both-on-one-line"),
+    pytest.param("Worker", id="capitalised"),
+    pytest.param("WEB", id="upper-case"),
+    pytest.param("wokrer", id="transposed-typo"),
+    pytest.param("*", id="glob-star-must-not-match-a-pattern"),
+    pytest.param("w*", id="glob-prefix"),
+    pytest.param("we?", id="glob-question"),
+    pytest.param("[w]eb", id="glob-class"),
+    pytest.param("wеb", id="cyrillic-ie-look-alike"),
+    pytest.param("ｗeb", id="fullwidth-w"),
+    pytest.param("web ", id="non-breaking-space"),
+    pytest.param("web; touch $CANARY", id="semicolon-injection"),
+    pytest.param("x && touch $CANARY", id="andand-injection"),
+    pytest.param("$(touch $CANARY)", id="command-substitution-injection"),
+    pytest.param("`touch $CANARY`", id="backtick-injection"),
+    pytest.param("web | touch $CANARY", id="pipe-injection"),
+    pytest.param("web' ; touch $CANARY ; '", id="single-quote-break-out"),
+    pytest.param('web" ; touch $CANARY ; "', id="double-quote-break-out"),
+    pytest.param("$CARE_ROLE", id="self-reference-must-not-re-expand"),
+    pytest.param("w" * 60000, id="60kb-value"),
+]
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+@pytest.mark.parametrize("role", HOSTILE)
+def test_a_hostile_care_role_launches_nothing_and_exits(sandbox, shell, role):
+    code, argv, stderr, canary = _start(sandbox, role, shell=shell)
+    assert argv is None, f"{role!r} started {argv}"
+    assert code != 0, f"{role!r} exited 0"
+    assert not canary, f"{role!r} executed an injected command"
+    assert "CARE_ROLE" in stderr
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_the_two_real_roles_still_reach_their_own_command(sandbox, shell):
+    # The other half of the same guarantee: refusing everything would also pass
+    # the test above.
+    assert _start(sandbox, None, shell=shell)[1] == WEB_ARGV
+    assert _start(sandbox, "web", shell=shell)[1] == WEB_ARGV
+    assert _start(sandbox, "worker", shell=shell)[1] == WORKER_ARGV
+
+
+# --- the dispatch must not depend on how Docker joins continuations ----------
+
+JOINS = {
+    # What Docker 29.6.2 actually does, verified against a built image: the
+    # continuation line keeps its leading indent.
+    "keep-indent": lambda b: b.replace("\\\n", ""),
+    # What a stricter parser might do instead.
+    "strip-indent": lambda b: re.sub(r"\\\n[ \t]*", "", b),
+    "collapse-to-one-space": lambda b: re.sub(r"[ \t]*\\\n[ \t]*", " ", b),
+}
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+@pytest.mark.parametrize("join", list(JOINS))
+def test_the_dispatch_is_insensitive_to_the_continuation_join_rule(sandbox,
+                                                                   shell, join):
+    # Only true while every continued line ends in whitespace before its
+    # backslash. Drop that space and `--timeout 180--access-logfile` becomes one
+    # token under a stripping parser — a break no host-shell test would catch,
+    # because the test does its own joining.
+    script = _script(JOINS[join])
+    assert _start(sandbox, "web", shell=shell, script=script)[1] == WEB_ARGV
+    assert _start(sandbox, "worker", shell=shell,
+                  script=script)[1] == WORKER_ARGV
+    assert _start(sandbox, "wokrer", shell=shell, script=script)[1] is None
+
+
+def test_every_continued_line_ends_in_whitespace_before_its_backslash():
+    # States the precondition of the test above directly, so a future edit that
+    # removes a space fails with a message that says why.
+    for number, line in enumerate(_cmd_block().splitlines(), 1):
+        if line.endswith("\\"):
+            assert line[:-1].endswith((" ", "\t")), (
+                f"CMD continuation line {number} joins without whitespace: "
+                f"{line!r}")
+
+
+# --- environment-driven flags reach the web command --------------------------
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_port_and_web_worker_overrides_reach_gunicorn(sandbox, shell):
+    _, argv, _, _ = _start(sandbox, "web", shell=shell, PORT="9999",
+                           CARE_WEB_WORKERS="7")
+    assert argv[argv.index("--bind") + 1] == "0.0.0.0:9999"
+    assert argv[argv.index("--workers") + 1] == "7"
+
+
+def test_the_web_command_is_unchanged_from_before_the_role_split():
+    # Byte-for-byte, not token-for-token: the durable-run split must not retune
+    # the web process while it adds a second role. The doubled internal spaces
+    # come from the line continuations and are part of the comparison.
+    previous = subprocess.run(
+        ["git", "-C", str(REPO), "show",
+         "f71d46e:deploy/careagents/Dockerfile"],
+        capture_output=True, text=True)
+    if previous.returncode != 0:
+        pytest.skip("f71d46e not present in this checkout")
+    before = json.loads(re.search(
+        r"^CMD (\[.*\])\s*$",
+        previous.stdout.replace("\\\n", ""), re.M).group(1))[2]
+    script = _script()
+    opening = 'case "${CARE_ROLE-web}" in   web) exec '
+    assert script.startswith(opening)
+    assert script[len(opening):script.index(" ;;   worker)")] == before
+
+
+# --- source-level guarantees a stub run cannot observe -----------------------
+
+def test_both_branches_exec_so_the_role_process_becomes_pid_one():
+    # Verified against a real container: with `exec`, `docker stop` on the
+    # worker returns in 0.2s with exit 0; with `sh` left in front of it, the
+    # same stop takes the full 30s grace period and ends in exit 137 (SIGKILL)
+    # with run leases still held. careagents/worker.py installs SIGTERM/SIGINT
+    # handlers and joins non-daemon threads, and PID 1 receives no default
+    # signal disposition, so a shell in front of it never forwards the signal.
+    script = _script()
+    assert "exec gunicorn " in script
+    assert "exec python -m careagents.worker" in script
+    for branch in ("web)", "worker)"):
+        body = script.split(branch, 1)[1].split(";;", 1)[0]
+        assert body.lstrip().startswith("exec "), (
+            f"the {branch} branch does not exec: {body!r}")
+
+
+def test_the_refusal_is_the_default_branch_not_a_fallthrough_to_web():
+    script = _script()
+    catch_all = script.split("*)", 1)[1]
+    assert re.search(r"\bexit [1-9]", catch_all), (
+        "the catch-all branch must exit non-zero")
+    assert "gunicorn" not in catch_all, (
+        "the catch-all branch must not reach the web command")
+    assert script.index("*)") > script.index("worker)"), (
+        "the catch-all must come after the real roles")

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -119,12 +119,22 @@ SECRET_FRAGMENTS = [
     "S3cr3tPassw0rd", "RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3",
     "mint_9f3a2b1c8d7e6f5a4b3c2d1e0f9a8b7c",
     "sk-proj-QAFAKEKEYQAFAKEKEYQAFAKEKEY", "re_QAFAKE_1234567890abcdef",
+    # The single-line FASTEN_PUBLIC_KEY, which only the `--kv` branch serves.
     "ZmFrZWtleWZvcnFhb25seQ",
+    # ...and the multi-line one the `--json` branch serves, which is the branch
+    # the snippet actually calls. Without this the leak assertion would not
+    # cover the value shape that motivated switching away from `--kv` at all.
+    "QUFAKEKEYQAFAKEKEYQAFAKEKEYQAFAKEKEY",
 ]
 
-# The operator's shell is whatever their terminal runs. On this project's
-# machines that is zsh; CI is Linux bash. Both must produce the same service.
-SHELLS = [name for name in ("bash", "zsh", "sh") if shutil.which(name)]
+# The block is fenced ```bash and uses bash/zsh arrays and a herestring, so it
+# is not POSIX sh — and it does not need to be. An operator pastes it into an
+# interactive shell, which on this project's machines is zsh and in CI is bash.
+# Running it under dash (Linux's /bin/sh) fails on `args=(` before reaching
+# anything under test, so `sh` is deliberately not in this list: it would pass
+# on macOS, where /bin/sh is bash, and fail in CI for a reason that is not a
+# defect.
+SHELLS = [name for name in ("bash", "zsh") if shutil.which(name)]
 
 
 def _snippet() -> str:
@@ -222,6 +232,93 @@ def test_railway_managed_and_role_variables_are_not_mirrored(stub, shell):
     assert "PORT" not in names
     assert names.count("CARE_ROLE") == 1
     assert "CARE_ROLE=worker" in _pairs(argv)
+
+
+# --- the snippet must not create a service it could not configure -----------
+
+# Every way `railway variables list` can fail to yield names. In each, the
+# enumeration produces nothing and the operator gets a traceback — but the
+# script keeps going, and `railway add` still runs.
+BROKEN_ENUMERATIONS = {
+    "empty-stdout": ("", 0),
+    "api-error-printed-to-stdout": ("Error: Project not found", 1),
+    "cli-warning-ahead-of-the-json": (
+        'warning: a new CLI version is available\n{"CARE_ENV":"production"}', 0),
+    "payload-is-null": ("null", 0),
+    "nothing-on-stdout-error-on-stderr": ("", 1),
+}
+
+
+def _stub_returning(path, stdout, code):
+    railway = path / "railway"
+    railway.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f"  variables|variable) printf '%s' {stdout!r}; exit {code} ;;\n"
+        '  add) : > "$STUB_ADD_ARGV";'
+        ' for a in "$@"; do printf \'%s\\n\' "$a" >> "$STUB_ADD_ARGV"; done;'
+        ' echo "railway: created service careagents-worker" ;;\n'
+        "  *) exit 1 ;;\n"
+        "esac\n")
+    railway.chmod(0o755)
+    return path
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+@pytest.mark.parametrize("case", list(BROKEN_ENUMERATIONS))
+def test_a_failed_enumeration_does_not_create_a_half_configured_service(
+        tmp_path, shell, case):
+    # The pipeline has no `set -o pipefail`, no exit check, and no count
+    # assertion, so a failed enumeration leaves NAMES empty and falls through
+    # to `railway add` with CARE_ROLE alone. That service is not a crash-loop
+    # an operator can find: with no CARE_ENV, Config() takes the development
+    # path, nothing is _require()d, and the container runs green while claiming
+    # nothing. It is the same silently-broken worker the enumeration rule was
+    # written to prevent, reached by a different route.
+    #
+    # The traceback on stderr is not the safeguard. It scrolls past, `railway
+    # add` prints "created service", and the deploy looks done.
+    stdout, code = BROKEN_ENUMERATIONS[case]
+    stub_dir = _stub_returning(tmp_path, stdout, code)
+    argv_file = tmp_path / "argv"
+    env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}",
+           "STUB_ADD_ARGV": str(argv_file)}
+    subprocess.run([shell, "-c", _snippet()], env=env, capture_output=True,
+                   text=True)
+    if not argv_file.exists():
+        return  # the snippet refused to create the service, which is correct
+    pairs = _pairs(argv_file.read_text().splitlines())
+    pytest.fail(
+        f"{case}: enumeration yielded nothing yet `railway add` still ran and "
+        f"would have created the worker service with {pairs} — guard the "
+        f"pipeline before `railway add`")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_only_well_formed_variable_names_are_forwarded(stub, shell):
+    # The sed the snippet replaced matched `^[A-Za-z_][A-Za-z0-9_]*=` and so
+    # could only ever emit a conforming name. json.load emits every key
+    # verbatim, so that validation is gone: a name holding a space or a brace
+    # flows into `--variables "$name=\${{$WEB.$name}}"` and produces a
+    # reference Railway cannot resolve.
+    _, argv = _run(stub, shell)
+    for name in [p.split("=", 1)[0] for p in _pairs(argv)]:
+        assert re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name), (
+            f"{name!r} is not a shell-safe environment variable name")
+
+
+def test_the_runbook_no_longer_parses_kv_output_for_names():
+    # NEW MEDIUM-2, kept pinned now that the snippet calls --json and nothing
+    # else exercises the stub's --kv branch. --kv prints raw values, and a
+    # multi-line value's continuation line matches a NAME= pattern, so parsing
+    # it turns key material into a variable name and carries it into an argv.
+    # Comments may still explain why --kv is avoided; the commands may not use
+    # it.
+    commands = "\n".join(line for line in _snippet().splitlines()
+                         if not line.lstrip().startswith("#"))
+    assert "--json" in commands
+    assert "--kv" not in commands, (
+        "names must not be parsed out of raw --kv output")
 
 
 def test_the_enumerated_set_satisfies_the_production_config_requirements():

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -30,12 +30,44 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent
 RUNBOOK = REPO / "docs" / "runbooks" / "careagents-durable-worker.md"
 
-# Stands in for `railway variables list --service careagents --kv`: the names
-# the live web service carries, with values shaped like the real secrets so a
-# leak would be visible. `add` records its argv.
+# Stands in for `railway variables list --service careagents`: the names the
+# live web service carries, with values shaped like the real secrets so a leak
+# would be visible. `add` records its argv.
+#
+# It answers both output modes, because the two are not interchangeable and the
+# tests below rely on the difference. `--json` is what the runbook uses: values
+# are JSON-escaped, so a multi-line value stays one entry. `--kv` is the raw
+# form the runbook deliberately stopped parsing — a multi-line value's
+# continuation line matches `NAME=...` and becomes a phantom variable name
+# carrying key material. FASTEN_PUBLIC_KEY below is multi-line for exactly that
+# reason: it is the shape that makes the two modes diverge.
 STUB_RAILWAY = """#!/bin/sh
 case "$1" in
   variables|variable)
+    for a in "$@"; do
+      if [ "$a" = "--json" ]; then
+        cat <<'JSON'
+{"CARE_DATABASE_URL":"postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway",
+ "CARE_EMAIL_FROM":"CareAgents <hello@careagents.cloud>","CARE_ENV":"production",
+ "CARE_IMESSAGE_HANDLE":"+15550100","CARE_MODEL":"claude-sonnet-5",
+ "CARE_OPENAI_MODEL":"gpt-4o-mini","CARE_ORIGIN":"https://careagents.cloud",
+ "CARE_RP_ID":"careagents.cloud","CARE_RP_NAME":"CareAgents",
+ "CARE_SESSION_SECRET":"RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3=",
+ "CARE_TELEGRAM_BOT":"example_bot",
+ "FASTEN_PUBLIC_KEY":"-----BEGIN PUBLIC KEY-----\\\\nQUFAKEKEYQAFAKEKEYQAFAKEKEYQAFAKEKEY=\\\\n-----END PUBLIC KEY-----",
+ "HEALTHCLAW_BASE":"https://app.healthclaw.io",
+ "HEALTHCLAW_MINT_SECRET":"mint_9f3a2b1c8d7e6f5a4b3c2d1e0f9a8b7c",
+ "OPENAI_API_KEY":"sk-proj-QAFAKEKEYQAFAKEKEYQAFAKEKEY",
+ "OPENAI_BASE_URL":"https://api.openai.com/v1",
+ "RESEND_API_KEY":"re_QAFAKE_1234567890abcdef","PORT":"8600",
+ "RAILWAY_PRIVATE_DOMAIN":"careagents.railway.internal",
+ "RAILWAY_PROJECT_NAME":"awake-serenity",
+ "RAILWAY_PUBLIC_DOMAIN":"careagents-production.up.railway.app",
+ "RAILWAY_SERVICE_NAME":"careagents"}
+JSON
+        exit 0
+      fi
+    done
     cat <<'VARS'
 CARE_DATABASE_URL=postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway
 CARE_EMAIL_FROM=CareAgents <hello@careagents.cloud>

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -19,6 +19,7 @@ what would be sent, not that the live service still carries those names.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -292,6 +293,63 @@ def test_a_failed_enumeration_does_not_create_a_half_configured_service(
         f"{case}: enumeration yielded nothing yet `railway add` still ran and "
         f"would have created the worker service with {pairs} — guard the "
         f"pipeline before `railway add`")
+
+
+def _run_against_payload(tmp_path, shell, payload):
+    """Run the snippet with `railway variables list` returning `payload`."""
+    stub_dir = _stub_returning(tmp_path, json.dumps(payload), 0)
+    argv_file = tmp_path / "argv"
+    if argv_file.exists():
+        argv_file.unlink()
+    subprocess.run(
+        [shell, "-c", _snippet()], capture_output=True, text=True,
+        env={**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}",
+             "STUB_ADD_ARGV": str(argv_file)})
+    if not argv_file.exists():
+        return None  # the snippet refused to create the service
+    return [p.split("=", 1)[0] for p in _pairs(argv_file.read_text().splitlines())
+            if p != "CARE_ROLE=worker"]
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_the_service_is_not_created_without_care_env(tmp_path, shell):
+    # CARE_ENV is the keystone, not just another name. Without it Config()
+    # takes the development path (careagents/config.py: `prod = self.app_env ==
+    # "production"`), every _require is skipped, and the worker boots green
+    # while draining nothing — the failure this whole section exists to
+    # prevent. A count threshold cannot see that: fifteen names that happen to
+    # exclude CARE_ENV pass it.
+    payload = {n: "v" for n in EXPECTED_NAMES if n != "CARE_ENV"}
+    forwarded = _run_against_payload(tmp_path, shell, payload)
+    assert forwarded is None or "CARE_ENV" in forwarded, (
+        "the snippet created a worker service with no CARE_ENV; that service "
+        "boots green and claims nothing")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_no_name_is_dropped_without_the_operator_being_told(tmp_path, shell):
+    # The guard counts the names that SURVIVED the filter, so filtering and
+    # enumeration failure are indistinguishable to it. If Railway returns a
+    # name the filter rejects, it vanishes: no error, no warning, and a count
+    # still above the threshold. The worker is then missing a variable nobody
+    # knows about. Every key must be either forwarded or excluded by a rule the
+    # runbook documents — never merely filtered away in silence.
+    documented_exclusions = {"PORT", "CARE_ROLE"}
+    odd = {"MY-VAR": "v", "MY.VAR": "v", "2FA_KEY": "v"}
+    payload = {n: "v" for n in EXPECTED_NAMES}
+    payload.update(odd)
+    payload["RAILWAY_SERVICE_NAME"] = "careagents"
+    payload["PORT"] = "8600"
+    forwarded = _run_against_payload(tmp_path, shell, payload)
+    if forwarded is None:
+        return  # refusing outright is a correct, loud outcome
+    dropped = [k for k in payload
+               if k not in forwarded
+               and k not in documented_exclusions
+               and not k.startswith("RAILWAY_")]
+    assert not dropped, (
+        f"{dropped} were silently dropped from the enumeration: the service "
+        f"was created without them and nothing said so")
 
 
 @pytest.mark.parametrize("shell", SHELLS)

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -1,0 +1,216 @@
+"""The Railway worker snippet in the runbook is a command an operator pastes.
+
+`docs/runbooks/careagents-durable-worker.md` tells whoever creates the worker
+service to enumerate the web service's variables rather than hand-pick them,
+because hand-picking is what produced the crash-loop QA found in review (the
+worker runs the same unconditional `Config()` the web app does, so production
+`_require`s `CARE_SESSION_SECRET` and `RESEND_API_KEY` from a process with no
+sessions that sends no email).
+
+The snippet is executable, so test it as code. These run the block extracted
+from the runbook against a stub `railway` on PATH, under every shell installed,
+and assert on the argv the stub receives: one `--variables` per name, every
+value a literal `${{web.NAME}}` reference, no secret value anywhere.
+
+What they do not prove: no Railway API is called and no service is created. The
+stub's variable list stands in for the live service, so these check the shape of
+what would be sent, not that the live service still carries those names.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+RUNBOOK = REPO / "docs" / "runbooks" / "careagents-durable-worker.md"
+
+# Stands in for `railway variables list --service careagents --kv`: the names
+# the live web service carries, with values shaped like the real secrets so a
+# leak would be visible. `add` records its argv.
+STUB_RAILWAY = """#!/bin/sh
+case "$1" in
+  variables|variable)
+    cat <<'VARS'
+CARE_DATABASE_URL=postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway
+CARE_EMAIL_FROM=CareAgents <hello@careagents.cloud>
+CARE_ENV=production
+CARE_IMESSAGE_HANDLE=+15550100
+CARE_MODEL=claude-sonnet-5
+CARE_OPENAI_MODEL=gpt-4o-mini
+CARE_ORIGIN=https://careagents.cloud
+CARE_RP_ID=careagents.cloud
+CARE_RP_NAME=CareAgents
+CARE_SESSION_SECRET=RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3=
+CARE_TELEGRAM_BOT=example_bot
+FASTEN_PUBLIC_KEY=public_test_ZmFrZWtleWZvcnFhb25seQ==
+HEALTHCLAW_BASE=https://app.healthclaw.io
+HEALTHCLAW_MINT_SECRET=mint_9f3a2b1c8d7e6f5a4b3c2d1e0f9a8b7c
+OPENAI_API_KEY=sk-proj-QAFAKEKEYQAFAKEKEYQAFAKEKEY
+OPENAI_BASE_URL=https://api.openai.com/v1
+RESEND_API_KEY=re_QAFAKE_1234567890abcdef
+PORT=8600
+RAILWAY_PRIVATE_DOMAIN=careagents.railway.internal
+RAILWAY_PROJECT_NAME=awake-serenity
+RAILWAY_PUBLIC_DOMAIN=careagents-production.up.railway.app
+RAILWAY_SERVICE_NAME=careagents
+VARS
+    ;;
+  add)
+    : > "$STUB_ADD_ARGV"
+    for a in "$@"; do printf '%s\\n' "$a" >> "$STUB_ADD_ARGV"; done
+    ;;
+  *) echo "stub: unhandled $*" >&2; exit 1 ;;
+esac
+"""
+
+# Every name the snippet must forward: the stub's list minus RAILWAY_*, PORT
+# and CARE_ROLE. These are exactly the 17 the live web service carries, and
+# they include the two whose absence crash-loops the worker.
+EXPECTED_NAMES = [
+    "CARE_DATABASE_URL", "CARE_EMAIL_FROM", "CARE_ENV", "CARE_IMESSAGE_HANDLE",
+    "CARE_MODEL", "CARE_OPENAI_MODEL", "CARE_ORIGIN", "CARE_RP_ID",
+    "CARE_RP_NAME", "CARE_SESSION_SECRET", "CARE_TELEGRAM_BOT",
+    "FASTEN_PUBLIC_KEY", "HEALTHCLAW_BASE", "HEALTHCLAW_MINT_SECRET",
+    "OPENAI_API_KEY", "OPENAI_BASE_URL", "RESEND_API_KEY",
+]
+
+# Fragments of the stub's values. None may appear in the argv, in stdout, or in
+# stderr: a reference is the whole point, and an argv is world-readable in the
+# process table and lands in shell history.
+SECRET_FRAGMENTS = [
+    "S3cr3tPassw0rd", "RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3",
+    "mint_9f3a2b1c8d7e6f5a4b3c2d1e0f9a8b7c",
+    "sk-proj-QAFAKEKEYQAFAKEKEYQAFAKEKEY", "re_QAFAKE_1234567890abcdef",
+    "ZmFrZWtleWZvcnFhb25seQ",
+]
+
+# The operator's shell is whatever their terminal runs. On this project's
+# machines that is zsh; CI is Linux bash. Both must produce the same service.
+SHELLS = [name for name in ("bash", "zsh", "sh") if shutil.which(name)]
+
+
+def _snippet() -> str:
+    """The fenced block in the runbook that creates the worker service."""
+    blocks = re.findall(r"```bash\n(.*?)```", RUNBOOK.read_text(), re.S)
+    matching = [b for b in blocks if "railway add" in b]
+    assert len(matching) == 1, (
+        f"expected exactly one worker-creation snippet, found {len(matching)}")
+    return matching[0]
+
+
+@pytest.fixture(scope="module")
+def stub(tmp_path_factory):
+    path = tmp_path_factory.mktemp("railway-stub")
+    railway = path / "railway"
+    railway.write_text(STUB_RAILWAY)
+    railway.chmod(0o755)
+    return path
+
+
+def _run(stub, shell):
+    argv_file = stub / f"argv-{shell}"
+    if argv_file.exists():
+        argv_file.unlink()
+    env = {**os.environ, "PATH": f"{stub}:{os.environ['PATH']}",
+           "STUB_ADD_ARGV": str(argv_file)}
+    result = subprocess.run([shell, "-c", _snippet()], env=env,
+                            capture_output=True, text=True)
+    argv = argv_file.read_text().splitlines() if argv_file.exists() else []
+    return result, argv
+
+
+def _pairs(argv):
+    """The KEY=VALUE arguments that followed each --variables flag."""
+    return [argv[i + 1] for i, a in enumerate(argv)
+            if a == "--variables" and i + 1 < len(argv)]
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_the_snippet_forwards_every_variable_as_its_own_flag(stub, shell):
+    # The failure this pins is not a crash. zsh does not word-split unquoted
+    # parameter expansions, so `for name in $NAMES` iterates once over the whole
+    # newline-joined list and the loop emits ONE malformed --variables holding
+    # every name at once. `railway add` then creates a worker with CARE_ROLE and
+    # one garbage variable: CARE_ENV is unset, so Config() takes the development
+    # path, raises nothing, and the container runs green while claiming nothing.
+    # The runbook's own troubleshooting step — look for a ConfigError — finds
+    # none.
+    result, argv = _run(stub, shell)
+    assert result.returncode == 0, result.stderr
+    pairs = _pairs(argv)
+    assert "CARE_ROLE=worker" in pairs
+    names = [p.split("=", 1)[0] for p in pairs if p != "CARE_ROLE=worker"]
+    assert names == EXPECTED_NAMES, (
+        f"under {shell} the snippet sent {len(names)} variable(s) instead of "
+        f"{len(EXPECTED_NAMES)}")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_the_snippet_sends_references_not_values(stub, shell):
+    result, argv = _run(stub, shell)
+    for pair in _pairs(argv):
+        if pair == "CARE_ROLE=worker":
+            continue
+        assert "=" in pair, (
+            f"under {shell} the snippet sent a --variables argument that is "
+            f"not a KEY=VALUE pair: {pair!r}")
+        name, value = pair.split("=", 1)
+        assert value == "${{careagents.%s}}" % name, (
+            f"{name} was not sent as a Railway reference: {value!r}")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_no_secret_value_reaches_the_argv_or_the_terminal(stub, shell):
+    # `railway variables list --kv` prints raw values by design. They must stay
+    # inside the pipe: an argv is readable from the process table and is written
+    # to shell history, and stdout/stderr land in a terminal scrollback or a CI
+    # log.
+    result, argv = _run(stub, shell)
+    haystack = "\n".join(argv) + result.stdout + result.stderr
+    for fragment in SECRET_FRAGMENTS:
+        assert fragment not in haystack, (
+            f"a secret value escaped under {shell}: {fragment!r}")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_railway_managed_and_role_variables_are_not_mirrored(stub, shell):
+    # RAILWAY_* are injected per service and PORT is assigned per service, so
+    # mirroring either points the worker at the web service's identity.
+    # CARE_ROLE must come from the explicit `CARE_ROLE=worker`, never the web
+    # service's `web`.
+    _, argv = _run(stub, shell)
+    names = [p.split("=", 1)[0] for p in _pairs(argv)]
+    assert not [n for n in names if n.startswith("RAILWAY_")]
+    assert "PORT" not in names
+    assert names.count("CARE_ROLE") == 1
+    assert "CARE_ROLE=worker" in _pairs(argv)
+
+
+def test_the_enumerated_set_satisfies_the_production_config_requirements():
+    # The defect that motivated the snippet: careagents/worker.py builds the
+    # same Config() the web app does, so production refuses to boot without
+    # these. Whatever the snippet forwards has to cover them.
+    required = {"CARE_SESSION_SECRET", "HEALTHCLAW_MINT_SECRET",
+                "RESEND_API_KEY"}
+    assert required <= set(EXPECTED_NAMES)
+    assert {"OPENAI_API_KEY", "ANTHROPIC_API_KEY"} & set(EXPECTED_NAMES), (
+        "the worker needs an LLM credential or every run fails at inference")
+    config = (REPO / "careagents" / "config.py").read_text()
+    for name in required:
+        assert f'_require("{name}"' in config, (
+            f"{name} is no longer required — re-check what the worker needs")
+
+
+def test_the_runbook_does_not_send_the_operator_back_to_a_repo_build():
+    # A repo-connected build picks up the repo-root railway.toml, hence the
+    # repo-root Dockerfile, which is the HealthClaw Flask app.
+    railway_section = RUNBOOK.read_text().split("## Railway", 1)[1]
+    assert "Do not create the service from the GitHub repo" in railway_section
+    assert "railway.toml" in railway_section
+    assert "--repo" not in railway_section

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -394,6 +394,32 @@ def test_the_enumerated_set_satisfies_the_production_config_requirements():
             f"{name} is no longer required — re-check what the worker needs")
 
 
+def test_the_snippets_required_set_tracks_every_require_in_config_py():
+    # The snippet names what the worker cannot boot without. That list is a
+    # second source of truth for careagents/config.py, and a second source of
+    # truth is what this repo keeps getting burned by. Nothing about adding a
+    # `_require` to config.py makes the runbook follow it, and the symptom
+    # would be the familiar one: the enumeration passes, the service is
+    # created, and the worker crash-loops on a variable the runbook never
+    # mentioned.
+    #
+    # So derive the expectation from config.py rather than restating it.
+    config = (REPO / "careagents" / "config.py").read_text()
+    required = set(re.findall(r'_require\(\s*"([A-Z_]+)"', config))
+    assert required, "no _require() calls found — has config.py moved?"
+    snippet = _snippet()
+    for name in sorted(required):
+        assert name in snippet, (
+            f"careagents/config.py _require()s {name} in production, but the "
+            f"runbook's enumeration guard does not check for it — a worker "
+            f"missing it would be created and then crash-loop")
+    # CARE_ENV is not _require()d; it is the switch that decides whether any
+    # _require runs at all (config.py: prod = app_env == "production"), which
+    # is why its absence produces a green worker rather than a crash. It has to
+    # be checked even though the regex above cannot find it.
+    assert "CARE_ENV" in snippet
+
+
 def test_the_runbook_does_not_send_the_operator_back_to_a_repo_build():
     # A repo-connected build picks up the repo-root railway.toml, hence the
     # repo-root Dockerfile, which is the HealthClaw Flask app.


### PR DESCRIPTION
Closes #273.

## Found by deploying, not by reading

CareAgents was deployed to Railway at `f71d46ef9205` — the first deploy carrying a build marker (#258). It came up **503**:

```
{"accounts":true,"build":"f71d46ef9205","run_workers":false,"status":"degraded"}
```

Landing and `/auth` render, but chat returns `run_workers_unavailable`. That is the durable-run design working as intended (two process roles; readiness fails closed with no fresh worker presence, #256/#257). The defect: `deploy/careagents/Dockerfile` **claimed** to support both roles while `CMD` was hardcoded to gunicorn and nothing read `CARE_ROLE`. The VPS path was unaffected — it uses systemd units, not the image — so only the container path was broken, and the container path is the declared target. `railway add` has no start-command option, so a worker service could not even be created while the image ignored the variable.

## The change

`CMD` dispatches: `web` (default) runs the existing gunicorn command **byte-for-byte unchanged**, `worker` runs `python -m careagents.worker`, anything else exits non-zero rather than quietly starting a second web server. Plus the Railway section the runbook lacked — it documented systemd only, the same "documented for one path" gap that produced #258.

**`exec` is load-bearing, not cosmetic.** `worker.py` installs SIGTERM handlers and joins *non-daemon* threads, so without it `sh` stays PID 1, never forwards the signal, and every redeploy ends in SIGKILL with run leases held. Measured in a real container: `docker stop -t 30` returns in **0.21s exit 0** with `exec`, versus the **full 30.2s and exit 137** without.

## Five QA rounds, four of them failures

The Dockerfile has been correct since the first commit. **Every subsequent round found a defect in the deploy instructions**, and all of them were the same species — *silent green*: a failure that produces a healthy-looking service, a 503, and no `ConfigError` for the runbook's own troubleshooting step to find.

1. The variable table omitted `CARE_SESSION_SECRET` and `RESEND_API_KEY` — the worker runs the same unconditional `Config()`, so it needs both despite having no sessions and sending no email. Crash-loop, reproduced twice against the built image.
2. "Same repo, same Dockerfile path" would have built **the HealthClaw Flask app** — repo-connected builds pick up repo-root `railway.toml`, and repo-root `Dockerfile` is `gunicorn main:app`, complete with `preDeployCommand` migrations and demo seeding.
3. `for name in $NAMES` collapses to **one iteration under zsh** (this project's shell), sending all 17 names as a single malformed argument. `CARE_ENV` never arrives, `Config()` takes the development path, and the worker boots green draining nothing. CI can't catch it — no zsh on ubuntu-latest — so it is pinned by tests that stay green in CI and go red on an operator's machine.
4. The pipeline had **no guard at all**: any enumeration failure still ran `railway add`. I hit this myself with a malformed stub and recorded it as "a good failure mode." It wasn't — I only saw the traceback because I was watching; in a real run it scrolls past and "created service" prints underneath.
5. My guard then measured **quantity where the property is identity**: fifteen names omitting `CARE_ENV` passed `-ge 15`, and a legitimate cleanup to fourteen would have blocked a correct deploy, whereupon the fix is to edit the number — which is how guards get deleted.

Now: two invariants, neither a number. The enumeration must carry what `careagents/config.py` actually requires — derived by parsing `_require(` out of `config.py`, so adding one fails the test until the runbook follows — and it must drop nothing silently. `railway up "$STAGE"` was also replaced with `cd "$STAGE" && railway up`, the form that actually deployed this service; the other roots the archive at the project directory and applies `.gitignore`, which lists `careagents/BUILD_SHA`.

## Verification

QA built and ran the real image rather than reasoning about it: CMD byte-identical to `f71d46e`, `CARE_ROLE=worker` at PID 1, the staged recipe producing the CareAgents image with the right `BUILD_SHA`, and **32 hostile `CARE_ROLE` values** (globs, Cyrillic and fullwidth homoglyphs, NBSP, embedded newlines, `$(...)`, backticks, a 60 kB string) across three shells, all exiting 2 launching nothing, with a canary proving no re-expansion.

Final mutation sweep: **27 mutants, both shells, zero survivors.**

```
1847 passed, 6 skipped, 2 xfailed
ruff: All checks passed!
```

## Known limits

- **No Railway API was called in any round** — every invocation was `--help` or a stub. Whether `${{careagents.NAME}}` resolves as documented, and whether Railway permits `MY-VAR`-style names at all, rest on the maintainer's platform access, not on tests. I separately verified the live service carries 17 app variables and sets no `healthcheckPath`, `startCommand` or `builder`.
- `railway up` was never executed in either form; the `cd`-into-stage rationale comes from the CLI's `--path-as-root`/`--no-gitignore` flags plus `.gitignore:15`, not an observed failed upload.
- Images were built **arm64**; Railway runs amd64.
- `docker-compose.yml` overrides `CMD`, so the one local runner of both roles bypasses the dispatch — filed as #276 rather than changed here.

## After merge

I create `careagents-worker` from this runbook and redeploy both services from one stage. That is the gate for the DNS cutover (#264) and the webinar demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)