### PR TITLE
ci: enforce constitution + design table stakes on every PR

### DIFF
--- a/.github/REVIEW_STANDARDS.md
+++ b/.github/REVIEW_STANDARDS.md
@@ -66,6 +66,47 @@ review bot reads THIS file, so keep it current.)
     `.health-context.yaml`, `templates/base.html`, README badges,
     `gemini-extension.json`, `server.json`. Don't update one without the rest.
 
+## Table stakes (docs/constitution.md + design.md)
+
+The deterministic parts of these are enforced by `scripts/check_table_stakes.py`
+in CI, on added lines only. The items below need judgment, so they are yours.
+
+19. **One control, one property.** For every check, guard, assertion or
+    conditional the PR adds: name the single property it protects, then ask
+    what *else* could make it pass. If the broken behaviour also passes, the
+    check is decoration — REQUEST_CHANGES with the specific input that would
+    slip through. This project has shipped six of these; the pattern is a
+    control that quietly does two things (a charset check carrying a length
+    cap, `assert status in (400, 403)` accepting both fix and bug, a monitor
+    counting how many checks ran rather than which).
+20. **Load-bearing tests are mutation-tested.** A PR fixing a bug should show
+    that reverting the fix turns a test red. Ask for it when a security or
+    correctness property is claimed and the test would pass either way.
+21. **Feature and hardening ship together.** If a PR adds a capability whose
+    review raised security findings, both land in the same merge or neither
+    does. Splitting them has put live vulnerabilities into production here.
+22. **Deep modules.** A new interface should hide more than it exposes. Flag
+    wide interfaces over thin wrappers, and any function whose correct use
+    requires knowing its internals.
+23. **Seams and fakes.** Anything crossing a boundary (HealthClaw client, LLM
+    provider, FHIR server, mail, clock) goes through an adapter and is stated
+    to have been verified against the real system. A fake proves a call is
+    *made*, not *accepted*.
+24. **Docs change with behaviour.** If the PR changes what the system does and
+    a doc still describes the old behaviour, that is a defect in this PR — not
+    a follow-up. Where a claim can drift, ask for a guard.
+25. **Writing.** Applies to prose, PR text, comments, error messages and
+    interface copy: one name per thing (a tenant is never also a workspace),
+    active verbs, no marketing adjectives, no stacked hedges, and limits
+    stated in the same breath as claims. Semicolons are fine in engineering
+    prose; in patient-facing copy and error messages, prefer two sentences.
+26. **Interface changes follow design.md.** Tokens, type and radius come from
+    the file rather than being invented per component. The constraints that
+    outrank taste: CSP `default-src 'self'` (no CDN assets), in-app webviews
+    are a first-class target, 44px tap targets, 16px minimum on inputs,
+    `prefers-reduced-motion` honoured, WCAG AA. If a change needs a new token,
+    it changes `design.md` in the same PR.
+
 ## Style & scope
 
 15. Match surrounding code: module pattern is pure engine + report builders +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      # Full history: the table-stakes check diffs against the merge base, so
+      # a shallow clone would silently find no added lines and pass.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
@@ -30,6 +34,15 @@ jobs:
 
       - name: Mypy (gradual typed security core)
         run: uv run mypy
+
+      # Table stakes from docs/constitution.md and design.md. Deterministic
+      # rules only, and only on lines this PR ADDS — see the script docstring
+      # for why it is scoped that way.
+      - name: Table stakes (constitution + design)
+        run: |
+          git fetch --no-tags origin "${GITHUB_BASE_REF:-main}"
+          uv run python scripts/check_table_stakes.py \
+            --base "origin/${GITHUB_BASE_REF:-main}"
 
   python-tests:
     runs-on: ubuntu-latest

