### PR TITLE
fix(careagents): a truncated record list must not read as a complete one

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -96,9 +96,26 @@ TOOL_LABELS = {
 
 
 def _summarize_bundle(bundle: dict, limit: int = 12) -> list[dict]:
-    """Compact, model-friendly view of a searchset bundle (already redacted)."""
+    """Compact, model-friendly view of a searchset bundle (already redacted).
+
+    Truncates to `limit` and SAYS SO. The list this returns is the model's
+    entire view of the person's records for that resource type, so a silent
+    cut is indistinguishable from "that is all there is" — a person on 30
+    medications would be told about 12, in a confident complete-sounding
+    sentence.
+
+    That is the same mistake as #207, four lines below: dropping an unreadable
+    record's name made the model report the condition as ABSENT. We fixed
+    unreadable-is-not-absent and left truncated-is-not-absent in the same
+    function. It cannot fire on the synthetic demo tenant, which is why
+    nothing caught it; it fires on the first real record with a long list.
+    """
+    entries = bundle.get("entry") or []
+    total = sum(1 for e in entries
+                if (e.get("resource") or {}).get("resourceType")
+                != "OperationOutcome")
     out = []
-    for entry in (bundle.get("entry") or [])[:limit]:
+    for entry in entries[:limit]:
         res = entry.get("resource") or {}
         rt = res.get("resourceType")
         if rt == "OperationOutcome":
@@ -127,6 +144,20 @@ def _summarize_bundle(bundle: dict, limit: int = 12) -> list[dict]:
         if res.get("effectiveDateTime"):
             item["date"] = str(res["effectiveDateTime"])[:10]
         out.append(item)
+
+    if total > len(out):
+        # Deliberately shaped so it cannot be mistaken for a record: no
+        # "type", no "name". The instruction is carried in the payload rather
+        # than left to the system prompt alone, because this is the one place
+        # the model can tell complete from partial.
+        out.append({
+            "truncated": True,
+            "shown": len(out),
+            "total": total,
+            "note": (f"Only {len(out)} of {total} records are shown. Do not "
+                     f"describe this list as complete or as all the person "
+                     f"has; say more exist and offer to narrow the search."),
+        })
     return out
 
 

--- a/careagents/personas.py
+++ b/careagents/personas.py
@@ -30,6 +30,11 @@ Non-negotiable rules, regardless of your voice:
   name, SAY a record is there that you could not read — never treat it as
   absence. "I don't see it in what I can read here" is honest; "No, you do
   not have that" is not yours to say.
+- If a result is marked truncated, you are seeing part of a list, not all of
+  it. Never present a truncated list as everything the person has, and never
+  count from it ("you are on 12 medications"). Say more records exist and
+  offer to narrow the search. A partial list read as complete is the same
+  error as treating an unreadable record as absence.
 - The person's records here may be clearly-labeled sample data. If asked,
   be straightforward about that.
 """

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1100,6 +1100,56 @@ def test_unreadable_record_is_never_summarized_as_nothing():
     assert "250.00" in items[0]["name"]
 
 
+def test_a_truncated_list_says_so_rather_than_looking_complete():
+    # The sibling of #207. The summarizer caps at 12 and the list it returns
+    # IS the model's whole view, so a silent cut reads as "that is all there
+    # is". A person on 30 medications would be told about 12, confidently.
+    from careagents.agent import _summarize_bundle
+    bundle = {"entry": [
+        {"resource": {"resourceType": "MedicationRequest",
+                      "medicationCodeableConcept": {"text": f"Drug {i}"}}}
+        for i in range(30)
+    ]}
+    items = _summarize_bundle(bundle)
+
+    marker = [i for i in items if i.get("truncated")]
+    assert marker, "a truncated list must carry a truncation marker"
+    assert marker[0]["total"] == 30
+    assert marker[0]["shown"] == 12
+    # Must not be mistakable for a record.
+    assert "name" not in marker[0] and "type" not in marker[0]
+    assert "complete" in marker[0]["note"].lower()
+
+
+def test_an_untruncated_list_carries_no_marker():
+    # Otherwise every answer hedges and the signal stops meaning anything.
+    from careagents.agent import _summarize_bundle
+    bundle = {"entry": [
+        {"resource": {"resourceType": "Condition",
+                      "code": {"text": f"Thing {i}"}}}
+        for i in range(3)
+    ]}
+    items = _summarize_bundle(bundle)
+    assert len(items) == 3
+    assert not any(i.get("truncated") for i in items)
+
+
+def test_truncation_total_ignores_operation_outcomes():
+    # OperationOutcome entries are skipped as records, so counting them would
+    # promise records that do not exist.
+    from careagents.agent import _summarize_bundle
+    entries = [{"resource": {"resourceType": "Condition",
+                             "code": {"text": f"C{i}"}}} for i in range(13)]
+    entries.append({"resource": {"resourceType": "OperationOutcome"}})
+    items = _summarize_bundle({"entry": entries})
+    marker = [i for i in items if i.get("truncated")][0]
+    assert marker["total"] == 13
+
+
+def test_safety_core_forbids_presenting_a_truncated_list_as_complete():
+    assert "truncated" in SAFETY_CORE.lower()
+
+
 def test_safety_core_forbids_answering_absence_with_a_bare_no():
     # The model must not convert "I couldn't read it" into "you don't have it".
     assert "bare \"no\"" in SAFETY_CORE or "bare 'no'" in SAFETY_CORE


### PR DESCRIPTION
Found by the CTO persona during next-phase planning — by reading for a known failure shape rather than waiting for a report. Verified before fixing.

## The bug

`careagents/agent.py:98` — `_summarize_bundle(bundle, limit=12)` slices to 12 and returns. That list is the model **entire view** of the person records for that resource type. A silent cut is indistinguishable from *"that is all there is"*.

A person on 30 medications is told about 12, confidently, with nothing anywhere signalling the list is partial. `hc.search` sends no `_count`, so the engine returns its default 50 and 38 records vanish between the API and the model.

## Why this one stings

It was sitting **four lines below** the comment that exists because of #207:

```python
# A record exists but carries no readable label. Say so explicitly ...
# the condition as ABSENT (#207). Unreadable is not absent.
```

We fixed unreadable-is-not-absent and left truncated-is-not-absent in the same function. Same failure shape, same function, unfixed.

It cannot fire on the synthetic demo tenant — which is exactly why nothing caught it. It fires on the first real record with a long list: the clinician testing her own records this week, and the advocates onboarding after Aug 18.

## The fix

- The summarizer appends an explicit marker when it truncates, shaped so it cannot be mistaken for a record (no `type`, no `name`), carrying the instruction in the payload rather than trusting the system prompt alone — this is the one place the model can tell complete from partial.
- `total` counts real records only. OperationOutcome entries are skipped as records, so counting them would promise records that do not exist.
- `SAFETY_CORE` gains the matching rule, placed next to the absence rule it mirrors, and explicitly forbids **counting** from a truncated list ("you are on 12 medications" is the sentence to prevent).

## Verification

Mutation-tested: removing the marker block fails two of the three new tests. There is also a test that an untruncated list carries **no** marker — otherwise every answer hedges and the signal stops meaning anything.

`1935 passed, 6 skipped, 2 xfailed`; ruff clean.

## Not fixed here

The underlying `_count` is still unbounded — we fetch up to 50 and show 12. Raising the limit or paginating is a product call about context budget, not a correctness one. This PR makes the truncation honest; it does not make it unnecessary.