### PR TITLE
fix(wearables): scope /wearables/sync-now to the authenticated tenant — second cross-tenant sweep (#311)

### DIFF
--- a/r6/wearables/poller.py
+++ b/r6/wearables/poller.py
@@ -59,9 +59,19 @@ def _ingest_base_url() -> str:
     ).rstrip('/')
 
 
-def run_once(app, client: WearablesClient | None = None) -> dict:
+def run_once(
+    app,
+    client: WearablesClient | None = None,
+    tenant_id: str | None = None,
+) -> dict:
     """
-    One sync pass across all WearableConnection rows.
+    One sync pass across WearableConnection rows.
+
+    When tenant_id is None (the background poller's call) every tenant's
+    connections are swept — the global pass the daemon relies on. When
+    tenant_id is given (the patient-triggered /wearables/sync-now) the sweep
+    is scoped to that one tenant, so a step-up token for tenant A can never
+    ingest into tenant B (issue #311).
 
     Returns a summary dict {connections_checked, observations_ingested,
     errors}. Safe to call manually (e.g. from /wearables/sync-now).
@@ -81,7 +91,10 @@ def run_once(app, client: WearablesClient | None = None) -> dict:
 
     with app.app_context():
         from models import db
-        connections = WearableConnection.query.all()
+        query = WearableConnection.query
+        if tenant_id is not None:
+            query = query.filter_by(tenant_id=tenant_id)
+        connections = query.all()
         for conn in connections:
             checked += 1
             try:

--- a/r6/wearables/routes.py
+++ b/r6/wearables/routes.py
@@ -260,7 +260,11 @@ def sync_now():
     if not valid:
         return jsonify({'error': f'token rejected: {err}'}), 403
 
-    summary = run_once(current_app)
+    # Scope the sweep to the authenticated tenant. run_once() defaults to a
+    # global sweep (the background poller relies on it); passing tenant_id
+    # here keeps this patient-triggered endpoint from touching other tenants
+    # (issue #311).
+    summary = run_once(current_app, tenant_id=tenant_id)
     record_audit_event(
         'update', 'WearableConnection', None,
         agent_id=request.headers.get('X-Agent-Id', 'wearable-manual-sync'),

--- a/tests/test_wearables.py
+++ b/tests/test_wearables.py
@@ -420,3 +420,93 @@ class TestPollerSyncOnce:
             os.environ.pop('OPEN_WEARABLES_URL', None)
             result = run_once(app)
             assert result.get('skipped_reason')
+
+
+# ─────────────────────────────────────────────
+# Tenant-scoping of run_once + /wearables/sync-now (issue #311)
+# ─────────────────────────────────────────────
+
+class _RecordingClient:
+    """Fake WearablesClient that records which ow_user_ids were polled.
+
+    Always enabled; fetch_deltas returns no samples so _sync_one never issues
+    the httpx ingest POST — the test only cares which connections got swept.
+    """
+
+    def __init__(self):
+        self.fetched: list[str] = []
+
+    def enabled(self) -> bool:
+        return True
+
+    def fetch_deltas(self, ow_user_id, provider, since, limit):
+        self.fetched.append(ow_user_id)
+        return []
+
+
+def _seed_two_tenant_connections(app):
+    """One WearableConnection each for two distinct tenants."""
+    from models import db
+    with app.app_context():
+        db.session.add(WearableConnection(
+            tenant_id='tenant-a', provider='oura', ow_user_id='hc-tenant-a',
+            connected_at=datetime.now(timezone.utc)))
+        db.session.add(WearableConnection(
+            tenant_id='tenant-b', provider='oura', ow_user_id='hc-tenant-b',
+            connected_at=datetime.now(timezone.utc)))
+        db.session.commit()
+
+
+class TestRunOnceTenantScope:
+    def test_run_once_with_tenant_id_scopes_to_that_tenant(self, app):
+        """MUTATION: drop the tenant_id filter in run_once (keep .all()) ->
+        tenant B's connection gets swept and this assertion reddens."""
+        from r6.wearables.poller import run_once
+        _seed_two_tenant_connections(app)
+        fake = _RecordingClient()
+
+        summary = run_once(app, client=fake, tenant_id='tenant-a')
+
+        assert fake.fetched == ['hc-tenant-a']  # ONLY tenant A polled
+        assert 'hc-tenant-b' not in fake.fetched
+        assert summary['connections_checked'] == 1
+
+    def test_run_once_without_tenant_id_sweeps_all_tenants(self, app):
+        """The poller's global pass (tenant_id=None) must still sweep every
+        tenant — the scoping fix must not neuter the background poller."""
+        from r6.wearables.poller import run_once
+        _seed_two_tenant_connections(app)
+        fake = _RecordingClient()
+
+        summary = run_once(app, client=fake)  # tenant_id defaults to None
+
+        assert set(fake.fetched) == {'hc-tenant-a', 'hc-tenant-b'}
+        assert summary['connections_checked'] == 2
+
+
+class TestSyncNowTenantScope:
+    def test_sync_now_polls_only_the_authenticated_tenant(self, app, client):
+        """A step-up token for tenant A must sync ONLY tenant A's wearables.
+
+        MUTATION: drop the tenant_id filter in run_once (keep .all()) ->
+        tenant B's connection is swept via this endpoint and the assertion
+        that 'hc-tenant-b' was never fetched reddens.
+
+        Against the pre-fix code the endpoint calls run_once(current_app)
+        with no tenant scope, so B is swept — this test fails.
+        """
+        from r6.stepup import generate_step_up_token
+        _seed_two_tenant_connections(app)
+        fake = _RecordingClient()
+
+        with patch('r6.wearables.poller.WearablesClient', return_value=fake):
+            resp = client.post('/wearables/sync-now', headers={
+                'X-Tenant-Id': 'tenant-a',
+                'X-Step-Up-Token': generate_step_up_token('tenant-a'),
+            })
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body['connections_checked'] == 1
+        assert fake.fetched == ['hc-tenant-a']
+        assert 'hc-tenant-b' not in fake.fetched