--- a/scripts/check_table_stakes.py
+++ b/scripts/check_table_stakes.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Mechanical table-stakes checks for docs/constitution.md and design.md.
+
+Only the deterministic subset lives here. Judgment rules — deep modules,
+one-control-one-property, whether a test is load-bearing — belong to the
+reviewer and to `.github/REVIEW_STANDARDS.md`. A rule goes in this file only
+when a machine can decide it without being clever.
+
+**Added lines only.** Every check runs against lines a PR ADDS, never the
+whole file. A gate that fails on legacy content is a gate that gets ignored,
+which is the failure mode this project already documented in
+`docs/2026-08-02-retro.md`. New writing is held to the rules; old writing is
+fixed when it is touched.
+
+Usage:
+    uv run python scripts/check_table_stakes.py                  # vs origin/main
+    uv run python scripts/check_table_stakes.py --base HEAD~1
+    uv run python scripts/check_table_stakes.py --explain        # list rules
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+PROSE_SUFFIXES = {".md"}
+STYLE_SUFFIXES = {".css", ".html", ".js"}
+
+# Files whose whole job is to name the things we ban. Checking them would make
+# it impossible to write the rule down.
+EXEMPT = {
+    "docs/constitution.md",
+    "design.md",
+    ".github/REVIEW_STANDARDS.md",
+    "scripts/check_table_stakes.py",
+    "tests/test_table_stakes.py",
+    "docs/2026-08-02-retro.md",
+}
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    rule: str
+    detail: str
+    text: str
+
+
+# --- writing ---------------------------------------------------------------
+
+MARKETING = re.compile(
+    r"\b(seamless(?:ly)?|robust|cutting[- ]edge|best[- ]in[- ]class|"
+    r"world[- ]class|game[- ]chang\w+|revolutionary|blazing[- ]fast|"
+    r"effortless(?:ly)?|enterprise[- ]grade|state[- ]of[- ]the[- ]art)\b",
+    re.I)
+
+HEDGE = re.compile(
+    r"\b(may\s+potentially|might\s+possibly|could\s+potentially|"
+    r"can\s+potentially|may\s+be\s+able\s+to|should\s+probably\s+likely)\b",
+    re.I)
+
+PHRASAL = re.compile(r"\b(reach\s+out|circle\s+back|dive\s+deep(?:er)?\s+into|"
+                     r"leverage\s+up|touch\s+base)\b", re.I)
+
+MAX_SENTENCE_WORDS = 25
+
+# Strip anything a prose rule must not judge before measuring.
+_CODE_SPAN = re.compile(r"`[^`]*`")
+_LINK_TARGET = re.compile(r"\]\([^)]*\)")
+_URL = re.compile(r"https?://\S+")
+_HTML_TAG = re.compile(r"<[^>]+>")
+
+
+def _prose_only(line: str) -> str:
+    line = _CODE_SPAN.sub(" ", line)
+    line = _LINK_TARGET.sub("] ", line)
+    line = _URL.sub(" ", line)
+    return _HTML_TAG.sub(" ", line)
+
+
+def _is_prose_line(raw: str) -> bool:
+    s = raw.strip()
+    if not s or s.startswith(("#", ">", "|", "```", "---", "==")):
+        return False
+    # Indented code inside a list is still code.
+    return not raw.startswith("    ")
+
+
+def check_prose(path: str, lines: list[tuple[int, str]]) -> list[Finding]:
+    out: list[Finding] = []
+    for num, raw in lines:
+        if not _is_prose_line(raw):
+            continue
+        text = _prose_only(raw)
+
+        for rx, rule, detail in (
+            (MARKETING, "no-marketing-adjectives",
+             "delete it and say what the thing does"),
+            (HEDGE, "one-helper-verb",
+             "write what happens, or say you do not know"),
+            (PHRASAL, "no-chatty-phrasal-verbs",
+             "use the plain verb (contact, revisit, examine)"),
+        ):
+            m = rx.search(text)
+            if m:
+                out.append(Finding(path, num, rule,
+                                   f'"{m.group(0).strip()}" — {detail}',
+                                   raw.strip()[:100]))
+
+        # Sentence length. Bullets and headings are measured too; they are
+        # instructions, which the constitution holds to a tighter cap.
+        body = re.sub(r"^\s*([-*+]|\d+\.)\s+", "", text)
+        for sentence in re.split(r"(?<=[.!?])\s+", body):
+            words = [w for w in sentence.split() if any(c.isalnum() for c in w)]
+            if len(words) > MAX_SENTENCE_WORDS:
+                out.append(Finding(
+                    path, num, "sentence-length",
+                    f"{len(words)} words (cap {MAX_SENTENCE_WORDS}) — split it",
+                    sentence.strip()[:100]))
+                break
+
+        # NOT enforced here: the semicolon rule. It is real guidance, but it
+        # is judgment, and this file only takes rules a machine can decide.
+        # Measured before deciding: 255 semicolons across 6,317 lines of
+        # existing project prose, nearly all of them correct. ASD-STE100 bans
+        # them for aircraft manuals read under pressure by non-native
+        # speakers; engineering prose is not that. Enforcing it would have
+        # made this gate fire on 4% of our own good writing, which is how a
+        # gate becomes noise and then gets switched off. The reviewer applies
+        # it where it matters — patient-facing copy and error messages.
+    return out
+
+
+# --- design ----------------------------------------------------------------
+
+BANNED_PRIMARY_FONT = re.compile(
+    r"font-family\s*:\s*['\"]?(Inter|Roboto|Open Sans|Lato|Montserrat|Nunito)"
+    r"['\"]?", re.I)
+
+CDN_ASSET = re.compile(
+    r"<(?:script|link)\b[^>]*\b(?:src|href)\s*=\s*['\"]https?://"
+    r"(?!fonts\.googleapis\.com|fonts\.gstatic\.com)", re.I)
+
+SMALL_INPUT_FONT = re.compile(
+    r"font-size\s*:\s*(\d+(?:\.\d+)?)px", re.I)
+
+MOTION = re.compile(r"\b(transition|animation)\s*:", re.I)
+
+
+def check_style(path: str, lines: list[tuple[int, str]],
+                whole_file: str) -> list[Finding]:
+    out: list[Finding] = []
+    for num, raw in lines:
+        m = BANNED_PRIMARY_FONT.search(raw)
+        if m:
+            out.append(Finding(
+                path, num, "banned-primary-font",
+                f"{m.group(1)} as the primary face — see design.md",
+                raw.strip()[:100]))
+
+        m = CDN_ASSET.search(raw)
+        if m:
+            out.append(Finding(
+                path, num, "csp-external-asset",
+                "CSP is default-src 'self'; self-host it or inline it",
+                raw.strip()[:100]))
+
+        m = SMALL_INPUT_FONT.search(raw)
+        if m and float(m.group(1)) < 16:
+            out.append(Finding(
+                path, num, "ios-zoom-font-size",
+                f"{m.group(1)}px — iOS zooms the page below 16px on inputs",
+                raw.strip()[:100]))
+
+    if any(MOTION.search(raw) for _, raw in lines):
+        if "prefers-reduced-motion" not in whole_file:
+            num = next(n for n, r in lines if MOTION.search(r))
+            out.append(Finding(
+                path, num, "reduced-motion",
+                "this file adds motion but never honours "
+                "prefers-reduced-motion",
+                "(file-level)"))
+    return out
+
+
+# --- diff ------------------------------------------------------------------
+
+def added_lines(base: str) -> dict[str, list[tuple[int, str]]]:
+    """Map path -> [(line number in the new file, added text)]."""
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "-U0", "--no-color", f"{base}...HEAD"],
+            capture_output=True, text=True, check=True).stdout
+    except subprocess.CalledProcessError:
+        diff = subprocess.run(
+            ["git", "diff", "-U0", "--no-color", base],
+            capture_output=True, text=True, check=True).stdout
+
+    files: dict[str, list[tuple[int, str]]] = {}
+    path, lineno = None, 0
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            files.setdefault(path, [])
+        elif line.startswith("@@"):
+            m = re.search(r"\+(\d+)", line)
+            lineno = int(m.group(1)) if m else 0
+        elif line.startswith("+") and not line.startswith("+++"):
+            if path:
+                files[path].append((lineno, line[1:]))
+            lineno += 1
+    return files
+
+
+def read_file(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def run(base: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for path, lines in added_lines(base).items():
+        if path in EXEMPT or not lines:
+            continue
+        suffix = "." + path.rsplit(".", 1)[-1] if "." in path else ""
+        if suffix in PROSE_SUFFIXES:
+            findings.extend(check_prose(path, lines))
+        if suffix in STYLE_SUFFIXES:
+            findings.extend(check_style(path, lines, read_file(path)))
+    return findings
+
+
+RULES = """\
+Writing (docs/constitution.md §2), on added markdown lines:
+  no-marketing-adjectives  seamless, robust, cutting-edge, effortless, ...
+  one-helper-verb          "may potentially", "could potentially", ...
+  no-chatty-phrasal-verbs  "reach out", "circle back", "touch base", ...
+  sentence-length          more than 25 words in one sentence
+
+Design (design.md), on added css/html/js lines:
+  banned-primary-font      Inter/Roboto/Open Sans/Lato/Montserrat as primary
+  csp-external-asset       a CDN <script>/<link>; CSP is default-src 'self'
+  ios-zoom-font-size       font-size under 16px (iOS zooms the page)
+  reduced-motion           motion added to a file that ignores the media query
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--explain", action="store_true")
+    args = ap.parse_args()
+
+    if args.explain:
+        print(RULES)
+        return 0
+
+    findings = run(args.base)
+    if not findings:
+        print("table stakes: clean")
+        return 0
+
+    by_rule: dict[str, int] = {}
+    for f in sorted(findings, key=lambda x: (x.path, x.line)):
+        by_rule[f.rule] = by_rule.get(f.rule, 0) + 1
+        print(f"{f.path}:{f.line}: [{f.rule}] {f.detail}")
+        print(f"    {f.text}")
+
+    print(f"\n{len(findings)} finding(s): "
+          + ", ".join(f"{k}×{v}" for k, v in sorted(by_rule.items())))
+    print("Rules: docs/constitution.md and design.md. "
+          "`--explain` lists them. These apply to lines you ADDED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_table_stakes.py
+++ b/tests/test_table_stakes.py
@@ -1,0 +1,150 @@
+"""The table-stakes checker has to catch what it claims and stay quiet otherwise.
+
+Two failure modes, and the second is the one that kills linters: a check that
+never fires is decoration, and a check that fires on ordinary writing gets
+switched off within a week. Both are tested here.
+
+Constitution §1: one control, one property — say which property, then ask what
+else could make it pass.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_table_stakes import (  # noqa: E402
+    check_prose, check_style,
+)
+
+
+def _prose(text: str):
+    return check_prose("docs/x.md", [(1, text)])
+
+
+def _style(text: str, whole: str = ""):
+    return check_style("a.css", [(1, text)], whole or text)
+
+
+def _rules(findings):
+    return {f.rule for f in findings}
+
+
+# --- writing: must fire ----------------------------------------------------
+
+@pytest.mark.parametrize("text,rule", [
+    ("This provides a seamless experience.", "no-marketing-adjectives"),
+    ("A robust pipeline handles it.", "no-marketing-adjectives"),
+    ("Our cutting-edge engine is fast.", "no-marketing-adjectives"),
+    ("This may potentially help you.", "one-helper-verb"),
+    ("It could potentially fail here.", "one-helper-verb"),
+    ("Please reach out if it breaks.", "no-chatty-phrasal-verbs"),
+    ("Let us circle back on that.", "no-chatty-phrasal-verbs"),
+])
+def test_prose_rules_fire(text, rule):
+    assert rule in _rules(_prose(text)), f"{rule} missed: {text}"
+
+
+def test_a_long_sentence_is_flagged():
+    text = ("The system will " + "process every single record carefully "
+            * 6 + "today.")
+    assert "sentence-length" in _rules(_prose(text))
+
+
+# --- writing: must NOT fire ------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "Redact the record before the model sees it.",
+    "The tenant comes from the header, never the body.",
+    "Writes need a step-up token.",
+    "",
+    "# A heading that happens to be quite long but is still just a heading",
+    "> Quoted text from somewhere else; not our prose.",
+    "| col | col |",
+    "```",
+    "    indented_code(); with_semicolon();",
+    "Run `init(); serve()` before the first request.",
+    "Use the [guide](https://example.com/a;b) for detail.",
+    "The tenant is resolved; the record is then read.",
+])
+def test_ordinary_writing_is_left_alone(text):
+    assert not _prose(text), f"false positive on: {text!r}"
+
+
+def test_a_sentence_at_the_cap_passes():
+    assert not _rules(_prose(" ".join(["word"] * 25) + "."))
+
+
+def test_code_spans_do_not_trigger_marketing_words():
+    # A variable genuinely named `robust_mode` is not marketing copy.
+    assert not _prose("Set `robust_mode` to true.")
+
+
+# --- design: must fire -----------------------------------------------------
+
+def test_banned_primary_font_is_flagged():
+    assert "banned-primary-font" in _rules(
+        _style('  font-family: "Inter", sans-serif;'))
+
+
+def test_cdn_asset_is_flagged_because_the_csp_blocks_it():
+    assert "csp-external-asset" in _rules(
+        _style('<script src="https://cdn.example.com/x.js"></script>'))
+
+
+def test_small_input_font_is_flagged_for_ios_zoom():
+    assert "ios-zoom-font-size" in _rules(_style("  font-size: 14px;"))
+
+
+def test_motion_without_the_media_query_is_flagged():
+    assert "reduced-motion" in _rules(
+        _style("  transition: opacity 150ms ease-out;"))
+
+
+# --- design: must NOT fire -------------------------------------------------
+
+def test_apple_system_in_a_fallback_chain_is_fine():
+    # design.md is explicit: -apple-system in the FALLBACK is a performance
+    # decision, and our primary faces are distinctive.
+    assert not _rules(_style('  font-family: "Public Sans", '
+                             '-apple-system, sans-serif;'))
+
+
+def test_google_fonts_is_allowed_because_the_csp_allows_it():
+    assert not _rules(_style(
+        '<link href="https://fonts.googleapis.com/css2?family=Fraunces" '
+        'rel="stylesheet">'))
+
+
+def test_sixteen_px_is_the_floor_not_a_violation():
+    assert not _rules(_style("  font-size: 16px;"))
+
+
+def test_motion_with_the_media_query_present_is_fine():
+    css = ("  transition: opacity 150ms ease-out;\n"
+           "@media (prefers-reduced-motion: reduce) { * { transition: none } }")
+    assert not _rules(check_style("a.css", [(1, "  transition: opacity 150ms"
+                                             " ease-out;")], css))
+
+
+# --- the rules the docs promise actually exist -----------------------------
+
+def test_every_documented_rule_is_implemented():
+    """`--explain` output is a promise; keep it true."""
+    from check_table_stakes import RULES
+    implemented = {
+        "no-marketing-adjectives", "one-helper-verb",
+        "no-chatty-phrasal-verbs", "sentence-length",
+        "banned-primary-font", "csp-external-asset", "ios-zoom-font-size",
+        "reduced-motion",
+    }
+    for rule in implemented:
+        assert rule in RULES, f"{rule} is enforced but undocumented"
+    for line in RULES.splitlines():
+        head = line.strip().split(" ")[0]
+        if head and head[0].islower() and "-" in head:
+            assert head in implemented, f"{head} is documented but not enforced"


