### PR TITLE
test: pin four security properties the suite claimed but never checked

### DIFF
--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -417,6 +417,23 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
         Check("phone number stripped", _PHONE not in blob),
         Check("street address stripped", _STREET not in blob),
     ]
+
+    # Search, not only read-by-id. This probe issued a single GET by id, so the
+    # grade it produces said nothing about the search path — and search is what
+    # builds an agent's context (`careagents/healthclaw.py` search()). Removing
+    # redaction from the search route left the whole suite green and the grade
+    # at A, which made the badge honest about the wrong path.
+    status, body, text = client.request(
+        "GET", f"/Patient?_id={pid}", ctx.read_headers())
+    sblob = text or json.dumps(body or {})
+    r.checks += [
+        Check("search succeeds", status == 200, f"status {status}"),
+        Check("family name not returned in full (search)", _FAMILY not in sblob),
+        Check("given name not returned in full (search)", _GIVEN not in sblob),
+        Check("SSN-class identifier masked (search)", _SSN not in sblob),
+        Check("phone number stripped (search)", _PHONE not in sblob),
+        Check("street address stripped (search)", _STREET not in sblob),
+    ]
     r.note = f"Patient/{pid}"
     return r
 
@@ -433,11 +450,29 @@ def probe_audit_trail(client, ctx) -> ProbeResult:
     st, body, text = client.request("GET", "/AuditEvent?_count=100", ctx.read_headers())
     blob = text or json.dumps(body or {})
     readable = isinstance(body, dict) and body.get("resourceType") == "Bundle"
+
+    # Look for a READ specifically. Matching only `Patient/{pid}` in the blob
+    # could not fail: the create above already emits an event whose
+    # `entity.what.reference` is exactly that string, so the check passed with
+    # read auditing deleted entirely. A check that the setup satisfies is not
+    # a check.
+    read_audited = False
+    if isinstance(body, dict):
+        for entry in body.get("entry") or []:
+            res = entry.get("resource") or {}
+            if res.get("resourceType") != "AuditEvent":
+                continue
+            action = res.get("action")
+            refs = json.dumps(res.get("entity") or [])
+            if action == "R" and pid and f"Patient/{pid}" in refs:
+                read_audited = True
+                break
+
     r.checks += [
         Check("AuditEvent endpoint readable", readable, f"status {st}"),
-        Check("resource access is recorded in the audit trail",
-              bool(pid) and f"Patient/{pid}" in blob,
-              "no AuditEvent references the accessed resource"),
+        Check("resource READ is recorded in the audit trail", read_audited,
+              "no AuditEvent with action=R references the resource that was "
+              "read (a create event alone does not demonstrate read auditing)"),
         Check("no raw SSN in the audit trail", _SSN not in blob,
               "PHI leaked into audit"),
     ]

