### PR TITLE
fix(docs): keyless quickstarts pointed at the token-locked MCP endpoint

### DIFF
--- a/adapters/examples/gemini_agent.py
+++ b/adapters/examples/gemini_agent.py
@@ -4,7 +4,7 @@ Requires: `pip install google-genai` and GEMINI_API_KEY. Reference example (not
 run in CI). Guardrails enforced by HealthClaw server-side.
 
     python adapters/examples/gemini_agent.py \
-        --mcp-base https://mcp-server-production-5112.up.railway.app \
+        --mcp-base https://mcp-demo-production-ee2c.up.railway.app \
         --tenant desktop-demo --prompt "List the patient's active conditions"
 """
 import argparse

--- a/adapters/examples/langchain_agent.py
+++ b/adapters/examples/langchain_agent.py
@@ -5,7 +5,7 @@ JSON-Schema dict as args_schema directly) and OPENAI_API_KEY. Reference
 example (not run in CI). Guardrails enforced by HealthClaw server-side.
 
     python adapters/examples/langchain_agent.py \
-        --mcp-base https://mcp-server-production-5112.up.railway.app \
+        --mcp-base https://mcp-demo-production-ee2c.up.railway.app \
         --tenant desktop-demo --prompt "List the patient's active conditions"
 """
 import argparse

--- a/adapters/examples/openai_agent.py
+++ b/adapters/examples/openai_agent.py
@@ -4,7 +4,7 @@ Requires: `pip install openai` and OPENAI_API_KEY. This is a reference example
 (not run in CI). The guardrails are enforced by HealthClaw server-side.
 
     python adapters/examples/openai_agent.py \
