### PR TITLE
docs: constitution + design system as table stakes for both surfaces

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,0 +1,151 @@
+# Design system
+
+Two surfaces, two committed looks. Neither is a default, and neither should
+drift toward one. Read this before generating any UI, and change this file
+first if the design needs to change — a component that disagrees with this
+page is a bug in one of them.
+
+**This file documents what ships.** Every value below was read out of the
+stylesheet, not invented. If you change a token, change it here in the same
+commit.
+
+---
+
+## The two surfaces
+
+| | **CareAgents** — the patient app | **HealthClaw** — the project site |
+| --- | --- | --- |
+| Who | A person on a phone, often anxious, often not technical | Developers, health-IT people, standards folk |
+| Where | `careagents/static/careagents.css`, `careagents/templates/` | `templates/index.html`, `static/css/` |
+| Look | Warm editorial. Cream paper, ink, clay | Dark technical. Deep navy, cyan, mono |
+| Feeling to aim for | Calm, unhurried, legible at arm's length | Precise, dense, credible |
+
+They are allowed to look unrelated. One is a health product; the other is
+documentation for an engine. Forcing a shared skin on both would make the
+patient app feel like a developer tool, which is the failure we care about.
+
+---
+
+## CareAgents tokens
+
+```css
+--cream:     #FBF6EE;   /* page */
+--paper:     #F4ECDF;   /* raised surface */
+--card:      #FFFDF8;   /* card */
+--ink:       #22190E;   /* body text */
+--ink-soft:  #5E5240;   /* secondary text */
+--clay:      #C2532E;   /* primary action */
+--clay-deep: #A03F1F;   /* links, hover */
+--sage:      #5F7D62;   /* support, success */
+--hairline:  #E4D7C2;   /* borders */
+--shadow:    0 2px 24px rgba(84, 62, 36, .10);
+--radius:    18px;
+```
+
+- **Display:** `"Fraunces", Georgia, serif` at weight 560, `letter-spacing:
+  -0.015em` — h1, h2, wordmark, chat name.
+- **Body:** `"Public Sans", -apple-system, sans-serif`, `line-height: 1.55`.
+- One radius (`18px`) and one shadow. Do not introduce a second of either.
+- The page background is a single soft radial warm-up at top right over
+  `--cream`. That is the only gradient in the product.
+
+## HealthClaw site tokens
+
+```css
+--bg: #0A0E17;  --bg-card: #111827;  --bg-hover: #1a2235;  --border: #1e293b;
+--cyan: #22d3ee;  --green: #34d399;  --amber: #fbbf24;  --red: #f87171;
+--white: #f1f5f9; --gray: #94a3b8; --gray-dim: #64748b; --gray-dark: #334155;
+--font-sans: 'Outfit', sans-serif;
+--font-mono: 'JetBrains Mono', monospace;
+```
+
+Cyan is the accent and the only glow. Green, amber and red carry meaning
+(pass / caution / fail) and must not be used decoratively — a red chip on this
+site means something failed.
+
+---
+
+## Banned
+
+- **Fonts:** Inter, Roboto, Open Sans, Lato, Montserrat, or a bare
+  `system-ui` stack as the *primary* face. `-apple-system` stays in the
+  fallback chain — that is performance, not laziness.
+- **Purple gradients**, neon glows, and "AI-looking" iridescence. The one
+  gradient we have is documented above.
+- **Generic vector illustrations** and stock photography of smiling people
+  holding tablets. Use real screenshots, real records (synthetic), or nothing.
+- **Lucide / Heroicons defaults** dropped in unchanged. If an icon set is
+  added, pick one deliberately and record it here.
+- **Emoji as UI iconography.** Emoji are fine in persona identity (the
+  personas ship with 🌿 🎯 ☀️) and in prose. They are not buttons.
+- **Uneven padding.** If the top is 20px, the bottom is 20px, unless there is
+  a stated optical reason.
+
+---
+
+## Constraints that outrank taste
+
+These are not stylistic preferences. Violating them breaks the product.
+
+1. **The CSP is `default-src 'self'`.** No CDN scripts. Anything you add is
+   self-hosted or inline. This alone rules out most drop-in animation
+   libraries.
+2. **In-app webviews are a first-class target.** People open CareAgents inside
+   Telegram, Instagram and iMessage. Issue #224 exists *because* those webviews
+   break native `prompt()`. Assume the webview lacks something before assuming
+   it works.
+3. **Phone first, one-handed, possibly outdoors.** Minimum tap target 44px.
+   Body text never below 16px — iOS zooms the whole page on a smaller input
+   font, which breaks the layout.
+4. **Respect `prefers-reduced-motion`.** Someone reading a lab result they are
+   frightened of should not have to sit through a transition.
+5. **Contrast:** WCAG AA minimum, AA-large for display type. `--ink-soft` on
+   `--cream` is the lightest permitted body combination; do not go lighter.
+
+---
+
+## Motion
+
+Restraint is the house style, and it is a decision rather than a shortfall.
+
+- Transitions exist to explain a state change. If nothing changed state,
+  nothing moves.
+- 120–200ms, ease-out. Nothing above 300ms.
+- Every interactive element has a defined hover **and** focus-visible state.
+  Focus rings are never removed; keyboard users are not an edge case here.
+- **No** scroll-jacking, parallax, or smooth-scroll libraries. Native scroll
+  is what a phone user expects and what a webview reliably gives us.
+
+---
+
+## Copy in the interface
+
+Interface copy follows [docs/constitution.md](docs/constitution.md), plus two
+rules specific to a health product:
+
+- **Never state a clinical fact the records do not support**, and never
+  present a partial list as complete. This is enforced in code
+  (`careagents/personas.py` `SAFETY_CORE`), not just in style.
+- **Say what a control does, not how it feels.** "Delete these records
+  permanently" — not "Manage your data". A person deciding whether to trust
+  us reads the button label, not the paragraph above it.
+
+---
+
+## Where we depart from general anti-slop advice
+
+Recorded so nobody re-adds these thinking they were an oversight.
+
+- **No WebGL hero, no Lenis or Locomotive scroll, no skeuomorphism.** Common
+  advice for making a marketing site memorable; wrong here. Blocked by the
+  CSP, hostile to webviews, and a person checking whether they are due for a
+  screening is not an audience to impress with a shader.
+- **No "cheeky", "abrasive" or "dark comedic" brand voice.** Standard advice
+  for escaping corporate blandness. In a product people open when they are
+  worried, it reads as not taking them seriously. Our voices are Calm Guide,
+  Straight Shooter and Sunny Coach — the range is *warmth*, not *edge*, and
+  capability is identical across all three.
+
+The goal these were meant to serve — do not look generated — is met by the
+committed typography, the warm non-default palette, and prose written to the
+constitution's rules.

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -4,8 +4,13 @@ If you (human or coding agent) are starting work on an issue in this repo, read
 this first. It exists so you don't begin from scratch: it tells you where things
 live, what you may not break, and what "done" means here.
 
