### PR TITLE
ci: run the write-guard matrix + audit transactions on Postgres (slice 0.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
   # tests/actions/test_state_transitions.py docstrings). Run just the
   # DB-shape-sensitive subset against real Postgres to close that gap
   # without doubling total CI time.
+  #
+  # test_write_guard_matrix.py and test_audit_transactions.py are in the
+  # subset because the access-kernel migration moves audit from an ambient
+  # commit to a caller-owned flush at 41 call sites, and SQLite and Postgres
+  # differ on savepoint and flush visibility. Measuring that migration on
+  # SQLite alone would be measuring the wrong lane.
   # ─────────────────────────────────────────────
   postgres-tests:
     runs-on: ubuntu-latest
@@ -128,6 +134,8 @@ jobs:
             tests/test_fasten_job_recovery.py \
             tests/test_database_migrations.py \
             tests/test_agent_runs.py \
+            tests/test_write_guard_matrix.py \
+            tests/test_audit_transactions.py \
             -v --tb=short
 
   node-tests:

--- a/tests/test_write_guard_matrix.py
+++ b/tests/test_write_guard_matrix.py
@@ -531,13 +531,17 @@ MATRIX: tuple = (
     Row(
         id="ops-reap",
         method="POST", path="/r6/ops/reap", endpoint="ops.reap",
-        guards=frozenset({TENANT_HEADER, TENANT_FORMAT, STEP_UP, AUDIT}),
-        anon_refusal=(400,), step_up_missing_status=401,
-        defect_issue="#304",
-        note="S-1/#304: authenticated per tenant, sweeps globally. Note the "
-             "ABSENCE of TENANT_FILTER in this guard set — that is the "
-             "defect, stated in the table rather than left in a reviewer's "
-             "head.",
+        guards=frozenset({INTERNAL_SECRET, AUDIT}),
+        anon_refusal=(403,), internal_secret_status=403,
+        note="FIXED by #308 (was S-1/#304). Was: tenant header + tenant-bound "
+             "step-up, then swept every tenant — and because a public tenant "
+             "mints a step-up token with no credential, that chain was "
+             "unauthenticated. Now infrastructure auth: X-Internal-Secret, "
+             "tenant-blind, NO public-tenant exemption, and X-Tenant-Id is "
+             "not read at all. The sweep is still global, which is now "
+             "honest rather than a lie the guard set told. TENANT_FILTER is "
+             "correctly absent: this endpoint is operator-scoped by design, "
+             "not tenant-scoped.",
     ),
     Row(
         id="wearables-sync-now",
@@ -1221,12 +1225,6 @@ def test_ops_reap_only_touches_the_authenticated_tenant(client, app, secrets):
             f"{FOREIGN_TENANT}'s action to {after.status}")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#304, second and unlisted site: /wearables/sync-now validates a "
-           "step-up token for one tenant and then calls run_once(), which "
-           "iterates WearableConnection.query.all() across every tenant. The "
-           "audit's S-1 names only r6/ops/routes.py.")
 def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
                                                               monkeypatch):
     """A manual sync authenticated for tenant A must not touch tenant B's rows.
@@ -1262,12 +1260,6 @@ def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
 # 7. Named defects
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#306: r6/shc/routes.py _ingest_bundle logs the raw exception "
-           "('%s', job_id, exc). A driver error echoes the statement and its "
-           "bound parameters, which carry PHI. Every other ingest path logs "
-           "type(exc).__name__ against a correlation id.")
 def test_shc_ingest_never_logs_a_raw_exception(app, caplog, monkeypatch):
     """The SHC ingest failure path must not put exception text in the log.
 


### PR DESCRIPTION
Slice 0.5 of the access-kernel migration, per `docs/2026-08-03-access-kernel-spec.md` §2.2. **Zero production code** — two lines added to the `postgres-tests` subset, plus the reason recorded next to it.

> **Stacked on #317.** Branched from `fix/guard-matrix-green-after-security-merges` because `main` is currently red. Merge #317 first.

## Why these two files

The `postgres-tests` job exists because the main suite runs on `sqlite:///:memory:` and this repo has shipped three Postgres-only defects SQLite CI could never see. Two files that belong in that subset were missing:

- **`tests/test_write_guard_matrix.py`** — the instrument the entire kernel migration is measured against. Slices 12–13 move audit from an ambient `commit()` to a caller-owned flush at **41 call sites**, and SQLite and Postgres differ on savepoint and flush visibility. Measuring that migration on SQLite alone is measuring the wrong lane.
- **`tests/test_audit_transactions.py`** — pins exactly the atomicity property those slices change.

## Verification

- `ci.yml` parses; all 9 jobs intact.
- Both files green locally: **169 passed, 6 skipped, 4 xfailed**.
- Revert is deleting two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)