### PR TITLE
fix(guardrails): close two live vulnerabilities in the direct-upload path (#267 review)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -335,6 +335,19 @@ def create_app(config: Config | None = None,
                             "message": "This connection does not accept file "
                                        "uploads. Create an 'Upload records' "
                                        "connection to import a FHIR bundle."}), 400
+        # Revocation was enforced only in the template (home.html hides the
+        # upload button once status == "revoked"), so a revoked connection
+        # still accepted uploads on a direct/crafted request — defeating the
+        # disconnect guarantee ("stop new data flowing", accounts.py). A
+        # `direct` connection's normal lifecycle is "empty" (created, no
+        # file yet) -> "active" (after the first successful upload), so the
+        # check must exclude "revoked" specifically rather than require
+        # "active" — requiring "active" would refuse every first upload.
+        if conn["status"] == "revoked":
+            return jsonify({"error": "connection_not_active",
+                            "status": conn["status"],
+                            "message": "This connection has been disconnected "
+                                       "and no longer accepts uploads."}), 409
 
         # Header short-circuit for callers that DO set Content-Length, but
         # never trusted alone — the stream read below is the real bound.
@@ -364,6 +377,17 @@ def create_app(config: Config | None = None,
 
         try:
             bundle = json.loads(raw.decode("utf-8")) if raw else {}
+        except RecursionError:
+            # Same crash lever as the engine's ingest-bundle endpoint
+            # (#267 review): CPython's JSON scanner recurses per nesting
+            # level, and a payload well under _UPLOAD_MAX_BYTES can nest
+            # deep enough to raise RecursionError, which is not a
+            # ValueError and was previously unhandled -> 500. This route
+            # already sits behind @login_required, so the engine-side fix
+            # (moving auth before parse) doesn't apply here; this is purely
+            # the crash fix.
+            return jsonify({"error": "invalid_json",
+                            "message": "nesting too deep to parse"}), 400
         except (ValueError, UnicodeDecodeError):
             return jsonify({"error": "invalid_json"}), 400
         if not isinstance(bundle, dict):

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -102,13 +102,22 @@ class HealthClawClient:
         # envelope call, NOT a raw FHIR Bundle post. `application/fhir+json`
         # would mis-label the envelope; the patient-facing route above
         # accepts fhir+json for the raw Bundle from the browser.
-        r = self.http.post(
-            f"{self.fhir}/internal/ingest-bundle",
-            json={"bundle": bundle},
-            headers={"X-Tenant-Id": tenant,
-                     "X-Internal-Secret": self.mint_secret,
-                     "Content-Type": "application/json"},
-            timeout=self.timeout)
+        try:
+            r = self.http.post(
+                f"{self.fhir}/internal/ingest-bundle",
+                json={"bundle": bundle},
+                headers={"X-Tenant-Id": tenant,
+                        "X-Internal-Secret": self.mint_secret,
+                        "Content-Type": "application/json"},
+                timeout=self.timeout)
+        except requests.RequestException as exc:
+            # A transport-level failure (connection refused, timeout) was
+            # previously unwrapped here, propagating out of
+            # upload_connection as an unhandled Flask 500 and breaking the
+            # JSON error contract the UI depends on (#267 review). Every
+            # other engine call in this file wraps requests.RequestException
+            # into HealthClawError; this one didn't.
+            raise HealthClawError("ingest failed", 0) from exc
         try:
             body = r.json()
         except ValueError:

--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -31,14 +31,25 @@ logger = logging.getLogger(__name__)
 _PROGRESS_BATCH = 10  # commit progress every N resources (observability)
 _DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0)
 
-# FHIR id: [A-Za-z0-9\-\.]{1,64} per the spec. A caller-supplied id outside
-# this shape was previously stored verbatim and copied into
+# The CHARSET is the security control here, not the length. A caller-supplied
+# id outside this shape was previously stored verbatim and copied into
 # AuditEventRecord.resource_id (#267 review) — audit `detail` stays PHI-free
-# by convention, but that convention did nothing for the adjacent column,
-# and health_compliance.py exports resource_id into the auditor-facing
-# compliance bundle. Validated before use, not filtered — an id this fails
-# is refused per-entry rather than silently truncated or replaced.
-_RESOURCE_ID_PATTERN = re.compile(r'^[A-Za-z0-9\-\.]{1,64}$')
+# by convention, but that convention did nothing for the adjacent column, and
+# health_compliance.py exports resource_id into the auditor-facing compliance
+# bundle. An id restricted to [A-Za-z0-9-.] cannot carry a name, a date, a
+# path, or markup, which is what that finding was about.
+#
+# The ceiling is 255 (R6Resource.id / AuditEventRecord.resource_id are both
+# String(255)), NOT the FHIR spec's 64. Real Epic exports routinely violate
+# the spec limit — the 2026-07-08 live incident documented in
+# tests/test_ingest_resilience.py had 65/250 ids over 64 chars, running to
+# ~109, and is exactly why that column was widened rather than truncated.
+# Capping at 64 here would silently re-impose the ceiling that incident
+# forced us off, as `invalid_id` skips on the live Fasten connector rather
+# than a crash — which is worse, because nothing would page. Validated
+# before use, not filtered: a failing id is refused per-entry, never
+# truncated or replaced.
+_RESOURCE_ID_PATTERN = re.compile(r'^[A-Za-z0-9\-\.]{1,255}$')
 
 
 def _is_fasten_download_host(url: str) -> bool:

--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -15,6 +15,7 @@ Design:
 import json
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from urllib.parse import urlparse
@@ -29,6 +30,15 @@ logger = logging.getLogger(__name__)
 
 _PROGRESS_BATCH = 10  # commit progress every N resources (observability)
 _DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0)
+
+# FHIR id: [A-Za-z0-9\-\.]{1,64} per the spec. A caller-supplied id outside
+# this shape was previously stored verbatim and copied into
+# AuditEventRecord.resource_id (#267 review) — audit `detail` stays PHI-free
+# by convention, but that convention did nothing for the adjacent column,
+# and health_compliance.py exports resource_id into the auditor-facing
+# compliance bundle. Validated before use, not filtered — an id this fails
+# is refused per-entry rather than silently truncated or replaced.
+_RESOURCE_ID_PATTERN = re.compile(r'^[A-Za-z0-9\-\.]{1,64}$')
 
 
 def _is_fasten_download_host(url: str) -> bool:
@@ -228,25 +238,44 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
 
 def _ingest_one(resource: dict, tenant_id: str,
                 agent_id: str = 'fasten-connect',
-                detail: str = 'Ingested via Fasten EHI export'
+                detail: str = 'Ingested via Fasten EHI export',
+                allowed_types: frozenset | None = None,
                 ) -> tuple[str, str | None]:
     """
     Ingest a single FHIR resource into the guardrails store.
 
-    Returns ('ok', resource_id) on success, ('skipped', None) for unsupported types.
+    Returns ('ok', resource_id) on success, ('skipped', None) for unsupported
+    types, ('forbidden', None) for a type excluded by `allowed_types`, or
+    ('invalid_id', None) for a caller-supplied id outside the FHIR id shape.
     Raises on unexpected DB errors.
 
     `agent_id` and `detail` parameterize the audit event so a caller other
     than Fasten (e.g. the #227 direct-upload path) records honest provenance
     rather than borrowing Fasten's. Defaults preserve prior behavior for the
     Fasten and SHC callers.
+
+    `allowed_types`, when given, is an additional allowlist checked AFTER
+    `is_supported_type` — it narrows, never widens. `None` preserves prior
+    behavior exactly (every supported type is ingestible), which is what the
+    Fasten/SHC callers still want; the direct-upload path (#227) passes an
+    explicit clinical-only set so an unauthenticated-adjacent caller cannot
+    author AuditEvent/Permission/Consent/Provenance/Bundle resources even
+    though the store technically supports storing them.
     """
     resource_type = resource.get('resourceType', '')
 
     if not resource_type or not R6Resource.is_supported_type(resource_type):
         return 'skipped', None
+    if allowed_types is not None and resource_type not in allowed_types:
+        return 'forbidden', None
 
-    resource_id = resource.get('id') or str(uuid.uuid4())
+    resource_id = resource.get('id')
+    if resource_id is not None:
+        resource_id = str(resource_id)
+        if not _RESOURCE_ID_PATTERN.fullmatch(resource_id):
+            return 'invalid_id', None
+    else:
+        resource_id = str(uuid.uuid4())
     resource_json = json.dumps(resource, separators=(',', ':'))
 
     # Identity is (tenant_id, resource_type, id) — composite PK. The same

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -1992,6 +1992,68 @@ def _internal_mint_authorized(tenant_id):
     return resolve_app_env() != 'production'
 
 
