### PR TITLE
fix(e2e): boot gate waited on readiness — no e2e spec has run since Aug 2

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -1036,9 +1036,19 @@ def create_app(config: Config | None = None,
         load balancer would route real sign-ins straight into failure. It now
         round-trips a trivial query so the answer reflects reality.
 
+        Readiness has two inputs, and both gate the status code: the account
+        store must answer, and a fresh agent-run worker must be present. A
+        deployment with no worker can serve pages but cannot complete a chat
+        turn, so advertising it as ready would route people into failure the
+        same way the hard-coded accounts=True once did.
+
         It also reports which build is running (#258). That is telemetry, not
         a gate: an absent marker reports "unknown" and changes nothing about
-        the status code, which still depends only on the account store.
+        the status code.
+
+        Callers that only need "is this process up" (a boot gate, a restart
+        probe) must not use this endpoint — it answers for the whole system,
+        including dependencies it does not control.
         """
         accounts_ok = svc.ping()
         workers_ok = _workers_available()

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -68,7 +68,15 @@ export default defineConfig({
       command:
         `rm -f ${CARE_DB} ${CARE_LOG} && cd .. && ` +
         `uv run flask --app careagents.wsgi run --port ${CARE_PORT} 2>> ${CARE_LOG}`,
-      url: `${CARE_BASE_URL}/healthz`,
+      // Liveness, NOT /healthz. `/healthz` is readiness, and since the durable
+      // agent-run control plane landed it also requires a live worker, which
+      // it learns by asking HealthClaw — which this harness deliberately pins
+      // to a dead port two entries below. So /healthz correctly answers 503
+      // here forever, Playwright waited the full 60s for a 200 that could
+      // never come, and every e2e run failed at boot with "Timed out waiting
+      // 60000ms from config.webServer" — no spec ever executed. The landing
+      // page is the honest "the server is up" signal for a boot gate.
+      url: `${CARE_BASE_URL}/`,
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,
       env: {

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -174,11 +174,24 @@ test.describe('CareAgents auth', () => {
 });
 
 test.describe('CareAgents health', () => {
+  // What this can honestly assert here is the account store, which is what
+  // the test was always named for. Overall readiness additionally requires a
+  // live agent-run worker, and this harness points HEALTHCLAW_BASE at a dead
+  // port on purpose so a stray call cannot reach the real records service.
+  // So `status` is legitimately "degraded" in e2e, and asserting "ok" was
+  // asserting that our own isolation had failed.
   test('healthz reports the account store reachable', async ({ request }) => {
     const res = await request.get('/healthz');
-    expect(res.status()).toBe(200);
     const body = await res.json();
-    expect(body.status).toBe('ok');
+
     expect(body.accounts).toBe(true);
+
+    // Degradation must be attributable. If the account store ever goes
+    // unreachable, that has to fail here rather than hide behind the
+    // worker's absence.
+    if (res.status() !== 200) {
+      expect(body.status).toBe('degraded');
+      expect(body.run_workers).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Found while acceptance-testing #288 and #291. **Merge this first** — until it lands, the `playwright-tests` check is red on every PR for reasons unrelated to that PR, and neither of those PRs e2e results mean anything.

## The gate is not flaky, it is off

Every CI run on `main` since 20:23 on 2026-08-02 fails with:

```
Error: Timed out waiting 60000ms from config.webServer.
```

**No spec executes.** The e2e gate has been reporting failure without testing anything for a day — which is worse than reporting nothing, because a red that is always red gets scrolled past.

## Cause

Playwright waited for CareAgents `/healthz` to return 200 before starting. `/healthz` is *readiness*, and since the durable agent-run control plane landed, readiness also requires a live worker — which it determines by asking HealthClaw:

```python
def _workers_available() -> bool:
    try:
        status = hc.agent_worker_health(cfg.run_worker_stale_seconds)
    except HealthClawError:
        return False
```

...and this harness deliberately pins `HEALTHCLAW_BASE` to a dead port so a stray call can never reach the real records service:

```
// A dead local port: the browser journey under test never touches
// HealthClaw, and anything that accidentally tries must fail fast
HEALTHCLAW_BASE: http://127.0.0.1:9,
```

Reproduced directly:

```
$ curl -s localhost:5098/healthz
{"accounts":true,"run_workers":false,"status":"degraded", ...}   # 503
```

**Both halves are correct.** `/healthz` should answer 503 with no worker. The harness should isolate itself. They were only wrong together: the boot gate asked *"is the whole system ready"* when it needed to ask *"is this process up"*.

This is the third instance this week of a control that looked like one thing and quietly did two.

## Changes

- **`e2e/playwright.config.ts`** — wait on the landing page. Liveness is what a boot gate needs.
- **`e2e/tests/careagents.spec.ts`** — the test asserted `200` and `status == "ok"`. Its name is *"healthz reports the account store reachable"*, and the account store **is** reachable here; what it actually asserted was that our own isolation had failed. Now asserts `accounts === true` unconditionally, and requires any degradation to be attributable to the worker — so an account store that genuinely breaks still fails, rather than hiding behind the workers absence.
- **`careagents/app.py`** — the `/healthz` docstring still claimed the status code *"depends only on the account store"*. That stopped being true when `ready = accounts_ok and workers_ok` landed. Corrected, plus a note that boot/restart probes must not use this endpoint.

## Verification

- `CI=1 E2E_PORT=5099 npx playwright test` → **42 passed** (25.8s). First full e2e run since the break.
- Reverting the one config line reproduces CIs exact error, so the fix is load-bearing.
- `1907 passed, 6 skipped, 2 xfailed`; ruff clean.

(`E2E_PORT` only because 5000 is macOS AirPlay locally — CI is unaffected and the default is unchanged.)

## Worth deciding separately

Nothing asserts that the e2e suite actually *ran*. A boot timeout and a real failure are the same red X, and that is why this survived a day. A guard that fails when zero specs execute would have caught it on the first run — happy to add it if you want it.