### PR TITLE
feat(careagents): real record counts on first chat visit

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -390,13 +390,31 @@ def create_app(config: Config | None = None,
         conversation_id = hc.conversation_id(agent_id)
         # Show the conversation they actually had. Rendering only the canned
         # greeting made every return visit look like a first visit.
+        past = hc.recent_messages(
+            ctx["tenant"], limit=30,
+            conversation_id=conversation_id,
+            agent_id=agent_id,
+        )
+        summary_counts = None
+        if not past:
+            # First visit: show real record counts so the user immediately sees
+            # the product's value rather than a generic prompt.
+            try:
+                conditions = hc.search(ctx["tenant"], "Condition")
+                medications = hc.search(ctx["tenant"], "MedicationRequest")
+                observations = hc.search(ctx["tenant"], "Observation")
+                summary_counts = {
+                    "conditions": len(conditions.get("entry", [])),
+                    "medications": len(medications.get("entry", [])),
+                    "labs": len(observations.get("entry", [])),
+                }
+            except HealthClawError:
+                pass  # fall back to generic greeting on any error
         return render_template("chat.html", me=ctx["agent"], persona=p,
                                agent_id=agent_id,
                                conversation_id=conversation_id,
-                               past=hc.recent_messages(
-                                   ctx["tenant"], limit=30,
-                                   conversation_id=conversation_id,
-                                   agent_id=agent_id))
+                               past=past,
+                               summary_counts=summary_counts)
 
     # --- chat API (SSE), scoped to the account's agent -----------------------
 

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -31,29 +31,29 @@
     {# First visit with connected records: show real counts so the user sees
        immediate value rather than a generic capabilities list. #}
     <div class="msg agent">
-      <p>Hi — I’m {{ me.name }}. I found
-      <strong>{{ summary_counts.conditions }} condition{{ ‘s’ if summary_counts.conditions != 1 else ‘’ }}</strong>,
-      <strong>{{ summary_counts.medications }} medication{{ ‘s’ if summary_counts.medications != 1 else ‘’ }}</strong>,
-      and <strong>{{ summary_counts.labs }} lab result{{ ‘s’ if summary_counts.labs != 1 else ‘’ }}</strong>
+      <p>Hi — I'm {{ me.name }}. I found
+      <strong>{{ summary_counts.conditions }} condition{{ 's' if summary_counts.conditions != 1 else '' }}</strong>,
+      <strong>{{ summary_counts.medications }} medication{{ 's' if summary_counts.medications != 1 else '' }}</strong>,
+      and <strong>{{ summary_counts.labs }} lab result{{ 's' if summary_counts.labs != 1 else '' }}</strong>
       in your records. Want me to walk through what they show?</p>
     </div>
     <div class="starters" id="starters">
       <button type="button" class="starter">What do my labs say?</button>
-      <button type="button" class="starter">Any screenings I’m due for?</button>
+      <button type="button" class="starter">Any screenings I'm due for?</button>
       <button type="button" class="starter">What medications am I on?</button>
       <button type="button" class="starter">Fill out my intake form for a new doctor</button>
     </div>
     {% else %}
     <div class="msg agent">
-      <p>Hi — I’m {{ me.name }}. I can read the health records in this space,
+      <p>Hi — I'm {{ me.name }}. I can read the health records in this space,
       explain labs in plain language, check what preventive care is due, and
-      fill out your new-patient intake form — though you’ll approve every line
+      fill out your new-patient intake form — though you'll approve every line
       of that yourself.</p>
       <p>What would you like to know?</p>
     </div>
     <div class="starters" id="starters">
       <button type="button" class="starter">What do my labs say?</button>
-      <button type="button" class="starter">Any screenings I’m due for?</button>
+      <button type="button" class="starter">Any screenings I'm due for?</button>
       <button type="button" class="starter">What medications am I on?</button>
       <button type="button" class="starter">Fill out my intake form for a new doctor</button>
     </div>

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -27,6 +27,22 @@
       <p>{{ m.content }}</p>
     </div>
     {% endfor %}
+    {% elif summary_counts %}
+    {# First visit with connected records: show real counts so the user sees
+       immediate value rather than a generic capabilities list. #}
+    <div class="msg agent">
+      <p>Hi — I’m {{ me.name }}. I found
+      <strong>{{ summary_counts.conditions }} condition{{ ‘s’ if summary_counts.conditions != 1 else ‘’ }}</strong>,
+      <strong>{{ summary_counts.medications }} medication{{ ‘s’ if summary_counts.medications != 1 else ‘’ }}</strong>,
+      and <strong>{{ summary_counts.labs }} lab result{{ ‘s’ if summary_counts.labs != 1 else ‘’ }}</strong>
+      in your records. Want me to walk through what they show?</p>
+    </div>
+    <div class="starters" id="starters">
+      <button type="button" class="starter">What do my labs say?</button>
+      <button type="button" class="starter">Any screenings I’m due for?</button>
+      <button type="button" class="starter">What medications am I on?</button>
+      <button type="button" class="starter">Fill out my intake form for a new doctor</button>
+    </div>
     {% else %}
     <div class="msg agent">
       <p>Hi — I’m {{ me.name }}. I can read the health records in this space,


### PR DESCRIPTION
Replace hardcoded greeting with actual record counts on first chat visit. Shows 'I found N conditions, M medications, L labs' on first visit with connected records. Falls back to generic greeting when records unavailable or queries fail. Non-gated Phase 1 item for Aug 31 demo.