+def _internal_ingest_authorized(tenant_id):
+    """Fail-closed authorization for internal FHIR-bundle ingestion (#267).
+
+    Deliberately NOT `_internal_mint_authorized`. That helper exempts public
+    tenants because minting a token for a public tenant grants nothing extra
+    — they already bypass read-auth by design. Ingestion is different: it
+    lets the caller choose what the tenant's records SAY. For `desktop-demo`
+    that means an unauthenticated caller could author content that lands in
+    an LLM context (stored prompt injection) and forge resource types the
+    caller should never be able to write — the reason `_ingest_one` below
+    also gets an explicit type allowlist. So every tenant, public or not,
+    requires a matching `X-Internal-Secret`. Fail-closed: if
+    `INTERNAL_TOKEN_MINT_SECRET` is unset, ingestion is refused in production
+    and allowed only outside production (backward compatible locally).
+    """
+    mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
+    if mint_secret:
+        provided = request.headers.get('X-Internal-Secret', '')
+        return hmac.compare_digest(provided, mint_secret)
+    return resolve_app_env() != 'production'
+
+
+# Resource types the direct-upload path (#227) may never author, regardless
+# of what the caller's bundle claims. AuditEvent is system-managed elsewhere
+# in this file (_SYSTEM_MANAGED_TYPES); the rest are trust/provenance/
+# envelope types whose presence in an uploaded bundle is either meaningless
+# (Bundle-in-Bundle) or actively dangerous (a forged Consent or Provenance
+# record, or a Permission grant) if a caller could author them directly.
+_INGEST_BUNDLE_FORBIDDEN_TYPES = frozenset(
+    {'AuditEvent', 'Permission', 'Consent', 'Provenance', 'Bundle'})
+
+# Computed, not hand-maintained: everything R6Resource supports, minus the
+# forbidden set above. A new SUPPORTED_TYPES entry is allowed by default
+# (matching current ingest semantics for Fasten/SHC) unless it is added to
+# the forbidden set explicitly — the forbidden list is the one that has to
+# stay intentional, not this one.
+_INGEST_BUNDLE_ALLOWED_TYPES = frozenset(
+    set(R6Resource.SUPPORTED_TYPES) - _INGEST_BUNDLE_FORBIDDEN_TYPES)
+
+
+_INGEST_MAX_JSON_DEPTH = 32
+
+
+def _json_depth_within(obj, limit, _depth=0):
+    """Bounded depth check, not a recursion-limit workaround.
+
+    Refuses at `limit` (32) regardless of Python's actual recursion ceiling
+    (typically ~1000), so a hostile payload is rejected long before it can
+    exhaust the stack — this walker itself never recurses past limit+1
+    levels. FHIR resources do not nest anywhere close to 32 levels deep in
+    practice; this is headroom, not a tight bound.
+    """
+    if _depth > limit:
+        return False
+    if isinstance(obj, dict):
+        return all(_json_depth_within(v, limit, _depth + 1)
+                  for v in obj.values())
+    if isinstance(obj, list):
+        return all(_json_depth_within(v, limit, _depth + 1) for v in obj)
+    return True
+
+
 @r6_blueprint.route('/internal/step-up-token', methods=['POST'])
 def issue_step_up_token():
     """
@@ -2232,8 +2294,10 @@ def ingest_bundle():
     but had no server-side path — this is that path. It reuses `_ingest_one`
     (the same code path Fasten/SHC take, with parameterized provenance so
     the audit event honestly records `direct-upload` rather than borrowing
-    Fasten's), is gated exactly like seed/purge (fail-closed via
-    `_internal_mint_authorized`), and is deliberately synchronous so a
+    Fasten's), is gated fail-closed via `_internal_ingest_authorized` —
+    unlike seed/purge, the public-tenant exemption does NOT apply here,
+    because authoring content is a different risk than minting a token (see
+    that function's docstring) — and is deliberately synchronous so a
     patient watching an upload sees an honest per-entry result.
 
     Request contract:
@@ -2241,7 +2305,8 @@ def ingest_bundle():
         the ONLY tenant selector; a `tenant_id` in the JSON body is rejected
         as a legacy selector rather than silently honored (an attacker who
         can influence the body could otherwise redirect the write).
-      - Header `X-Internal-Secret`: required for non-public tenants.
+      - Header `X-Internal-Secret`: required unconditionally (no
+        public-tenant exemption — see `_internal_ingest_authorized`).
       - Header `Content-Type`: `application/json` (charset optional). The
         body is an envelope carrying a Bundle, NOT a raw FHIR resource,
         so `application/fhir+json` is refused here. The patient-facing
@@ -2268,6 +2333,20 @@ def ingest_bundle():
     """
     max_bytes, max_entries = _ingest_bundle_limits()
 
