### PR TITLE
fix(fasten): the consent dialog was unreachable on a short viewport (iPad)

### DIFF
--- a/static/css/r6-dashboard.css
+++ b/static/css/r6-dashboard.css
@@ -467,3 +467,35 @@
 
 
 .footer-legal { font-size: 0.78rem; }
+
+/* ---------------------------------------------------------------------------
+   Fasten Connect (Stitch) widget container.
+
+   The container used to carry `overflow: hidden` (for the rounded corner).
+   <fasten-stitch-element> renders its own consent dialog INSIDE this element,
+   so that one declaration clipped the dialog's bottom — the policy-agreement
+   checkbox and the Continue button — with no way to scroll to them. Reported
+   from an iPad, where the viewport is short enough for the dialog to exceed
+   the container.
+
+   A rounded corner is not worth a dead end in the connect flow, so the clip
+   is gone. The widget's own dialog positions itself against the viewport.
+   --------------------------------------------------------------------------- */
+.stitch-container {
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--r6-info);
+  border-radius: 8px;
+  overflow: visible;
+}
+
+/* The vendor bundle sizes its dialog for a desktop window. Give it the short-
+   viewport behaviour the rest of the product has: fit the visible area, and
+   scroll inside itself rather than off the bottom of the screen. iPad in
+   landscape and any phone in landscape both land here. */
+@media (max-height: 820px) {
+  .stitch-container [class*="modal"],
+  .stitch-container [class*="dialog"] {
+    max-height: calc(100vh - 24px);
+    overflow-y: auto;
+  }
+}

--- a/templates/fasten_connect.html
+++ b/templates/fasten_connect.html
@@ -134,14 +134,26 @@
     z-index: 1000;
     align-items: center;
     justify-content: center;
+    /* Keep the dialog clear of the notch and home indicator, and give it room
+       to breathe on a phone. */
+    padding: 12px;
+    padding-top: max(12px, env(safe-area-inset-top));
+    padding-bottom: max(12px, env(safe-area-inset-bottom));
   }
   .fasten-modal-backdrop.open { display: flex; }
   .fasten-modal {
     background: #161b22;
     border-radius: 14px;
     border: 1px solid rgba(34,211,238,0.2);
-    width: min(680px, 96vw);
-    height: min(640px, 90vh);
+    width: min(680px, 100%);
+    /* Was `height: min(640px, 90vh)`, which clipped the widget's own consent
+       checkbox and Continue button with no way to reach them (reported on
+       iPad). `max-height: 100%` resolves against the backdrop, which is
+       `position: fixed; inset: 0` and therefore already the visible viewport
+       minus its safe-area padding — more reliable here than `90vh`, which iOS
+       measures against the viewport with browser chrome EXPANDED. */
+    height: 640px;
+    max-height: 100%;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -149,8 +161,14 @@
   }
   .fasten-modal-close {
     position: absolute;
-    top: 12px;
-    right: 14px;
+    top: 4px;
+    right: 4px;
+    /* 44px minimum tap target (design.md). The glyph stays 22px. */
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     border: none;
     color: var(--gray-dim);
@@ -159,9 +177,23 @@
     z-index: 10;
     line-height: 1;
   }
