### PR TITLE
fix(careagents): every connector error path was broken by a duplicate say()

### DIFF
--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -281,7 +281,7 @@
   const fileInput = $("upload-file");
   let currentUploadCard = null;
 
-  function say(msg, text, cls) {
+  function sayUpload(msg, text, cls) {
     msg.textContent = text;
     msg.className = "conn-refresh-msg" + (cls ? " " + cls : "");
     msg.hidden = false;
@@ -308,16 +308,16 @@
       // will be refused (server enforces the same cap).
       const MAX = 5 * 1024 * 1024;
       if (file.size > MAX) {
-        return say(msg, messageForError("payload_too_large"), "form-error");
+        return sayUpload(msg, messageForError("payload_too_large"), "form-error");
       }
       btn.disabled = true;
-      say(msg, "Uploading " + file.name + "…");
+      sayUpload(msg, "Uploading " + file.name + "…");
       let text;
       try {
         text = await file.text();
       } catch (e) {
         btn.disabled = false;
-        return say(msg, messageForError("invalid_body"), "form-error");
+        return sayUpload(msg, messageForError("invalid_body"), "form-error");
       }
       let r, d;
       try {
@@ -329,13 +329,13 @@
         d = await r.json().catch(() => ({}));
       } catch (e) {
         btn.disabled = false;
-        return say(msg, messageForError("ingest_failed"), "form-error");
+        return sayUpload(msg, messageForError("ingest_failed"), "form-error");
       }
       btn.disabled = false;
       if (!r.ok) {
         let line = messageForError(d.error);
         if (d.correlation_id) line += " Support code: " + d.correlation_id + ".";
-        return say(msg, line, "form-error");
+        return sayUpload(msg, line, "form-error");
       }
       // Success or partial success — show a plain-language summary of
       // what actually landed. When entries failed, surface the unique
@@ -358,7 +358,7 @@
                      + ": " + codes.join(", "));
         }
       }
-      say(msg, parts.join(" · "),
+      sayUpload(msg, parts.join(" · "),
           (fld || skp) ? "form-warn" : "form-ok");
       if (ing > 0) {
         // Reload so the card flips from `empty` to `active` and the

--- a/tests/test_browser_js_hygiene.py
+++ b/tests/test_browser_js_hygiene.py
@@ -1,0 +1,77 @@
+"""Guard: two `function name()` declarations in one browser script.
+
+`careagents/static/home.js` declared `say` twice — `say(anchor, el, text)` at
+module scope and `say(msg, text, cls)` 187 lines later. Hoisting means the
+second wins *everywhere*, including at the four call sites written for the
+first. Every one of those is an error path:
+
+    say(tile, $("connect-msg"), "Couldn't connect that source.")
+      -> tile.textContent = "[object HTMLElement]"     the label is destroyed
+      -> tile.className   = "conn-refresh-msg Couldn't connect that source."
+      -> the message element stays hidden               nothing is shown
+
+So a person taps a connector, it fails, and the tile turns into unstyled
+`[object HTMLButtonElement]` with no explanation — the dead end #224 exists to
+remove, reintroduced by #224's own fix.
+
+Nothing could have caught it. These files have no linter: `node-tests` covers
+`services/agent-orchestrator` only, and there is no ESLint config in the repo.
+Happy-path Playwright never renders an error state. ESLint `no-redeclare` is
+the better long-term answer; this is the zero-dependency stand-in that runs in
+the suite we already have.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SCRIPT_DIRS = [
+    REPO_ROOT / "careagents" / "static",
+    REPO_ROOT / "static" / "js",
+]
+
+# `function name(` — the hoisted form, which is the one that collides
+# silently. Arrow functions assigned to const/let are block-scoped and error
+# loudly on redeclaration, so they are not the risk here.
+DECL = re.compile(r"^\s*function\s+([A-Za-z_$][\w$]*)\s*\(", re.M)
+
+# Strings and comments would otherwise contribute phantom declarations —
+# home.js has a comment literally naming `say(anchor, el, text)`.
+LINE_COMMENT = re.compile(r"//[^\n]*")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _scripts() -> list[Path]:
+    out: list[Path] = []
+    for d in SCRIPT_DIRS:
+        if d.is_dir():
+            out.extend(sorted(p for p in d.glob("*.js")))
+    return out
+
+
+def _strip(src: str) -> str:
+    return LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", src))
+
+
+def test_there_are_browser_scripts_to_check():
+    """Guards the guard: a moved directory must not silently pass."""
+    assert _scripts(), "no browser scripts found — did static/ move?"
+
+
+@pytest.mark.parametrize("path", _scripts(), ids=lambda p: p.name)
+def test_no_function_is_declared_twice_in_one_script(path: Path):
+    names = DECL.findall(_strip(path.read_text(encoding="utf-8")))
+    dupes = {n: c for n, c in Counter(names).items() if c > 1}
+    rel = path.relative_to(REPO_ROOT)
+    assert not dupes, (
+        f"{rel} declares the same function more than once: "
+        + ", ".join(f"{n}×{c}" for n, c in sorted(dupes.items()))
+        + ". Hoisting makes the LAST one win at every call site, including "
+          "those written for the first signature. Rename one."
+    )


### PR DESCRIPTION
Live in the build deployed today. Found by mutation testing, not by a bug report — and it could not have been reported, because it only appears when something else fails.

## The defect

`careagents/static/home.js` declares `say` twice in one IIFE:

- line 97 — `say(anchor, el, text)`, module scope, 4 callers
- line 284 — `say(msg, text, cls)`, card-local upload helper, 6 callers

Function hoisting makes the **second win everywhere**. All four of the first form callers are error paths:

```
say(tile, $("connect-msg"), "Couldn't connect that source.")
  tile.textContent -> "[object HTMLElement]"     the tile's label is destroyed
  tile.className   -> "conn-refresh-msg Couldn't connect that source."
  connectMsg.hidden = true                        the message is never shown

say(null, msgEl, text)  ->  TypeError: Cannot set properties of null
```

A person taps "Apple Health", it fails, and the tile turns into unstyled `[object HTMLButtonElement]` with no explanation. **That is the dead end #224 exists to remove, reintroduced by #224 own fix.**

Line 212 makes it sharper — a helper there is named `report` with the comment *"Named apart from the module-scope say(anchor, el, text)"*. The hazard was known. The second declaration landed anyway.

## Why nothing caught it

`careagents/static/*.js` and `static/js/*.js` have **no static analysis at all**. `node-tests` covers `services/agent-orchestrator` only, and there is no ESLint config in the repo. Playwright exercises the happy path, and this is invisible until something fails.

## The fix and the guard

Renames the card-local helper to `sayUpload`. The module-scope `say` keeps its four callers.

`tests/test_browser_js_hygiene.py` fails on any function declared twice in one browser script — zero dependencies, runs in the suite we already have. It strips comments first, since home.js has a comment naming `say(anchor, el, text)`. Mutation-verified: restoring the duplicate name fails it.

ESLint with `no-redeclare` over both script directories is the better long-term answer and is worth doing separately.

`1973 passed, 6 skipped, 2 xfailed`; ruff clean.