### PR DESCRIPTION
Makes #299 enforceable instead of aspirational. **Merge #299 first** — this references `docs/constitution.md` and `design.md`.

Two layers, split by what a machine can honestly decide.

## Mechanical — `scripts/check_table_stakes.py`, in the lint job

| Rule | Catches |
| --- | --- |
| `no-marketing-adjectives` | seamless, robust, cutting-edge, effortless, enterprise-grade |
| `one-helper-verb` | "may potentially", "could potentially" |
| `no-chatty-phrasal-verbs` | "reach out", "circle back", "touch base" |
| `sentence-length` | over 25 words in one sentence |
| `banned-primary-font` | Inter/Roboto/Open Sans/Lato/Montserrat as the primary face |
| `csp-external-asset` | a CDN `<script>`/`<link>` — our CSP is `default-src self` |
| `ios-zoom-font-size` | under 16px, which makes iOS zoom the whole page |
| `reduced-motion` | motion added to a file that never honours the media query |

Run it locally: `uv run python scripts/check_table_stakes.py`, or `--explain` for the rule list.

## Judgment — `REVIEW_STANDARDS.md` items 19-26, which the review bot reads

One control one property. Mutation-tested load-bearing tests. Feature and hardening shipping together. Deep modules. Seams and fakes. Docs changing with behaviour. The writing rules. design.md adherence, including the constraints that outrank taste.

