### PR TITLE
test: green the write-guard matrix — main has been red since the security merges

### DIFF
--- a/tests/test_write_guard_matrix.py
+++ b/tests/test_write_guard_matrix.py
@@ -531,13 +531,17 @@ MATRIX: tuple = (
     Row(
         id="ops-reap",
         method="POST", path="/r6/ops/reap", endpoint="ops.reap",
-        guards=frozenset({TENANT_HEADER, TENANT_FORMAT, STEP_UP, AUDIT}),
-        anon_refusal=(400,), step_up_missing_status=401,
-        defect_issue="#304",
-        note="S-1/#304: authenticated per tenant, sweeps globally. Note the "
-             "ABSENCE of TENANT_FILTER in this guard set — that is the "
-             "defect, stated in the table rather than left in a reviewer's "
-             "head.",
+        guards=frozenset({INTERNAL_SECRET, AUDIT}),
+        anon_refusal=(403,), internal_secret_status=403,
+        note="FIXED by #308 (was S-1/#304). Was: tenant header + tenant-bound "
+             "step-up, then swept every tenant — and because a public tenant "
+             "mints a step-up token with no credential, that chain was "
+             "unauthenticated. Now infrastructure auth: X-Internal-Secret, "
+             "tenant-blind, NO public-tenant exemption, and X-Tenant-Id is "
+             "not read at all. The sweep is still global, which is now "
+             "honest rather than a lie the guard set told. TENANT_FILTER is "
+             "correctly absent: this endpoint is operator-scoped by design, "
+             "not tenant-scoped.",
     ),
     Row(
         id="wearables-sync-now",
@@ -1221,12 +1225,6 @@ def test_ops_reap_only_touches_the_authenticated_tenant(client, app, secrets):
             f"{FOREIGN_TENANT}'s action to {after.status}")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#304, second and unlisted site: /wearables/sync-now validates a "
-           "step-up token for one tenant and then calls run_once(), which "
-           "iterates WearableConnection.query.all() across every tenant. The "
-           "audit's S-1 names only r6/ops/routes.py.")
 def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
                                                               monkeypatch):
     """A manual sync authenticated for tenant A must not touch tenant B's rows.
@@ -1262,12 +1260,6 @@ def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
 # 7. Named defects
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#306: r6/shc/routes.py _ingest_bundle logs the raw exception "
-           "('%s', job_id, exc). A driver error echoes the statement and its "
-           "bound parameters, which carry PHI. Every other ingest path logs "
-           "type(exc).__name__ against a correlation id.")
 def test_shc_ingest_never_logs_a_raw_exception(app, caplog, monkeypatch):
     """The SHC ingest failure path must not put exception text in the log.
 


### PR DESCRIPTION
**`main` is red right now.** `tests/test_write_guard_matrix.py` → `10 failed, 162 passed`. This makes it green. Zero production code.

## What happened

The matrix (#313) was written against pre-fix behavior. #308, #309 and #315 then changed that behavior. Each PR was green against `main` as it stood; collectively they were not, and the merge order I recommended didn't account for the interaction. My error.

| Failures | Cause |
|---|---|
| 8 × `[ops-reap]` | The row declared `TENANT_HEADER, TENANT_FORMAT, STEP_UP`. #308 replaced that with internal-secret infrastructure auth and stopped reading `X-Tenant-Id` entirely. |
| `test_wearables_sync_only_touches_the_authenticated_tenant` | `xfail(strict=True)` → **XPASS**, because #315 fixed it. |
| `test_shc_ingest_never_logs_a_raw_exception` | `xfail(strict=True)` → **XPASS**, because #309 fixed it. |

The two XPASSes are `strict=True` **working as designed** — a pinned defect flips red the moment it's fixed, so a fix can't land while the table still calls it broken. The mechanism is right; the sequencing was wrong.

## The fix

- `ops-reap` row now declares `{INTERNAL_SECRET, AUDIT}` with `anon_refusal=(403,)`, and its note records what changed and why `TENANT_FILTER` is *correctly* absent (the endpoint is operator-scoped by design — now honest, where before the guard set told a lie).
- Both `xfail` markers **removed**, not re-pointed, so the tests assert the fixed behavior permanently.

## Verification

- Matrix: **167 passed, 6 skipped, 4 xfailed**
- Full suite: **2172 passed, 12 skipped, 6 xfailed**
- Conformance **Grade A**; ruff clean
- **Mutation-verified:** reverting the SHC fix turns `test_shc_ingest_never_logs_a_raw_exception` red — it still catches its bug rather than passing by accident.

## Why this is slice 0 of the refactor

The matrix is the instrument the kernel migration is measured against. It has to be a real gate before it can be a safety net. Per `docs/2026-08-03-refactor-working-protocol.md` (#316): pins before moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)