+    # Auth gate FIRST — before content-type sniffing, before the body is
+    # read, before anything is parsed. #267's review found the body read and
+    # JSON parse both happened before this check, so a deeply-nested payload
+    # could crash the worker (RecursionError, uncaught) with NO credentials
+    # at all, against ANY tenant. Tenant selection needs only the header, so
+    # nothing below this point requires touching the request body.
+    tenant_id = request.headers.get('X-Tenant-Id', '').strip()
+    if not tenant_id:
+        return jsonify({'error': 'tenant_id is required'}), 400
+    if not _TENANT_ID_PATTERN.fullmatch(tenant_id):
+        return jsonify({'error': 'invalid tenant_id format'}), 400
+    if not _internal_ingest_authorized(tenant_id):
+        return jsonify({'error': 'forbidden'}), 403
+
     ct_raw = (request.content_type or '').split(';', 1)[0].strip().lower()
     if ct_raw not in _INGEST_BUNDLE_MIME_TYPES:
         return jsonify({'error': 'content_type_required',
@@ -2281,11 +2360,27 @@ def ingest_bundle():
 
     try:
         body = json.loads(raw.decode('utf-8')) if raw else {}
+    except RecursionError:
+        # CPython's JSON array/object scanner recurses per nesting level.
+        # A 120KB payload nested ~60,000 deep reproduces this with no size
+        # cap anywhere near triggering — the byte cap below is irrelevant to
+        # this crash lever. Caught explicitly because RecursionError is not
+        # a ValueError and was previously unhandled -> 500.
+        return jsonify({'error': 'invalid_json',
+                        'message': 'nesting too deep to parse'}), 400
     except (ValueError, UnicodeDecodeError):
         return jsonify({'error': 'invalid_json'}), 400
     if not isinstance(body, dict):
         return jsonify({'error': 'invalid_json',
                         'message': 'body must be a JSON object'}), 400
+    if not _json_depth_within(body, _INGEST_MAX_JSON_DEPTH):
+        # Defense in depth beyond the RecursionError catch above: a payload
+        # that parses successfully (recursion limit not hit) but is still
+        # absurdly nested can cause problems downstream — audit-event
+        # construction, redaction, re-serialization. Refuse it here rather
+        # than trust every later consumer to be equally careful.
+        return jsonify({'error': 'bundle_too_deep',
+                        'max_depth': _INGEST_MAX_JSON_DEPTH}), 400
 
     # Header is the ONLY tenant selector — any body `tenant_id` is a legacy
     # client-controlled selector and is refused rather than treated as
@@ -2295,14 +2390,6 @@ def ingest_bundle():
         return jsonify({'error': 'legacy_body_selector',
                         'message': 'Tenant is derived from X-Tenant-Id only; '
                                    'remove "tenant_id" from the body.'}), 400
-    tenant_id = request.headers.get('X-Tenant-Id', '').strip()
-    if not tenant_id:
-        return jsonify({'error': 'tenant_id is required'}), 400
-    if not _TENANT_ID_PATTERN.fullmatch(tenant_id):
-        return jsonify({'error': 'invalid tenant_id format'}), 400
-
-    if not _internal_mint_authorized(tenant_id):
-        return jsonify({'error': 'forbidden'}), 403
 
     bundle = body.get('bundle')
     if not isinstance(bundle, dict) or bundle.get('resourceType') != 'Bundle':
@@ -2346,7 +2433,8 @@ def ingest_bundle():
                 result, _rid = _ingest_one(
                     resource, tenant_id,
                     agent_id='direct-upload',
-                    detail='Ingested via patient direct upload')
+                    detail='Ingested via patient direct upload',
+                    allowed_types=_INGEST_BUNDLE_ALLOWED_TYPES)
         except Exception as exc:  # noqa: BLE001
             # NEVER return `str(exc)` — SQL driver messages can echo
             # statements and parameters that carry PHI. Log ONLY the
@@ -2366,6 +2454,18 @@ def ingest_bundle():
             continue
         if result == 'ok':
             ingested += 1
+        elif result == 'forbidden':
+            skipped += 1
+            errors.append({'index': idx, 'resourceType': rtype,
+                           'code': 'forbidden_type',
+                           'message': f'{rtype!r} may not be authored via '
+                                      'direct upload'})
+        elif result == 'invalid_id':
+            skipped += 1
+            errors.append({'index': idx, 'resourceType': rtype,
+                           'code': 'invalid_resource_id',
+                           'message': 'entry.resource.id is not a valid '
+                                      'FHIR id and was refused'})
         else:
             skipped += 1
             errors.append({'index': idx, 'resourceType': rtype,

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2130,6 +2130,66 @@ def test_upload_rejects_text_plain_with_415(cfg, svc, monkeypatch):
     assert r.status_code == 415
 
 
+def test_upload_refuses_a_revoked_connection(cfg, svc, monkeypatch):
+    # #267 review: revocation was enforced only in the template (the hub
+    # hides the upload button once status == "revoked"), so a crafted
+    # request straight to the endpoint still accepted uploads after
+    # disconnect — defeating the "stop new data flowing" guarantee.
+    from careagents.app import create_app
+    app = create_app(config=cfg, client=FakeClient(), accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn_id = _make_direct_conn(c)
+    r = c.post(f"/api/connections/{conn_id}/disconnect")
+    assert r.status_code == 200 and r.get_json()["status"] == "revoked"
+
+    r = c.post(_DIRECT_UPLOAD_ENDPOINT.format(conn=conn_id),
+               data=json.dumps(_tiny_bundle("post-revoke-1")),
+               headers={"Content-Type": "application/fhir+json"})
+    assert r.status_code == 409
+    assert r.get_json()["error"] == "connection_not_active"
+
+
+def test_upload_still_works_on_a_fresh_empty_connection(cfg, svc, monkeypatch):
+    # Regression guard for the revoked-connection fix above: a `direct`
+    # connection's normal lifecycle starts at status "empty" (not "active")
+    # until the first upload lands — checking for anything other than
+    # "revoked" specifically would refuse every first upload.
+    from careagents.app import create_app
+    app = create_app(config=cfg, client=FakeClient(), accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn_id = _make_direct_conn(c)
+
+    r = c.post(_DIRECT_UPLOAD_ENDPOINT.format(conn=conn_id),
+               data=json.dumps(_tiny_bundle("fresh-empty-1")),
+               headers={"Content-Type": "application/fhir+json"})
+    assert r.status_code == 200
+    assert r.get_json()["ingested"] == 1
+
+
+def test_upload_deeply_nested_json_does_not_crash(cfg, svc, monkeypatch):
+    # #267 review: json.loads on a deeply-nested payload can raise
+    # RecursionError, which is not a ValueError and was previously
+    # unhandled -> 500. Already behind @login_required here, so this is
+    # purely the crash fix, not an auth-ordering fix.
+    from careagents.app import create_app
+    app = create_app(config=cfg, client=FakeClient(), accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn_id = _make_direct_conn(c)
+    huge = "1"
+    for _ in range(60000):
+        huge = "[" + huge + "]"
+    r = c.post(_DIRECT_UPLOAD_ENDPOINT.format(conn=conn_id),
+               data=huge, headers={"Content-Type": "application/fhir+json"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid_json"
+
+
 def test_upload_rejects_wrong_kind_connection(app, svc, monkeypatch):
     # `sample` is not an upload target — only `direct` connections accept
     # patient-provided files. A caller pointing at their own sample

--- a/tests/test_ingest_bundle_endpoint.py
+++ b/tests/test_ingest_bundle_endpoint.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 
 from r6.models import R6Resource, AuditEventRecord
 
@@ -377,7 +378,8 @@ def test_per_entry_exception_never_leaks_str_exc_to_caller(client,
 
     calls = {"n": 0}
 
-    def _boom(resource, tenant_id, agent_id=None, detail=None):
+    def _boom(resource, tenant_id, agent_id=None, detail=None,
+              allowed_types=None):
         calls["n"] += 1
         raise _BadExc("INSERT INTO x VALUES ('SSN=123-45-6789','john@a.com')")
 
@@ -414,10 +416,12 @@ def test_savepoint_isolates_a_mid_bundle_failure(client, app, monkeypatch):
     real = ingester_mod._ingest_one
 
     def _sometimes_boom(resource, tenant_id, agent_id='fasten-connect',
-                        detail='Ingested via Fasten EHI export'):
+                        detail='Ingested via Fasten EHI export',
+                        allowed_types=None):
         if resource.get('id') == 'atom-boom':
             raise RuntimeError('driver blew up on this row')
-        return real(resource, tenant_id, agent_id=agent_id, detail=detail)
+        return real(resource, tenant_id, agent_id=agent_id, detail=detail,
+                    allowed_types=allowed_types)
 
     monkeypatch.setattr('r6.fasten.ingester._ingest_one', _sometimes_boom)
 
@@ -451,3 +455,132 @@ def test_reingest_of_same_id_updates_rather_than_duplicates(client, app):
             tenant_id="test-tenant", resource_type="Patient",
             id="dup-1").all()
         assert len(rows) == 1  # upsert on (tenant, type, id)
+
+
+# --- security (#267 CTO review) -----------------------------------------------
+#
+# 850 lines of tests in this file, written before the review, and NONE of
+# them asserted: that a public tenant is not writable without a secret, that
+# AuditEvent/Permission/Consent/Provenance/Bundle are refused, that a caller-
+# supplied resource id is validated, or that the upstream `display`/`text`
+# a resource carries is stripped on read-back. Every test above runs through
+# `_post`'s default `tenant="test-tenant"`, which is public — the suite's
+# default path *is* what B1 exploited. These close that gap directly.
+
+_MINT_SECRET = "qa-verify-secret-not-a-real-one"
+
+
+# NOT autouse — setting INTERNAL_TOKEN_MINT_SECRET globally would flip every
+# test above (including `test_display_and_text_do_not_survive_to_the_read_back`
+# below, which deliberately does NOT request this fixture) out of the
+# fail-open dev-mode path and break the plain `_post` helper's 850 lines of
+# existing coverage, none of which ever sends X-Internal-Secret.
+@pytest.fixture
+def _mint_secret_env(monkeypatch):
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", _MINT_SECRET)
+
+
+def _post_with_secret(client, body, tenant="test-tenant", secret=None):
+    headers = {"X-Tenant-Id": tenant, "Content-Type": "application/json"}
+    if secret is not None:
+        headers["X-Internal-Secret"] = secret
+    return client.post(_ENDPOINT, data=json.dumps(body), headers=headers)
+
+
+def test_public_tenant_write_requires_the_secret_too(client, _mint_secret_env):
+    # B1: `_internal_mint_authorized`'s public-tenant exemption does NOT
+    # apply to ingestion — authoring content is a different risk than
+    # minting a token. No secret, public tenant -> still 403.
+    r = _post_with_secret(client, {"bundle": _bundle([_patient("attack-1")])},
+                          tenant="test-tenant", secret=None)
+    assert r.status_code == 403, r.get_json()
+
+
+def test_forbidden_types_are_refused_not_ingested(client, _mint_secret_env):
+    body = {"bundle": _bundle([
+        {"resourceType": "AuditEvent", "id": "forged-1"},
+        {"resourceType": "Permission", "id": "forged-2"},
+        {"resourceType": "Consent", "id": "forged-3"},
+        {"resourceType": "Provenance", "id": "forged-4"},
+        {"resourceType": "Bundle", "id": "forged-5"},
+    ])}
+    r = _post_with_secret(client, body, secret=_MINT_SECRET)
+    result = r.get_json()
+    assert result["ingested"] == 0, result
+    codes = sorted(e["code"] for e in result["errors"])
+    assert codes == ["forbidden_type"] * 5, codes
+
+
+def test_deeply_nested_json_is_refused_not_crashed_no_credentials(
+        client, _mint_secret_env):
+    # B2: the body was previously parsed BEFORE the auth check, so this
+    # crashed (RecursionError, uncaught -> 500) with zero credentials
+    # against ANY tenant. 60000-deep nesting, well under the byte cap.
+    huge = "1"
+    for _ in range(60000):
+        huge = "[" + huge + "]"
+    payload = ('{"bundle":' + huge + "}").encode()
+    r = client.post(_ENDPOINT, data=payload,
+                    headers={"X-Tenant-Id": "someone-elses-private-tenant",
+                             "Content-Type": "application/json"})
+    assert r.status_code in (400, 403), r.status_code
+
+
+def test_deeply_nested_json_refused_as_too_deep_with_credentials(
+        client, _mint_secret_env):
+    huge = "1"
+    for _ in range(60000):
+        huge = "[" + huge + "]"
+    payload = ('{"bundle":' + huge + "}").encode()
+    r = client.post(_ENDPOINT, data=payload,
+                    headers={"X-Tenant-Id": "someone-elses-private-tenant",
+                             "Content-Type": "application/json",
+                             "X-Internal-Secret": _MINT_SECRET})
+    assert r.status_code == 400, r.get_json()
+
+
+def test_malformed_resource_ids_are_refused_not_stored_or_audited(
+        client, app, _mint_secret_env):
+    body = {"bundle": _bundle([
+        {"resourceType": "Patient", "id": "Jane Doe 1980-01-01 MRN 12345"},
+        {"resourceType": "Patient", "id": "../../etc/passwd"},
+        {"resourceType": "Patient", "id": "x" * 400},
+    ])}
+    r = _post_with_secret(client, body, tenant="someone-elses-private-tenant",
+                          secret=_MINT_SECRET)
+    result = r.get_json()
+    assert result["ingested"] == 0, result
+    codes = sorted(e["code"] for e in result["errors"])
+    assert codes == ["invalid_resource_id"] * 3, codes
+    with app.app_context():
+        # The rejected ids must never reach the audit trail — CTO review
+        # found an unvalidated id copied into AuditEventRecord.resource_id,
+        # which health_compliance.py later exports to the auditor-facing
+        # compliance bundle.
+        leaked = AuditEventRecord.query.filter_by(
+            tenant_id="someone-elses-private-tenant",
+            resource_id="../../etc/passwd").count()
+        assert leaked == 0
+
+
+def test_a_normal_id_still_ingests_after_the_validation_fix(client, _mint_secret_env):
+    r = _post_with_secret(
+        client, {"bundle": _bundle([_patient("pt-legit-1")])},
+        tenant="someone-elses-private-tenant", secret=_MINT_SECRET)
+    assert r.get_json()["ingested"] == 1
+
+
+def test_display_and_text_do_not_survive_to_the_read_back(client, app,
+                                                          tenant_headers):
+    # The non-negotiable this whole product is named after, and the one
+    # existing happy-path test never actually checked: it asserted only
+    # status_code == 200 despite its own fixture carrying a display and a
+    # family name. Stored raw is fine (matches the Fasten contract); NOT
+    # stripping it on read would be the leak this repo has been bitten by
+    # before.
+    r = _post(client, {"bundle": _bundle([_patient("canary-1",
+                                                    family="Secretname")])})
+    assert r.status_code == 200
+    read = client.get("/r6/fhir/Patient/canary-1", headers=tenant_headers)
+    text = read.get_data(as_text=True)
+    assert "Secretname" not in text

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -134,3 +134,36 @@ def test_curatr_engine_api_matches_ingester_usage():
     result = engine.evaluate({"resourceType": "Condition", "id": "c1"})
     assert hasattr(result, "issues")
     assert isinstance(result.issues, list)
+
+
+def test_resource_id_pattern_is_a_charset_control_not_a_length_control():
+    """#267's id validation must keep rejecting injectable ids WITHOUT
+    re-imposing the 64-char FHIR ceiling this file's incident forced us off.
+
+    The security finding it closes is that a caller-supplied id reached
+    `AuditEventRecord.resource_id`, which `health_compliance.py` exports into
+    the auditor-facing compliance bundle — so an id could smuggle a name, a
+    date, a path, or markup into an audit artifact. The CHARSET stops that.
+    The LENGTH never had anything to do with it, and capping at 64 silently
+    skipped real Epic resources on the live Fasten connector (caught in
+    review, not by 1772 green tests).
+
+    Pinned in both directions so a future "tighten it to spec" edit fails
+    here instead of in production.
+    """
+    from r6.fasten.ingester import _RESOURCE_ID_PATTERN as pat
+    from r6.models import R6Resource
+
+    # Injectable shapes stay refused, regardless of length.
+    for bad in ("../../etc/passwd", "Jane Doe 1980-01-01 MRN 12345",
+                "<script>alert(1)</script>", "id with spaces", "a/b", "a_b"):
+        assert not pat.fullmatch(bad), bad
+
+    # Real Epic-shaped ids (~109 chars per the 2026-07-08 export) are fine.
+    assert pat.fullmatch("e-" + "a" * 107)
+
+    # The ceiling tracks the column width, so validation and storage cannot
+    # disagree: an id we accept must be an id we can store.
+    width = R6Resource.__table__.c.id.type.length
+    assert pat.fullmatch("a" * width)
+    assert not pat.fullmatch("a" * (width + 1))

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -32,6 +32,48 @@ def test_long_id_resource_stores_and_round_trips(client, tenant_id):
     assert got is not None and got.id == long_id
 
 
+def test_fasten_ingest_still_accepts_real_epic_shaped_long_ids(client, tenant_id):
+    """Regression guard for #267's `_RESOURCE_ID_PATTERN`
+    (r6/fasten/ingester.py): `^[A-Za-z0-9\\-\\.]{1,64}$`, enforced
+    unconditionally inside `_ingest_one` -- the SAME function Fasten's
+    `stream_ingest` calls for every real EHR export, not just the
+    direct-upload path #267 was fixing.
+
+    `test_long_id_resource_stores_and_round_trips` above proves the DB
+    column is wide enough for a ~86-char Epic id, but it writes the
+    R6Resource row directly and never calls `_ingest_one` -- so it could
+    not have caught this. This test drives the real ingester entry point.
+
+    #267's own docstring says the pattern is "FHIR id: ... per the spec",
+    and 64 chars IS the FHIR spec limit -- but this file's docstring (and
+    the 2026-07-08 live-Epic-export incident it documents: 65/250 resource
+    ids over varchar(64), which is why R6Resource.id was widened to
+    varchar(128) instead of truncated or rejected) is the standing record
+    that real Epic exports routinely violate that limit. `_ingest_one`
+    previously stored whatever id Epic sent, subject only to the DB column
+    width; #267 now rejects it at the application layer as `invalid_id`
+    before it ever reaches the DB -- same ceiling the 128-char column was
+    widened specifically to avoid, reintroduced silently (a skipped/
+    invalid_id entry, not a crash) for the live Fasten/Epic connector.
+    """
+    from r6.fasten.ingester import _ingest_one
+
+    long_id = "e-" + uuid.uuid4().hex + uuid.uuid4().hex + "X" * 20  # ~86 chars
+    assert len(long_id) > 64
+    resource = {"resourceType": "Observation", "id": long_id, "status": "final"}
+
+    result, rid = _ingest_one(resource, tenant_id)
+
+    assert result == "ok" and rid == long_id, (
+        f"real Epic-shaped id (len={len(long_id)}) was refused as "
+        f"{result!r} by _RESOURCE_ID_PATTERN -- #267's id-shape "
+        "validation silently drops real Fasten/Epic resources whose "
+        "ids exceed 64 characters, exactly the case "
+        "test_resource_id_column_fits_real_ehr_ids above widened the "
+        "column for"
+    )
+
+
 def test_ingest_error_rolls_back_session_so_next_resource_succeeds(client, tenant_id):
     # The core resilience contract: a failed resource must not poison the
     # session for the ones after it. Simulate by forcing one flush to fail,


### PR DESCRIPTION
Fixes the CTO review findings on #267 / `agent/direct-upload-227`. **This branch does not merge #267's feature — it hardens it.** Whether the feature itself ships before Aug 18 is a separate call; see the recommendation at the bottom.

## Why

#267 added a direct FHIR-bundle upload path, written overnight, never security-reviewed. The CTO reviewed it and returned **BLOCK** with two live vulnerabilities — found by probing a running server, not by reading — plus three more findings.

**B1 — unauthenticated arbitrary write into the demo tenant.** The endpoint gated on `_internal_mint_authorized`, which exempts public tenants (`PUBLIC_TENANTS=desktop-demo` in production). That exemption is right for *minting a token* — a public tenant already bypasses read-auth, so there's nothing extra to protect — and wrong for *authoring content*. An unauthenticated caller could write arbitrary FHIR resources into the exact tenant used for the live demo, content that then flows into an LLM context: stored prompt injection on top of defacement. The ingester also never consulted `_SYSTEM_MANAGED_TYPES`, so `AuditEvent` / `Permission` / `Consent` / `Provenance` / `Bundle` could all be forged.

**B2 — unauthenticated remote crash. 120KB, zero credentials, any tenant.** The body was read and parsed *before* the auth check. CPython's JSON scanner recurses per nesting level, so a 60,000-deep payload raised `RecursionError` — not a `ValueError`, so uncaught → 500. The carefully-built 5MB cap was irrelevant; the crash lever sits three orders of magnitude beneath it.

## What changed

- **`_internal_ingest_authorized`** — requires `X-Internal-Secret` unconditionally, no public-tenant exemption, fail-closed in production. CareAgents already sends the secret on every call, so the legitimate path is untouched.
- **Auth gate moved first** — before content-type sniffing, before the body is read, before anything is parsed. `RecursionError` is now caught explicitly, plus a bounded depth-walk as defence in depth. Same crash fixed on the CareAgents forwarding path.
- **Ingest type allowlist** — `_ingest_one` gained `allowed_types`, defaulting to `None` so Fasten/SHC keep prior behaviour exactly; the upload path passes a clinical-only set.
- **Resource-id validation** — a caller-supplied id was reaching `AuditEventRecord.resource_id`, which `health_compliance.py` exports into the auditor-facing compliance bundle. Now charset-validated before use.
- **Revoked-connection upload bypass** — enforced only in the template; a crafted request still uploaded after disconnect. Now refused server-side.
- **Transport-exception wrapping** on `hc.ingest_bundle`, matching the idiom every other engine call in that file already used.

## The regression I introduced, and QA caught

Worth reading, because it is the most instructive part of this branch.

My id validation used the FHIR spec pattern verbatim — charset **and** its 64-char ceiling — without asking which half was the security control. Only the charset was. But `tests/test_ingest_resilience.py` documents a live 2026-07-08 Epic export where **65 of 250 resource ids exceeded 64 characters**, running to ~109 — which is precisely why `R6Resource.id` was widened rather than truncated. My regex re-imposed that ceiling inside `_ingest_one`, which Fasten and SHC both call and which #267 was never meant to touch.

The failure mode was the dangerous one: **silent data loss on real patient records**, as `invalid_id` skips on the live connector rather than a crash. 1774 green tests missed it, because the existing regression guard for that exact incident writes the ORM row directly and never calls `_ingest_one` — the same shape as the B1 hole, where the test that should have covered it ran past the code that mattered.

Ceiling is now 255, matching both columns so validation and storage cannot disagree.

## Verification

QA verified independently across two rounds — live HTTP probing plus direct SQLite reads, not just the shipped tests:

- **B1**: no secret / wrong secret / empty-string secret → all `403`; correct secret → `200`. Empty-vs-unset `INTERNAL_TOKEN_MINT_SECRET` confirmed consistent between both auth helpers.
- **B2**: deep arrays *and* deep objects, with and without credentials → `400`/`403` in ~0.01s, body never read; server alive after all four.
- **17 id cases** through the live endpoint: 12 refused (including newline injection, CSV formula, null byte, Cyrillic homoglyph, and the 256-char boundary), 5 accepted (including the 109-char real-incident length and the exact 255 column width). Direct DB query confirmed refused ids reached neither `r6_resources` nor `audit_events`.
- **`allowed_types` verified across all 40 supported types**: omitted → refuses nothing (Fasten/SHC genuinely unaffected); upload set → refuses exactly the 5 declared, no gap.
- **Revoked-connection logic traced exhaustively** against every status the codebase actually persists — `direct` connections can only be `empty → active → revoked`, so checking `== 'revoked'` (not `!= 'active'`) is correct against every real state. Requiring `'active'` would have refused every legitimate first upload; I caught that against my own first draft.
- **11 mutations** run against the id tests — all caught, none survived.

```
1774 passed, 6 skipped, 2 xfailed
conformance: 28/28, Grade A
ruff: All checks passed!
```

## Known limits

- No production-mode boot; the fail-closed-in-production branch is verified by code inspection (identical logic to the already-tested `_internal_mint_authorized` equivalent).
- **SQLite only.** The original 2026-07-08 incident was Postgres-only, so a Postgres lane would be the honest final check on column widths.
- No real Fasten/SHC cassette data exists in the repo, so "real Epic id shapes" rests on this repo's own incident record rather than fresh samples.
- Deferred, filed, and explicitly **not** fixed here: #279 (audit `resource_id` exposure in compliance export), #280 (revoked-connection — fixed here, issue tracks the broader pattern), #281 (general id-length validation), #282 (non-redacting read paths), #286 (blank-id semantics), #287 (the id-test ensemble must not be pruned).
- The 50–100MB parse / memory-exhaustion finding from the CTO review is **not** addressed by the depth-walk and remains open. Nothing here should be read as closing it.

## Recommendation — yours to decide

The CTO recommends **deferring #267 itself past Aug 18**, independent of these fixes. The reasoning: fixing the blockers took about an hour, but convincing yourself a caller-supplied-bundle ingest path is genuinely safe took a full review that found five things — and then the fix introduced a HIGH regression caught only by adversarial review. That ratio is the signal. The feature is also not on the webinar's critical path.

These patches are sound and can merge on their own terms. Shipping the *feature* before the webinar is the separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)