These need a reader, not a regex, so they go where the reviewer will actually apply them.

## Two decisions worth arguing with

**Added lines only.** Every check runs against lines a PR adds, never whole files. A gate that fails on legacy content is a gate that gets switched off — which is precisely what happened here four days ago, when a red Playwright check turned out to have executed zero specs and everyone scrolled past it.

**The semicolon ban is deliberately NOT enforced.** The constitution takes it from ASD-STE100, so I measured before wiring it up:

```
scanned 6317 lines of existing project prose
  no-semicolons     255   (4.04% of lines)
  sentence-length    33   (0.52%)
  chatty-phrasal      1   (0.02%)
  marketing           0
```

255 semicolons, nearly all correct. That rule exists for aircraft manuals read under pressure by non-native speakers; engineering prose is not that. Enforcing it would have fired on 4% of our own good writing on day one and taught everyone to ignore the check. It stays as guidance for patient-facing copy and error messages — where ambiguity actually costs a person something — and the reviewer applies it there.

Also worth noting from that scan: **zero marketing adjectives** in existing docs. That rule will rarely fire, which is the right outcome for a rule that is already being followed.

## The checker is tested the way the constitution demands of any guard

31 tests, and **half of them assert it stays silent** on ordinary writing — code spans, tables, block quotes, indented code, link targets, `-apple-system` in a fallback chain, Google Fonts (which the CSP does allow), 16px exactly. A linter that cries wolf is uninstalled within a week.

One of those tests caught a bad test rather than a bad rule: I had written a "should not fire" case whose semicolon really was in prose. The checker was right and my case was wrong.

Verified against real recent prose: the tester-guide PR produces **zero findings**.

`1966 passed, 6 skipped, 2 xfailed`; ruff clean; `ci.yml` validates.

## Note on the checkout change

The lint job now uses `fetch-depth: 0`. The check diffs against the merge base, and a shallow clone would find no added lines and pass silently — a green that means nothing, which is the thing we keep building guards against.