### PR DESCRIPTION
Closes #311. A second cross-tenant sweep of the same class as #304 (S-1), found by the write-guard matrix (#313), not the original audit.

## The vulnerability

`POST /wearables/sync-now` validated a step-up token for the request's tenant ([r6/wearables/routes.py:259](r6/wearables/routes.py#L259)), then called `run_once(current_app)` — which swept `WearableConnection.query.all()` across **every** tenant ([r6/wearables/poller.py:84](r6/wearables/poller.py#L84)) and ingested Observations into each. A patient triggering "sync my wearables now" caused all other tenants' wearables to be polled and re-ingested. Because `desktop-demo`'s step-up token is free-mintable (see #304), same unauthenticated trigger.

## Why scoping, not infra-auth (differs from #304)

`/r6/ops/*` is genuinely global operator work, so #304 made it internal-secret infrastructure. `/wearables/sync-now` is the opposite — it's patient-triggered ("sync **my** wearables"), so the fix is to scope the sweep to the caller's tenant, keeping it a patient-facing endpoint.

## The fix

`run_once(app, client=None, tenant_id=None)` gains an optional `tenant_id`: when set, `WearableConnection.query.filter_by(tenant_id=tenant_id)`; when `None`, unchanged `.all()`. The endpoint passes the authenticated tenant; **the background poller keeps calling `run_once(app)` with no argument** ([poller.py:196](r6/wearables/poller.py#L196)), so its legitimate global sweep is untouched.

## Guards

- `TestSyncNowTenantScope`: a step-up token for tenant A polls only tenant A (B never fetched). `TestRunOnceTenantScope`: `tenant_id=None` still sweeps all tenants — proves the poller isn't neutered.
- **Transition-verified:** both scoping tests FAIL on `main` (endpoint sweeps 2 tenants), pass here; the poller-global test passes on both. `MUTATION:` lines present and reddened.
- Full suite **1997 passed, 6 skipped, 2 xfailed**; conformance **Grade A**; ruff clean. Python 3.11.

Status codes unchanged (the 401-vs-403 normalization is deferred, open question 1). No access-kernel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)