### PR TITLE
fix(fasten): the scroll container could never scroll — follow-up to #323

### DIFF
--- a/templates/fasten_connect.html
+++ b/templates/fasten_connect.html
@@ -152,7 +152,7 @@
        `position: fixed; inset: 0` and therefore already the visible viewport
        minus its safe-area padding — more reliable here than `90vh`, which iOS
        measures against the viewport with browser chrome EXPANDED. */
-    height: 640px;
+    height: min(1000px, 100%);
     max-height: 100%;
     display: flex;
     flex-direction: column;
@@ -190,10 +190,18 @@
   .fasten-modal-body iframe {
     display: block;
     width: 100%;
-    height: 100%;
-    /* Tall enough that the widget lays out normally on a roomy screen; the
-       wrapper scrolls when the viewport is shorter than this. */
-    min-height: 560px;
+    /* NOT `height: 100%`. That made the iframe exactly fill .fasten-modal-body,
+       so the wrapper never overflowed, `overflow-y: auto` had nothing to
+       scroll, and the widget's own content stayed clipped — iOS will not
+       scroll an iframe's internals, which is the whole reason the wrapper
+       exists. A scroll container whose only child always fits is not a scroll
+       container.
+       A fixed height taller than any phone or tablet viewport is what makes
+       the wrapper actually scroll. The content is cross-origin so we cannot
+       measure it; 1000px covers the Fasten flow through its Continue button
+       with room to spare, and over-reserving costs only a little scroll on a
+       tall desktop window. */
+    height: 1000px;
     border: none;
   }
 </style>

--- a/tests/test_fasten_dialog_reachable.py
+++ b/tests/test_fasten_dialog_reachable.py
@@ -87,6 +87,42 @@ def test_the_connect_modal_scrolls_in_a_wrapper_not_the_iframe():
         're-creates the clip even with overflow-y set')
 
 
+def test_the_iframe_is_taller_than_its_scroll_container():
+    """The declaration that decides whether the scroll container can scroll.
+
+    The first fix for this bug set `height: 100%` on the iframe. That makes it
+    exactly fill .fasten-modal-body, so the wrapper never overflows, its
+    `overflow-y: auto` never engages, and the widget stays clipped — iOS will
+    not scroll an iframe's internals, which is the only reason the wrapper is
+    there. The dialog shipped still broken and the earlier version of this file
+    passed, because it asserted that a scroll container EXISTED rather than
+    that scrolling could ever HAPPEN.
+
+    A scroll container whose only child always fits is not a scroll container.
+
+    MUTATION: set the iframe back to `height: 100%` (or any percentage) -> red.
+    """
+    src = CONNECT.read_text(encoding='utf-8')
+    match = re.search(r'\.fasten-modal-body iframe\s*\{(.*?)\}', src, re.S)
+    assert match, '.fasten-modal-body iframe rule not found'
+    rule = _CSS_COMMENT.sub('', match.group(1))
+
+    height = re.search(r'(?<!min-)(?<!max-)height:\s*([^;]+);', rule)
+    assert height, 'the iframe declares no height, so its size is content-'\
+                   'driven and iOS will clip it'
+    value = height.group(1).strip()
+    assert '%' not in value, (
+        f'the iframe height is {value!r}: a percentage resolves against '
+        '.fasten-modal-body, so the iframe can never exceed it and the wrapper '
+        'can never scroll. Use an absolute height taller than the tallest '
+        'phone/tablet viewport.')
+    px = re.match(r'(\d+)px$', value)
+    assert px and int(px.group(1)) >= 900, (
+        f'the iframe height is {value!r}; it must be an absolute height of at '
+        'least 900px so the wrapper overflows and scrolls on a phone-sized '
+        'viewport, which is where this was reported')
+
+
 def test_the_iframe_is_inside_the_scroll_wrapper():
     """The wrapper only helps if the iframe is actually in it."""
     src = CONNECT.read_text(encoding='utf-8')


### PR DESCRIPTION
#323 shipped and **the dialog is still cut off with no Continue button**, reported from a phone on the real `/connect/<tenant>` path. I confirmed against the deployed page that the fix was live and insufficient — this is a correction, not a re-report.

## What #323 got wrong

One declaration:

```css
.fasten-modal-body iframe { height: 100%; min-height: 560px; }
```

`height: 100%` resolves against `.fasten-modal-body`, so the iframe **exactly filled its wrapper**. The wrapper never overflowed, its `overflow-y: auto` never engaged, and the widget's content stayed clipped — iOS will not scroll an iframe's internals, which is the only reason that wrapper exists.

**#323 built a scroll container and then guaranteed it could never scroll.** `min-height: 560px` sat below the wrapper height, so it never engaged either.

## The fix

The iframe is now an absolute **1000px** — taller than any phone or tablet viewport — so the wrapper genuinely overflows and scrolls. The modal takes the height available to it, `min(1000px, 100%)`, so on a roomy window there is nothing to scroll at all. The content is cross-origin and cannot be measured; 1000px clears the Fasten flow through its Continue button, and over-reserving costs only a little scroll on a tall desktop.

## The test change matters more than the CSS

The previous test asserted that a scroll container **existed**, not that scrolling could ever **happen** — so it went green while the dialog stayed broken in production. That is the same defect shape the retro describes, in the guard itself.

`test_the_iframe_is_taller_than_its_scroll_container` now rejects any percentage height and requires ≥900px absolute. **Verified against the shipped-broken state:** it goes red on `height: 100%`.

Full suite **2253 passed, 12 skipped, 6 xfailed**; ruff clean.

Still worth a real-device confirmation before closing — the guard asserts source, not rendered layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)