### PR TITLE
fix(shc): log exception class, not the raw exception — stops PHI leak in SHC ingest (#306)

### DIFF
--- a/r6/shc/routes.py
+++ b/r6/shc/routes.py
@@ -254,7 +254,11 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
                     skipped += 1
             except Exception as exc:
                 failed += 1
-                logger.warning('SHC ingest error (job=%s): %s', job_id, exc)
+                # Log the exception CLASS only — str(exc) on a DBAPIError
+                # serialises the failing statement and bound parameters (the
+                # FHIR record), leaking PHI into logs (#306, S-4).
+                logger.warning('SHC ingest error (job=%s): %s',
+                               job_id, type(exc).__name__)
 
         record_audit_event(
             event_type='shc_import_complete',
@@ -277,7 +281,7 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
                 from r6.fasten.ingester import _run_curatr_scan
                 curatr_issues = _run_curatr_scan(curatr_eligible_ids, tenant_id, job_id) or 0
             except Exception as exc:
-                logger.warning('SHC curatr scan failed: %s', exc)
+                logger.warning('SHC curatr scan failed: %s', type(exc).__name__)
 
         try:
             from r6.telegram_push import notify_tenant
@@ -299,4 +303,4 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
             msg_lines += ['', 'Try `/summary`, `/conditions`, or `/dashboard`.']
             notify_tenant(tenant_id, '\n'.join(msg_lines))
         except Exception as exc:
-            logger.warning('SHC notify push failed: %s', exc)
+            logger.warning('SHC notify push failed: %s', type(exc).__name__)

--- a/tests/test_shc_bridge.py
+++ b/tests/test_shc_bridge.py
@@ -6,6 +6,7 @@ untested-live-path class as the Fasten webhook envelope bug. Pins:
 """
 
 import json
+import logging
 from unittest.mock import patch
 
 
@@ -79,6 +80,42 @@ class TestShcIngest:
             resp = _ingest(client, body)
         assert resp.status_code == 200
         assert resp.get_json()["entries"] == 1
+
+    def test_ingest_error_logs_exception_class_not_phi(self, app, caplog):
+        """A failing entry must log the exception CLASS name, never the
+        exception object. str() on a SQLAlchemy DBAPIError serialises the
+        failing statement and its bound parameters — i.e. the FHIR record
+        being ingested — so `%s` on the exception leaks PHI into logs. Issue
+        #306 (S-4); .github/REVIEW_STANDARDS.md rule 1; docs/2026-08-02-retro.md.
+
+        MUTATION: reverting the fix at r6/shc/routes.py:257 to
+        `logger.warning('SHC ingest error (job=%s): %s', job_id, exc)` (logging
+        `exc` instead of `type(exc).__name__`) turns this test red.
+        """
+        from r6.shc import routes as shc_routes
+
+        phi = "Rosa PHI-LEAK Kowalski dob=1971-03-02 ssn=123-45-6789"
+
+        class PoisonedStatementError(Exception):
+            pass
+
+        def _boom(resource, tenant_id):
+            # Mimic a DBAPIError whose str() echoes the bound parameters.
+            raise PoisonedStatementError(
+                "(psycopg2.errors.StringDataRightTruncation) INSERT INTO "
+                "fhir_resource (...) VALUES (...) -- parameters: "
+                f"{{'patient': '{phi}'}}"
+            )
+
+        entries = [{"resourceType": "Observation", "status": "final"}]
+        with caplog.at_level(logging.WARNING, logger="r6.shc.routes"):
+            with patch("r6.fasten.ingester._ingest_one", _boom):
+                shc_routes._ingest_bundle(
+                    app, entries, "shc-tenant", "flexpa", "job-306-test")
+
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert phi not in logged, f"PHI leaked into logs: {logged!r}"
+        assert "PoisonedStatementError" in logged
 
 
 class TestOAuthBrokers:


### PR DESCRIPTION
Partial fix for #306 (finding S-4). **Scope: the PHI-in-logs half only.** The SAVEPOINT/rollback restructure is deliberately deferred to the post-webinar ingest-engine work per the CTO ruling — see #306 for the deferred half.

## The leak

`r6/shc/routes.py` logged the raw exception object at three sites in `_ingest_bundle`:

```python
logger.warning('SHC ingest error (job=%s): %s', job_id, exc)
```

`%s` on a SQLAlchemy `DBAPIError` serializes the failing statement **and its bound parameters** — which include the FHIR resource being ingested. So an ordinary DB error during a legitimate ingest writes patient data to the logs. No attacker required.

Verified: against `main`, the added test emits
`WARNING … (psycopg2…StringDataRightTruncation) INSERT INTO fhir_resource … parameters: {'patient': 'Rosa PHI-LEAK Kowalski dob=1971-03-02 ssn=123-45-6789'}` — real PHI shape in a log record.

## The fix

Three sites now log `type(exc).__name__` (PHI-free class name), matching the two sibling ingest paths that already do this — `r6/fasten/ingester.py:152-153` and `r6/routes.py:2445-2448`. Required by `.github/REVIEW_STANDARDS.md` rule 1.

## Guards

- New `tests/test_shc_bridge.py::TestShcIngest::test_ingest_error_logs_exception_class_not_phi` drives the real `_ingest_bundle` → `_ingest_one` path with a synthetic PHI marker in the exception and asserts (via `caplog`) the marker is absent and the class name present.
- **Transition-verified:** the test FAILS on `main` (leaks the marker) and PASSES on this branch. Carries a `MUTATION:` line; reverting line 257 to `…, exc` turns it red.
- Full suite **1995 passed, 6 skipped, 2 xfailed**; conformance **Grade A** (28 passed); ruff clean. Python 3.11.

## Deliberately not in this PR

No rollback, no `db.session`/SAVEPOINT changes, no loop restructure — that is the deferred half of S-4, tracked in #306 for the ingest-engine work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)