-        --mcp-base https://mcp-server-production-5112.up.railway.app \
+        --mcp-base https://mcp-demo-production-ee2c.up.railway.app \
         --tenant desktop-demo --prompt "Summarize the patient's recent vitals"
 """
 import argparse

--- a/docs/quickstarts/README.md
+++ b/docs/quickstarts/README.md
@@ -4,16 +4,23 @@ HealthClaw Guardrails is a remote MCP server. Any agent that speaks MCP can
 connect to it and work with health records behind enforced guardrails (PHI
 redaction, audit trail, human-in-the-loop, disclaimers).
 
-**Connector URL (live production server):**
+**Connector URL (public demo server):**
 
 ```text
-https://mcp-server-production-5112.up.railway.app/mcp
+https://mcp-demo-production-ee2c.up.railway.app/mcp
 ```
 
-No API key needed to try it: without credentials you get the `desktop-demo`
-tenant — a synthetic demo patient panel with realistic conditions, labs,
-immunizations, and medications. **Nothing in it is real patient data, which
-makes it safe to demo on camera.**
+No API key needed: this server is hard-pinned to the `desktop-demo` tenant — a
+synthetic demo patient panel with realistic conditions, labs, immunizations,
+and medications. **Nothing in it is real patient data, which makes it safe to
+demo on camera.**
+
+Real records live on a separate production endpoint
+(`https://mcp-server-production-5112.up.railway.app/mcp`) that requires a
+deployment-scoped `Authorization: Bearer <token>` and returns 401 without one.
+Don't paste that URL into a hosted connector — it cannot attach the header, and
+the sign-in step will fail. See
+[mcp-generic.md](mcp-generic.md#tenancy-and-auth).
 
 ## Pick your agent
 

--- a/docs/quickstarts/chatgpt.md
+++ b/docs/quickstarts/chatgpt.md
@@ -14,7 +14,7 @@ Plus/Pro user add a remote MCP server by URL** — HealthClaw works there today.
 1. Settings → **Apps & Connectors** → **Create** (or **Add connector**).
 2. Fill in:
    - **Name:** `HealthClaw`
-   - **MCP server URL:** `https://mcp-server-production-5112.up.railway.app/mcp`
+   - **MCP server URL:** `https://mcp-demo-production-ee2c.up.railway.app/mcp`
    - **Authentication:** No authentication
 3. Accept the unverified-connector notice and save.
 

--- a/docs/quickstarts/claude.md
+++ b/docs/quickstarts/claude.md
@@ -10,7 +10,7 @@ are not available on the free tier).
 3. Click **Add custom connector**.
 4. Fill in:
    - **Name:** `HealthClaw`
-   - **URL:** `https://mcp-server-production-5112.up.railway.app/mcp`
+   - **URL:** `https://mcp-demo-production-ee2c.up.railway.app/mcp`
 5. Click **Add**. No login screen appears — anonymous access lands in the
    synthetic `desktop-demo` tenant (safe, fake data).
 
@@ -45,7 +45,7 @@ If you use Claude Desktop and prefer a config file, add to
       "command": "npx",
       "args": [
         "-y", "mcp-remote",
-        "https://mcp-server-production-5112.up.railway.app/mcp"
+        "https://mcp-demo-production-ee2c.up.railway.app/mcp"
       ]
     }
   }
@@ -55,6 +55,16 @@ If you use Claude Desktop and prefer a config file, add to
 Restart Claude Desktop; the tools appear under the tools icon.
 
 ## Pointing at your own records (optional)
+
+> **Not available through a claude.ai connector today.** The demo URL above is
+> hard-pinned to the synthetic tenant: it *ignores* the tenant and token that
+> the setup message passes, and answers from demo data anyway — so it will look
+> like it worked while showing you fake records. Real tenants require the
+> production endpoint, which needs a bearer header that hosted connectors
+> cannot attach ([#290](https://github.com/aks129/HealthClawGuardrails/issues/290)).
+> Until that lands, use your own records through
+> [CareAgents](https://careagents.cloud) or a local MCP client that can set
+> headers. The rest of this section describes the intended flow.
 
 Connect your providers at `https://app.healthclaw.io/connect/<your-tenant-id>`
 (identity-verified via CLEAR/ID.me). When the connection completes, the page
@@ -67,6 +77,16 @@ Do not do this while screen-recording.
 
 ## Troubleshooting
 
+- **"Couldn't register with HealthClaw's sign-in service" / Claude asks for an
+  OAuth Client ID:** you are pointed at the production endpoint
+  (`mcp-server-production-5112...`), not the demo one. That server requires a
+  bearer token, so it answers `401`, and Claude tries to start an OAuth
+  sign-in — but the server publishes no OAuth metadata, so registration fails
+  and Claude falls back to asking you for a Client ID. **There is no Client ID
+  to enter.** Remove the connector and re-add it with the demo URL in step 4
+  above. (Hosted connectors cannot attach a static bearer header, so the
+  production endpoint is not usable from claude.ai —
+  [#290](https://github.com/aks129/HealthClawGuardrails/issues/290).)
 - **Connector added but no tools show:** toggle it off/on in the tools menu,
   or start a fresh chat.
 - **"Tool call failed":** the server may be cold-starting; retry once.

--- a/docs/quickstarts/mcp-generic.md
+++ b/docs/quickstarts/mcp-generic.md
@@ -1,13 +1,18 @@
 # Quickstart: any MCP client (Claude Code, Cursor, LibreChat, custom agents)
 
-**Endpoint:** `https://mcp-server-production-5112.up.railway.app/mcp`
+**Endpoint (keyless demo):** `https://mcp-demo-production-ee2c.up.railway.app/mcp`
 (Streamable HTTP; legacy SSE at `/sse` + `/messages`).
+
+This is the **public demo server**. It needs no credentials and is hard-pinned
+to the synthetic `desktop-demo` tenant, so it can only ever serve fake data.
+Real tenants live on the production endpoint, which requires a bearer token —
+see [Tenancy and auth](#tenancy-and-auth).
 
 ## Claude Code
 
 ```bash
 claude mcp add --transport http healthclaw \
-  https://mcp-server-production-5112.up.railway.app/mcp
+  https://mcp-demo-production-ee2c.up.railway.app/mcp
 ```
 
 ## Cursor / VS Code MCP config
@@ -16,7 +21,7 @@ claude mcp add --transport http healthclaw \
 {
   "mcpServers": {
     "healthclaw": {
-      "url": "https://mcp-server-production-5112.up.railway.app/mcp"
+      "url": "https://mcp-demo-production-ee2c.up.railway.app/mcp"
     }
   }
 }
@@ -28,27 +33,50 @@ claude mcp add --transport http healthclaw \
 mcpServers:
   healthclaw:
     type: streamable-http
-    url: https://mcp-server-production-5112.up.railway.app/mcp
+    url: https://mcp-demo-production-ee2c.up.railway.app/mcp
 ```
 
 ## No MCP client at all? Plain JSON-RPC bridge
 
 ```bash
 curl -s -X POST \
-  https://mcp-server-production-5112.up.railway.app/mcp/rpc \
+  https://mcp-demo-production-ee2c.up.railway.app/mcp/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
 ## Tenancy and auth
 
-- No headers → synthetic `desktop-demo` tenant (fake data; safe to demo).
+There are two hosted endpoints, and which one you point at decides what the
+tenancy headers below do.
+
+| | Demo `mcp-demo-production-ee2c` | Production `mcp-server-production-5112` |
+| --- | --- | --- |
+| Credential | none | `Authorization: Bearer <token>` (401 without it) |
+| Tenant | pinned to `desktop-demo` | selected by header/argument |
+| Data | synthetic only | real tenants |
+
+**On the demo endpoint, tenancy and bring-your-own-FHIR headers are ignored,
+not honored.** The server drops them and answers from the pinned synthetic
+tenant. That is deliberate — an open caller must not be able to reach a real
+tenant — but it means a request that *looks* like it selected your tenant will
+quietly return demo data instead. If you are passing any of the headers below,
+you want the production endpoint.
+
+On the production endpoint:
+
 - `X-Tenant-ID` header (or `_tenantId` tool argument) selects a tenant.
 - Non-public tenants need a tenant-bound token: `X-Step-Up-Token` header or
   `_stepUpToken` argument. Writes always require step-up; clinical writes
   additionally require an explicit human confirmation (HTTP 428 otherwise).
 - Bring-your-own FHIR server: pass `_fhirServerUrl` (+ `_fhirAccessToken`)
   and the guardrail stack proxies it per-request (SHARP-on-MCP).
+
+The production endpoint's bearer token is deployment-scoped and issued by the
+operator; it is not self-serve. Note that hosted chat connectors (claude.ai,
+ChatGPT, Perplexity) cannot attach a static bearer header, so they can only use
+the demo endpoint today — tracked in
+[#290](https://github.com/aks129/HealthClawGuardrails/issues/290).
 
 ## The 28 tools
 

--- a/docs/quickstarts/perplexity.md
+++ b/docs/quickstarts/perplexity.md
@@ -9,7 +9,7 @@ Time: about 3 minutes. Custom connectors require a paid Perplexity plan.
 2. Choose **Add connector** → **Custom / Remote MCP**.
 3. Fill in:
    - **Name:** `HealthClaw`
-   - **Server URL:** `https://mcp-server-production-5112.up.railway.app/mcp`
+   - **Server URL:** `https://mcp-demo-production-ee2c.up.railway.app/mcp`
    - **Authentication:** none
 4. Save, and enable the connector for your searches/threads.
 

--- a/docs/quickstarts/telegram.md
+++ b/docs/quickstarts/telegram.md
@@ -31,7 +31,7 @@ a human approves, and only then does anything change.
    ```bash
    TELEGRAM_BOT_TOKEN=<your token> \
    TENANT_ID=desktop-demo \
-   MCP_BASE_URL=https://mcp-server-production-5112.up.railway.app \
+   MCP_BASE_URL=https://mcp-demo-production-ee2c.up.railway.app \
    FHIR_BASE_URL=https://app.healthclaw.io/r6/fhir \
    uv run --with "python-telegram-bot==21.*" --with requests python openclaw/bot.py
    ```

--- a/docs/quickstarts/telegram.md
+++ b/docs/quickstarts/telegram.md
@@ -36,8 +36,14 @@ a human approves, and only then does anything change.
    uv run --with "python-telegram-bot==21.*" --with requests python openclaw/bot.py
    ```
 
-3. Message your bot `/start`. That's it — it talks to the production
-   guardrail stack against the synthetic demo tenant.
+3. Message your bot `/start`. That's it — it talks to the public demo server
+   against the synthetic demo tenant.
+
+`TENANT_ID` above is set to the demo tenant deliberately. The demo server is
+pinned to that tenant and ignores the value, so pointing this at a real tenant
+would not fail — it would quietly keep answering with synthetic data. Real
+tenants need the production endpoint and its bearer token; see
+[mcp-generic.md](mcp-generic.md#tenancy-and-auth).
 
 Docker alternative: `docker-compose --profile openclaw up -d` with the same
 env vars.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,7 +4,7 @@
   "description": "Guardrailed FHIR access for AI agents: PHI redaction, immutable audit, step-up auth, tenant isolation over a remote MCP server.",
   "mcpServers": {
     "healthclaw": {
-      "httpUrl": "https://mcp-server-production-5112.up.railway.app/mcp",
+      "httpUrl": "https://mcp-demo-production-ee2c.up.railway.app/mcp",
       "headers": {
         "X-Tenant-Id": "desktop-demo"
       }

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -51,7 +51,7 @@ The hosted server is seeded with the synthetic Grover Keeling sample so you can 
 
 ### Hosted demo (default)
 
-Uses `https://mcp-server-production-5112.up.railway.app/mcp` with tenant `desktop-demo`. Synthetic data only. No setup beyond the installer. This is what the installer turns on by default.
+Uses `https://mcp-demo-production-ee2c.up.railway.app/mcp` with tenant `desktop-demo`. Synthetic data only. No setup beyond the installer. This is what the installer turns on by default.
 
 ### Local mode
 
@@ -100,7 +100,7 @@ Hermes has built-in OpenClaw migration support: skills imported from an existing
 
 | Symptom | Probable cause | Fix |
 |---|---|---|
-| `/mcp list` shows healthclaw-hosted as disconnected | Outbound HTTPS blocked, or Railway cold start in flight | `curl https://mcp-server-production-5112.up.railway.app/health` from the same shell. If that times out, network. If 200 quickly, retry in 30s. |
+| `/mcp list` shows healthclaw-hosted as disconnected | Outbound HTTPS blocked, or Railway cold start in flight | `curl https://mcp-demo-production-ee2c.up.railway.app/health` from the same shell. If that times out, network. If 200 quickly, retry in 30s. |
 | Tool calls return `{"error": "X-Tenant-Id header is required"}` | Tenant header not forwarded | Confirm `headers.X-Tenant-Id` is set in `~/.hermes/config.json` for the active server. Hosted mode defaults to `desktop-demo`. |
 | Write tools 401 with `requires_step_up: true` | No step-up token in the request | Have Hermes call `fhir_get_token` first; pass the returned token as `_stepUpToken` in the next tool call. The SOUL persona handles this for you. |
 | Write tools 428 | Human-in-the-loop gate didn't see `X-Human-Confirmed: true` | The SOUL persona asks you to confirm before commit; say *"yes confirm"* and retry. |

--- a/hermes/mcp.json
+++ b/hermes/mcp.json
@@ -3,11 +3,8 @@
   "mcp_servers": {
     "healthclaw-hosted": {
       "transport": "streamable_http",
-      "url": "https://mcp-server-production-5112.up.railway.app/mcp",
-      "headers": {
-        "X-Tenant-Id": "desktop-demo"
-      },
-      "description": "Public hosted HealthClaw MCP server seeded with synthetic Grover Keeling sample data. Good for trying everything out without standing up the stack locally."
+      "url": "https://mcp-demo-production-ee2c.up.railway.app/mcp",
+      "description": "Public keyless HealthClaw demo server seeded with synthetic Grover Keeling sample data. Good for trying everything out without standing up the stack locally. Hard-pinned to the synthetic 'desktop-demo' tenant — it ignores any X-Tenant-Id you send, so there is no header to set here."
     },
     "_healthclaw-local": {
       "transport": "streamable_http",
@@ -21,11 +18,12 @@
       "transport": "streamable_http",
       "url": "https://mcp-server-production-5112.up.railway.app/mcp",
       "headers": {
+        "Authorization": "Bearer YOUR_HEALTHCLAW_MCP_TOKEN",
         "X-FHIR-Server-URL": "https://hapi.fhir.org/baseR4",
         "X-FHIR-Access-Token": "Bearer YOUR_SMART_ON_FHIR_TOKEN",
         "X-Patient-ID": "YOUR_PATIENT_ID"
       },
-      "description": "SHARP-on-MCP mode. Hermes forwards a SMART-on-FHIR access token from the agent host to HealthClaw, which proxies the call to any FHIR endpoint (Epic, Cerner, MEDITECH, athenahealth, eClinicalWorks, HAPI, SMART Health IT) while applying the full guardrail stack on the response. Rename to 'healthclaw-sharp' once your agent host wiring forwards real tokens."
+      "description": "SHARP-on-MCP mode. Hermes forwards a SMART-on-FHIR access token from the agent host to HealthClaw, which proxies the call to any FHIR endpoint (Epic, Cerner, MEDITECH, athenahealth, eClinicalWorks, HAPI, SMART Health IT) while applying the full guardrail stack on the response. This runs against the token-locked production server, NOT the keyless demo — the demo ignores bring-your-own-FHIR headers and would silently answer from synthetic data. Set Authorization to the deployment-scoped token from your operator, then rename to 'healthclaw-sharp'."
     }
   }
 }

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -123,6 +123,13 @@ def get(url: str, timeout: float, **kw):
         return type(exc).__name__
 
 
+def post(url: str, timeout: float, **kw):
+    try:
+        return requests.post(url, timeout=timeout, **kw)
+    except requests.RequestException as exc:
+        return type(exc).__name__
+
+
 def run(timeout: float, expect_sha: list[str]) -> int:
     # Reset, because this is module state and a stale verdict is worse than no
     # verdict: a second run in informational mode would otherwise inherit the
@@ -249,10 +256,37 @@ def run(timeout: float, expect_sha: list[str]) -> int:
           f"unauthenticated /mcp -> {code}")
 
     # The public demo is meant to answer without a token; it is pinned to a
-    # synthetic tenant server-side. Alive is all we assert here.
+    # synthetic tenant server-side.
     r = get(f"{MCP_DEMO}/health", timeout)
     check("mcp (public demo): alive", getattr(r, "status_code", None) == 200,
           str(getattr(r, "status_code", r)))
+
+    # ...but "alive" was all this asserted for a while, and that is the gap a
+    # design partner found for us: every quickstart, the Gemini extension, the
+    # registry entry and the homepage now send strangers here, and what they
+    # actually do is an unauthenticated MCP handshake — not a /health GET. A
+    # token accidentally set on this deployment would flip it to 401 and leave
+    # this script fully green, because /health stays public on both servers.
+    # So assert the thing users depend on: a keyless `initialize` succeeds.
+    r = post(
+        f"{MCP_DEMO}/mcp", timeout,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize",
+              "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                         "clientInfo": {"name": "prod-watch",
+                                        "version": "1"}}},
+    )
+    code = getattr(r, "status_code", None)
+    served = False
+    if code == 200:
+        try:
+            served = "result" in (r.json() or {})
+        except ValueError:
+            served = False
+    check("mcp (public demo): serves an unauthenticated handshake", served,
+          f"keyless initialize -> {code}"
+          + ("" if served else " (no JSON-RPC result)"))
 
     failed = [n for n, ok, _ in results if not ok]
     hard = [n for n in failed if n != BUILD_CHECK]

--- a/server.json
+++ b/server.json
@@ -11,10 +11,21 @@
   "remotes": [
     {
       "type": "streamable-http",
+      "url": "https://mcp-demo-production-ee2c.up.railway.app/mcp",
+      "headers": []
+    },
+    {
+      "type": "streamable-http",
       "url": "https://mcp-server-production-5112.up.railway.app/mcp",
       "headers": [
         {
-          "description": "Tenant identifier — the public demo tenant 'desktop-demo' works without credentials",
+          "description": "Deployment-scoped bearer credential, required on every request — this endpoint returns 401 without it. Issued by the operator; not self-serve. For a keyless trial use the demo remote listed first, which is hard-pinned to a synthetic tenant.",
+          "isRequired": true,
+          "isSecret": true,
+          "name": "Authorization"
+        },
+        {
+          "description": "Tenant identifier",
           "isRequired": false,
           "name": "X-Tenant-Id"
         },

--- a/skills/hermes/SKILL.md
+++ b/skills/hermes/SKILL.md
@@ -17,7 +17,7 @@ references:
   healthclaw_repo: https://github.com/aks129/HealthClawGuardrails
   openclaw_integration: https://github.com/aks129/HealthClawGuardrails/tree/main/openclaw
   hermes_integration: https://github.com/aks129/HealthClawGuardrails/tree/main/hermes
-  mcp_endpoint: https://mcp-server-production-5112.up.railway.app/mcp
+  mcp_endpoint: https://mcp-demo-production-ee2c.up.railway.app/mcp
 ---
 
 # Hermes — self-improving HealthClaw gateway
@@ -131,7 +131,7 @@ Mirrors the OpenClaw troubleshooting matrix. The most common Hermes-specific iss
 
 | Symptom | Fix |
 |---|---|
-| `/mcp list` shows healthclaw-hosted as disconnected | Outbound HTTPS blocked, or Railway cold start. `curl https://mcp-server-production-5112.up.railway.app/health` — if 200, retry. |
+| `/mcp list` shows healthclaw-hosted as disconnected | Outbound HTTPS blocked, or Railway cold start. `curl https://mcp-demo-production-ee2c.up.railway.app/health` — if 200, retry. |
 | Hermes refuses to load `SOUL.md` | Check `~/.hermes/personas/healthclaw.md` exists and is readable. Re-run `./hermes/install.sh`. |
 | Skills changed unexpectedly | `./hermes/install.sh --skills-only` restores the repo copy. |
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -538,7 +538,7 @@
   </div>
 
   <div class="fade-up" style="text-align:center;margin-top:28px;color:var(--gray-dim);font-size:13px">
-    Need raw MCP &mdash; Claude Desktop, MCP Inspector, or your own client? Point it at <code style="font-family:var(--font-mono);font-size:12px;color:var(--cyan)">https://mcp-server-production-5112.up.railway.app/mcp</code> with header <code style="font-family:var(--font-mono);font-size:12px;color:var(--cyan)">X-Tenant-Id: desktop-demo</code>.
+    Need raw MCP &mdash; Claude Desktop, MCP Inspector, or your own client? Point it at <code style="font-family:var(--font-mono);font-size:12px;color:var(--cyan)">https://mcp-demo-production-ee2c.up.railway.app/mcp</code> &mdash; no credential needed, and it is pinned server-side to the synthetic <code style="font-family:var(--font-mono);font-size:12px;color:var(--cyan)">desktop-demo</code> tenant, so it only ever serves fake data.
   </div>
 </div>
 

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -250,8 +250,14 @@ def _read_text(tmp_path, text):
 
 # --- the monitor: open defects ----------------------------------------------
 
-def _prod_watch_with(payload, expect):
-    """Run prod_watch against a fully-healthy fake, varying only /healthz."""
+def _prod_watch_with(payload, expect, demo_handshake=None):
+    """Run prod_watch against a fully-healthy fake, varying only /healthz.
+
+    `demo_handshake` overrides the public demo's keyless `initialize` reply.
+    Both `get` and `post` are stubbed: leaving `post` real let the demo
+    handshake check reach the live server from inside a unit test, which is
+    exactly the kind of green-for-the-wrong-reason this file exists to stop.
+    """
     import prod_watch
 
     class _Resp:
@@ -277,15 +283,23 @@ def _prod_watch_with(payload, expect):
             return _Resp(401)
         return _Resp(200, text='<a href="/auth">start</a>')
 
+    def post(url, timeout, **kw):
+        if demo_handshake is not None:
+            return demo_handshake
+        return _Resp(200, {"jsonrpc": "2.0", "id": 1,
+                           "result": {"protocolVersion": "2025-06-18"}})
+
     prod_watch.results.clear()
-    real, prod_watch.get = prod_watch.get, get
+    real_get, prod_watch.get = prod_watch.get, get
+    real_post, prod_watch.post = prod_watch.post, post
     try:
         buf = io.StringIO()
         with redirect_stdout(buf):
             code = prod_watch.run(1.0, expect)
         return code, buf.getvalue()
     finally:
-        prod_watch.get = real
+        prod_watch.get = real_get
+        prod_watch.post = real_post
         prod_watch.results.clear()
 
 
@@ -296,15 +310,40 @@ TIP = "4f2a91cbeef1a9d3c05e7b21fd8460ac9e13d7f5"
 def test_a_current_build_is_counted_as_a_real_check():
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [TIP])
-    assert code == 0 and "all 10 checks passing" in out
+    assert code == 0 and "all 11 checks passing" in out
 
 
 def test_an_unasserted_build_never_inflates_the_count():
-    # The script's honesty property. "all 9 checks passing" must stay literally
-    # true when nothing pinned the build.
+    # The script's honesty property. "all 10 checks passing" must stay
+    # literally true when nothing pinned the build.
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [])
-    assert code == 0 and "all 9 checks passing" in out
+    assert code == 0 and "all 10 checks passing" in out
+
+
+class _Refused:
+    """A demo server that has stopped answering keyless callers."""
+    status_code = 401
+    text = ""
+
+    def json(self):
+        return {"error": "Unauthorized"}
+
+
+def test_a_demo_server_that_stops_serving_keyless_callers_is_an_outage():
+    """The failure a design partner reported before the monitor did.
+
+    A credential accidentally set on the public demo deployment flips it to
+    401. `/health` stays public on both servers, so the old "alive" check
+    could not see it — every quickstart, the Gemini extension and the registry
+    entry would be broken while the monitor read fully green.
+    """
+    code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
+                                  "built_at": 1754056800}, [TIP],
+                                 demo_handshake=_Refused())
+    assert code == 1, "a demo server refusing keyless callers must be an outage"
+    assert "serves an unauthenticated handshake" in out
+    assert "all 11 checks passing" not in out
 
 
 @pytest.mark.parametrize("supplied", ["", ",", " ", ",,"])

--- a/tests/test_docs_endpoint_drift.py
+++ b/tests/test_docs_endpoint_drift.py
@@ -1,0 +1,190 @@
+"""Guard: a keyless claim must never point at the token-locked MCP endpoint.
+
+There are two hosted MCP deployments and they differ only in a URL:
+
+  * the **demo** server  — `MCP_PUBLIC_DEMO=true`, no credential, hard-pinned
+    to a synthetic tenant;
+  * the **production** server — `MCP_AUTH_TOKEN` set, 401 without a bearer.
+
+#194 locked the production endpoint and moved the keyless pitch to the demo
+server, but only `README.md` was updated. Every per-client quickstart kept
+telling readers to paste the *production* URL and promising "no login screen
+appears". The result was a connector that adds fine and then fails at sign-in
+with "Couldn't register", because a 401 makes MCP clients start an OAuth flow
+against a server that publishes no OAuth metadata.
+
+Nothing caught it: the URL was reachable, the tests were green, and the claim
+and the URL sat on adjacent lines in a file no test read. It took a design
+partner four days later to report it.
+
+So this asserts the invariant that was violated, rather than pinning the
+current URLs: **wherever a doc promises keyless access, the endpoint nearest
+that promise must be the keyless one.** Swapping either host string keeps the
+test meaningful; deleting the pairing is what it exists to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The two deployments, identified by host. Kept as bare hosts so the check
+# fires for any path or scheme (/mcp, /mcp/rpc, /health, curl lines, JSON).
+DEMO_HOST = "mcp-demo-production-ee2c.up.railway.app"
+LOCKED_HOST = "mcp-server-production-5112.up.railway.app"
+
+# Phrases that promise a reader they need no credential. Deliberately narrow:
+# a bare "none" in a comparison table is not a promise, "Authentication: none"
+# in a setup step is.
+KEYLESS_CLAIM = re.compile(
+    r"""
+      no\s+api\s+key
+    | no\s+key\s+required
+    | without\s+credentials
+    | no\s+credentials\s+needed
+    | no\s+login\s+screen
+    | anonymous\s+access
+    | authentication:\W*\s*(?:no\s+authentication|none)\b
+    | works\s+without\s+credentials
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# `templates` and `adapters` are in scope because they were broken too: the
+# public homepage handed visitors the locked URL, and all three adapter
+# examples used it as their `--mcp-base` default.
+SEARCH_DIRS = ("docs", "skills", "hermes", "templates", "adapters")
+ROOT_FILES = ("README.md", "server.json", "glama.json", ".mcp.json",
+              "gemini-extension.json")
+SCAN_SUFFIXES = {".md", ".json", ".yaml", ".yml", ".html", ".py"}
+SKIP_PARTS = {"node_modules", ".git", "dist", "__pycache__"}
+
+
+def _candidate_files() -> list[Path]:
+    found: list[Path] = []
+    for directory in SEARCH_DIRS:
+        base = REPO_ROOT / directory
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix.lower() not in SCAN_SUFFIXES:
+                continue
+            if SKIP_PARTS & set(path.parts):
+                continue
+            found.append(path)
+    found.extend(REPO_ROOT / name for name in ROOT_FILES
+                 if (REPO_ROOT / name).is_file())
+    return sorted(found)
+
+
+def _nearest_host(lines: list[str], index: int) -> str | None:
+    """Which deployment is this line talking about? None if neither is near.
+
+    Ties resolve to LOCKED: an ambiguous keyless claim is exactly the kind of
+    thing a human should disambiguate, not something to wave through.
+    """
+    best: tuple[int, str] | None = None
+    for offset, line in enumerate(lines):
+        for host in (DEMO_HOST, LOCKED_HOST):
+            if host in line:
+                distance = abs(offset - index)
+                if best is None or distance < best[0]:
+                    best = (distance, host)
+                elif distance == best[0] and host == LOCKED_HOST:
+                    best = (distance, LOCKED_HOST)
+    return None if best is None else best[1]
+
+
+def test_repo_still_references_both_deployments():
+    """Sanity: the corpus this guard scans has not moved out from under it."""
+    blob = "\n".join(p.read_text(encoding="utf-8", errors="ignore")
+                     for p in _candidate_files())
+    assert DEMO_HOST in blob, "no demo endpoint in docs — did a host change?"
+    assert LOCKED_HOST in blob, "no locked endpoint in docs — host change?"
+
+
+def test_no_keyless_claim_points_at_the_token_locked_endpoint():
+    violations: list[str] = []
+
+    for path in _candidate_files():
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        if LOCKED_HOST not in "\n".join(lines):
+            continue
+        for index, line in enumerate(lines):
+            if not KEYLESS_CLAIM.search(line):
+                continue
+            if _nearest_host(lines, index) == LOCKED_HOST:
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{index + 1}: {line.strip()[:100]}")
+
+    assert not violations, (
+        "These lines promise keyless access next to the token-locked endpoint "
+        f"({LOCKED_HOST}), which answers 401 and sends MCP clients into an "
+        "OAuth flow that cannot complete. Point them at the demo endpoint "
+        f"({DEMO_HOST}) or state the bearer requirement:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.parametrize("path", [
+    "docs/quickstarts/claude.md",
+    "docs/quickstarts/chatgpt.md",
+    "docs/quickstarts/perplexity.md",
+    "docs/quickstarts/mcp-generic.md",
+    "docs/quickstarts/README.md",
+])
+def test_consumer_quickstarts_lead_with_the_keyless_endpoint(path):
+    """The URL a non-developer pastes into a hosted connector must be keyless.
+
+    Hosted connectors (claude.ai, ChatGPT, Perplexity) cannot attach a static
+    bearer header at all, so the locked endpoint is not merely inconvenient
+    there — it is unusable. These guides must not be the place it appears
+    first.
+    """
+    lines = (REPO_ROOT / path).read_text(encoding="utf-8").splitlines()
+    first = {}
+    for index, line in enumerate(lines):
+        for host in (DEMO_HOST, LOCKED_HOST):
+            if host in line and host not in first:
+                first[host] = index
+
+    assert DEMO_HOST in first, f"{path} never names the keyless endpoint"
+    if LOCKED_HOST in first:
+        assert first[DEMO_HOST] < first[LOCKED_HOST], (
+            f"{path} names the token-locked endpoint (line "
+            f"{first[LOCKED_HOST] + 1}) before the keyless one (line "
+            f"{first[DEMO_HOST] + 1}); a reader following along top-to-bottom "
+            "will paste the one that 401s."
+        )
+
+
+def test_server_json_keyless_remote_is_the_demo_host():
+    """Catalog clients surface `remotes` — a remote with no required secret
+    header reads as 'try me, no signup', so it had better be the demo."""
+    import json
+
+    remotes = json.loads((REPO_ROOT / "server.json").read_text())["remotes"]
+    assert remotes, "server.json advertises no remotes"
+
+    for remote in remotes:
+        url = remote["url"]
+        needs_secret = any(
+            header.get("isRequired") and header.get("isSecret")
+            for header in remote.get("headers") or []
+        )
+        if LOCKED_HOST in url:
+            assert needs_secret, (
+                "server.json advertises the token-locked endpoint without "
+                "marking a required secret header; catalogs will present it "
+                "as keyless and every visitor gets a 401."
+            )
+        elif DEMO_HOST in url:
+            assert not needs_secret, (
+                "server.json demands a secret for the demo endpoint, which "
+                "accepts none — visitors will hunt for a credential that "
+                "does not exist."
+            )


### PR DESCRIPTION
Reported by Dr. Gigi Magan, blocking her demo recording. Diagnosed against live production, not just the code.

## What she saw

Connector adds fine, then: *"Couldnt register with HealthClaws sign-in service"* and a prompt for an OAuth Client ID. Our quickstart promises anonymous access with no login.

## Root cause

#194 (merged 2026-07-29) locked the production MCP server and moved the keyless pitch to a new public demo deployment. **Only `README.md` followed.** Everything else kept handing people the production URL next to a promise that no key was needed:

| Surface | Was |
| --- | --- |
| `docs/quickstarts/{claude,chatgpt,perplexity,mcp-generic,telegram,README}.md` | locked URL + "No login screen appears" / "Authentication: none" |
| `skills/hermes/SKILL.md`, `hermes/README.md`, `hermes/mcp.json` | locked URL as the installer default |
| `gemini-extension.json` | locked URL — the `gemini extensions install` one-liner |
| `server.json` | locked URL, headers advertising "works without credentials" |
| `templates/index.html` | **the app.healthclaw.io homepage** told every visitor to point raw MCP clients at it |
| `adapters/examples/*.py` | locked URL as `--mcp-base` in all three |

The locked server answers `401`. A `401` makes an MCP client start OAuth; the server publishes no OAuth metadata; registration fails; the client asks for a Client ID that does not exist. Her diagnosis was right in shape — one server-side bug, not two — but the 404s she checked on `app.healthclaw.io` are a red herring: that host is the Flask app, whose SMART discovery correctly lives under `/r6/fhir/.well-known/`, and the connector never talks to it.

So this is a **doc/deploy split-brain**, not an auth regression. The lock is working as intended and stays.

## What this does

Points every keyless surface at the demo deployment. Describes the production endpoint accurately wherever it appears.

Two traps documented rather than papered over:

1. **The demo server ignores tenancy and BYO-FHIR headers rather than rejecting them.** A request that looks like it selected your tenant quietly returns synthetic data. That is correct security behaviour — an open caller must never reach a real tenant — but it is a silent-wrong-answer trap, so `mcp-generic.md` now says so plainly, and `hermes/mcp.json`s SHARP profile stays on the locked server with an explicit bearer placeholder instead of being moved somewhere it would appear to work.
2. **`claude.md`s "point at your own records" flow is not available through a hosted connector today** — hosted connectors cannot attach a bearer header. Marked unavailable and pointed at #290 rather than left as a promise.

## Guards

The failure was live for four days with the endpoint reachable and CI green, so the fix is not complete without something that fires.

- **`tests/test_docs_endpoint_drift.py`** asserts the invariant that broke: a keyless claim must never sit closer to the locked host than to the demo host. Mutation-checked — restoring the original line 13 of `claude.md` fails two tests independently, naming the file, the line, and the failure mode. It scans docs, skills, hermes, templates, adapters and the root manifests, so the homepage and the Gemini extension are covered too.
- **`prod_watch`** now asserts the demo server *serves an unauthenticated handshake*, not merely that `/health` is up. `/health` is public on both deployments, so a credential accidentally set on the demo would have been invisible to the monitor while every quickstart broke. Covered by a test that a refusing demo server exits non-zero.

Writing that second guard surfaced a real defect in the test harness: it stubbed `get` but not `post`, so the new check was reaching the live network from inside a unit test. Fixed, and the harness now stubs both.

The pre-existing `gemini-extension.json` ↔ `server.json` pin caught the extension needing to move as well — it did its job.

## Verification

- `1916 passed, 6 skipped, 2 xfailed`; `uv run ruff check .` clean; conformance Grade A.
- Live `prod_watch`: **all 10 checks passing**, including `mcp (locked): refuses unauthenticated callers -> 401` and the new `mcp (public demo): serves an unauthenticated handshake -> 200`.
- Keyless `initialize` + `tools/list` against the demo endpoint verified by hand: 27 tools, no credential.

## Not fixed here

**#290** — the locked endpoint is unreachable from any hosted connector, and its `401` leads users into a dead end with no correct action available. That is a product call, filed separately.

## Note for the maintainer

The demo endpoint is now the advertised entry point in `server.json` and `gemini-extension.json`. Republishing to the MCP registry may need a version bump; `server.json` still says `1.8.0` while the repo is at `1.9.0`. Not touched here — flagging it.

Gigi is unblocked immediately by swapping her connector URL; she does not need this merged.