### PR TITLE
feat(access): the access kernel, adopted by nothing (slice 1)

### DIFF
--- a/r6/access.py
+++ b/r6/access.py
@@ -1,0 +1,777 @@
+"""Access kernel — one tenant reader, one step-up gate, one audit call, one
+FHIR exit.
+
+Implements `docs/2026-08-03-access-kernel-spec.md` §1. This module is slice 1
+of the migration: it is **adopted by nothing**. No production module imports
+it yet (pinned by `tests/test_access_kernel.py`), so it cannot change any
+behavior. Adoption happens one guard and one blueprint at a time, per
+`docs/2026-08-03-refactor-working-protocol.md`.
+
+Each primitive below enforces exactly ONE property, named in its docstring.
+Anything the primitive does not promise stays the caller's job — the point of
+the kernel is that a reviewer can tell those apart without reading the
+implementation.
+
+§1.0 — collaborators are resolved by MODULE ATTRIBUTE, never by
+`from r6.stepup import validate_step_up_token`. 33 tests monkeypatch
+`r6.stepup.*` by module path; a direct import binds at import time and those
+tests would keep passing while patching an object this module no longer
+consults. That is the quietest way the migration can fail.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from flask import g, has_app_context, jsonify, request, session
+
+from models import db
+from r6 import audit as _audit_mod
+from r6 import fhir_proxy as _fhir_proxy_mod
+from r6 import health_compliance as _compliance_mod
+from r6 import redaction as _redaction_mod
+from r6 import stepup as _stepup_mod
+from r6.read_auth import TENANT_SESSION_KEY
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'TenantSource', 'Tenant', 'TenantRejected', 'tenant_from_request',
+    'Scope', 'Grant', 'StepUpDenied', 'require_grant',
+    'register_error_handlers',
+    'audit', 'AuditAssertionError',
+    'install_audit_assertions', 'install_read_audit_assertion',
+    'Profile', 'fhir_response', 'unredacted_response', 'outcome_response',
+]
+
+# The tenant-id format enforced everywhere. Same character class as
+# r6/routes.py:239 (_TENANT_ID_PATTERN) — this module is where it becomes the
+# only one.
+_TENANT_ID_PATTERN = re.compile(r'[A-Za-z0-9_-]{1,64}')
+
+_TRUE_VALUES = frozenset({'1', 'true', 'yes'})
+
+
+# ---------------------------------------------------------------------------
+# §1.1 Tenant
+# ---------------------------------------------------------------------------
+
+class TenantSource(Enum):
+    """Where an endpoint is willing to learn its tenant from.
+
+    Not a ranking and not a security level. Naming the source is what makes
+    "this endpoint reads the tenant from the body" a reviewable fact instead
+    of a line of code someone has to find.
+    """
+
+    SESSION = 'session'   # command-center signed-link cookie (TENANT_SESSION_KEY)
+    HEADER = 'header'     # X-Tenant-Id
+    QUERY = 'query'       # ?tenant_id= / ?tenant= / ?t=
+    BODY = 'body'         # {"tenant_id": ...}
+    SHARP = 'sharp'       # synthesized from X-FHIR-Server-URL (routes.py:223-228)
+    DEFAULT = 'default'   # a literal fallback the endpoint supplies
+
+
+@dataclass(frozen=True)
+class Tenant:
+    """A tenant id that passed format validation, plus where it came from.
+
+    Carrying the source lets an audit row and a log line say which input
+    selected the tenant. It does NOT mean the caller is authorized to act on
+    that tenant — see require_grant and r6.read_auth.
+    """
+
+    id: str
+    source: TenantSource
+
+
+class TenantRejected(Exception):
+    """The request did not supply a usable tenant id.
+
+    reason: 'absent' | 'malformed'. The two map to different FHIR
+    OperationOutcome codes ('security' vs 'invalid'), both at HTTP 400,
+    matching r6/routes.py:230-247 exactly.
+    """
+
+    ABSENT = 'absent'
+    MALFORMED = 'malformed'
+
+    def __init__(self, reason: str):
+        if reason not in (self.ABSENT, self.MALFORMED):
+            raise ValueError(
+                "TenantRejected reason must be 'absent' or 'malformed'")
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _session_tenant() -> str | None:
+    return session.get(TENANT_SESSION_KEY)
+
+
+def _sharp_tenant() -> str | None:
+    """Synthesize the SHARP tenant, exactly as r6/routes.py:223-228 does.
+
+    Gated on is_sharp_context_active(), which is the SSRF guard: an
+    unvalidated upstream URL must never mint a tenant.
+    """
+    if not _fhir_proxy_mod.is_sharp_context_active():
+        return None
+    raw = request.headers.get(_fhir_proxy_mod.SHARP_SERVER_URL_HEADER) or ''
+    digest = hashlib.sha256(raw.strip().encode('utf-8')).hexdigest()[:16]
+    return f'sharp-{digest}'
+
+
+def tenant_from_request(
+    *,
+    sources: tuple[TenantSource, ...] = (TenantSource.HEADER,),
+    default: str | None = None,
+    query_keys: tuple[str, ...] = ('tenant_id',),
+    body_key: str = 'tenant_id',
+) -> Tenant:
+    """Return the tenant this request names, in the caller's declared order.
+
+    THE ONE PROPERTY: the returned id matched ``[A-Za-z0-9_-]{1,64}`` and
+    came from a source this endpoint declared it accepts. Nothing else.
+
+    ``sources`` is an ORDERED tuple, not a set. The first source in the tuple
+    that yields a non-empty value wins. A set would force the kernel to
+    invent a precedence, and the invented one differs from
+    r6/command_center/routes.py:76-82 (session, then query, then header) —
+    adopting it would silently change which tenant that page renders when a
+    caller sends both. Ordering is per endpoint because today it already is.
+
+    Raises TenantRejected('absent') when no declared source yields a value
+    and ``default`` is None. Raises TenantRejected('malformed') when a source
+    yields a value that fails the pattern — including a value that came from
+    ``default``, so a typo'd literal fails loudly rather than at query time.
+
+    TenantSource.DEFAULT is only consulted when ``default`` is not None, and
+    it is always last regardless of its position in ``sources``.
+    """
+    for source in sources:
+        if source is TenantSource.DEFAULT:
+            # Always last, regardless of its position in `sources`.
+            continue
+        value = _read_source(source, query_keys=query_keys, body_key=body_key)
+        if value:
+            return _validated(value, source)
+
+    if default is not None:
+        return _validated(default, TenantSource.DEFAULT)
+
+    raise TenantRejected(TenantRejected.ABSENT)
+
+
+def _read_source(source: TenantSource, *, query_keys: tuple[str, ...],
+                 body_key: str) -> str | None:
+    """Return the raw, unvalidated value one declared source offers."""
+    if source is TenantSource.SESSION:
+        return _session_tenant()
+    if source is TenantSource.HEADER:
+        return request.headers.get('X-Tenant-Id')
+    if source is TenantSource.QUERY:
+        for key in query_keys:
+            value = request.args.get(key)
+            if value:
+                return value
+        return None
+    if source is TenantSource.BODY:
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return None
+        value = body.get(body_key)
+        return value if isinstance(value, str) else None
+    if source is TenantSource.SHARP:
+        return _sharp_tenant()
+    raise ValueError(f'unhandled tenant source: {source!r}')
+
+
+def _validated(value: str, source: TenantSource) -> Tenant:
+    # Deliberately NOT stripped. r6/routes.py:239 matches the raw header, so a
+    # leading space is malformed there and must stay malformed here; trimming
+    # would widen the accepted set during migration.
+    if not isinstance(value, str) or not _TENANT_ID_PATTERN.fullmatch(value):
+        raise TenantRejected(TenantRejected.MALFORMED)
+    return Tenant(id=value, source=source)
+
+
+# ---------------------------------------------------------------------------
+# §1.2 Scope, Grant, require_grant
+# ---------------------------------------------------------------------------
+
+class Scope(Enum):
+    """What a step-up token must be able to authorize.
+
+    TENANT_BOUND maps to validate_step_up_token(require_scope=None) and
+    accepts a read-scoped token. WRITE maps to require_scope='write' and
+    rejects one. The names say what the check does, not what the caller
+    wishes it did — the exact mistake behind _RESOURCE_ID_PATTERN.
+    """
+
+    TENANT_BOUND = 'tenant-bound'   # r6/read_auth.py:88-93 needs this
+    WRITE = 'write'                 # every write gate today
+
+
+#: Scope -> the `require_scope` argument validate_step_up_token expects.
+_SCOPE_REQUIREMENT: dict[Scope, str | None] = {
+    Scope.TENANT_BOUND: None,
+    Scope.WRITE: 'write',
+}
+
+
+@dataclass(frozen=True)
+class Grant:
+    """Proof that a step-up token authorized THIS tenant for THIS scope.
+
+    Frozen and carrying tenant_id so a handler scopes its query to
+    grant.tenant_id rather than re-reading a header. It does not make the
+    handler do that — see the spec §3(e).
+    """
+
+    tenant_id: str
+    scope: Scope
+    audience: str | None
+    operation: str | None
+    nonce_consumed: bool
+
+
+class StepUpDenied(Exception):
+    """A step-up check ran and refused. Rendered by the app errorhandler.
+
+    THE ONE PROPERTY: ``checked is True`` means require_grant decided this,
+    on the single line in this module that passes that flag. Any other
+    StepUpDenied — raised by a helper, a test double, a copy-paste, or a
+    future bug — carries checked=False, and the errorhandler RE-RAISES it so
+    it surfaces as a 500.
+
+    Without that flag the errorhandler is a hazard: it would convert an
+    unexpected raise from anywhere in the request into a clean 401, which
+    reads to a client exactly like a working guard. That is the retro's
+    defect shape with an HTTP status on it.
+
+    Subclasses Exception, NOT BaseException: Flask calls handle_user_exception
+    from inside `except Exception` in full_dispatch_request, so a
+    BaseException subclass would bypass the errorhandler entirely and reach
+    the WSGI server.
+    """
+
+    def __init__(self, reason: str, *, http_status: int, checked: bool = False):
+        super().__init__(reason)
+        self.reason = reason
+        self.http_status = http_status
+        self.checked = checked
+
+
+#: Public refusal text. The validator's own message (e.g. 'Token tenant
+#: mismatch', 'Step-up token expired') is deliberately NOT propagated to the
+#: client — r6/read_auth.py:262 makes the same call, and a per-reason answer
+#: is an oracle for a caller probing another tenant's token.
+_DENIED_ABSENT = 'Step-up token required'
+_DENIED_REJECTED = 'Invalid step-up token'
+
+
+def _step_up_token(*, also_bearer: bool, also_body_field: str | None) -> str:
+    """Return the step-up token this request presents, in the fixed order.
+
+    X-Step-Up-Token, then Authorization: Bearer when the endpoint opted in,
+    then the named body field when the endpoint opted in. Each later source
+    is opt-in for the same reason TenantSource is: a reader must be able to
+    see which inputs an endpoint trusts without reading this helper.
+    """
+    token = (request.headers.get('X-Step-Up-Token') or '').strip()
+    if token:
+        return token
+
+    if also_bearer:
+        auth = (request.headers.get('Authorization') or '').strip()
+        if auth.lower().startswith('bearer '):
+            token = auth[7:].strip()
+            if token:
+                return token
+
+    if also_body_field:
+        body = request.get_json(silent=True)
+        if isinstance(body, dict):
+            value = body.get(also_body_field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    return ''
+
+
+def require_grant(
+    *,
+    scope: Scope,
+    tenant: Tenant,
+    audience: str | None = None,
+    operation: str | None = None,
+    consume_nonce: bool = False,
+    also_bearer: bool = False,
+    also_body_field: str | None = None,
+    absent_status: int = 401,
+    rejected_status: int = 401,
+) -> Grant:
+    """Require a step-up token bound to ``tenant`` and return the Grant.
+
+    THE ONE PROPERTY: a Grant exists only if validate_step_up_token returned
+    True for this tenant, scope, audience and operation. There is no tuple to
+    mis-destructure, no truthy object to test, and no status-code choice at
+    the call site.
+
+    Token sources are read in this order. First X-Step-Up-Token. Then
+    Authorization: Bearer when ``also_bearer`` (r6/read_auth.py:83-86,
+    r6/actions/routes.py:256-260). Then the named body field when
+    ``also_body_field`` (r6/routes.py:2097-2098).
+
+    ``absent_status`` / ``rejected_status`` exist because the same failure
+    answers 401 at 9 sites and 403 at 3. Normalizing them is the founder's
+    call, not this migration's; each migrated site passes the status it
+    answers TODAY.
+
+    Raises StepUpDenied with the checked flag set. Never returns None, never
+    returns False, never returns a tuple.
+    """
+    if not isinstance(tenant, Tenant):
+        # A raw string here would mean the caller skipped format validation.
+        raise TypeError(
+            'require_grant needs a Tenant from tenant_from_request, '
+            f'not {type(tenant).__name__}')
+
+    token = _step_up_token(also_bearer=also_bearer,
+                           also_body_field=also_body_field)
+    if not token:
+        reason, status = _DENIED_ABSENT, absent_status
+    else:
+        # Destructure both halves. A truthiness test on the tuple is a silent
+        # auth bypass — this module exists so that idiom has one home.
+        valid, error = _stepup_mod.validate_step_up_token(
+            token,
+            tenant.id,
+            consume_nonce=consume_nonce,
+            require_scope=_SCOPE_REQUIREMENT[scope],
+            require_audience=audience,
+            require_operation=operation,
+        )
+        if valid:
+            return Grant(
+                tenant_id=tenant.id,
+                scope=scope,
+                audience=audience,
+                operation=operation,
+                nonce_consumed=consume_nonce,
+            )
+        logger.info('step-up refused for tenant %s: %s', tenant.id, error)
+        reason, status = _DENIED_REJECTED, rejected_status
+
+    # The ONLY place in the repository that sets the checked flag. Pinned by
+    # test_the_checked_flag_is_set_in_exactly_one_place.
+    raise StepUpDenied(reason, http_status=status, checked=True)
+
+
+def register_error_handlers(app) -> None:
+    """Register the StepUpDenied and TenantRejected renderers app-wide.
+
+    HANDLERS ONLY. This registers no before_request hook and changes no
+    blueprint's request pipeline. r6/sdc/delivery.py:8-11 is deliberately off
+    r6_blueprint because the HMAC signature in the URL is the credential and
+    the route must work with no headers. Extending the hooks would break it.
+    An errorhandler is inert until something raises.
+
+    A StepUpDenied whose checked flag is unset is re-raised here, unhandled,
+    and becomes a 500.
+    """
+    app.register_error_handler(StepUpDenied, _render_step_up_denied)
+    app.register_error_handler(TenantRejected, _render_tenant_rejected)
+
+
+def _render_step_up_denied(exc: StepUpDenied):
+    if not exc.checked:
+        # Not a decision this kernel made. Rendering it as a clean 401 would
+        # make an unrelated bug look exactly like a working guard.
+        raise exc
+    return outcome_response('error', 'security', exc.reason,
+                            status=exc.http_status)
+
+
+def _render_tenant_rejected(exc: TenantRejected):
+    if exc.reason == TenantRejected.ABSENT:
+        return outcome_response('error', 'security',
+                                'X-Tenant-Id header is required', status=400)
+    return outcome_response('error', 'invalid',
+                            'X-Tenant-Id must match [a-zA-Z0-9_-]{1,64}',
+                            status=400)
+
+
+# ---------------------------------------------------------------------------
+# §1.3 Audit
+# ---------------------------------------------------------------------------
+
+#: flask.g attribute set by audit() and CLEARED when the session commits or
+#: rolls back. Set means "an audit row is flushed into a transaction nobody has
+#: resolved yet" — the state install_audit_assertions refuses to let a request
+#: end in.
+#:
+#: The spec words this condition as "db.session.new or db.session.dirty is
+#: non-empty at teardown". Measured, that condition can never fire: flush()
+#: moves the AuditEvent out of session.new into the persistent identity map,
+#: so both sets are empty for exactly the request this control exists to
+#: catch. A marker cleared by the commit/rollback events is the same property
+#: with a signal that actually observes it. See the PR body.
+_AUDIT_PENDING = '_hc_access_audit_pending'
+
+#: flask.g attribute recording that audit() ran at least once in this request,
+#: whatever happened to the transaction afterwards. This is what
+#: install_read_audit_assertion needs — a read that audited AND committed must
+#: pass, so it cannot share the pending marker above.
+_AUDIT_EMITTED = '_hc_access_audit_emitted'
+
+#: SQLAlchemy session listeners are process-global, so they are installed once
+#: per process rather than once per app. Registering per app would stack one
+#: listener per Flask app the test suite builds.
+_marker_listeners_installed = False
+
+
+class AuditAssertionError(AssertionError):
+    """A request-lifecycle audit assertion failed.
+
+    Testing-mode only — see install_audit_assertions and
+    install_read_audit_assertion. Not part of the spec's §1 signature list;
+    the two installers need something to raise.
+    """
+
+
+def audit(
+    *,
+    tenant: Tenant | str,
+    event_type: str,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    agent_id: str | None = None,
+    context_id: str | None = None,
+    outcome: str = 'success',
+    detail: str | None = None,
+    outcome_detail_code: str | None = None,
+) -> None:
+    """Add and flush an AuditEvent inside the CALLER's transaction.
+
+    THE ONE PROPERTY: when this returns, an AuditEvent row is flushed in the
+    caller's unit of work, and it will be committed or rolled back with the
+    state change it describes. It never commits.
+
+    This is r6/audit.py:46-61 (add_audit_event) becoming the only pattern.
+    r6/audit.py:64-113 (record_audit_event) opens a SAVEPOINT and then calls
+    db.session.commit() — an ambient commit at 41 call sites, which means a
+    caller cannot know whether its own pending work was committed as a side
+    effect of auditing.
+
+    ``detail`` stays PHI-free. The kernel does not sanitize it, because a
+    sanitizer that silently drops PHI is worse than a reviewer who sees the
+    string. Composition of the detail line stays where the facts are.
+
+    Records the flush on ``g`` for install_audit_assertions.
+    """
+    tenant_id = tenant.id if isinstance(tenant, Tenant) else tenant
+    _install_marker_listeners()
+    _audit_mod.add_audit_event(
+        event_type,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        agent_id=agent_id,
+        context_id=context_id,
+        outcome=outcome,
+        detail=detail,
+        tenant_id=tenant_id,
+        outcome_detail_code=outcome_detail_code,
+    )
+    if has_app_context():
+        setattr(g, _AUDIT_PENDING, True)
+        setattr(g, _AUDIT_EMITTED, True)
+
+
+def _clear_pending_marker(*_args) -> None:
+    """The audit row's transaction was resolved — nothing is pending."""
+    if has_app_context():
+        g.pop(_AUDIT_PENDING, None)
+
+
+def _install_marker_listeners() -> None:
+    """Attach the commit/rollback listeners that clear the pending marker.
+
+    Idempotent and once per process: SQLAlchemy session events are global, so
+    installing per app would stack one listener per Flask app the suite makes.
+    """
+    global _marker_listeners_installed
+    if _marker_listeners_installed:
+        return
+    from sqlalchemy import event
+    event.listen(db.session, 'after_commit', _clear_pending_marker)
+    event.listen(db.session, 'after_soft_rollback', _clear_pending_marker)
+    _marker_listeners_installed = True
+
+
+def _assertions_enabled(app) -> bool:
+    if app.config.get('TESTING'):
+        return True
+    return os.environ.get('HC_ASSERT_AUDIT_COMMITTED', '').strip().lower() \
+        in _TRUE_VALUES
+
+
+def _install_marker_cleanup(app) -> None:
+    """Drop both markers at the end of every request.
+
+    flask.g is app-context scoped, and a test that pushes one app context
+    around several client calls shares g between them. Without this, request N
+    would inherit request N-1's audit markers and the assertions would be
+    reading the wrong request. Registered before either assertion so it runs
+    LAST (teardown functions run in reverse registration order).
+    """
+    if getattr(app, '_hc_access_marker_cleanup', False):
+        return
+    app._hc_access_marker_cleanup = True
+
+    @app.teardown_request
+    def _clear_audit_markers(_exc=None):
+        g.pop(_AUDIT_PENDING, None)
+        g.pop(_AUDIT_EMITTED, None)
+
+
+def install_audit_assertions(app) -> None:
+    """Testing-mode only: fail a request that flushed audit rows and never
+    resolved the transaction.
+
+    THE ONE PROPERTY: no request leaves an audit row flushed-but-uncommitted.
+
+    Installed as a teardown_request, active only when app.config['TESTING']
+    or HC_ASSERT_AUDIT_COMMITTED is set. It fires when g still carries the
+    pending marker at teardown — the signature of a handler that called
+    audit() and then returned without commit() or rollback(). A rollback path
+    clears the marker and passes, correctly: a refused write should carry no
+    audit row.
+
+    Without this, moving 41 sites from an ambient commit to a caller-owned
+    commit is 41 chances to drop an audit row behind a 201.
+    """
+    _install_marker_cleanup(app)
+    _install_marker_listeners()
+
+    @app.teardown_request
+    def _assert_audit_committed(exc=None):
+        if exc is not None:
+            # The request is already failing. Flask-SQLAlchemy rolls back on
+            # its own teardown; masking the real error with ours helps nobody.
+            return
+        if not _assertions_enabled(app):
+            return
+        if getattr(g, _AUDIT_PENDING, False):
+            raise AuditAssertionError(
+                'audit() flushed a row and the request returned without '
+                'commit() or rollback() — the AuditEvent is pending in an '
+                'unresolved transaction')
+
+
+#: A path under this prefix whose next segment starts with an uppercase letter
+#: is a FHIR resource route. Discovery paths (metadata, health, docs,
+#: .well-known) are lowercase by construction, so this separates them without
+#: importing r6.routes' exemption list into the kernel.
+_FHIR_ROOT = '/r6/fhir/'
+
+
+def _is_fhir_resource_path(path: str) -> bool:
+    if not path.startswith(_FHIR_ROOT):
+        return False
+    rest = path[len(_FHIR_ROOT):]
+    return bool(rest) and rest[0].isupper()
+
+
+def install_read_audit_assertion(app) -> None:
+    """Testing-mode only: fail a FHIR read that returned without auditing.
+
+    THE ONE PROPERTY: a request to a /r6/fhir/ resource route that answered
+    200 or 404 flushed at least one AuditEvent.
+
+    This is the ONLY structural answer to S-9, the five unaudited 404 paths
+    (r6/routes.py:596-598, 692-694, 1268-1270, 1810-1812, 3106-3110). audit()
+    is a function you must call, so the kernel alone cannot make an early
+    ``return 404`` audit itself.
+
+    It lands in its own slice and it goes red on those five paths
+    immediately. That redness IS the S-9 pin. Do not install it in the same
+    PR as the fix — which is why slice 1 defines it and registers it nowhere.
+    """
+    _install_marker_cleanup(app)
+
+    @app.after_request
+    def _assert_read_audited(response):
+        if not _assertions_enabled(app):
+            return response
+        if request.method != 'GET':
+            return response
+        if response.status_code not in (200, 404):
+            return response
+        if not _is_fhir_resource_path(request.path):
+            return response
+        if not getattr(g, _AUDIT_EMITTED, False):
+            raise AuditAssertionError(
+                f'{request.method} {request.path} answered '
+                f'{response.status_code} without emitting an AuditEvent')
+        return response
+
+
+# ---------------------------------------------------------------------------
+# §1.4 Response shaping
+# ---------------------------------------------------------------------------
+
+class Profile(Enum):
+    """Which redaction policy produced this payload.
+
+    There is deliberately NO member meaning "no redaction". An enum member
+    for the absence of a property makes the absence look like a policy, and
+    a reviewer scanning for the risky case sees a valid-looking constant. The
+    opt-out is a different function with a different signature — see
+    unredacted_response.
+    """
+
+    STANDARD = 'standard'                      # r6/redaction.py:22 + add_disclaimer
+    PATIENT_CONTROLLED = 'patient-controlled'  # r6/redaction.py:180
+    INTAKE = 'intake'                          # r6/routes.py:3318 _intake_strip
+
+
+_SSN_SYSTEMS = ('http://hl7.org/fhir/sid/us-ssn',
+                'urn:oid:2.16.840.1.113883.4.1')
+
+
+def _intake_profile(resource):
+    """Intake profile: identified for clinic check-in (name/DOB/address/telecom
+    preserved) but SSN-class identifiers and clinician free-text never ship.
+
+    Byte-for-byte the behavior of r6/routes.py:_intake_strip, which slice 14
+    deletes when $share-bundle adopts fhir_response. Until then the two are
+    pinned equal by test_intake_profile_matches_the_shipped_intake_strip, so
+    the copy cannot drift while it waits.
+    """
+    res = resource
+    res.pop('note', None)
+    res.pop('text', None)
+    idents = res.get('identifier')
+    if isinstance(idents, list):
+        kept = [i for i in idents
+                if not (isinstance(i, dict) and i.get('system') in _SSN_SYSTEMS)]
+        if kept:
+            res['identifier'] = kept
+        else:
+            res.pop('identifier', None)
+    return res
+
+
+def fhir_response(payload, *, profile: Profile, status: int = 200,
+                  resource_type: str | None = None, etag: str | None = None,
+                  patient_id: str | None = None):
+    """The only exit for a FHIR payload that carries patient data.
+
+    THE ONE PROPERTY: the body was produced by the named redaction profile.
+
+    Profile.STANDARD calls apply_redaction, which strips every upstream
+    ``display`` and ``CodeableConcept.text`` and then re-applies labels from
+    r6/terminology.py keyed by code (r6/redaction.py:22-38). The kernel does
+    not reorder that. It only removes the choice of whether to call it.
+
+    ``patient_id`` is required by Profile.PATIENT_CONTROLLED and rejected by
+    the others. The spec's §1.4 signature omits it, but
+    apply_patient_controlled_redaction(resource, patient_id) cannot be called
+    without it — see the PR body.
+    """
+    if not isinstance(profile, Profile):
+        raise TypeError('fhir_response needs a Profile member')
+    if profile is Profile.PATIENT_CONTROLLED and not patient_id:
+        raise ValueError(
+            'Profile.PATIENT_CONTROLLED needs the canonical patient_id it '
+            'injects as the sole identifier')
+    if profile is not Profile.PATIENT_CONTROLLED and patient_id:
+        raise ValueError(
+            f'patient_id is meaningless for {profile.value}; it would read as '
+            'though patient-controlled redaction had run')
+
+    if profile is Profile.STANDARD:
+        body = _redaction_mod.apply_redaction(payload)
+        body = _compliance_mod.add_disclaimer(body, resource_type)
+    elif profile is Profile.PATIENT_CONTROLLED:
+        body = _redaction_mod.apply_patient_controlled_redaction(
+            payload, patient_id)
+    else:
+        body = _intake_profile(payload)
+
+    response = jsonify(body)
+    response.status_code = status
+    if etag:
+        response.headers['ETag'] = etag
+    return response
+
+
+#: Endpoint names permitted to answer with an unredacted payload. Adding a
+#: name here is a deliberate two-file change: this frozenset, and the literal
+#: expected set in tests/test_unredacted_exits.py.
+_UNREDACTED_EXITS: frozenset[str] = frozenset({
+    # populated slice by slice; each entry names its reason in the test
+    'r6.subscription_topics',   # SubscriptionTopic is server metadata (routes.py:1671)
+    'r6.audit_search',          # AuditEventRecord is PHI-free by construction
+})
+
+
+def unredacted_response(payload, *, endpoint: str, reason: str,
+                        status: int = 200):
+    """Answer with a payload no redaction profile touched.
+
+    THE ONE PROPERTY: ``endpoint`` appears in _UNREDACTED_EXITS. Raises
+    RuntimeError otherwise, at request time, in every environment.
+
+    ``reason`` is a required sentence for the reviewer and is never sent to
+    the client. A required argument nobody can leave blank is what turns
+    "this path applies no redaction" from an omission into a claim.
+
+    r6/routes.py:719-723 (update_resource returning the stored resource) is
+    NOT on the allowlist. It is S-11, a defect, and it migrates to
+    fhir_response(profile=Profile.STANDARD) with its own PR and its own pin.
+    """
+    if endpoint not in _UNREDACTED_EXITS:
+        raise RuntimeError(
+            f"'{endpoint}' is not an approved unredacted exit; add it to "
+            'r6.access._UNREDACTED_EXITS and to tests/test_unredacted_exits.py '
+            'or answer through fhir_response()')
+    if not reason or not reason.strip():
+        raise ValueError('unredacted_response requires a written reason')
+
+    response = jsonify(payload)
+    response.status_code = status
+    return response
+
+
+def outcome_response(severity: str, code: str, diagnostics: str, *,
+                     status: int):
+    """Build a FHIR OperationOutcome. This is r6/routes.py:3705-3716 with a
+    status attached.
+
+    Separate from fhir_response because an OperationOutcome carries text this
+    system authored, never stored patient data. Running it through a
+    redaction profile would be a no-op that teaches a reader the wrong thing
+    about what fhir_response protects.
+
+    ``diagnostics`` must not contain a token, an id from another tenant, or a
+    driver exception string.
+    """
+    response = jsonify({
+        'resourceType': 'OperationOutcome',
+        'issue': [
+            {
+                'severity': severity,
+                'code': code,
+                'diagnostics': diagnostics,
+            }
+        ],
+    })
+    response.status_code = status
+    return response

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1,0 +1,1094 @@
+"""Behavior tests for the access kernel (r6/access.py).
+
+Slice 1 of `docs/2026-08-03-access-kernel-spec.md`: the kernel exists and is
+adopted by nothing. Everything here tests `r6.access` directly, because there
+is no call site to observe it through yet — that is the point of the slice.
+
+Three of these are structural rather than behavioral, and they ship now
+because they cannot honestly ship later:
+
+- `test_the_kernel_is_not_adopted_yet` — the zero-risk claim, mechanised.
+- `test_no_guard_call_sits_inside_a_swallowing_try` — spec §4.1. A guard added
+  after the violations exist gets an allowlist, and an allowlist is where this
+  defect class comes back.
+- `test_the_checked_flag_is_set_in_exactly_one_place` — spec §1.2.
+"""
+
+import ast
+import dataclasses
+import json
+import pathlib
+import re
+
+import pytest
+from flask import Flask
+
+from models import db
+from r6.access import (
+    AuditAssertionError,
+    Grant,
+    Profile,
+    Scope,
+    StepUpDenied,
+    Tenant,
+    TenantRejected,
+    TenantSource,
+    audit,
+    fhir_response,
+    install_audit_assertions,
+    install_read_audit_assertion,
+    outcome_response,
+    register_error_handlers,
+    require_grant,
+    tenant_from_request,
+    unredacted_response,
+)
+from r6.stepup import generate_step_up_token
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Directories that ship as the product. tests/ is excluded on purpose: a test
+# is allowed to import the kernel, and in slice 1 only a test may.
+_PRODUCTION_DIRS = ('r6', 'careagents', 'adapters', 'api', 'services',
+                    'scripts', 'openclaw', 'hermes', 'migrations')
+_PRODUCTION_ROOT_FILES = ('main.py', 'app.py', 'models.py')
+
+
+def _production_python_files():
+    for name in _PRODUCTION_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            yield path
+    for folder in _PRODUCTION_DIRS:
+        base = REPO_ROOT / folder
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob('*.py')):
+            if '__pycache__' in path.parts:
+                continue
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# §1.1 tenant_from_request
+# ---------------------------------------------------------------------------
+
+def test_a_well_formed_header_yields_a_tenant_that_names_its_source(app):
+    """MUTATION: drop `source=source` from _validated -> red."""
+    with app.test_request_context(headers={'X-Tenant-Id': 'acme-1'}):
+        tenant = tenant_from_request()
+    assert tenant == Tenant(id='acme-1', source=TenantSource.HEADER)
+
+
+def test_a_missing_tenant_is_rejected_as_absent(app):
+    """MUTATION: return Tenant('', HEADER) instead of raising -> red."""
+    with app.test_request_context():
+        with pytest.raises(TenantRejected) as exc:
+            tenant_from_request()
+    assert exc.value.reason == 'absent'
+
+
+@pytest.mark.parametrize('bad', [
+    'has space', 'sql;drop', 'a' * 65, '../etc/passwd', ' leading',
+])
+def test_a_malformed_tenant_is_rejected_whatever_the_source(app, bad):
+    """THE ONE PROPERTY: nothing that fails [A-Za-z0-9_-]{1,64} gets out.
+
+    MUTATION: delete the fullmatch check in _validated -> red.
+
+    ' leading' is here deliberately: r6/routes.py:239 matches the raw header,
+    so a leading space is malformed today and must stay malformed. Trimming
+    inside the kernel would widen the accepted set during migration.
+    """
+    with app.test_request_context(headers={'X-Tenant-Id': bad}):
+        with pytest.raises(TenantRejected) as exc:
+            tenant_from_request()
+    assert exc.value.reason == 'malformed'
+
+
+def test_sources_are_an_ordered_tuple_and_the_first_match_wins(app):
+    """THE ONE PROPERTY that forced a tuple over a frozenset.
+
+    MUTATION: sort or set()-ify `sources` inside tenant_from_request -> red.
+    """
+    ctx = dict(query_string={'tenant_id': 'from-query'},
+               headers={'X-Tenant-Id': 'from-header'})
+    with app.test_request_context('/x', **ctx):
+        header_first = tenant_from_request(
+            sources=(TenantSource.HEADER, TenantSource.QUERY))
+        query_first = tenant_from_request(
+            sources=(TenantSource.QUERY, TenantSource.HEADER))
+    assert header_first.id == 'from-header'
+    assert header_first.source is TenantSource.HEADER
+    assert query_first.id == 'from-query'
+    assert query_first.source is TenantSource.QUERY
+
+
+def test_an_earlier_source_that_yields_nothing_falls_through(app):
+    with app.test_request_context('/x', query_string={'tenant_id': 'q'}):
+        tenant = tenant_from_request(
+            sources=(TenantSource.HEADER, TenantSource.QUERY))
+    assert tenant == Tenant(id='q', source=TenantSource.QUERY)
+
+
+def test_query_keys_are_consulted_in_the_order_given(app):
+    with app.test_request_context('/x', query_string={'t': 'short',
+                                                      'tenant': 'long'}):
+        tenant = tenant_from_request(sources=(TenantSource.QUERY,),
+                                     query_keys=('tenant', 't'))
+    assert tenant.id == 'long'
+
+
+def test_the_body_source_reads_the_named_field_only(app):
+    body = {'tenant_id': 'body-tenant', 'other': 'ignored'}
+    with app.test_request_context('/x', json=body):
+        assert tenant_from_request(sources=(TenantSource.BODY,)).id == 'body-tenant'
+    with app.test_request_context('/x', json=body):
+        with pytest.raises(TenantRejected):
+            tenant_from_request(sources=(TenantSource.BODY,), body_key='nope')
+
+
+def test_the_session_source_reads_the_command_center_cookie(app):
+    from r6.read_auth import TENANT_SESSION_KEY
+    with app.test_request_context('/x'):
+        from flask import session
+        session[TENANT_SESSION_KEY] = 'cc-tenant'
+        tenant = tenant_from_request(sources=(TenantSource.SESSION,
+                                              TenantSource.HEADER))
+    assert tenant == Tenant(id='cc-tenant', source=TenantSource.SESSION)
+
+
+def test_the_default_is_last_even_when_declared_first(app):
+    """MUTATION: consult DEFAULT in tuple position -> red."""
+    with app.test_request_context(headers={'X-Tenant-Id': 'real'}):
+        tenant = tenant_from_request(
+            sources=(TenantSource.DEFAULT, TenantSource.HEADER),
+            default='fallback')
+    assert tenant == Tenant(id='real', source=TenantSource.HEADER)
+
+
+def test_the_default_applies_only_when_nothing_else_answered(app):
+    with app.test_request_context():
+        tenant = tenant_from_request(sources=(TenantSource.HEADER,),
+                                     default='desktop-demo')
+    assert tenant == Tenant(id='desktop-demo', source=TenantSource.DEFAULT)
+
+
+def test_a_malformed_default_fails_loudly_rather_than_at_query_time(app):
+    """A typo'd literal is a bug at the endpoint, not a mystery empty result.
+
+    MUTATION: return the default without validating it -> red.
+    """
+    with app.test_request_context():
+        with pytest.raises(TenantRejected) as exc:
+            tenant_from_request(default='desktop demo')
+    assert exc.value.reason == 'malformed'
+
+
+def test_the_sharp_source_honours_the_ssrf_guard(app, monkeypatch):
+    """A SHARP tenant is synthesized only from an upstream that PASSED the
+    guard — the property r6/fhir_proxy.py:816 exists to hold.
+
+    MUTATION: drop the is_sharp_context_active() check in _sharp_tenant ->
+    red (the second half starts returning a tenant).
+    """
+    headers = {'X-FHIR-Server-URL': 'https://fhir.example.org/r4'}
+
+    monkeypatch.setattr('r6.fhir_proxy.is_sharp_context_active', lambda: True)
+    with app.test_request_context('/x', headers=headers):
+        tenant = tenant_from_request(sources=(TenantSource.HEADER,
+                                              TenantSource.SHARP))
+    assert tenant.source is TenantSource.SHARP
+    assert tenant.id.startswith('sharp-')
+
+    monkeypatch.setattr('r6.fhir_proxy.is_sharp_context_active', lambda: False)
+    with app.test_request_context('/x', headers=headers):
+        with pytest.raises(TenantRejected):
+            tenant_from_request(sources=(TenantSource.HEADER,
+                                         TenantSource.SHARP))
+
+
+def test_the_synthesized_sharp_tenant_matches_the_shipped_formula(app,
+                                                                  monkeypatch):
+    """Pins the digest against r6/routes.py:223-228 so slice 11k is a move."""
+    import hashlib
+    url = 'https://fhir.example.org/r4'
+    expected = 'sharp-' + hashlib.sha256(url.encode('utf-8')).hexdigest()[:16]
+    monkeypatch.setattr('r6.fhir_proxy.is_sharp_context_active', lambda: True)
+    with app.test_request_context('/x', headers={'X-FHIR-Server-URL': url}):
+        assert tenant_from_request(sources=(TenantSource.SHARP,)).id == expected
+
+
+def test_the_kernel_accepts_exactly_what_the_shipped_pattern_accepts(app):
+    """Slices 9-11 must be a move, not a change: the kernel's format rule and
+    r6/routes.py:97 have to agree on every candidate, or migrating a tenant
+    read silently widens or narrows what an endpoint accepts.
+
+    MUTATION: change the kernel's character class -> red.
+    """
+    from r6.access import _TENANT_ID_PATTERN as kernel_pattern
+    from r6.routes import _TENANT_ID_PATTERN as shipped_pattern
+
+    candidates = ['acme', 'ACME_1', 'a-b_c', 'a' * 64, 'a' * 65, '', ' ',
+                  'a b', 'a.b', 'a/b', 'a\nb', 'sharp-0123456789abcdef',
+                  'tenant\n', '../x', 'ünïcode']
+    for value in candidates:
+        assert bool(kernel_pattern.fullmatch(value)) is \
+            bool(shipped_pattern.fullmatch(value)), value
+
+
+def test_a_tenant_is_frozen(app):
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        Tenant(id='a', source=TenantSource.HEADER).id = 'b'
+
+
+# ---------------------------------------------------------------------------
+# §1.2 require_grant
+# ---------------------------------------------------------------------------
+
+def _headers(token=None, **extra):
+    headers = dict(extra)
+    if token:
+        headers['X-Step-Up-Token'] = token
+    return headers
+
+
+def test_a_valid_write_token_yields_a_grant(app, tenant_id):
+    """THE ONE PROPERTY: a Grant exists only after the validator said True.
+
+    MUTATION: return Grant(...) before calling validate_step_up_token -> the
+    refusal tests below go red.
+    """
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant)
+    assert grant == Grant(tenant_id=tenant_id, scope=Scope.WRITE,
+                          audience=None, operation=None, nonce_consumed=False)
+
+
+def test_an_absent_token_is_denied_with_the_absent_status(app, tenant_id):
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context():
+        with pytest.raises(StepUpDenied) as exc:
+            require_grant(scope=Scope.WRITE, tenant=tenant, absent_status=403)
+    assert exc.value.http_status == 403
+    assert exc.value.checked is True
+
+
+def test_a_rejected_token_is_denied_with_the_rejected_status(app, tenant_id):
+    """The 403 dialect (r6/wearables/routes.py:257-261) survives migration."""
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers('not-a-token')):
+        with pytest.raises(StepUpDenied) as exc:
+            require_grant(scope=Scope.WRITE, tenant=tenant,
+                          absent_status=401, rejected_status=403)
+    assert exc.value.http_status == 403
+    assert exc.value.checked is True
+
+
+def test_a_token_for_another_tenant_never_yields_a_grant(app, tenant_id):
+    """MUTATION: pass a literal instead of tenant.id to the validator -> red."""
+    token = generate_step_up_token('some-other-tenant')
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+
+
+def test_a_read_scoped_token_cannot_buy_a_write_grant(app, tenant_id):
+    """H4: Scope.WRITE maps to require_scope='write', which rejects it.
+
+    MUTATION: map Scope.WRITE to None in _SCOPE_REQUIREMENT -> red.
+    """
+    token = generate_step_up_token(tenant_id, scope='read')
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+
+
+def test_a_read_scoped_token_does_buy_a_tenant_bound_grant(app, tenant_id):
+    """r6/read_auth.py:88-93 passes require_scope=None and that is
+    load-bearing — slice 8 depends on this mapping.
+
+    MUTATION: map Scope.TENANT_BOUND to 'write' -> red.
+    """
+    token = generate_step_up_token(tenant_id, scope='read')
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        grant = require_grant(scope=Scope.TENANT_BOUND, tenant=tenant)
+    assert grant.scope is Scope.TENANT_BOUND
+
+
+def test_the_bearer_header_is_ignored_unless_the_endpoint_opted_in(app,
+                                                                  tenant_id):
+    """MUTATION: read Authorization unconditionally -> the first half red."""
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    headers = {'Authorization': f'Bearer {token}'}
+
+    with app.test_request_context(headers=headers):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+
+    with app.test_request_context(headers=headers):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant,
+                              also_bearer=True)
+    assert grant.tenant_id == tenant_id
+
+
+def test_the_body_field_is_ignored_unless_the_endpoint_named_it(app, tenant_id):
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+
+    with app.test_request_context('/x', json={'step_up_token': token}):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+
+    with app.test_request_context('/x', json={'step_up_token': token}):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant,
+                              also_body_field='step_up_token')
+    assert grant.tenant_id == tenant_id
+
+
+def test_the_step_up_header_outranks_the_opted_in_sources(app, tenant_id):
+    good = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    headers = _headers('garbage', Authorization=f'Bearer {good}')
+    with app.test_request_context(headers=headers):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant, also_bearer=True)
+
+
+def test_audience_and_operation_bindings_are_enforced(app, tenant_id):
+    """MUTATION: stop forwarding require_audience/require_operation -> red."""
+    token = generate_step_up_token(tenant_id, audience='actions',
+                                   operation='commit')
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+
+    with app.test_request_context(headers=_headers(token)):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant,
+                              audience='actions', operation='commit')
+    assert grant.audience == 'actions' and grant.operation == 'commit'
+
+    with app.test_request_context(headers=_headers(token)):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant,
+                          audience='actions', operation='cancel')
+
+
+def test_consume_nonce_makes_a_token_single_use(app, tenant_id):
+    from r6.stepup import clear_nonce_cache
+    clear_nonce_cache()
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+
+    with app.test_request_context(headers=_headers(token)):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant,
+                              consume_nonce=True)
+    assert grant.nonce_consumed is True
+
+    with app.test_request_context(headers=_headers(token)):
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant, consume_nonce=True)
+    clear_nonce_cache()
+
+
+def test_require_grant_refuses_a_raw_string_tenant(app, tenant_id):
+    """A str here means the caller skipped format validation.
+
+    MUTATION: accept `str` by falling back to `tenant` when it has no .id ->
+    red.
+    """
+    token = generate_step_up_token(tenant_id)
+    with app.test_request_context(headers=_headers(token)):
+        with pytest.raises(TypeError):
+            require_grant(scope=Scope.WRITE, tenant=tenant_id)
+
+
+def test_a_grant_is_frozen_so_a_handler_cannot_widen_it(app, tenant_id):
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        grant.tenant_id = 'someone-else'
+
+
+def test_a_denial_never_repeats_the_validators_reason_to_the_client(app,
+                                                                    tenant_id):
+    """r6/read_auth.py:262 refuses to say why a token failed; so does this.
+
+    A per-reason answer ('Token tenant mismatch' vs 'Step-up token expired')
+    is an oracle for a caller probing another tenant.
+    """
+    expired = generate_step_up_token(tenant_id, ttl_seconds=-10)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(expired)):
+        with pytest.raises(StepUpDenied) as exc:
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+    assert exc.value.reason == 'Invalid step-up token'
+
+
+def test_step_up_denied_is_catchable_as_exception(app):
+    """Flask calls handle_user_exception from inside `except Exception`.
+
+    MUTATION: make StepUpDenied subclass BaseException -> red, and the
+    errorhandler would silently stop running in production.
+    """
+    assert issubclass(StepUpDenied, Exception)
+    assert StepUpDenied.__bases__ == (Exception,)
+
+
+# ---------------------------------------------------------------------------
+# §1.2 register_error_handlers
+# ---------------------------------------------------------------------------
+
+def _handler_app():
+    handler_app = Flask(__name__)
+    handler_app.config['TESTING'] = True
+    register_error_handlers(handler_app)
+    return handler_app
+
+
+def test_a_checked_denial_renders_as_an_operation_outcome():
+    handler_app = _handler_app()
+
+    @handler_app.route('/denied')
+    def denied():
+        raise StepUpDenied('Step-up token required', http_status=401,
+                           **{'checked': True})
+
+    response = handler_app.test_client().get('/denied')
+    assert response.status_code == 401
+    body = response.get_json()
+    assert body['resourceType'] == 'OperationOutcome'
+    assert body['issue'][0]['code'] == 'security'
+
+
+def test_an_unchecked_denial_is_re_raised_and_becomes_a_500():
+    """THE ONE PROPERTY of the checked flag. Without it the errorhandler turns
+    any stray raise into a clean 401 that reads like a working guard.
+
+    MUTATION: delete the `if not exc.checked: raise exc` branch -> red.
+    """
+    handler_app = _handler_app()
+    handler_app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    @handler_app.route('/stray')
+    def stray():
+        raise StepUpDenied('raised by a helper', http_status=401)
+
+    response = handler_app.test_client().get('/stray')
+    assert response.status_code == 500
+
+
+def test_a_rejected_tenant_renders_the_shipped_400s():
+    """Matches r6/routes.py:230-247 exactly, both code and status."""
+    handler_app = _handler_app()
+
+    @handler_app.route('/absent')
+    def absent():
+        raise TenantRejected('absent')
+
+    @handler_app.route('/malformed')
+    def malformed():
+        raise TenantRejected('malformed')
+
+    client = handler_app.test_client()
+    absent_response = client.get('/absent')
+    malformed_response = client.get('/malformed')
+    assert absent_response.status_code == 400
+    assert absent_response.get_json()['issue'][0]['code'] == 'security'
+    assert malformed_response.status_code == 400
+    assert malformed_response.get_json()['issue'][0]['code'] == 'invalid'
+
+
+def test_register_error_handlers_installs_handlers_only():
+    """HANDLERS ONLY — r6/sdc/delivery.py must keep working with no headers.
+
+    MUTATION: add a before_request hook in register_error_handlers -> red.
+    """
+    before = Flask(__name__)
+    hooks_before = (len(before.before_request_funcs),
+                    len(before.after_request_funcs),
+                    len(before.teardown_request_funcs),
+                    len(before.url_value_preprocessors))
+    register_error_handlers(before)
+    hooks_after = (len(before.before_request_funcs),
+                   len(before.after_request_funcs),
+                   len(before.teardown_request_funcs),
+                   len(before.url_value_preprocessors))
+    assert hooks_before == hooks_after
+    assert StepUpDenied in before.error_handler_spec[None][None]
+    assert TenantRejected in before.error_handler_spec[None][None]
+
+
+# ---------------------------------------------------------------------------
+# §1.3 audit
+# ---------------------------------------------------------------------------
+
+def test_audit_flushes_a_row_without_committing(app, tenant_id):
+    """THE ONE PROPERTY: flushed in the caller's unit of work, never committed.
+
+    MUTATION: call db.session.commit() inside audit() -> red (the row
+    survives the rollback).
+    """
+    from r6.models import AuditEventRecord
+    with app.test_request_context():
+        audit(tenant=Tenant(id=tenant_id, source=TenantSource.HEADER),
+              event_type='read', resource_type='Observation',
+              resource_id='obs-1')
+        assert AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id).count() == 1
+        db.session.rollback()
+        assert AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id).count() == 0
+
+
+def test_audit_accepts_a_bare_tenant_id_string(app, tenant_id):
+    from r6.models import AuditEventRecord
+    with app.test_request_context():
+        audit(tenant=tenant_id, event_type='read', detail='string tenant')
+        row = AuditEventRecord.query.filter_by(tenant_id=tenant_id).one()
+        assert row.detail == 'string tenant'
+        db.session.rollback()
+
+
+def test_audit_forwards_every_field_to_the_shipped_writer(app, tenant_id,
+                                                          monkeypatch):
+    """§1.0: patched by module path, because that is how the suite patches.
+
+    MUTATION: change r6/access.py to `from r6.audit import add_audit_event`
+    -> red.
+    """
+    seen = {}
+
+    def fake(event_type, **kwargs):
+        seen['event_type'] = event_type
+        seen.update(kwargs)
+
+    monkeypatch.setattr('r6.audit.add_audit_event', fake)
+    with app.test_request_context():
+        audit(tenant=Tenant(id=tenant_id, source=TenantSource.HEADER),
+              event_type='create', resource_type='Observation',
+              resource_id='o1', agent_id='a1', context_id='c1',
+              outcome='failure', detail='no phi here',
+              outcome_detail_code='code-1')
+    assert seen == {
+        'event_type': 'create', 'resource_type': 'Observation',
+        'resource_id': 'o1', 'agent_id': 'a1', 'context_id': 'c1',
+        'outcome': 'failure', 'detail': 'no phi here',
+        'tenant_id': tenant_id, 'outcome_detail_code': 'code-1',
+    }
+
+
+# ---------------------------------------------------------------------------
+# §1.3.1 install_audit_assertions
+# ---------------------------------------------------------------------------
+
+def _audit_routes(target_app, tenant):
+    @target_app.route('/kernel/flush-only', methods=['POST'])
+    def flush_only():
+        audit(tenant=tenant, event_type='create', detail='flush only')
+        return '', 201
+
+    @target_app.route('/kernel/flush-and-commit', methods=['POST'])
+    def flush_and_commit():
+        audit(tenant=tenant, event_type='create', detail='committed')
+        db.session.commit()
+        return '', 201
+
+    @target_app.route('/kernel/flush-and-rollback', methods=['POST'])
+    def flush_and_rollback():
+        audit(tenant=tenant, event_type='create', detail='refused')
+        db.session.rollback()
+        return '', 400
+
+    @target_app.route('/kernel/no-audit', methods=['POST'])
+    def no_audit():
+        return '', 201
+
+
+def test_a_flushed_audit_row_that_is_never_committed_fails_the_request(
+        app, tenant_id):
+    """THE ONE PROPERTY: no request leaves an audit row flushed-but-uncommitted.
+
+    MUTATION: delete the raise in _assert_audit_committed -> red. This is the
+    control that makes moving 41 sites off the ambient commit survivable.
+    """
+    _audit_routes(app, tenant_id)
+    install_audit_assertions(app)
+    with pytest.raises(AuditAssertionError):
+        app.test_client().post('/kernel/flush-only')
+
+
+def test_committing_or_rolling_back_satisfies_the_assertion(app, tenant_id):
+    """A refused write carries no audit row and passes, correctly."""
+    _audit_routes(app, tenant_id)
+    install_audit_assertions(app)
+    client = app.test_client()
+    assert client.post('/kernel/flush-and-commit').status_code == 201
+    assert client.post('/kernel/flush-and-rollback').status_code == 400
+    assert client.post('/kernel/no-audit').status_code == 201
+
+
+def test_the_assertion_is_inert_for_a_request_that_never_audited(app,
+                                                                 tenant_id):
+    """Unmigrated sites use record_audit_event, which sets no marker, so the
+    guard arrives with the first migrated site rather than all at once."""
+    from r6.audit import record_audit_event
+
+    @app.route('/kernel/legacy-audit', methods=['POST'])
+    def legacy_audit():
+        record_audit_event('create', tenant_id=tenant_id, detail='legacy')
+        return '', 201
+
+    install_audit_assertions(app)
+    assert app.test_client().post('/kernel/legacy-audit').status_code == 201
+
+
+def test_the_marker_does_not_leak_from_one_request_into_the_next(app,
+                                                                 tenant_id):
+    """flask.g is app-context scoped and a test can share one across requests.
+
+    MUTATION: delete _install_marker_cleanup's teardown -> red (the second,
+    innocent request inherits the first's pending marker).
+    """
+    _audit_routes(app, tenant_id)
+    install_audit_assertions(app)
+    client = app.test_client()
+    with pytest.raises(AuditAssertionError):
+        client.post('/kernel/flush-only')
+    db.session.rollback()
+    assert client.post('/kernel/no-audit').status_code == 201
+
+
+def test_the_assertion_is_off_when_neither_testing_nor_the_env_var_is_set(
+        app, tenant_id, monkeypatch):
+    _audit_routes(app, tenant_id)
+    install_audit_assertions(app)
+    monkeypatch.delenv('HC_ASSERT_AUDIT_COMMITTED', raising=False)
+    monkeypatch.setitem(app.config, 'TESTING', False)
+    assert app.test_client().post('/kernel/flush-only').status_code == 201
+    db.session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# §1.3.1 install_read_audit_assertion
+# ---------------------------------------------------------------------------
+
+def _read_routes(target_app, tenant):
+    @target_app.route('/r6/fhir/Widget/<wid>')
+    def widget(wid):
+        if wid == 'audited':
+            audit(tenant=tenant, event_type='read', resource_type='Widget',
+                  resource_id=wid)
+            db.session.commit()
+            return {'resourceType': 'Widget', 'id': wid}
+        if wid == 'missing':
+            return {'resourceType': 'OperationOutcome'}, 404
+        return {'resourceType': 'Widget', 'id': wid}
+
+    @target_app.route('/r6/fhir/discovery-ish')
+    def discovery_ish():
+        return {'resourceType': 'CapabilityStatement'}
+
+
+def test_a_fhir_read_that_never_audited_fails_the_request(app, tenant_id):
+    """THE ONE PROPERTY: a /r6/fhir/ resource route answering 200 or 404
+    emitted an AuditEvent. This is the structural answer to S-9 — the five
+    unaudited 404 paths. It is defined here and installed by NOTHING, because
+    installing it goes red on those five paths and that redness is its own
+    slice (spec §2.7, 12x).
+
+    MUTATION: delete the raise in _assert_read_audited -> red.
+    """
+    _read_routes(app, tenant_id)
+    install_read_audit_assertion(app)
+    client = app.test_client()
+    with pytest.raises(AuditAssertionError):
+        client.get('/r6/fhir/Widget/unaudited')
+    with pytest.raises(AuditAssertionError):
+        client.get('/r6/fhir/Widget/missing')
+
+
+def test_a_fhir_read_that_audited_and_committed_passes(app, tenant_id):
+    """The emitted marker must survive the commit — a read that audits and
+    commits is the correct shape, not a violation."""
+    _read_routes(app, tenant_id)
+    install_read_audit_assertion(app)
+    assert app.test_client().get('/r6/fhir/Widget/audited').status_code == 200
+
+
+def test_the_read_assertion_ignores_discovery_and_non_reads(app, tenant_id):
+    _read_routes(app, tenant_id)
+    install_read_audit_assertion(app)
+    client = app.test_client()
+    assert client.get('/r6/fhir/discovery-ish').status_code == 200
+    assert client.post('/r6/fhir/Widget/unaudited').status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# §1.4 response shaping
+# ---------------------------------------------------------------------------
+
+_PATIENT = {
+    'resourceType': 'Patient',
+    'id': 'p1',
+    'name': [{'family': 'Rivera', 'given': ['Marisol']}],
+    'birthDate': '1984-07-02',
+    'telecom': [{'system': 'phone', 'value': '555-0100'}],
+    'text': {'status': 'generated', 'div': '<div>Marisol Rivera</div>'},
+    'note': [{'text': 'patient reports chest pain'}],
+    'identifier': [
+        {'system': 'http://hl7.org/fhir/sid/us-ssn', 'value': '123-45-6789'},
+        {'system': 'urn:mrn', 'value': 'MRN-99'},
+    ],
+}
+
+
+def test_there_is_no_profile_member_meaning_no_redaction():
+    """The opt-out is a different function with a different signature.
+
+    MUTATION: add Profile.NONE -> red.
+    """
+    assert {p.name for p in Profile} == {'STANDARD', 'PATIENT_CONTROLLED',
+                                         'INTAKE'}
+
+
+def test_the_standard_profile_strips_upstream_display_and_adds_a_disclaimer(
+        app):
+    """MUTATION: return jsonify(payload) without apply_redaction -> red.
+
+    Guards the non-negotiable directly: an upstream `display` carrying a
+    patient name never reaches the wire.
+    """
+    payload = {
+        'resourceType': 'Observation',
+        'id': 'o1',
+        'code': {'coding': [{'system': 'http://loinc.org', 'code': '8480-6',
+                             'display': 'Rivera, Marisol'}],
+                 'text': 'Rivera, Marisol'},
+    }
+    with app.test_request_context():
+        response = fhir_response(payload, profile=Profile.STANDARD,
+                                 resource_type='Observation')
+    body = json.loads(response.get_data(as_text=True))
+    coding = body['code']['coding'][0]
+    assert coding.get('display') != 'Rivera, Marisol'
+    assert body['code'].get('text') != 'Rivera, Marisol'
+    assert '_disclaimer' in body
+
+
+def test_the_standard_profile_carries_the_status_and_etag_it_was_given(app):
+    with app.test_request_context():
+        response = fhir_response({'resourceType': 'Patient'},
+                                 profile=Profile.STANDARD, status=201,
+                                 etag='W/"3"')
+    assert response.status_code == 201
+    assert response.headers['ETag'] == 'W/"3"'
+
+
+def test_the_patient_controlled_profile_requires_the_patient_id(app):
+    """The spec's §1.4 signature omits patient_id, but
+    apply_patient_controlled_redaction(resource, patient_id) cannot run
+    without it. Named and required rather than defaulted to something."""
+    with app.test_request_context():
+        with pytest.raises(ValueError):
+            fhir_response(dict(_PATIENT), profile=Profile.PATIENT_CONTROLLED)
+        response = fhir_response(dict(_PATIENT),
+                                 profile=Profile.PATIENT_CONTROLLED,
+                                 patient_id='hc-123')
+    body = json.loads(response.get_data(as_text=True))
+    assert 'name' not in body and 'telecom' not in body
+    assert body['birthDate'] == '1984-07-02'
+
+
+def test_a_patient_id_on_another_profile_is_refused(app):
+    """It would read as though patient-controlled redaction had run."""
+    with app.test_request_context():
+        with pytest.raises(ValueError):
+            fhir_response({'resourceType': 'Patient'},
+                          profile=Profile.STANDARD, patient_id='hc-123')
+
+
+def test_the_intake_profile_matches_the_shipped_intake_strip(app):
+    """The kernel carries a copy of r6/routes.py:_intake_strip until slice 14
+    deletes the original. Pinned equal so the copy cannot drift while it waits.
+
+    MUTATION: drop the SSN filter from _intake_profile -> red.
+    """
+    from r6.routes import _intake_strip
+    expected = _intake_strip(json.loads(json.dumps(_PATIENT)))
+    with app.test_request_context():
+        response = fhir_response(json.loads(json.dumps(_PATIENT)),
+                                 profile=Profile.INTAKE)
+    body = json.loads(response.get_data(as_text=True))
+    assert body == expected
+    assert [i['system'] for i in body['identifier']] == ['urn:mrn']
+    assert 'note' not in body and 'text' not in body
+
+
+def test_fhir_response_refuses_anything_that_is_not_a_profile(app):
+    with app.test_request_context():
+        with pytest.raises(TypeError):
+            fhir_response({'resourceType': 'Patient'}, profile='standard')
+
+
+def test_the_redaction_module_is_reached_by_module_path(app, monkeypatch):
+    """§1.0 again, for r6.redaction.
+
+    MUTATION: change r6/access.py to `from r6.redaction import
+    apply_redaction` -> red.
+    """
+    monkeypatch.setattr('r6.redaction.apply_redaction',
+                        lambda res: {'resourceType': 'Patched'})
+    with app.test_request_context():
+        response = fhir_response({'resourceType': 'Patient'},
+                                 profile=Profile.STANDARD)
+    assert json.loads(response.get_data(as_text=True))['resourceType'] == 'Patched'
+
+
+def test_an_unredacted_exit_must_be_on_the_allowlist(app):
+    """THE ONE PROPERTY: the endpoint name appears in _UNREDACTED_EXITS.
+
+    MUTATION: delete the membership check -> red. Raises at request time in
+    every environment, not only under a flag.
+    """
+    with app.test_request_context():
+        with pytest.raises(RuntimeError):
+            unredacted_response({'resourceType': 'Bundle'},
+                                endpoint='r6.patient_read',
+                                reason='I just needed the raw record')
+
+
+def test_an_allowlisted_exit_answers_untouched(app):
+    payload = {'resourceType': 'Bundle', 'entry': [
+        {'resource': {'resourceType': 'SubscriptionTopic',
+                      'title': 'kept verbatim'}}]}
+    with app.test_request_context():
+        response = unredacted_response(
+            payload, endpoint='r6.subscription_topics',
+            reason='SubscriptionTopic is server metadata, never patient data')
+    assert json.loads(response.get_data(as_text=True)) == payload
+
+
+def test_the_reason_is_required_and_never_reaches_the_client(app):
+    with app.test_request_context():
+        with pytest.raises(ValueError):
+            unredacted_response({'resourceType': 'Bundle'},
+                                endpoint='r6.audit_search', reason='   ')
+        response = unredacted_response(
+            {'resourceType': 'Bundle'}, endpoint='r6.audit_search',
+            reason='AuditEventRecord is PHI-free by construction')
+    assert 'PHI-free' not in response.get_data(as_text=True)
+
+
+def test_outcome_response_is_the_shipped_shape_with_a_status(app):
+    with app.test_request_context():
+        response = outcome_response('error', 'not-found', 'Widget/1 not found',
+                                    status=404)
+    assert response.status_code == 404
+    assert json.loads(response.get_data(as_text=True)) == {
+        'resourceType': 'OperationOutcome',
+        'issue': [{'severity': 'error', 'code': 'not-found',
+                   'diagnostics': 'Widget/1 not found'}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Structural guards — these ship before the first adoption, on purpose
+# ---------------------------------------------------------------------------
+
+def test_the_kernel_is_not_adopted_yet():
+    """MUTATION: import r6.access from r6/routes.py -> red.
+
+    Slice 1's entire risk argument is this assertion. The kernel cannot change
+    any behavior while no production module can reach it.
+    """
+    importers = []
+    scanned = 0
+    for path in _production_python_files():
+        scanned += 1
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                if any(alias.name == 'r6.access' or
+                       alias.name.startswith('r6.access.')
+                       for alias in node.names):
+                    importers.append(f'{path.relative_to(REPO_ROOT)}:{node.lineno}')
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ''
+                named_access = (module == 'r6' and
+                                any(a.name == 'access' for a in node.names))
+                if module == 'r6.access' or module.startswith('r6.access.') \
+                        or named_access:
+                    importers.append(f'{path.relative_to(REPO_ROOT)}:{node.lineno}')
+    # A scan that walks nothing would pass this test forever. 172 production
+    # modules exist today; the floor only has to catch a broken path list.
+    assert scanned > 100, f'the adoption scan only walked {scanned} files'
+    assert not importers, (
+        'slice 1 adopts the kernel nowhere, but it is imported by: '
+        + ', '.join(importers))
+
+
+def test_the_checked_flag_is_set_in_exactly_one_place():
+    """Spec §1.2. The flag is what stops the errorhandler turning a stray
+    raise into a clean 401, so it must not be copyable.
+
+    MUTATION: add a second one anywhere (a helper, a test double) -> red.
+    """
+    needle = re.compile(r'\bchecked\s*=\s*' + 'True')
+    hits = []
+    for path in sorted(REPO_ROOT.rglob('*.py')):
+        # Relative to REPO_ROOT: an agent worktree lives under .claude/, so
+        # testing the absolute parts would skip the entire repository.
+        parts = set(path.relative_to(REPO_ROOT).parts)
+        if parts & {'.venv', '.git', '__pycache__', 'node_modules', '.claude'}:
+            continue
+        for lineno, line in enumerate(
+                path.read_text(encoding='utf-8').splitlines(), start=1):
+            if needle.search(line):
+                hits.append((path, lineno))
+
+    assert len(hits) == 1, (
+        'the checked flag must be set on exactly one line; found: '
+        + ', '.join(f'{p.relative_to(REPO_ROOT)}:{n}' for p, n in hits))
+
+    path, lineno = hits[0]
+    assert path == REPO_ROOT / 'r6' / 'access.py'
+
+    tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+    enclosing = [
+        node.name for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.lineno <= lineno <= (node.end_lineno or node.lineno)
+    ]
+    assert enclosing == ['require_grant'], (
+        f'the checked flag is set inside {enclosing}, not require_grant')
+
+
+# The names whose refusal must never be swallowed. A `raise` from any of these
+# is the guard doing its job; a broad except above it turns the refusal into a
+# fall-through and the response into a 200.
+_GUARD_CALLS = frozenset({
+    'require_grant', 'audit', 'tenant_from_request', 'unredacted_response',
+})
+
+
+def _catches_broadly(handler):
+    """True when this except clause catches Exception/BaseException/everything."""
+    if handler.type is None:  # bare `except:`
+        return True
+    candidates = (handler.type.elts if isinstance(handler.type, ast.Tuple)
+                  else [handler.type])
+    for node in candidates:
+        name = getattr(node, 'id', None) or getattr(node, 'attr', None)
+        if name in ('Exception', 'BaseException'):
+            return True
+    return False
+
+
+def _re_raises(handler):
+    """True when the handler body contains a bare `raise`."""
+    return any(isinstance(node, ast.Raise) and node.exc is None
+               for node in ast.walk(handler))
+
+
+def _guard_calls_in(nodes):
+    for node in nodes:
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            name = getattr(func, 'id', None) or getattr(func, 'attr', None)
+            if name in _GUARD_CALLS:
+                yield name, child.lineno
+
+
+def test_no_guard_call_sits_inside_a_swallowing_try():
+    """Spec §4.1. 99 `except Exception` blocks live in r6/; any one wrapped
+    around a require_grant call swallows StepUpDenied and lets the handler
+    fall through into the write. The guard would look like it fired and the
+    response would be a 200.
+
+    MUTATION: wrap a require_grant call in `try: ... except Exception: pass`
+    -> red.
+
+    This lands BEFORE the first adoption on purpose. A guard added after the
+    violations exist gets an allowlist, and an allowlist is where this defect
+    class comes back.
+    """
+    offenders = []
+    for path in sorted((REPO_ROOT / 'r6').rglob('*.py')):
+        if '__pycache__' in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            swallowing = [h for h in node.handlers
+                          if _catches_broadly(h) and not _re_raises(h)]
+            if not swallowing:
+                continue
+            # Only node.body is protected by these handlers — an exception
+            # raised in `orelse` or in another handler is not caught here.
+            for name, lineno in _guard_calls_in(node.body):
+                offenders.append(
+                    f'{path.relative_to(REPO_ROOT)}:{lineno} ({name}())')
+
+    assert not offenders, (
+        'a kernel guard call sits inside a try that swallows Exception; its '
+        'refusal would be discarded and the handler would fall through: '
+        + ', '.join(sorted(offenders)))
+
+
+def test_the_broad_except_guard_actually_detects_the_shape(tmp_path):
+    """The §4.1 guard is only worth having if it fires. Proven on a fixture
+    rather than by mutating r6/, so the proof survives in CI.
+    """
+    sample = tmp_path / 'offender.py'
+    sample.write_text(
+        'def handler():\n'
+        '    try:\n'
+        '        grant = require_grant(scope=1, tenant=2)\n'
+        '    except Exception:\n'
+        '        grant = None\n'
+        '    return grant\n', encoding='utf-8')
+    tree = ast.parse(sample.read_text(encoding='utf-8'))
+    tries = [n for n in ast.walk(tree) if isinstance(n, ast.Try)]
+    assert len(tries) == 1
+    handler = tries[0].handlers[0]
+    assert _catches_broadly(handler) and not _re_raises(handler)
+    assert [name for name, _ in _guard_calls_in(tries[0].body)] == ['require_grant']
+
+    reraising = ast.parse(
+        'def handler():\n'
+        '    try:\n'
+        '        require_grant(scope=1, tenant=2)\n'
+        '    except Exception:\n'
+        '        raise\n')
+    handler = [n for n in ast.walk(reraising)
+               if isinstance(n, ast.Try)][0].handlers[0]
+    assert _re_raises(handler)
+
+
+def test_the_kernel_resolves_its_collaborators_by_module_attribute():
+    """Spec §1.0. 33 tests monkeypatch r6.stepup.* by module path; a
+    `from r6.stepup import validate_step_up_token` here binds at import time
+    and those tests would keep passing while patching nothing.
+
+    MUTATION: rewrite any of the three as a `from X import name` -> red.
+    """
+    source = (REPO_ROOT / 'r6' / 'access.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    forbidden = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in (
+                'r6.stepup', 'r6.audit', 'r6.redaction'):
+            forbidden.append(f'{node.module}:{node.lineno}')
+    assert not forbidden, (
+        'the kernel binds a collaborator at import time, which silently '
+        'unhooks the suite monkeypatches: ' + ', '.join(forbidden))

--- a/tests/test_unredacted_exits.py
+++ b/tests/test_unredacted_exits.py
@@ -1,0 +1,53 @@
+"""The security allowlist of endpoints permitted to answer unredacted.
+
+`r6.access._UNREDACTED_EXITS` is the only way a FHIR payload leaves this
+server without a redaction profile having produced it. Adding a name is
+therefore a deliberate TWO-file change: the frozenset in `r6/access.py`, and
+the literal expected set below with the reason written out.
+
+Splitting it across two files is the whole control. A one-file allowlist is a
+line someone adds while fixing something else; a two-file one has to be
+argued for in a review.
+"""
+
+from r6.access import _UNREDACTED_EXITS
+
+#: endpoint name -> why answering unredacted is correct there.
+EXPECTED_EXITS = {
+    'r6.subscription_topics': (
+        'SubscriptionTopic is server metadata describing subscribable events '
+        '(r6/routes.py:1671). It carries no stored patient data, so a '
+        'redaction profile would be a no-op that misleads the next reader.'
+    ),
+    'r6.audit_search': (
+        'AuditEventRecord is PHI-free by construction — the audit `detail` '
+        'line is a stated invariant, not a field redaction could rescue.'
+    ),
+}
+
+
+def test_the_unredacted_allowlist_is_exactly_the_two_metadata_endpoints():
+    """MUTATION: add any endpoint to _UNREDACTED_EXITS without adding it here
+    -> red. That is the two-file change this test exists to force.
+
+    r6/routes.py:719-723 (update_resource echoing the stored resource) is
+    deliberately NOT here. It is S-11, a defect, and it migrates to
+    fhir_response(profile=Profile.STANDARD) with its own PR and its own pin —
+    allowlisting it would launder a bug into a policy.
+    """
+    assert _UNREDACTED_EXITS == frozenset(EXPECTED_EXITS)
+
+
+def test_every_allowlisted_exit_states_a_reason():
+    """An entry with no written reason is an omission wearing a policy's
+    clothes. The reason is for the reviewer; it never reaches a client.
+    """
+    for endpoint, reason in EXPECTED_EXITS.items():
+        assert reason.strip(), f'{endpoint} is allowlisted with no reason'
+        assert len(reason.split()) >= 8, (
+            f'{endpoint} needs a reason a reviewer can disagree with')
+
+
+def test_the_allowlist_is_immutable():
+    """A frozenset so no import-time hook can widen it."""
+    assert isinstance(_UNREDACTED_EXITS, frozenset)

--- a/tests/test_write_guard_matrix.py
+++ b/tests/test_write_guard_matrix.py
@@ -531,13 +531,17 @@ MATRIX: tuple = (
     Row(
         id="ops-reap",
         method="POST", path="/r6/ops/reap", endpoint="ops.reap",
-        guards=frozenset({TENANT_HEADER, TENANT_FORMAT, STEP_UP, AUDIT}),
-        anon_refusal=(400,), step_up_missing_status=401,
-        defect_issue="#304",
-        note="S-1/#304: authenticated per tenant, sweeps globally. Note the "
-             "ABSENCE of TENANT_FILTER in this guard set — that is the "
-             "defect, stated in the table rather than left in a reviewer's "
-             "head.",
+        guards=frozenset({INTERNAL_SECRET, AUDIT}),
+        anon_refusal=(403,), internal_secret_status=403,
+        note="FIXED by #308 (was S-1/#304). Was: tenant header + tenant-bound "
+             "step-up, then swept every tenant — and because a public tenant "
+             "mints a step-up token with no credential, that chain was "
+             "unauthenticated. Now infrastructure auth: X-Internal-Secret, "
+             "tenant-blind, NO public-tenant exemption, and X-Tenant-Id is "
+             "not read at all. The sweep is still global, which is now "
+             "honest rather than a lie the guard set told. TENANT_FILTER is "
+             "correctly absent: this endpoint is operator-scoped by design, "
+             "not tenant-scoped.",
     ),
     Row(
         id="wearables-sync-now",
@@ -1221,12 +1225,6 @@ def test_ops_reap_only_touches_the_authenticated_tenant(client, app, secrets):
             f"{FOREIGN_TENANT}'s action to {after.status}")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#304, second and unlisted site: /wearables/sync-now validates a "
-           "step-up token for one tenant and then calls run_once(), which "
-           "iterates WearableConnection.query.all() across every tenant. The "
-           "audit's S-1 names only r6/ops/routes.py.")
 def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
                                                               monkeypatch):
     """A manual sync authenticated for tenant A must not touch tenant B's rows.
@@ -1262,12 +1260,6 @@ def test_wearables_sync_only_touches_the_authenticated_tenant(client, app,
 # 7. Named defects
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#306: r6/shc/routes.py _ingest_bundle logs the raw exception "
-           "('%s', job_id, exc). A driver error echoes the statement and its "
-           "bound parameters, which carry PHI. Every other ingest path logs "
-           "type(exc).__name__ against a correlation id.")
 def test_shc_ingest_never_logs_a_raw_exception(app, caplog, monkeypatch):
     """The SHC ingest failure path must not put exception text in the log.
 


### PR DESCRIPTION
Slice 1 of the access-kernel migration, per `docs/2026-08-03-access-kernel-spec.md` §2.3 (#318). Adds `r6/access.py` and its tests. **Imported by no production module** — risk is zero by construction, and a test proves it.

> **Stacked on #317** (and #319). `main` is red without #317; merge that first.

## What it adds

Every §1 primitive: `TenantSource`/`Tenant`/`TenantRejected`/`tenant_from_request` · `Scope`/`Grant`/`StepUpDenied`/`require_grant`/`register_error_handlers` · `audit`/`install_audit_assertions`/`install_read_audit_assertion` · `Profile`/`fhir_response`/`_UNREDACTED_EXITS`/`unredacted_response`/`outcome_response`.

Hard rules verified in review:
- Collaborators resolved by **module attribute** (`_stepup_mod.validate_step_up_token`), never direct import — 33 tests monkeypatch `r6.stepup.*` by path and a direct import would leave them green while testing nothing.
- **`checked=True` appears exactly once in the repo** (`r6/access.py:373`), on the single raise inside `require_grant`. Everything else re-raises as a 500 rather than rendering a clean 401.
- `sources` is an **ordered tuple**; **no `Profile` member for "no redaction"**; `audit()` never commits; `register_error_handlers` adds **zero** request hooks (pinned by counting all four hook dicts before/after).

## Eight places the spec was wrong or silent — corrected, not papered over

The most important: **§1.3.1's assertion condition cannot fire.** The spec said to fail when `db.session.new` or `db.session.dirty` is non-empty at teardown. Measured against the real app, after `add_audit_event`'s `flush()` the AuditEvent leaves `session.new` for the identity map — so **both sets are empty for exactly the request the control exists to catch.** Shipping it literally would have been a control that looks like one thing and does nothing: the retro's defect shape, inside the guard written to prevent it. Implemented instead as a `g` marker set by `audit()` and cleared by `after_commit`/`after_soft_rollback` — same property, a signal that actually observes it.

Also: `fhir_response` needed a `patient_id` keyword (§1.4's signature couldn't call `apply_patient_controlled_redaction`); two markers were needed, not one; `flask.g` is app-context scoped so both installers clear their markers (pinned against cross-request leakage); `INTAKE` carries a pinned copy of `_intake_strip` rather than importing `r6.routes`; a denial never repeats the validator's message (`'tenant mismatch'` vs `'expired'` is an oracle).

## Verification

- Full suite **2241 passed, 12 skipped, 6 xfailed** (+69 over the base branch's 2172)
- Guard matrix **167 passed, 0 failed, 0 xpassed**
- Conformance **Grade A**; ruff clean; Python 3.11
- **11 mutations verified red-then-reverted** by Dev. I independently re-ran two: neutering `require_grant`'s validation reddens **7** tests; adding `import r6.access` to `r6/routes.py` reddens the zero-adoption pin.
- `test_the_kernel_is_not_adopted_yet` AST-parses 172 production modules and asserts the scan walked >100 files, so it cannot pass vacuously.

## Ships alongside (same unit, per §2.3)

The broad-except AST guard — it must exist **before** first adoption so it can never be retrofitted onto a codebase already violating it — the `checked=True` uniqueness test, and `tests/test_unredacted_exits.py`.

`install_read_audit_assertion` is defined but registered nowhere: installing it goes red on the five S-9 unaudited-404 paths, and that redness is its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)