-**Read order:** this file → [docs/development.md](development.md)
+**Read order:** this file → [docs/constitution.md](constitution.md) (how we
+build — architecture, writing, working with agents) → [docs/development.md](development.md)
 (build/test/deploy detail) → the issue.
+
+If the task touches any interface, read [design.md](../design.md) too. It
+documents the tokens and type that actually ship, and the constraints — CSP,
+in-app webviews, reduced motion — that outrank visual preference.
 
 > Maintainers may also have a local `CLAUDE.md` with the same invariants. It is
 > deliberately not published, so everything you need is here or in
@@ -188,6 +193,9 @@ auditor.
 
 ## Related
 
+- [docs/constitution.md](constitution.md) — how we build: deep modules, seams,
+  one-control-one-property, the writing rules, working with agents
+- [design.md](../design.md) — the design system both surfaces actually ship
 - [docs/development.md](development.md) — full contributor guide
 - [docs/healthcare-ai-advisors-roadmap.md](healthcare-ai-advisors-roadmap.md) — where this is all going
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — ground rules, DCO

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -1,0 +1,153 @@
+# Constitution
+
+Table stakes for everyone building HealthClaw and CareAgents — human or agent.
+Not aspirations. A change that violates one of these is wrong even when it
+works, and reviewers should say so.
+
+The invariants in [agent-task-guide.md](agent-task-guide.md#2-the-invariants--non-negotiable)
+still outrank everything here. This file governs *how* we build; that one
+governs what must never break.
+
+Visual rules live in [design.md](../design.md).
+
+---
+
+## 1. Architecture
+
+**Build deep modules.** A module earns its place by hiding more than it
+exposes. A simple interface over real complexity is the goal; a wide interface
+over a thin wrapper is a liability, because every caller now depends on
+detail that bought them nothing.
+
+**Judge an interface by what a caller must learn.** If using a function
+correctly requires knowing how it works inside, the interface is wrong. Our
+own worst examples were controls that *looked* simple and hid a second
+behaviour — see the rule below.
+
+**Keep related things together.** A feature, its tests, its failure modes and
+its docs change together, so they live together. Splitting by technical layer
+means every change touches five directories and no one can see the whole
+behaviour at once.
+
+**Name the seams.** The places where a module meets the outside world —
+HealthClaw's HTTP client, the LLM provider, the clock, the mail sender, the
+FHIR server — are where behaviour is swapped and where tests attach. Put an
+adapter there deliberately rather than letting a call to a third-party SDK
+sprawl through the code.
+
+**Test at the seams, and probe the real thing.** A fake proves a call is
+*made*, not *accepted*. CareAgents tests fake the HealthClaw client, so they
+cannot tell you a cross-boundary call would be honoured. Anything that crosses
+a boundary gets checked against a running system before it is called done.
+
+**One control, one property.** Every check protects exactly one property, and
+you must be able to say which in one sentence. Then ask what *else* could make
+the check pass. If the answer includes the broken behaviour, the check is
+decoration.
+
+This is the rule the project has broken most often — six times in one week.
+An id regex that carried a data-loss length cap inside a charset check. An
+assertion that accepted both the fix and the bug. A monitor that counted how
+many checks ran rather than which. A readiness endpoint used as a liveness
+probe. See [2026-08-02-retro.md](2026-08-02-retro.md).
+
+**Mutation-test anything load-bearing.** Break the code, watch a test go red,
+restore it. A guard nobody has seen fail is a guard nobody has tested. This
+takes two minutes and has caught real regressions here.
+
+**Ship a feature and its hardening as one unit,** or ship neither. Splitting
+them across merges converts "we caught two vulnerabilities in review" into
+"we shipped two vulnerabilities and fixed them later." That has happened.
+
+**Documentation is product surface.** A doc that contradicts the system is a
+defect with the same severity as the code being wrong, because it is what
+users act on. If you change what the system does, the docs change in the same
+PR — and where it matters, add a guard that fails when they drift apart.
+
+---
+
+## 2. Writing
+
+Applies to READMEs, docs, PR descriptions, commit messages, code comments,
+error messages, and interface copy. Adapted from ASD-STE100, the aerospace
+standard for text that must not be misread.
+
+**One name per thing.** Pick the word and keep it. A *tenant* is never also a
+workspace, an account, or an org. A *record* is never also an entry or a
+document. Synonym rotation reads as variety to the writer and as three
+different concepts to the reader.
+
+**Short sentences.** Instructions: 20 words. Descriptions: 25. **No
+semicolons** — if you need one, you need two sentences.
+
+**Active verbs, not nouns.** "Analyze the bundle", not "perform an analysis
+of the bundle". "Redact the record", not "apply redaction to the record".
+
+**One helper verb, maximum.** "This may potentially help" says nothing. Write
+what happens, or say you do not know.
+
+**No marketing adjectives.** Seamless, robust, cutting-edge, powerful,
+effortless, comprehensive, enterprise-grade. Delete them; the sentence is
+always better. Say what it does and what it costs.
+
+**No chatty phrasal verbs.** Remove, not *take off*. Contact, not *reach out*.
+Continue, not *carry on with*.
+
+**State limits in the same breath as claims.** "Grade A on seven properties"
+needs the seven named. "Works with any FHIR server" needs the ones actually
+tested. A claim that omits its scope is the kind of thing we have had to
+retract.
+
+**Errors say what happened and what to do.** "Something went wrong" is not an
+error message. Name the thing that failed and the next action, and never leak
+PHI or a token into the text.
+
+This is not a banned-word list. The point is that vague writing hides broken
+thinking, and a reader acting on our text can be a patient.
+
+---
+
+## 3. Working with agents
+
+**The human makes the strategic calls.** An agent is a fast tactical
+engineer: excellent at the change in front of it, structurally unable to weigh
+what the codebase should look like in six months or what a patient will feel.
+Architecture, product direction, and anything irreversible stay with the
+person. Decision rights are in `.claude/team.md`.
+
+**Never accept the first output.** Quality comes from iteration. A first draft
+that runs is a starting point, not a result. If a change was accepted without
+a single revision, it probably was not read.
+
+**Record recurring mistakes where they will be read again.** When an agent —
+or a person — makes the same error twice, write it down in the guide or the
+retro, not in a chat message that scrolls away. This file and
+[agent-task-guide.md](agent-task-guide.md#6-traps-that-have-actually-bitten-this-project)
+exist because of that rule.
+
+**Report faithfully.** If tests fail, say so and show the output. If a step
+was skipped, say which. "Done" means verified, not "the code is written". An
+agent that reports success it did not confirm is worse than one that fails
+loudly.
+
+**Verify the operation, not the exit code.** `git push -q` has silently failed
+here and a guard was reported as shipped while the remote carried the old
+snippet. Check the remote ref. Read the deployed build's version. Curl the
+endpoint. The pattern that keeps hurting us is an operation that *looked*
+successful because nothing said otherwise.
+
+---
+
+## 4. Deliberately not adopted
+
+Recorded with reasons so nobody adds them later assuming an oversight.
+
+- **A banned-word list as the writing rule.** Banning "delve" moves slop
+  somewhere else. The length, naming and hedging rules above attack the cause.
+- **WebGL heroes, smooth-scroll libraries, skeuomorphism.** Blocked by our
+  CSP, hostile to in-app webviews, and wrong for someone checking a lab
+  result. See [design.md](../design.md#where-we-depart-from-general-anti-slop-advice).
+- **A "cheeky" or "abrasive" brand voice.** People open this product worried.
+  Edge reads as not taking them seriously.
+- **Banning system fonts outright.** Our display faces are distinctive;
+  `-apple-system` in the *fallback* chain is a performance decision on phones.


### PR DESCRIPTION
Adopts the anti-slop guidance as project rules, adapted where it conflicts with building a health product. Wired into the read order in `agent-task-guide.md` so teams hit it before starting, not after.

## `docs/constitution.md` — how we build

**Architecture.** Deep modules. Judge an interface by what a caller must learn. Keep related things together. Name the seams — HealthClaw client, LLM provider, clock, mail, FHIR server — and test at them, while remembering a fake proves a call is *made*, not *accepted*.

Plus the rule this project has broken most, stated as a rule:

> **One control, one property.** Every check protects exactly one property, and you must be able to say which in one sentence. Then ask what *else* could make it pass. If the answer includes the broken behaviour, the check is decoration.

Six violations in one week — an id regex carrying a data-loss length cap inside a charset check, an assertion that accepted both the fix and the bug, a monitor counting how many checks ran rather than which, a readiness endpoint used as a liveness probe. With it: mutation-test anything load-bearing, ship a feature and its hardening as one unit, treat docs as product surface.

**Writing.** Adapted from ASD-STE100 rather than a banned-word list, because banning "delve" just relocates the slop. One name per thing (a tenant is never also a workspace). 20/25-word caps. No semicolons. Active verbs. One helper verb maximum. No marketing adjectives. State limits in the same breath as claims — "Grade A on seven properties" needs the seven named.

**Working with agents.** The human makes strategic calls. Never accept a first output. Record recurring mistakes where they get read again. Report faithfully. And verify the *operation*, not the exit code — `git push -q` has silently failed here while a guard was reported as shipped.

## `design.md` — the system that actually ships

Every token read out of the stylesheets, not invented. A design.md that disagrees with the product would be the exact drift we spent this week fixing.

- **CareAgents** — warm editorial: `#FBF6EE` cream, `#22190E` ink, `#C2532E` clay, `#5F7D62` sage; Fraunces 560 display, Public Sans body; one radius, one shadow, one gradient.
- **HealthClaw site** — dark technical: `#0A0E17` navy, `#22d3ee` cyan; Outfit + JetBrains Mono. Green/amber/red carry meaning and are never decorative.

Two surfaces, two committed looks, allowed to look unrelated — one is a health product, the other is documentation for an engine.

Also documents the constraints that **outrank taste**: CSP is `default-src self`, in-app webviews are first-class, 44px targets, 16px minimum body text (iOS zooms below it), `prefers-reduced-motion`, WCAG AA.

## What we deliberately did NOT adopt

Recorded with reasons so nobody re-adds them assuming an oversight.

- **WebGL heroes, Lenis/Locomotive smooth scroll, skeuomorphism.** Blocked by our CSP, hostile to in-app webviews — #224 exists *because* those webviews break `prompt()` — and someone checking whether they are due for a screening is not an audience to impress with a shader.
- **A "cheeky", "abrasive" or "dark comedic" brand voice.** Standard advice for escaping corporate blandness. In a product people open when they are worried, it reads as not taking them seriously. Our voices are Calm Guide, Straight Shooter, Sunny Coach — the range is *warmth*, not *edge*.
- **Banning system fonts outright.** Our display faces are already distinctive; `-apple-system` in the *fallback* chain is a phone performance decision, not laziness.

The goal that advice serves — do not look generated — is already met by the committed typography, the warm non-default palette, and prose written to the rules above.

Docs-only. All internal links verified; `1935 passed`; ruff clean.