### PR TITLE
fix(docs): mcp-generic advertised tool arguments and tools that do not exist

### DIFF
--- a/docs/quickstarts/mcp-generic.md
+++ b/docs/quickstarts/mcp-generic.md
@@ -63,14 +63,24 @@ tenant — but it means a request that *looks* like it selected your tenant will
 quietly return demo data instead. If you are passing any of the headers below,
 you want the production endpoint.
 
-On the production endpoint:
+On the production endpoint, **all of these are headers. None of them is a tool
+argument.** Verified against the deployed server: no tool in `tools/list`
+exposes `_tenantId`, `_stepUpToken`, `_fhirServerUrl` or `_fhirAccessToken` in
+its input schema, and every schema is closed. Passing one as an argument is
+silently dropped — the call still succeeds, against whatever tenant the
+headers selected. This page previously claimed otherwise.
 
-- `X-Tenant-ID` header (or `_tenantId` tool argument) selects a tenant.
-- Non-public tenants need a tenant-bound token: `X-Step-Up-Token` header or
-  `_stepUpToken` argument. Writes always require step-up; clinical writes
-  additionally require an explicit human confirmation (HTTP 428 otherwise).
-- Bring-your-own FHIR server: pass `_fhirServerUrl` (+ `_fhirAccessToken`)
-  and the guardrail stack proxies it per-request (SHARP-on-MCP).
+- `X-Tenant-Id` header selects a tenant.
+- Non-public tenants need a tenant-bound token in `X-Step-Up-Token`. Writes
+  always require step-up; clinical writes additionally require an explicit
+  human confirmation (HTTP 428 otherwise).
+- Bring-your-own FHIR server: `X-FHIR-Server-URL` (+ `X-FHIR-Access-Token`,
+  `X-Patient-ID`) and the guardrail stack proxies it per-request
+  (SHARP-on-MCP).
+
+**A client that cannot set headers cannot select a tenant.** That is the whole
+of #290: it is not that hosted connectors are inconvenient for real records,
+it is that they have no mechanism to ask for one.
 
 The production endpoint's bearer token is deployment-scoped and issued by the
 operator; it is not self-serve. Note that hosted chat connectors (claude.ai,
@@ -78,16 +88,27 @@ ChatGPT, Perplexity) cannot attach a static bearer header, so they can only use
 the demo endpoint today — tracked in
 [#290](https://github.com/aks129/HealthClawGuardrails/issues/290).
 
-## The 28 tools
+## The tools
+
+A hosted deployment serves **27**. The tool catalogue defines 29; two —
+`fhir_get_token` and `fhir_seed` — are `PRIVILEGED_TOOL_NAMES` and are
+withheld from network transports on purpose, so they will not appear in your
+client's `tools/list`. That is deliberate, not a fault: minting step-up tokens
+and seeding tenants are operator actions, not agent actions.
 
 Read: `context_get`, `fhir_read`, `fhir_search`, `fhir_validate`,
 `fhir_stats`, `fhir_lastn`, `fhir_permission_evaluate`,
 `fhir_subscription_topics`, `questionnaire_populate`, `curatr_evaluate`,
-`action_status`, `fhir_interpret_labs`, `care_gaps`, `guardrail_conformance`.
+`action_status`, `fhir_interpret_labs`, `care_gaps`, `guardrail_conformance`,
+`wearables_sync_status`, `sources_check`, `fhir_compiled_truth`.
 Write (step-up gated): `fhir_propose_write`, `fhir_commit_write`,
-`curatr_apply_fix`, `action_propose`, `action_commit`, `shl_generate`,
-`questionnaire_extract`. Utility: `fhir_compiled_truth`, `fhir_get_token`,
-`fhir_seed`, and friends.
+`curatr_apply_fix`, `action_propose`, `action_commit`, `rx_transfer_request`,
+`shl_generate`, `questionnaire_extract`.
+ChatGPT-connector shims: `search`, `fetch`.
+
+Step-up for the write tier comes from the `X-Step-Up-Token` header, issued by
+the operator or by the patient connect flow — not from a tool call, because
+the tool that mints it is one of the two withheld above.
 
 Run the [10-minute demo script](README.md#the-10-minute-demo-script-works-in-any-connected-agent)
 from any of these clients.

--- a/tests/test_docs_tool_catalogue_drift.py
+++ b/tests/test_docs_tool_catalogue_drift.py
@@ -1,0 +1,102 @@
+"""Guard: the tool list a reader is handed must match the tools that exist.
+
+`docs/quickstarts/mcp-generic.md` named `fhir_get_token` and `fhir_seed` as
+things you can call. Both are in `PRIVILEGED_TOOL_NAMES` and are withheld from
+network transports, so no hosted client has ever been able to see them. The
+page also advertised "28 tools" while the deployed server serves 27 and the
+catalogue defines 29 — three numbers, no two agreeing.
+
+That is not pedantry about a count. A reader who believes `fhir_get_token`
+exists will write an agent that calls it, and the failure arrives at runtime
+in someone else's client.
+
+Source of truth is `adapters/tools.manifest.json`, which is generated from the
+same catalogue the server serves.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC = REPO_ROOT / "docs" / "quickstarts" / "mcp-generic.md"
+MANIFEST = REPO_ROOT / "adapters" / "tools.manifest.json"
+TOOLS_TS = (REPO_ROOT / "services" / "agent-orchestrator" / "src" / "tools.ts")
+
+# Prose that legitimately names the withheld tools in order to explain that
+# they are withheld. Only the catalogue section is under inventory rules.
+_TOOLS_SECTION = re.compile(r"^## The tools$(.*?)^## ", re.M | re.S)
+
+
+def _manifest_names() -> set[str]:
+    data = json.loads(MANIFEST.read_text())
+    tools = data if isinstance(data, list) else data.get("tools", [])
+    return {t["name"] for t in tools}
+
+
+def _privileged_names() -> set[str]:
+    src = TOOLS_TS.read_text(encoding="utf-8")
+    m = re.search(r"PRIVILEGED_TOOL_NAMES\s*=\s*new Set\(\[(.*?)\]\)", src,
+                  re.S)
+    assert m, "PRIVILEGED_TOOL_NAMES not found — did tools.ts move?"
+    return set(re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def _doc_section() -> str:
+    body = DOC.read_text(encoding="utf-8")
+    m = _TOOLS_SECTION.search(body + "\n## ")
+    assert m, "the '## The tools' section is gone from mcp-generic.md"
+    return m.group(1)
+
+
+def test_every_tool_the_docs_name_actually_exists():
+    named = set(re.findall(r"`([a-z][a-z0-9_]+)`", _doc_section()))
+    # Header names appear in the same section; they are not tool names.
+    named -= {"x_step_up_token", "tools_list"}
+    unknown = sorted(n for n in named if n not in _manifest_names())
+    assert not unknown, (
+        "mcp-generic.md names tools that are not in the catalogue: "
+        + ", ".join(unknown))
+
+
+def test_docs_do_not_offer_tools_the_server_withholds():
+    """The specific error this file exists for.
+
+    A privileged tool may be *mentioned* — explaining the withholding is
+    useful — but it must not appear in the Read/Write/shim inventory lines,
+    which read as "here is what you can call".
+    """
+    privileged = _privileged_names()
+    assert privileged, "expected at least one privileged tool"
+
+    # Exempt by MEANING, not by line shape. An earlier version of this guard
+    # whitelisted the prefixes "Read"/"Write"/"ChatGPT-connector", so adding a
+    # "Utility: `fhir_get_token`" line sailed straight through it — the guard
+    # was pinned to the formatting of the day it was written. Any paragraph
+    # that does not explain the withholding is an inventory paragraph.
+    explains = re.compile(r"withheld|privileged|PRIVILEGED|not appear|"
+                          r"withholding", re.I)
+
+    leaked = set()
+    for para in re.split(r"\n\s*\n", _doc_section()):
+        if explains.search(para):
+            continue
+        leaked |= set(re.findall(r"`([a-z][a-z0-9_]+)`", para)) & privileged
+
+    leaked = sorted(leaked)
+    assert not leaked, (
+        "mcp-generic.md offers withheld tools as callable: "
+        + ", ".join(leaked)
+        + " — these are in PRIVILEGED_TOOL_NAMES and never appear in a "
+          "hosted client's tools/list.")
+
+
+def test_the_documented_count_matches_what_a_hosted_client_sees():
+    served = len(_manifest_names() - _privileged_names())
+    m = re.search(r"serves \*\*(\d+)\*\*", _doc_section())
+    assert m, "mcp-generic.md no longer states how many tools are served"
+    assert int(m.group(1)) == served, (
+        f"docs say a hosted deployment serves {m.group(1)}; catalogue minus "
+        f"privileged is {served}")


### PR DESCRIPTION
Found while verifying, against the live server, that Gigi could actually reach her own records. I had carried these claims forward in #291 without checking them.

## What was wrong

**1. Tool arguments that do not exist.** The page documented `_tenantId`, `_stepUpToken`, `_fhirServerUrl`, `_fhirAccessToken` as tool arguments. Queried the deployed server: **zero of 27 tools expose any of them**, and every input schema is closed.

```
tools exposing _tenantId/_stepUpToken/_fhir* as arguments: 0
action_commit     -> action_id                | additionalProperties: None
fhir_commit_write -> operation, resource      | additionalProperties: None
```

Tenant, step-up and BYO-FHIR are **headers**. That distinction is the whole of #290: a client that cannot set headers cannot select a tenant. It is not that hosted connectors are inconvenient for real records — they have no mechanism to ask for one.

And the failure is silent. Confirmed directly:

```
demo server,   _tenantId=zzz-nonexistent  -> 12 conditions (demo patient)
locked server, X-Tenant-Id=zzz-nonexistent ->  0, OperationOutcome error
```

The argument is dropped and the call succeeds against whoever the headers selected. Someone following this page would have shown a patient the demo record and had no signal anything was wrong.

**2. Tools that are deliberately withheld.** `fhir_get_token` and `fhir_seed` were offered as callable. Both are in `PRIVILEGED_TOOL_NAMES` and never appear in a hosted `tools/list` — correct design, wrong documentation.

**3. Three tool counts, no two agreeing.** Page said 28, catalogue defines 29, hosted deployment serves 27.

## Guard

`tests/test_docs_tool_catalogue_drift.py` checks the page against `adapters/tools.manifest.json` and the real `PRIVILEGED_TOOL_NAMES`: every named tool must exist, withheld tools must not be offered as callable, stated count must equal catalogue-minus-privileged.

**The guard failed the same way the docs did, and that is worth recording.** My first version located the inventory by whitelisting the line prefixes `Read`/`Write`/`ChatGPT-connector`. A mutation adding `Utility: ` + "`fhir_get_token`" sailed straight through — the check was pinned to the formatting of the day I wrote it rather than to the meaning. It now exempts paragraphs by what they *say* (those explaining the withholding) rather than by how they start. Both mutations fail it now; I verified each.

## Gates

`1931 passed, 6 skipped, 2 xfailed`; ruff clean.

## Not fixed here — needs its own review

Four tool **descriptions** in `services/agent-orchestrator/src/tools.ts` still tell the model to call `fhir_get_token` and pass `_stepUpToken`:

```
tools.ts:983  action_commit — "Requires step-up authorization
              (call fhir_get_token first; pass as _stepUpToken)."
```

On a hosted deployment that tool is withheld and that argument is rejected, while the handler reads `headers["x-step-up-token"]` (tools.ts:1156). So the model is instructed to do two impossible things, on the write path.

This is agent-facing guidance for the action rail, so it wants deliberate review rather than a docs PR. Filed separately.