### PR TITLE
fix(runbook): railway link is per-directory — link inside the stage before uploading

### DIFF
--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -242,15 +242,26 @@ the upload, leaving a deployment that reports `build: unknown` and alarms as
 stale forever. `cd`-then-`up` is the form that has actually been used to deploy
 this service.
 
+**`railway link` is per-directory, so you must link again inside the stage.**
+The earlier link applied to the repo root. `railway up` in an unlinked
+directory does not fail — it **creates a brand-new project** named after the
+directory and deploys there, printing a cheerful `✓ Project tmp.XXXXXXXX`.
+Your real services are untouched, the deploy you think you shipped is running
+somewhere nobody looks, and the only clue is a project name you did not choose.
+This happened on the first run of this runbook.
+
 ```bash
-cd "$STAGE" && railway up --service careagents-worker --detach
+cd "$STAGE"
+railway link --project <project-id> --service careagents-worker --environment production
+railway up --service careagents-worker --detach
 ```
 
-You linked the project before creating the service, and `--service` on each
-`railway up` picks the target, so no second `railway link` is needed.
+Sanity-check before you upload: `railway status` from inside `$STAGE` must name
+your real project. If it names anything else, stop — do not `railway up`.
 
 One stage serves both roles. Upload it twice — once per service — and the two
-report the same `build`:
+report the same `build`. You are already linked to the project from the step
+above, so `--service` alone picks the target:
 
 ```bash
 cd "$STAGE"


### PR DESCRIPTION
Found by running the #273 runbook for real — the first live use of it.

## What happened

Ran the worker-creation block, then `cd "$STAGE" && railway up --service careagents-worker --detach`. It printed `✓ Project tmp.wUDFPKCGUF` and a build-logs link — success, by every visible signal.

`railway link` is **per-directory**. The runbook linked from the repo root; the stage was never linked. `railway up` in an unlinked directory does not fail — it silently creates a brand-new project named after the directory and deploys there. `awake-serenity` was untouched; the real deploy never happened.

Caught only because the returned project name (`tmp.wUDFPKCGUF`) didn't match anything I'd choose. Deleted the stray project by hand (it needs interactive confirmation `railway delete` didn't accept non-interactively — flagged separately below).

## Fix

Link **inside** the stage before the first upload, and add a sanity check: `railway status` from inside `$STAGE` must name the real project before `railway up` runs.

Re-ran end to end after the fix: worker service created correctly this time, both services deployed from one stage, `/healthz` reports `run_workers: true` with both carrying `build: 9493be302a25`, and `prod_watch.py --expect-sha` passes **10/10** — the first time the fully-green asserted build-check path has been proven against a real deployment rather than a fake.

## The pattern, named for the record

This is the same defect class every round of #273's review found: a command that reports success and does something else entirely. Five QA rounds closed it in the enumeration snippet; this is the same shape in the deploy command, and it only surfaces by actually running the thing — no test in `tests/test_careagents_runbook_railway_qa.py` could have caught it, since none of them touch the real Railway CLI's project-linking behavior.

## Not fixed here

`railway delete --yes` still prompted for interactive project selection despite `--project <id>` being passed, so the stray project could not be cleaned up non-interactively. Filing that as a follow-up rather than guessing at a fix without confirming the flag's actual contract.

```
28 passed (runbook tests)
ruff: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)