### PR TITLE
fix(ops): authenticate /r6/ops/* as infrastructure — closes live cross-tenant sweep (#304)

### DIFF
--- a/r6/internal_auth.py
+++ b/r6/internal_auth.py
@@ -1,0 +1,33 @@
+"""Shared internal-secret authorization for infrastructure/operator surfaces.
+
+The internal-secret scheme authenticates a caller as *infrastructure*, not as
+a tenant: a request presents `X-Internal-Secret`, matched constant-time against
+`INTERNAL_TOKEN_MINT_SECRET`, fail-closed in production. Unlike the mint gate
+(`_internal_mint_authorized`) it grants NO public-tenant exemption — a public
+tenant bypasses read-auth, but that says nothing about whether a caller may
+drive an operator action across all tenants.
+
+Extracted so `/internal/*` ingestion (#267) and `/r6/ops/*` (#304) share one
+gate rather than each carrying its own copy. Tenant-independent by design.
+"""
+import hmac
+import os
+
+from flask import request
+
+from r6.runtime_config import resolve_app_env
+
+
+def internal_secret_authorized():
+    """True iff the caller presents the configured internal secret.
+
+    If `INTERNAL_TOKEN_MINT_SECRET` is unset, the surface is open only outside
+    production (backward compatible for local/dev and the test harness) and
+    refused in production. Takes no tenant argument: this authenticates the
+    caller as infrastructure, not as any one tenant.
+    """
+    mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
+    if mint_secret:
+        provided = request.headers.get('X-Internal-Secret', '')
+        return hmac.compare_digest(provided, mint_secret)
+    return resolve_app_env() != 'production'

--- a/r6/ops/routes.py
+++ b/r6/ops/routes.py
@@ -12,26 +12,27 @@ POST /r6/ops/reap — the external-tick reaper (5-minute external cron; no
      auto-retried); 'unknown' rows with a ref are reconciled; lapsed
      approval windows expire with a summary-only nudge to re-propose.
 
-Auth: the same step-up gate as action commit (X-Tenant-Id + a valid
-tenant-bound X-Step-Up-Token). The sweeps themselves are global — the tenant
-binding just keeps this surface consistent with every other guarded endpoint
-rather than inventing an infra-only credential.
+Auth (#304): the internal-secret scheme (`X-Internal-Secret`, fail-closed in
+production, NO public-tenant exemption) — the same gate as `/internal/*`
+ingestion. `/r6/ops/*` is an OPERATOR surface: the sweeps are global by design,
+so authenticating it as a tenant let any tenant's step-up token drive every
+tenant's rows. It takes NO `X-Tenant-Id`; a tenant header, if present, is
+ignored. See `r6.internal_auth.internal_secret_authorized`.
 """
 import json
 import logging
-import re
 from datetime import timedelta
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 
 from models import db
 from r6.actions.models import ProposedAction, _utcnow
 from r6.actions.registry import get_executor
 from r6.actions.state import transition_action
 from r6.audit import record_audit_event
+from r6.internal_auth import internal_secret_authorized
 from r6.ops import checks as preflight_checks
 from r6.rate_limit import rate_limit_middleware
-from r6.stepup import validate_step_up_token
 from r6.telegram_push import notify_tenant
 
 logger = logging.getLogger(__name__)
@@ -40,26 +41,18 @@ ops_blueprint = Blueprint('ops', __name__, url_prefix='/r6/ops')
 
 rate_limit_middleware(ops_blueprint)
 
-_TENANT_PATTERN = re.compile(r'^[a-zA-Z0-9_-]{1,64}$')
-
 
 def _error(status, message):
     return jsonify({'error': message}), status
 
 
 def _auth_error_or_none():
-    """Gate 1, same as action commit: tenant header + valid tenant-bound
-    step-up token (multi-use validation; ops calls are not executions, so
-    no nonce is consumed). Returns an error response or None."""
-    tenant_id = request.headers.get('X-Tenant-Id', '')
-    if not tenant_id or not _TENANT_PATTERN.match(tenant_id):
-        return _error(400, 'X-Tenant-Id header is required')
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _error(401, 'Ops endpoints require X-Step-Up-Token header')
-    valid, err = validate_step_up_token(step_up_token, tenant_id)
-    if not valid:
-        return _error(401, 'Step-up token rejected: %s' % err)
+    """Infrastructure gate (#304): a valid `X-Internal-Secret`, tenant-blind.
+    /r6/ops/* acts globally, so it authenticates as an operator, never as a
+    tenant — a tenant-bound step-up token grants nothing here. Returns an
+    error response or None."""
+    if not internal_secret_authorized():
+        return _error(403, 'Ops endpoints require a valid X-Internal-Secret')
     return None
 
 

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2006,12 +2006,14 @@ def _internal_ingest_authorized(tenant_id):
     requires a matching `X-Internal-Secret`. Fail-closed: if
     `INTERNAL_TOKEN_MINT_SECRET` is unset, ingestion is refused in production
     and allowed only outside production (backward compatible locally).
+
+    The internal-secret check lives in `r6.internal_auth` so this gate and the
+    `/r6/ops/*` operator gate (#304) share one implementation; `tenant_id` is
+    accepted for call-site symmetry but intentionally unused (the secret is
+    tenant-independent).
     """
-    mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
-    if mint_secret:
-        provided = request.headers.get('X-Internal-Secret', '')
-        return hmac.compare_digest(provided, mint_secret)
-    return resolve_app_env() != 'production'
+    from r6.internal_auth import internal_secret_authorized
+    return internal_secret_authorized()
 
 
 # Resource types the direct-upload path (#227) may never author, regardless

--- a/tests/ops/test_preflight.py
+++ b/tests/ops/test_preflight.py
@@ -265,25 +265,33 @@ def green_fatal_env(monkeypatch):
 
 
 class TestPreflightEndpoint:
-    def test_requires_tenant_header(self, client):
-        resp = client.get('/r6/ops/preflight')
-        assert resp.status_code == 400
+    # #304: preflight shares the ops gate — infrastructure (internal secret),
+    # not tenant step-up. A tenant token (even a public tenant's) is rejected.
+    OPS_SECRET = 'ops-internal-secret-value-304'
 
-    def test_requires_step_up_token(self, client, tenant_headers):
-        resp = client.get('/r6/ops/preflight', headers=tenant_headers)
-        assert resp.status_code == 401
-
-    def test_rejects_bad_token(self, client, tenant_id):
-        resp = client.get('/r6/ops/preflight', headers={
-            'X-Tenant-Id': tenant_id, 'X-Step-Up-Token': 'garbage.token'})
-        assert resp.status_code == 401
-
-    def test_rejects_foreign_tenant_token(self, client, tenant_id):
+    def test_public_tenant_stepup_token_is_rejected(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', self.OPS_SECRET)
         from r6.stepup import generate_step_up_token
         resp = client.get('/r6/ops/preflight', headers={
-            'X-Tenant-Id': tenant_id,
-            'X-Step-Up-Token': generate_step_up_token('other-tenant')})
-        assert resp.status_code == 401
+            'X-Tenant-Id': 'desktop-demo',
+            'X-Step-Up-Token': generate_step_up_token('desktop-demo')})
+        assert resp.status_code == 403
+
+    def test_missing_internal_secret_is_rejected(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', self.OPS_SECRET)
+        assert client.get('/r6/ops/preflight').status_code == 403
+
+    def test_wrong_internal_secret_is_rejected(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', self.OPS_SECRET)
+        resp = client.get('/r6/ops/preflight',
+                          headers={'X-Internal-Secret': 'wrong'})
+        assert resp.status_code == 403
+
+    def test_correct_internal_secret_succeeds(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', self.OPS_SECRET)
+        resp = client.get('/r6/ops/preflight',
+                          headers={'X-Internal-Secret': self.OPS_SECRET})
+        assert resp.status_code == 200
 
     def test_response_shape_and_always_200(self, client, auth_headers,
                                            monkeypatch):

--- a/tests/ops/test_reaper.py
+++ b/tests/ops/test_reaper.py
@@ -103,18 +103,83 @@ def reap(client, auth_headers):
 
 # ------------------------------------------------------------------ auth
 
+OPS_SECRET = 'ops-internal-secret-value-304'
+
+
 class TestReapAuth:
-    def test_requires_tenant_header(self, client):
-        assert client.post('/r6/ops/reap').status_code == 400
+    """#304: /r6/ops/* authenticates as *infrastructure* via the internal
+    secret (X-Internal-Secret, no public-tenant exemption), NOT as a tenant.
+    A tenant-bound step-up token grants nothing here; no X-Tenant-Id is
+    consulted for auth."""
 
-    def test_requires_step_up_token(self, client, tenant_headers):
-        resp = client.post('/r6/ops/reap', headers=tenant_headers)
-        assert resp.status_code == 401
-
-    def test_rejects_bad_token(self, client, tenant_id):
+    def test_public_tenant_stepup_token_is_rejected(self, client, monkeypatch):
+        # This is the vulnerability (finding S-1): desktop-demo is a public
+        # tenant, so a full-capability step-up token mints with no credential.
+        # It used to drive the global sweep. With an internal secret required
+        # and none supplied, the request must be refused.
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        from r6.stepup import generate_step_up_token
         resp = client.post('/r6/ops/reap', headers={
-            'X-Tenant-Id': tenant_id, 'X-Step-Up-Token': 'garbage.token'})
-        assert resp.status_code == 401
+            'X-Tenant-Id': 'desktop-demo',
+            'X-Step-Up-Token': generate_step_up_token('desktop-demo')})
+        assert resp.status_code == 403
+
+    def test_correct_internal_secret_succeeds(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        resp = client.post('/r6/ops/reap',
+                           headers={'X-Internal-Secret': OPS_SECRET})
+        assert resp.status_code == 200
+
+    def test_wrong_internal_secret_is_rejected(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        resp = client.post('/r6/ops/reap',
+                           headers={'X-Internal-Secret': 'wrong'})
+        assert resp.status_code == 403
+
+    def test_missing_internal_secret_is_rejected(self, client, monkeypatch):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        assert client.post('/r6/ops/reap').status_code == 403
+
+
+class TestOpsIsInfraNotTenantScoped:
+    """#304 regression: the sweep is global by design, but the X-Tenant-Id
+    header must not scope it (the retro's "looks scoped, acts global"
+    defect). With the internal secret present, an unrelated tenant header is
+    inert — every tenant's lapsed rows are still swept, and each tenant is
+    notified about its OWN row only."""
+
+    def test_tenant_header_does_not_scope_or_leak(
+            self, app, client, monkeypatch, notifications):
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        a_id = make_action(status='awaiting_confirmation', tenant_id='tenant-a',
+                           expires_at=_utcnow() - timedelta(minutes=1))
+        b_id = make_action(status='awaiting_confirmation', tenant_id='tenant-b',
+                           expires_at=_utcnow() - timedelta(minutes=1))
+        resp = client.post('/r6/ops/reap', headers={
+            'X-Internal-Secret': OPS_SECRET,
+            'X-Tenant-Id': 'tenant-a'})   # present but must be ignored
+        assert resp.status_code == 200
+        body = resp.get_json()
+        moved = {t['id'] for t in body['transitions']}
+        assert moved == {a_id, b_id}   # global sweep — header did NOT scope
+        assert get_action(a_id).status == 'expired'
+        assert get_action(b_id).status == 'expired'
+        # each tenant is nudged about its own row, not tenant-a's for both
+        assert {n['tenant_id'] for n in notifications} == {'tenant-a', 'tenant-b'}
+
+    def test_sweep_end_to_end_under_internal_secret(
+            self, app, client, monkeypatch, patch_executor):
+        # (c) the reaper still reconciles rows under the new auth scheme.
+        monkeypatch.setenv('INTERNAL_TOKEN_MINT_SECRET', OPS_SECRET)
+        patch_executor(ExecutionResult(status='completed',
+                                       outcome={'ok': True}))
+        action_id = make_action(external_ref='call-42')
+        resp = client.post('/r6/ops/reap',
+                           headers={'X-Internal-Secret': OPS_SECRET})
+        assert resp.status_code == 200
+        assert resp.get_json()['transitions'] == [
+            {'id': action_id, 'from': 'executing', 'to': 'completed'}]
+        assert get_action(action_id).status == 'completed'
 
 
 # ------------------------------------------- executing + ref -> reconcile

--- a/tests/ops/test_reaper.py
+++ b/tests/ops/test_reaper.py
@@ -182,6 +182,32 @@ class TestOpsIsInfraNotTenantScoped:
         assert get_action(action_id).status == 'completed'
 
 
+class TestInternalSecretUnsetFailClosed:
+    """#304 fail-closed pin for the no-secret branch of
+    internal_secret_authorized() (r6/internal_auth.py:33): when
+    INTERNAL_TOKEN_MINT_SECRET is unset, /r6/ops/* is open outside production
+    (dev/test convenience) but REFUSED in production. Fail-closed is exactly
+    the property that regresses silently, so it gets an explicit pin.
+
+    MUTATION: flip `!=` to `==` in r6/internal_auth.py:33
+    (`return resolve_app_env() == 'production'`) — test_production_unset_refuses
+    turns red (403 -> 200; the operator surface would open to anyone).
+    """
+
+    def test_production_unset_refuses(self, client, monkeypatch):
+        # No secret configured + APP_ENV=production -> fail closed.
+        monkeypatch.delenv('INTERNAL_TOKEN_MINT_SECRET', raising=False)
+        monkeypatch.setenv('APP_ENV', 'production')
+        assert client.post('/r6/ops/reap').status_code == 403
+
+    def test_nonproduction_unset_allows(self, client, monkeypatch):
+        # No secret + default test env (TESTING=1, no APP_ENV) -> 'testing',
+        # so the surface stays open locally without a secret.
+        monkeypatch.delenv('INTERNAL_TOKEN_MINT_SECRET', raising=False)
+        monkeypatch.delenv('APP_ENV', raising=False)
+        assert client.post('/r6/ops/reap').status_code == 200
+
+
 # ------------------------------------------- executing + ref -> reconcile
 
 class TestReconcileExecutingWithRef:


### PR DESCRIPTION
Closes #304 (audit finding S-1).

## ⚠️ Deploy requirement — read before merging

This gate is **fail-closed**. After deploy, two external callers must change or they will silently break:

1. **The 5-minute reaper cron** (`POST /r6/ops/reap`) — must send `X-Internal-Secret: <INTERNAL_TOKEN_MINT_SECRET>` and stop sending `X-Tenant-Id`/`X-Step-Up-Token`. If it keeps the old headers, the reaper 403s and **stops running with no fatal signal** (`check_reaper_heartbeat` is informational-only, [r6/ops/checks.py:149](r6/ops/checks.py#L149)).
2. **Any preflight/uptime monitor** hitting `/r6/ops/preflight` — same requirement; both endpoints share the one gate.

Also confirm `INTERNAL_TOKEN_MINT_SECRET` is set on the Railway service that runs these callers. The external cron is not in the repo, so this cannot be fixed in code — it is a deploy-time change.

## The vulnerability (was live and unauthenticated)

Verified against production (non-destructively — the sweep itself was not executed):

- `POST /r6/fhir/internal/step-up-token {"tenant_id":"desktop-demo"}` → **200, token issued with no credential** (public tenants skip the secret check).
- The old `/r6/ops/*` gate accepted that tenant-bound token, then swept `ProposedAction` rows **across all tenants** — expiring other tenants' pending approvals and firing Telegram notifications at their patients.

So the full chain required no secret. This is the retro's pattern: a control that looked tenant-scoped while acting globally.

## The fix (CTO-approved design)

- `/r6/ops/*` now authenticates with the **internal-secret scheme** (`X-Internal-Secret`, constant-time compare, no public-tenant exemption) — the same gate `/internal/*` ingestion uses. Extracted into a shared `r6/internal_auth.py::internal_secret_authorized()`; `_internal_ingest_authorized` delegates to it (behavior unchanged).
- **`X-Tenant-Id` is no longer read** under `/r6/ops/*`. The sweeps stay global by design, now honestly authenticated as an operator action.

## Guards

- **QA verdict: PASS.** Transition-proving test: the attack (`desktop-demo` step-up token, no secret) returns **200 on `main`, 403 on this branch**.
- Fail-closed pinned: unset secret + `APP_ENV=production` → 403 (with a `MUTATION:` line; flipping `!=`→`==` at internal_auth.py:33 turns it red).
- Mutation-verified, constant-time compare, no scope creep.
- Full suite **1997 passed, 6 skipped, 2 xfailed**; conformance **Grade A**; ruff clean. Python 3.11.

## Not in this PR (deliberately)

The other audit findings (S-2 `/fasten/demo`, S-4 SHC ingest, S-3/S-5) ship as separate PRs. No access-kernel or routes.py work — that program is post-Aug-18 per the CTO/Product sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)