### PR TITLE
fix(fasten): /fasten/demo persists nothing — removes the unauthenticated write (#305)

### DIFF
--- a/r6/fasten/routes.py
+++ b/r6/fasten/routes.py
@@ -513,7 +513,6 @@ def run_demo():
     Returns a structured result with each step's outcome.
     """
     import uuid as _uuid
-    from r6.models import R6Resource
     from r6.redaction import apply_redaction as redact_resource
 
     demo_tenant = 'fasten-demo-tenant'
@@ -523,14 +522,11 @@ def run_demo():
     steps = []
 
     # ── Step 1: Register connection ──────────────────────────────────────────
-    conn = FastenConnection(
-        org_connection_id=org_connection_id,
-        tenant_id=demo_tenant,
-        platform_type='demo',
-        connection_status='authorized',
-    )
-    db.session.add(conn)
-    db.session.flush()
+    # SECURITY (#305, S-2): this endpoint is unauthenticated and fires on every
+    # real Stitch connection. It persists NOTHING — no FastenConnection,
+    # FastenJob, or R6Resource rows. The `steps` response is built in memory and
+    # is byte-identical to the persisted version. The three audit events below
+    # stay real (they are append-only, PHI-free) so step 5's count is honest.
     record_audit_event(
         event_type='fasten_connection_registered',
         agent_id='fasten-demo',
@@ -547,14 +543,6 @@ def run_demo():
     })
 
     # ── Step 2: Simulate webhook receipt ─────────────────────────────────────
-    job = FastenJob(
-        task_id=task_id,
-        org_connection_id=org_connection_id,
-        tenant_id=demo_tenant,
-    )
-    db.session.add(job)
-    conn.last_export_at = datetime.now(timezone.utc)
-    db.session.flush()
     record_audit_event(
         event_type='fasten_import_start',
         agent_id='fasten-demo',
@@ -612,27 +600,13 @@ def run_demo():
         },
     ]
 
-    ingested = []
-    for resource in sample_resources:
-        r_type = resource['resourceType']
-        r_id = resource['id']
-        existing = R6Resource.query.filter_by(
-            resource_type=r_type, id=r_id, tenant_id=demo_tenant
-        ).first()
-        if not existing:
-            row = R6Resource(
-                resource_type=r_type,
-                resource_id=r_id,
-                tenant_id=demo_tenant,
-                resource_json=json.dumps(resource),
-            )
-            db.session.add(row)
-            ingested.append(f'{r_type}/{r_id}')
-
-    job.ingested_resources = len(ingested)
-    job.status = 'completed'
-    job.completed_at = datetime.now(timezone.utc)
-    db.session.commit()
+    # Built in memory — nothing is written (see Step 1 security note). The ids
+    # are freshly minted per request, so every sample counts as "ingested",
+    # matching the prior persisted behaviour.
+    ingested = [
+        f'{resource["resourceType"]}/{resource["id"]}'
+        for resource in sample_resources
+    ]
 
     record_audit_event(
         event_type='fasten_import_complete',
@@ -650,10 +624,10 @@ def run_demo():
     })
 
     # ── Step 4: Read back Patient with PHI redaction ─────────────────────────
-    pt_row = R6Resource.query.filter_by(
-        resource_type='Patient', id=patient_id, tenant_id=demo_tenant
-    ).first()
-    raw_patient = json.loads(pt_row.resource_json) if pt_row else {}
+    # In-memory instead of a DB round-trip. json.loads(json.dumps(...)) mirrors
+    # the exact copy the persisted path produced (resource_json → json.loads),
+    # so `original_fields` and `redacted` are byte-identical to before.
+    raw_patient = json.loads(json.dumps(sample_resources[0]))
     redacted = redact_resource(raw_patient)
     steps.append({
         'step': 4,

--- a/tests/test_fasten_demo_no_persist.py
+++ b/tests/test_fasten_demo_no_persist.py
@@ -1,0 +1,94 @@
+"""
+Security interim for #305 (finding S-2): the unauthenticated POST /fasten/demo
+endpoint must persist NOTHING, while keeping its HTTP contract byte-identical.
+
+The route is triggered on every real Stitch connection (r6-dashboard.js
+onStitchComplete) and used to write a FastenConnection, a FastenJob, and four
+R6Resource rows to a hardcoded `fasten-demo-tenant` — an unauthenticated write.
+The frontend consumes only `data.steps`; the persisted rows were read back only
+within the same request. So the persistence is removable without changing the
+response.
+
+Audit rows (append-only, PHI-free) are deliberately kept: step 5 claims
+"N audit events recorded", so those events must really be recorded.
+
+MUTATION: re-introduce the resource write in run_demo() — e.g. restore
+`db.session.add(row)` + `db.session.commit()` for the four sample resources
+(or a FastenConnection/FastenJob write). Then test_demo_persists_no_rows
+reddens because a row for `fasten-demo-tenant` reappears. Verified 2026-08-03.
+"""
+
+from r6.fasten.models import FastenConnection, FastenJob
+from r6.models import R6Resource
+
+DEMO_TENANT = 'fasten-demo-tenant'
+
+# Raw PHI that lives in the in-memory sample Patient and must never survive
+# redaction into the step-4 payload.
+RAW_PHI = ['DemoPatient', 'Jane', 'MRN-DEMO-001', '123 Main St', 'Springfield']
+
+
+def _post_demo(client):
+    resp = client.post('/fasten/demo')
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    return resp.get_json()
+
+
+def test_demo_response_shape_unchanged(client):
+    """The steps contract the frontend reads stays identical."""
+    body = _post_demo(client)
+
+    assert body['demo'] == 'fasten_connect_e2e'
+    assert body['org_connection_id']
+    assert body['task_id']
+
+    steps = body['steps']
+    assert [s['step'] for s in steps] == [1, 2, 3, 4, 5]
+    assert all(s['status'] == 'success' for s in steps)
+
+    # Step 3: four resources "ingested"
+    step3 = steps[2]
+    assert len(step3['data']['ingested']) == 4
+    assert step3['data']['resource_types'] == [
+        'Patient', 'Observation', 'Condition', 'MedicationRequest'
+    ]
+
+    # Step 4: a redacted patient with no raw name / identifier / address
+    step4 = steps[3]
+    redacted = step4['data']['redacted_patient']
+    assert redacted['resourceType'] == 'Patient'
+    assert redacted['name'][0]['family'] == 'D.'
+    assert redacted['name'][0]['given'] == ['J.']
+    assert redacted['birthDate'] == '1985'
+    import json as _json
+    blob = _json.dumps(redacted)
+    for raw in RAW_PHI:
+        assert raw not in blob, f'raw PHI {raw!r} leaked into redacted patient'
+
+    # Step 5: audit events really recorded
+    step5 = steps[4]
+    events = step5['data']['audit_events']
+    assert len(events) >= 1
+    assert all('event_type' in e for e in events)
+
+
+def test_demo_persists_no_rows(client):
+    """No connection / job / resource rows for fasten-demo-tenant afterward.
+
+    Audit rows MAY exist (they are kept on purpose); the three write-side
+    tables must be empty for the demo tenant.
+    """
+    _post_demo(client)
+
+    conns = FastenConnection.query.filter_by(tenant_id=DEMO_TENANT).count()
+    jobs = FastenJob.query.filter_by(tenant_id=DEMO_TENANT).count()
+    resources = R6Resource.query.filter_by(tenant_id=DEMO_TENANT).count()
+
+    assert conns == 0, f'{conns} FastenConnection rows persisted'
+    assert jobs == 0, f'{jobs} FastenJob rows persisted'
+    assert resources == 0, f'{resources} R6Resource rows persisted'
+
+    # Sanity: the demo still worked (audit rows are allowed to exist).
+    from r6.models import AuditEventRecord
+    audits = AuditEventRecord.query.filter_by(tenant_id=DEMO_TENANT).count()
+    assert audits >= 3, 'expected the three demo audit events to be recorded'


### PR DESCRIPTION
Security interim for #305 (finding S-2). **Not** the deletion (blocked — the route feeds live UI) and **not** the honesty redesign (that is #310, post-webinar, Product-owned). Scope: stop the route persisting rows, keep its HTTP contract byte-identical.

## Why an interim, not a delete or a gate

`/fasten/demo` turned out to be wired into the real `/r6-dashboard` Stitch flow (`static/js/r6-dashboard.js:1193`), so deleting it 404s a live path and gating it breaks an anonymous browser `fetch()` that can't hold the mint secret. The CTO traced that the frontend consumes only `data.steps`, and the persisted rows were read back only within the same request — so removing persistence closes the unauthenticated-write surface without changing the response.

## What changed (`r6/fasten/routes.py`, `run_demo()` only)

Removed the FastenConnection write, the FastenJob write, the R6Resource write-loop + `commit()`, and the read-back — replaced with in-memory construction. `apply_redaction` runs on the in-memory dict (it's a pure function). **Kept** all three `record_audit_event` calls, so step 5's "audit events recorded" claim stays literally true.

## Guards

- `tests/test_fasten_demo_no_persist.py`: asserts the response shape is unchanged (5 steps, step-4 redacted patient with no raw name/MRN/address, step-5 audit events present) AND that **zero** FastenConnection/FastenJob/R6Resource rows exist for `fasten-demo-tenant` afterward.
- **Transition-verified:** `test_demo_persists_no_rows` FAILS on `main` (1 FastenConnection persisted) and PASSES here. `MUTATION:` line documented; re-adding a write reddens it.
- Full suite **1996 passed, 6 skipped, 2 xfailed**; conformance **Grade A**; ruff clean. Python 3.11.

## Still open (deliberately, tracked in #310)

The `/r6-dashboard` showcase still shows a fabricated "Health data imported" animation on a real connection. This PR removes the *write*; it does not fix the *honesty* defect — that is the Product-owned redesign in #310, gated on whether `/r6-dashboard` is in the Aug 18 demo. The real patient journey (`/connect/<tenant>`) is unaffected and already honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)