--- a/tests/test_claimed_properties_are_pinned.py
+++ b/tests/test_claimed_properties_are_pinned.py
@@ -1,0 +1,194 @@
+"""Pins for properties this project claims but did not test.
+
+Found by a mutation audit: 48 mutations, 8 survivors. Each test below has a
+`MUTATION:` line naming the exact edit that must turn it red. If you change
+the code these guard, verify the named mutation still fails — a pin that
+cannot fail is the thing this file exists to stop.
+
+The properties here are load-bearing in the README, the conformance badge and
+the webinar deck. Two of them were previously demonstrated only on a path no
+user takes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+TENANT = "test-tenant"
+
+_FAMILY = "Secretsurname"
+_GIVEN = "Confidentialgiven"
+_SSN = "123-45-6789"
+_PHONE = "617-555-0142"
+_STREET = "42 Realstreet Ave"
+_DOB = "1980-03-14"
+
+
+def _patient_with_phi(pid: str) -> dict:
+    return {
+        "resourceType": "Patient",
+        "id": pid,
+        "name": [{"family": _FAMILY, "given": [_GIVEN],
+                  "text": f"{_GIVEN} Q. {_FAMILY}"}],
+        "identifier": [{"system": "http://hl7.org/fhir/sid/us-ssn",
+                        "value": _SSN}],
+        "telecom": [{"system": "phone", "value": _PHONE}],
+        "address": [{"line": [_STREET], "city": "Boston"}],
+        "birthDate": _DOB,
+    }
+
+
+def _seed(app, pid: str) -> None:
+    from models import db
+    from r6.models import R6Resource
+    with app.app_context():
+        db.session.add(R6Resource(
+            tenant_id=TENANT, resource_type="Patient", resource_id=pid,
+            resource_json=json.dumps(_patient_with_phi(pid))))
+        db.session.commit()
+
+
+_MARKERS = [("family name", _FAMILY), ("given name", _GIVEN),
+            ("SSN", _SSN), ("phone", _PHONE), ("street", _STREET),
+            ("date of birth", _DOB)]
+
+
+# --- S1: redaction on the SEARCH path --------------------------------------
+
+def test_search_redacts_phi(client, app):
+    """MUTATION: drop `apply_redaction` from the search loop in r6/routes.py.
+
+    Read-by-id was well covered. Search was not — and search is what builds an
+    agent's context (`careagents/healthclaw.py` search()). With redaction
+    removed from this loop the entire suite stayed green and the conformance
+    grade stayed A, so the badge attested to a path no model reads through.
+    """
+    _seed(app, "phi-search-probe")
+    r = client.get("/r6/fhir/Patient?_id=phi-search-probe",
+                   headers={"X-Tenant-Id": TENANT})
+    assert r.status_code == 200
+    blob = r.get_data(as_text=True)
+    leaked = [label for label, value in _MARKERS if value in blob]
+    assert not leaked, f"search leaked {', '.join(leaked)}"
+
+
+def test_search_redacts_phi_even_without_an_id_filter(client, app):
+    """The unfiltered listing is the shape an agent actually issues."""
+    _seed(app, "phi-search-probe-2")
+    r = client.get("/r6/fhir/Patient?_count=20",
+                   headers={"X-Tenant-Id": TENANT})
+    assert r.status_code == 200
+    blob = r.get_data(as_text=True)
+    leaked = [label for label, value in _MARKERS if value in blob]
+    assert not leaked, f"search listing leaked {', '.join(leaked)}"
+
+
+def test_read_and_search_redact_the_same_fields(client, app):
+    """Neither path may be the lenient one."""
+    _seed(app, "phi-parity-probe")
+    h = {"X-Tenant-Id": TENANT}
+    read = client.get("/r6/fhir/Patient/phi-parity-probe",
+                      headers=h).get_data(as_text=True)
+    search = client.get("/r6/fhir/Patient?_id=phi-parity-probe",
+                        headers=h).get_data(as_text=True)
+    for label, value in _MARKERS:
+        assert (value in read) == (value in search), (
+            f"{label} is treated differently by read and search")
+
+
+def test_human_name_text_never_survives(client, app):
+    """MUTATION: stop stripping HumanName.text in r6/redaction.py.
+
+    CLAUDE.md calls this out by name: real feeds put the full patient name in
+    `name[].text`. `Coding.display` and `CodeableConcept.text` were pinned;
+    this sibling field was not.
+    """
+    _seed(app, "phi-nametext-probe")
+    for path in ("/r6/fhir/Patient/phi-nametext-probe",
+                 "/r6/fhir/Patient?_id=phi-nametext-probe"):
+        blob = client.get(path, headers={"X-Tenant-Id": TENANT}
+                          ).get_data(as_text=True)
+        assert f"{_GIVEN} Q. {_FAMILY}" not in blob, f"name text survived {path}"
+
+
+# --- S4: step-up token expiry ----------------------------------------------
+
+def test_an_expired_step_up_token_is_refused():
+    """MUTATION: delete the `exp` check in r6/stepup.py validate_step_up_token.
+
+    Signature, tenant binding, scope and replay were all pinned. The TTL was
+    not, so `DEFAULT_TOKEN_TTL_SECONDS = 300` was enforced by code no test
+    exercised. A token from a screenshot or an old log would authorize writes
+    forever.
+    """
+    from r6.stepup import generate_step_up_token, validate_step_up_token
+
+    token = generate_step_up_token(TENANT, ttl_seconds=-1)
+    ok, reason = validate_step_up_token(token, TENANT)
+    assert ok is False, "an expired token was accepted"
+    assert "expired" in reason.lower(), reason
+
+
+def test_a_live_step_up_token_is_still_accepted():
+    """Otherwise the expiry check could be a blanket refusal."""
+    from r6.stepup import generate_step_up_token, validate_step_up_token
+
+    ok, _ = validate_step_up_token(
+        generate_step_up_token(TENANT, ttl_seconds=300), TENANT)
+    assert ok is True
+
+
+def test_the_default_ttl_is_short():
+    """A silent bump to days would pass every other test in the suite."""
+    from r6.stepup import DEFAULT_TOKEN_TTL_SECONDS
+    assert 0 < DEFAULT_TOKEN_TTL_SECONDS <= 900, (
+        f"default step-up TTL is {DEFAULT_TOKEN_TTL_SECONDS}s; a step-up "
+        "credential is meant to be minutes, not hours")
+
+
+def test_expiry_is_enforced_at_the_boundary(monkeypatch):
+    """Pins the direction of the comparison, not just that one exists."""
+    from r6.stepup import generate_step_up_token, validate_step_up_token
+
+    token = generate_step_up_token(TENANT, ttl_seconds=60)
+    assert validate_step_up_token(token, TENANT)[0] is True
+
+    real = time.time
+    monkeypatch.setattr(time, "time", lambda: real() + 61)
+    ok, reason = validate_step_up_token(token, TENANT)
+    assert ok is False and "expired" in reason.lower(), reason
+
+
+# --- S2: audit on read -----------------------------------------------------
+
+def test_a_read_writes_its_own_audit_event(client, app):
+    """MUTATION: remove `record_audit_event` from local read_resource.
+
+    The existing test asserted `total >= 1` after a POST that had already
+    emitted a create event, so it passed with read auditing deleted. This
+    filters to the read.
+    """
+    _seed(app, "audit-read-probe")
+    client.get("/r6/fhir/Patient/audit-read-probe",
+               headers={"X-Tenant-Id": TENANT})
+
+    from r6.models import AuditEventRecord
+    with app.app_context():
+        reads = AuditEventRecord.query.filter_by(
+            tenant_id=TENANT, resource_type="Patient",
+            resource_id="audit-read-probe", event_type="read").all()
+    assert reads, "reading a resource emitted no read AuditEvent"
+
+
+@pytest.mark.parametrize("marker", [v for _, v in _MARKERS])
+def test_the_audit_trail_carries_no_phi(client, app, marker):
+    """The audit trail is shown to patients; it must not become the leak."""
+    _seed(app, "audit-phi-probe")
+    client.get("/r6/fhir/Patient/audit-phi-probe",
+               headers={"X-Tenant-Id": TENANT})
+    blob = client.get("/r6/fhir/AuditEvent?_count=100",
+                      headers={"X-Tenant-Id": TENANT}).get_data(as_text=True)
+    assert marker not in blob

--- a/tests/test_ingest_bundle_endpoint.py
+++ b/tests/test_ingest_bundle_endpoint.py
@@ -523,7 +523,82 @@ def test_deeply_nested_json_is_refused_not_crashed_no_credentials(
     r = client.post(_ENDPOINT, data=payload,
                     headers={"X-Tenant-Id": "someone-elses-private-tenant",
                              "Content-Type": "application/json"})
-    assert r.status_code in (400, 403), r.status_code
+    # 403, not "400 or 403". Accepting 400 here accepted the bug: the
+    # RecursionError catch also answers 400, so the loose assertion passed
+    # whether auth ran before the parse or after it. Mutation-checked —
+    # moving the auth gate back below json.loads leaves this test green if
+    # 400 is allowed.
+    assert r.status_code == 403, r.status_code
+
+
+@pytest.mark.parametrize("label,body,headers", [
+    # Each of these fails a DIFFERENT check further down the handler. If auth
+    # runs first, every one of them is 403 and none of the later codes can
+    # appear. That is the property, stated as a property rather than inferred
+    # from one input.
+    ("unparseable body", b"not-json{", {"Content-Type": "application/json"}),
+    ("wrong content type", b'{"bundle":{}}', {"Content-Type": "text/plain"}),
+    ("missing content type", b'{"bundle":{}}', {}),
+    ("legacy body selector", b'{"tenant_id":"x","bundle":{}}',
+     {"Content-Type": "application/json"}),
+    ("not even a JSON object", b'"a string"',
+     {"Content-Type": "application/json"}),
+])
+def test_auth_is_the_first_gate_whatever_else_is_wrong_with_the_request(
+        client, _mint_secret_env, label, body, headers):
+    """B2's real defect was ORDER, not any single input.
+
+    The endpoint used to sniff the content type, read the body and parse it
+    before asking whether the caller was allowed to be here at all. Every
+    check below the auth gate is therefore reachable by an anonymous caller,
+    and each one is a different way to spend our CPU and memory for free.
+
+    So this asserts the ordering itself: a request that is wrong in some
+    *other* way, sent with no credentials, must still be refused as
+    unauthorized — never with the downstream code that describes what else
+    was wrong with it.
+    """
+    r = client.post(_ENDPOINT, data=body,
+                    headers={"X-Tenant-Id": "someone-elses-private-tenant",
+                             **headers})
+    assert r.status_code == 403, (
+        f"{label}: got {r.status_code} — a downstream check ran before the "
+        f"auth gate: {r.get_data(as_text=True)[:120]}")
+
+
+def test_the_depth_guard_refuses_nesting_python_can_still_parse(
+        client, _mint_secret_env):
+    """Covers `_json_depth_within`, which nothing else reaches.
+
+    The 60000-deep case below trips `RecursionError` inside `json.loads`
+    first, so it exercises the except-clause and never the depth walk —
+    `_INGEST_MAX_JSON_DEPTH` could be raised to ten million and the suite
+    stayed green. This nests deep enough to break the limit but shallow
+    enough that CPython parses it happily, so the constant is load-bearing.
+    """
+    from r6.routes import _INGEST_MAX_JSON_DEPTH
+
+    depth = _INGEST_MAX_JSON_DEPTH + 20
+    payload = ('{"bundle":' + "[" * depth + "1" + "]" * depth + "}").encode()
+
+    r = client.post(_ENDPOINT, data=payload,
+                    headers={"X-Tenant-Id": "someone-elses-private-tenant",
+                             "Content-Type": "application/json",
+                             "X-Internal-Secret": _MINT_SECRET})
+    assert r.status_code == 400, r.get_json()
+
+    # And a bundle just inside the limit must still be accepted, or the guard
+    # is a blanket refusal wearing a depth check's name.
+    ok_depth = max(1, _INGEST_MAX_JSON_DEPTH - 4)
+    nested = "[" * ok_depth + "1" + "]" * ok_depth
+    r = client.post(
+        _ENDPOINT,
+        data=('{"bundle":{"resourceType":"Bundle","type":"collection",'
+              '"entry":[],"_probe":' + nested + "}}").encode(),
+        headers={"X-Tenant-Id": "someone-elses-private-tenant",
+                 "Content-Type": "application/json",
+                 "X-Internal-Secret": _MINT_SECRET})
+    assert r.status_code == 200, r.get_json()
 
 
 def test_deeply_nested_json_refused_as_too_deep_with_credentials(


### PR DESCRIPTION
A mutation audit ran 48 edits against the tree. **8 survived with the full suite green.** These are the four that matter, plus fixes to the conformance probes that were grading them.

Every test carries a `MUTATION:` line naming the edit that must turn it red, and each was verified by applying that edit.

| | Property | Mutation applied | Before | After |
|---|---|---|---|---|
| **S1** | Redaction on the search path | drop `apply_redaction` from the search loop | 0 failures | **7** |
| **S2** | Audit on read | remove `record_audit_event` from local read | 0 | **4** |
| **S4** | Step-up token expiry | delete the `exp` check | 0 | **2** |
| **S5** | Auth before parse (#288) | move the gate below `json.loads` | 0 | **5** |

## S1 — the property in our name, on the path that feeds the model

Deleting `apply_redaction` from the search loop left **1931 tests passing and the conformance grade at A**. `probe_phi_redaction` issued exactly one request — `GET /Patient/{pid}` — so the badge attested to read-by-id while search, which is what `careagents/healthclaw.py search()` calls to build an agent context, was never checked.

**Production is redacting correctly today.** I verified against live before writing anything: names come back as `{"family": "R.", "given": ["M.", "E."]}`, no SSN, phone or DOB. This was a test gap, not a leak — but nothing would have caught a regression, and the badge would have kept saying A.

Now pinned on search, on the unfiltered listing an agent actually issues, and for read/search parity so neither path can become the lenient one. The probe checks both.

Also pins `HumanName.text` — the field CLAUDE.md names specifically because real feeds put patient names there. `Coding.display` and `CodeableConcept.text` were strongly covered; the sibling field was not.

## S2 — the check that could not fail

`probe_audit_trail` asserted `f"Patient/{pid}" in blob`. The `_create_synthetic` call in its own setup emits an event whose `entity.what.reference` is exactly that string — so the check passed with read auditing deleted entirely. A check its own setup satisfies is not a check. It now looks for an event with `action=R`.

The unit-test equivalent had the same shape: `assert data["total"] >= 1` after a POST that had already audited. The correctly-written version was fourteen lines above it.

## S5 — I reported this as fixed and it was not

The work was written, reviewed and reported as landed. It was pushed **five minutes after #288 merged**, so it went to a branch that no longer fed main. I verified the remote ref matched; I did not verify the branch was still the thing being merged.

`assert r.status_code in (400, 403)` was still on main — and the `RecursionError` catch answers 400, so restoring the vulnerability passed. Restored here.

## Gates

`1987 passed, 6 skipped, 2 xfailed`; ruff clean; **conformance still Grade A** with the stricter probes — the grade did not need to drop, it needed to be measuring the right thing.

## Still open from the audit

#S3 is [#301](https://github.com/aks129/HealthClawGuardrails/pull/301). Remaining survivors worth separate work: the CareAgents streaming upload cap, the e2e suite still cannot assert it ran, and three of my own drift guards from #291/#295 pass for the wrong reason — including a word-whitelist that is, in QA words, "the same defect, one layer down" as the prefix-whitelist it replaced.