### PR TITLE
docs: retro for 2026-08-02 — one defect shape, four times

### DIFF
--- a/docs/2026-08-02-retro.md
+++ b/docs/2026-08-02-retro.md
@@ -1,0 +1,187 @@
+# Retro — 2026-08-02
+
+Four PRs merged (#288, #291, #292, #295), two live production vulnerabilities
+closed, and a design partner unblocked. Almost none of it was new capability.
+This was a day of finding out that things we believed were working were not,
+and the way we found out is the part worth keeping.
+
+Written for the team — CTO, Dev, QA, Product — as input to the next phase.
+
+---
+
+## The one pattern
+
+Six defects this week were the same shape: **a control that looked like one
+thing and quietly did another**, or that passed for a reason unrelated to the
+property it was supposed to protect.
+
+| # | The control | What it looked like | What it actually did |
+| --- | --- | --- | --- |
+| 1 | prod-watch `-ge 15` guard | "the checks ran" | counted *how many*, never *which* |
+| 2 | prod-watch alarm predicate | "nothing is wrong" | "nothing **this alarm** speaks for" |
+| 3 | `_RESOURCE_ID_PATTERN` | a charset security control | charset **plus a 64-char ceiling** that silently drops real records |
+| 4 | `assert status in (400, 403)` | "the auth gate refused" | passed whether auth ran before **or after** the parse |
+| 5 | docs drift guard (ours, same day) | "no keyless claim points at the locked host" | matched **line prefixes**, so a reformatted line slipped past |
+| 6 | `/healthz` as a boot gate | "the server is up" | "the whole system, including a dependency we deliberately broke, is ready" |
+
+Number 3 is the most instructive. The FHIR spec's id pattern was copied
+verbatim — charset *and* its length cap — without asking which half was the
+security control. Only the charset was. This repo has a documented 2026-07-08
+incident where a real Epic export carried 65 of 250 ids longer than 64
+characters, which is precisely why the column was widened to 255. The regex
+re-imposed the ceiling inside `_ingest_one`, which both the Fasten and SHC
+paths call. The failure mode was **silent data loss on real patient records** —
+`invalid_id` skips, not a crash. 1,772 green tests missed it, because the
+regression guard written for that very incident writes the ORM row directly and
+never calls the ingester.
+
+Number 4 is the most alarming. `assert r.status_code in (400, 403)` was the
+only assertion standing between us and a reintroduced vulnerability. The
+`RecursionError` catch also answers 400, so moving the auth gate back below
+`json.loads` — literally restoring the bug — left the suite green at 1,919
+passed. **The central property of a security fix was pinned by nothing.**
+
+Number 5 matters because it happened *while writing a guard against number 5's
+own category*, on the same day, by someone who had just described the pattern
+in a commit message. Knowing the shape is not the same as being immune to it.
+
+**The rule that falls out:** when you write a check, name the property it
+protects in one sentence, then ask what else could make it pass. If the answer
+is "the broken behaviour," the check is decoration. Mutation-test anything
+load-bearing: break the code, confirm something red appears, restore.
+
+---
+
+## The second pattern: reality drifted and nothing noticed
+
+**#194 changed deployment posture and one doc followed.** The MCP server split
+into a keyless demo deployment and a token-locked production one. `README.md`
+was updated. Not updated: six quickstarts, the Gemini one-command install, the
+MCP registry entry (`server.json`), the public homepage, and three adapter
+examples — all of which kept handing strangers the locked URL beside a promise
+that no login was needed.
+
+It was broken for **four days**. The endpoint was reachable, CI was green, and
+1,900 tests passed the whole time. **A design partner found it.** Dr. Gigi
+Magan sat down to record a demo and got "Couldn't register with HealthClaw's
+sign-in service."
+
+The same class produced #295 the same day: our docs described tool arguments
+(`_tenantId`, `_stepUpToken`, `_fhirServerUrl`) that **exist on zero of the 27
+deployed tools**. A reader following that page would have shown a patient the
+synthetic demo record while believing they were looking at their own, because
+the argument is silently dropped rather than rejected.
+
+**What this says:** we have no test that compares what we *tell people* against
+what the system *does*. Two guards now exist
+(`tests/test_docs_endpoint_drift.py`, `tests/test_docs_tool_catalogue_drift.py`)
+but they cover two pages. Documentation is part of the product surface and it
+is the only part with no CI.
+
+---
+
+## The third pattern: green that meant nothing
+
+**The Playwright gate was red on main for a full day and no spec executed.**
+Every run died at `Timed out waiting 60000ms from config.webServer`. A boot
+timeout and a genuine test failure render as the same red X, so it read as
+"e2e is flaky again" and got scrolled past.
+
+Two correct decisions collided. `/healthz` correctly reports 503 when no
+agent-run worker is reachable. The e2e harness correctly pins `HEALTHCLAW_BASE`
+to a dead port so a stray call can never touch real records. Neither is wrong;
+the boot gate simply asked "is the whole system ready" when it needed to ask
+"is this process up."
+
+**Nothing asserts that the e2e suite ran at all.** That is the actual gap. A
+check that "zero specs executed" is a failure would have caught it on the first
+run.
+
+---
+
+## The fourth pattern: a feature shipped without its hardening
+
+**#267's feature merged to main as `0d5246b`. Its security fixes sat in an
+unmerged PR.** Both vulnerabilities were therefore live in production —
+verified by probing the running system:
+
+```
+POST /r6/fhir/internal/ingest-bundle   (no credential, unparseable body)
+→ 400 {"error":"invalid_json"}        # parsed BEFORE any auth check
+```
+
+Reproduced through the WSGI app, `main` versus the fix:
+
+| assertion | `main` | fixed |
+| --- | --- | --- |
+| auth runs before the body is parsed | fail | pass |
+| deep nesting refused without credentials | fail | pass |
+| public-tenant write requires the internal secret | fail | pass |
+| a refused write leaves no record behind | **persisted an Observation** | pass |
+| the authorized path still works | pass | pass |
+
+A feature and the review that blocks it are one unit. Splitting them across
+merges converts "we found two vulnerabilities in review" into "we shipped two
+vulnerabilities and fixed them later."
+
+---
+
+## What worked, and should become habit
+
+- **Attacking the running system, not the code.** Both #267 vulnerabilities and
+  the entire #291 defect were found by probing production. Reading the diff
+  would not have surfaced either.
+- **Adversarial review with mutation testing.** QA caught a HIGH regression *in
+  a security fix* and then proved the fix's central property was untested. Both
+  came from deliberately breaking things, not from reading.
+- **Verifying the remote ref after every push.** `git push -q` failed silently
+  twice earlier in this cycle; a guard was reported as shipped while the remote
+  carried the unguarded snippet. Every push is now followed by `git ls-remote`.
+- **Reading the neighbouring code before committing.** The revoked-connection
+  fix was first written as `if conn["status"] != "active"`, which would have
+  blocked **every legitimate first upload**, since `direct` connections start
+  at `status="empty"`. Reading `connectors.py` caught it before the commit.
+- **Building the new DNS zone before making it authoritative.** The whole
+  careagents.cloud zone was constructed and corrected in Vercel while Hostinger
+  was still authoritative — zero user impact — and only then were nameservers
+  flipped. Three latent problems (a stale Vercel project still claiming the
+  domain, a duplicate apex ALIAS, and a `www` record that would have thrown a
+  TLS error) were found and fixed in that window.
+
+---
+
+## Standing corrections
+
+- **"Here is the signed PDF" is false.** There is no cryptographic signature.
+  There is an HMAC-signed expiring delivery link and a provenance footer
+  stating a machine filled the form and a human reviewed it. Equally strong,
+  and true.
+- **Real records are not reachable from a hosted chat connector** (#290).
+  Hosted connectors cannot attach the credential the locked server requires,
+  and it publishes no OAuth metadata. CareAgents is the supported path.
+- **Tenant selection is header-only.** No tool accepts it as an argument.
+
+---
+
+## Open, ranked by what they would cost us
+
+| Issue | Why it matters |
+| --- | --- |
+| #290 | No supported route from a hosted chat surface to a real patient tenant |
+| #296 | Four tool descriptions instruct the model to call a withheld tool and pass a rejected argument — on the **write/action path** |
+| #293 | Invalid ids collapse to `skipped` with no log — the same silence that would have hidden the ceiling regression |
+| #289 | prod_watch monitors the Railway origin, not the origin users reach |
+| #286 | Blank-id semantics changed; correct behaviour is a product call |
+| #287 | The id-validation tests only work as an ensemble; deleting any one opens a mutation |
+| #294 | Transport-failure wrap has no regression pin |
+
+---
+
+## Carry into the next phase
+
+1. Every load-bearing check gets mutation-tested. Break it, see red, restore.
+2. Ship a feature and its hardening as one unit, or ship neither.
+3. Documentation is product surface. Claims we make in docs need guards.
+4. A gate that cannot distinguish "failed" from "never ran" is not a gate.
+5. Probe production. Our failures this week were invisible to us and obvious to
+   the person trying to use the thing.


### PR DESCRIPTION
Input for the CTO / Product / QA next-phase planning, which is running now.

Four PRs merged today and two live production vulnerabilities closed — and almost none of it was new capability. The day was spent discovering that things we believed were working were not. How we discovered them is the part worth keeping.

## The finding

Six defects this week were the same shape: **a control that looked like one thing and quietly did another.**

The two that should worry us most:

**The id regex.** We copied the FHIR spec pattern verbatim — charset *and* its 64-char ceiling — without asking which half was the security control. Only the charset was. This repo has a documented 2026-07-08 Epic export with 65 of 250 ids over 64 characters; that incident is *why* the column is 255. The regex re-imposed the ceiling inside `_ingest_one`, which Fasten and SHC both call. Failure mode: silent data loss on real patient records. 1,772 green tests missed it, because the regression guard written for that exact incident writes the ORM row directly and never calls the ingester.

**The assertion that accepted the bug.** `assert r.status_code in (400, 403)` was the only thing standing between us and a reintroduced vulnerability. The `RecursionError` catch also answers 400, so moving the auth gate back below `json.loads` — literally restoring the bug — left the suite green at 1,919 passed. The central property of a security fix was pinned by nothing.

And one worth sitting with: **a drift guard we wrote the same day had the same flaw**, matching line prefixes rather than meaning — written by someone who had just described the pattern in a commit message. Knowing the shape is not immunity.

## Three more patterns

- **Docs drifted from deployment and nothing noticed.** #194 split the MCP server; one doc followed. Six quickstarts, the Gemini install, the registry entry, the homepage and three adapter examples kept promising keyless access against a token-locked server. Four days. A design partner found it, not CI.
- **A gate that was red without running.** Playwright failed at boot for a day; zero specs executed. A boot timeout and a real failure render as the same red X. Nothing asserts the suite ran at all.
- **A feature shipped without its hardening.** #267 merged; its security fixes sat in a PR. Both vulnerabilities were live in production, verified by probing the running system.

## What worked

Probing production rather than reading diffs. Adversarial mutation testing. Verifying the remote ref after every push (`git push -q` had failed silently twice). Reading neighbouring code before committing — that caught a fix that would have blocked every legitimate first upload. And building the new DNS zone while the old one was still authoritative, which surfaced three latent faults at zero user impact.

## Five things to carry forward

1. Every load-bearing check gets mutation-tested — break it, see red, restore.
2. Ship a feature and its hardening as one unit, or ship neither.
3. Documentation is product surface and currently the only part with no CI.
4. A gate that cannot distinguish "failed" from "never ran" is not a gate.
5. Probe production. This week our failures were invisible to us and obvious to the person trying to use the thing.

Also records three standing corrections, including that **"here is the signed PDF" is false** — there is no cryptographic signature, there is an HMAC-signed expiring link and a provenance footer. Worth fixing in the demo script before Aug 18.

Docs-only. Lint clean; doc/link tests pass.