-  .fasten-modal iframe {
-    flex: 1;
+  /* iOS and iPadOS expand an iframe to its content height and will not scroll
+     it internally, whatever the iframe's own overflow says. So the WRAPPER is
+     the scroll container — this is what actually makes the bottom of the
+     Fasten widget reachable on an iPad. */
+  .fasten-modal-body {
+    flex: 1 1 auto;
+    min-height: 0;          /* a flex child defaults to min-height:auto and
+                               refuses to shrink, which re-creates the clip */
+    overflow-y: auto;
+  }
+  .fasten-modal-body iframe {
+    display: block;
     width: 100%;
+    height: 100%;
+    /* Tall enough that the widget lays out normally on a roomy screen; the
+       wrapper scrolls when the viewport is shorter than this. */
+    min-height: 560px;
     border: none;
   }
 </style>
@@ -201,12 +233,16 @@
 {% if fasten_public_key %}
 <div class="fasten-modal-backdrop" id="stitch-backdrop">
   <div class="fasten-modal">
-    <button type="button" class="fasten-modal-close" id="close-stitch" title="Close">&times;</button>
-    <iframe
-      id="stitch-iframe"
-      src="https://embed.connect.fastenhealth.com/?public-id={{ fasten_public_key }}{% if tefca_mode %}&tefca-mode=true&search-only=false{% endif %}&external-id={{ tenant_id }}"
-      allow="camera; microphone; clipboard-write"
-    ></iframe>
+    <button type="button" class="fasten-modal-close" id="close-stitch"
+            title="Close" aria-label="Close">&times;</button>
+    <div class="fasten-modal-body">
+      <iframe
+        id="stitch-iframe"
+        title="Fasten Connect"
+        src="https://embed.connect.fastenhealth.com/?public-id={{ fasten_public_key }}{% if tefca_mode %}&tefca-mode=true&search-only=false{% endif %}&external-id={{ tenant_id }}"
+        allow="camera; microphone; clipboard-write"
+      ></iframe>
+    </div>
   </div>
 </div>
 {% endif %}

--- a/templates/r6_dashboard.html
+++ b/templates/r6_dashboard.html
@@ -492,7 +492,7 @@
 
         {% if fasten_public_key %}
         <!-- Stitch widget — shown inline when Connect is clicked -->
-        <div id="stitch-container" style="display:none;margin-bottom:1.25rem;border:1px solid var(--r6-info);border-radius:8px;overflow:hidden;">
+        <div id="stitch-container" class="stitch-container" style="display:none;">
           <fasten-stitch-element id="stitch-widget" public-id="{{ fasten_public_key }}"></fasten-stitch-element>
         </div>
         {% endif %}

--- a/tests/test_fasten_dialog_reachable.py
+++ b/tests/test_fasten_dialog_reachable.py
@@ -1,0 +1,133 @@
+"""Guard: the Fasten consent dialog must be reachable on a short viewport.
+
+Reported from an iPad: the Fasten dialog rendered with its policy-agreement
+checkbox and Continue button below the fold, and nothing would scroll to them.
+A patient could start the connect flow and simply not be able to finish it.
+
+Two independent causes, one per surface, and both are a container clipping a
+child that is taller than it:
+
+- ``templates/fasten_connect.html`` sized the modal ``height: min(640px, 90vh)``
+  with ``overflow: hidden``. A fixed height cannot shrink, ``overflow: hidden``
+  removes the scrollbar that would have rescued it, and iOS measures ``vh``
+  against the viewport with browser chrome EXPANDED, so 90vh regularly exceeds
+  what is actually visible. On top of that, iOS and iPadOS expand an iframe to
+  its content height and will not scroll it internally whatever the iframe's
+  own overflow says — so the scroll container has to be a wrapper element.
+- ``templates/r6_dashboard.html`` gave ``#stitch-container`` ``overflow: hidden``
+  for a rounded corner. ``<fasten-stitch-element>`` renders its consent dialog
+  inside that element, so the corner radius clipped the dialog.
+
+These assert the source, not a rendered layout, because the widget itself is a
+third-party bundle we do not control and cannot render in CI. That is a real
+limit and it is stated in each test: this catches the regression shape we hit,
+not every possible way a dialog can be cut off.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONNECT = REPO_ROOT / 'templates' / 'fasten_connect.html'
+DASHBOARD_CSS = REPO_ROOT / 'static' / 'css' / 'r6-dashboard.css'
+DASHBOARD_HTML = REPO_ROOT / 'templates' / 'r6_dashboard.html'
+
+
+_CSS_COMMENT = re.compile(r'/\*.*?\*/', re.S)
+
+
+def _connect_modal_css() -> str:
+    """The .fasten-modal rule body, comments stripped.
+
+    Stripping matters: these rules carry comments that quote the OLD broken
+    declarations to explain the fix, and a naive search finds the quote and
+    reports the bug as still present. A guard that reads its own documentation
+    as evidence is not a guard.
+    """
+    src = CONNECT.read_text(encoding='utf-8')
+    match = re.search(r'\.fasten-modal\s*\{(.*?)\}', src, re.S)
+    assert match, '.fasten-modal rule not found — did the modal move?'
+    return _CSS_COMMENT.sub('', match.group(1))
+
+
+def test_the_connect_modal_is_not_a_fixed_height_that_cannot_shrink():
+    """MUTATION: restore `height: min(640px, 90vh)` and drop max-height -> red.
+
+    A dialog that cannot shrink below its content on a short viewport puts its
+    own submit control off-screen.
+    """
+    body = _connect_modal_css()
+    assert 'max-height' in body, (
+        '.fasten-modal has no max-height, so it cannot shrink to fit a short '
+        'viewport — the iPad clip')
+    assert not re.search(r'height:\s*min\(\s*640px\s*,\s*90vh\s*\)', body), (
+        'the fixed 90vh height is back; iOS measures vh against the '
+        'chrome-expanded viewport, so it overflows what is visible')
+
+
+def test_the_connect_modal_scrolls_in_a_wrapper_not_the_iframe():
+    """iOS/iPadOS will not scroll an iframe internally.
+
+    MUTATION: delete .fasten-modal-body (or its overflow-y) -> red.
+    """
+    src = CONNECT.read_text(encoding='utf-8')
+    assert 'fasten-modal-body' in src, (
+        'the iframe scroll wrapper is gone; an iframe alone does not scroll on '
+        'iOS, so the bottom of the widget becomes unreachable')
+    match = re.search(r'\.fasten-modal-body\s*\{(.*?)\}', src, re.S)
+    assert match, '.fasten-modal-body rule not found'
+    rule = match.group(1)
+    assert 'overflow-y: auto' in rule, (
+        '.fasten-modal-body must scroll; without it the wrapper clips exactly '
+        'like the modal used to')
+    assert 'min-height: 0' in rule, (
+        'a flex child defaults to min-height:auto and refuses to shrink, which '
+        're-creates the clip even with overflow-y set')
+
+
+def test_the_iframe_is_inside_the_scroll_wrapper():
+    """The wrapper only helps if the iframe is actually in it."""
+    src = CONNECT.read_text(encoding='utf-8')
+    match = re.search(
+        r'<div class="fasten-modal-body">(.*?)</div>', src, re.S)
+    assert match, 'fasten-modal-body element not found in the markup'
+    assert 'stitch-iframe' in match.group(1), (
+        'the Fasten iframe is not inside .fasten-modal-body, so nothing '
+        'scrolls it')
+
+
+def test_the_close_control_meets_the_tap_target_minimum():
+    """design.md: minimum tap target 44px. A 22px glyph is not a 44px target,
+    and this dialog is the one a stuck patient reaches for.
+
+    MUTATION: drop width/height from .fasten-modal-close -> red.
+    """
+    src = CONNECT.read_text(encoding='utf-8')
+    match = re.search(r'\.fasten-modal-close\s*\{(.*?)\}', src, re.S)
+    assert match, '.fasten-modal-close rule not found'
+    rule = match.group(1)
+    assert re.search(r'width:\s*44px', rule), (
+        'the close control is narrower than the 44px minimum in design.md')
+    assert re.search(r'height:\s*44px', rule), (
+        'the close control is shorter than the 44px minimum in design.md')
+
+
+def test_the_dashboard_stitch_container_does_not_clip_its_dialog():
+    """MUTATION: put `overflow: hidden` back on .stitch-container -> red.
+
+    <fasten-stitch-element> renders its consent dialog inside this element, so
+    clipping it for a rounded corner hides the checkbox and Continue button.
+    """
+    css = DASHBOARD_CSS.read_text(encoding='utf-8')
+    match = re.search(r'\.stitch-container\s*\{(.*?)\}', css, re.S)
+    assert match, '.stitch-container rule not found in r6-dashboard.css'
+    assert 'overflow: hidden' not in match.group(1), (
+        '.stitch-container clips its own child dialog again')
+
+    html = DASHBOARD_HTML.read_text(encoding='utf-8')
+    container = re.search(r'<div id="stitch-container"[^>]*>', html)
+    assert container, 'stitch-container element not found'
+    assert 'overflow:hidden' not in container.group(0).replace(' ', ''), (
+        'the clip came back as an inline style, which beats the stylesheet')


### PR DESCRIPTION
A user reported the Fasten dialog would not let them check the policy-agreement box on an iPad. The checkbox and the Continue button were below the fold with no way to scroll to them — so a patient could start the connect flow and be unable to finish it. This is the dead-end class #224 exists to remove, on the flow the webinar journey and the clinical pilot both depend on.

Same defect shape on both surfaces: **a container clipping a child taller than itself.**

## `templates/fasten_connect.html` — the page CareAgents sends patients to

```css
/* before */
.fasten-modal { height: min(640px, 90vh); overflow: hidden; }
.fasten-modal iframe { flex: 1; }
```

Three compounding problems:
1. A **fixed height cannot shrink** on a short viewport, and `overflow: hidden` removes the scrollbar that would have rescued it.
2. iOS measures `vh` against the viewport with browser chrome **expanded**, so `90vh` routinely exceeds what is actually visible.
3. **iOS and iPadOS expand an iframe to its content height and will not scroll it internally**, whatever the iframe's own overflow says. So no amount of iframe CSS fixes this — the scroll container has to be a wrapper element.

Now: a 640px preference with `max-height: 100%` resolved against a backdrop that is already the visible viewport minus safe-area padding; the iframe sits inside a scrolling `.fasten-modal-body`; safe-area padding clears the notch and home indicator. `min-height: 0` on the wrapper is load-bearing — a flex child defaults to `min-height: auto` and refuses to shrink, which re-creates the clip even with `overflow-y` set.

Also: the close control is now a **44px tap target** (design.md) with the glyph still at 22px, plus `aria-label`; the iframe gained a `title`.

## `templates/r6_dashboard.html` — the surface in the screenshot

`#stitch-container` carried `overflow: hidden` for a rounded corner. `<fasten-stitch-element>` renders its consent dialog **inside** that element, so the corner radius clipped the dialog. A rounded corner is not worth a dead end in the connect flow. Moved out of an inline style into a real rule in `r6-dashboard.css`, and short viewports get a `max-height` plus internal scroll for the vendor dialog.

## Guard

`tests/test_fasten_dialog_reachable.py`, verified in **both** directions: **5 pass on the fix, 5 fail on the old code.**

Honest limit, stated in the module docstring rather than implied: these assert the **source**, not a rendered layout, because the widget is a third-party bundle we cannot render in CI. They catch the regression shape we actually hit — not every way a dialog can be cut off. Worth a real device check on the iPad that reported it before calling it closed.

Full suite **2246 passed, 12 skipped, 6 xfailed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)