### PR TITLE
fix(mcp): generate the tool manifest, make tier the step-up gate, drop the self-asserted human-confirm header

### DIFF
--- a/adapters/tools.manifest.json
+++ b/adapters/tools.manifest.json
@@ -4,6 +4,7 @@
   "tools": [
     {
       "name": "context_get",
+      "title": "Get Health Context",
       "description": "Retrieve a pre-built context envelope with patient-centric FHIR resources. Returns bounded, policy-stamped, time-limited context.",
       "inputSchema": {
         "type": "object",
@@ -21,11 +22,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Get Health Context"
+      }
     },
     {
       "name": "fhir_read",
+      "title": "Read FHIR Resource",
       "description": "Read a specific FHIR resource by type and ID. Supports FHIR R4 US Core v9 stable resources and FHIR R6 ballot3 experimental resources. Returns redacted resource with PHI protection.",
       "inputSchema": {
         "type": "object",
@@ -85,11 +86,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Read FHIR Resource"
+      }
     },
     {
       "name": "fhir_search",
+      "title": "Search FHIR Resources",
       "description": "Search for FHIR resources. Supports FHIR R4 US Core v9 stable resources and FHIR R6 ballot3 experimental resources. Supports patient, code, status, _lastUpdated, _count, _sort parameters. Returns paginated, redacted Bundle.",
       "inputSchema": {
         "type": "object",
@@ -141,7 +142,7 @@
           },
           "code": {
             "type": "string",
-            "description": "Code filter \u2014 matches code.coding[].code in JSON (e.g., '2339-0' for Glucose)"
+            "description": "Code filter — matches code.coding[].code in JSON (e.g., '2339-0' for Glucose)"
           },
           "status": {
             "type": "string",
@@ -169,11 +170,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Search FHIR Resources"
+      }
     },
     {
       "name": "fhir_validate",
+      "title": "Validate FHIR Resource",
       "description": "Validate a proposed FHIR R6 resource against structural rules. Returns OperationOutcome.",
       "inputSchema": {
         "type": "object",
@@ -191,12 +192,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Validate FHIR Resource"
+      }
     },
     {
       "name": "questionnaire_populate",
-      "description": "SDC $populate \u2014 pre-fill a Questionnaire for a subject. Returns a QuestionnaireResponse. Read tier; mints a tenant token for non-public tenants.",
+      "title": "Pre-fill Health Form",
+      "description": "SDC $populate — pre-fill a Questionnaire for a subject. Returns a QuestionnaireResponse. Read tier; mints a tenant token for non-public tenants.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -221,12 +222,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Pre-fill Health Form"
+      }
     },
     {
       "name": "questionnaire_extract",
-      "description": "SDC $extract \u2014 extract FHIR resources from a completed QuestionnaireResponse into a transaction Bundle. Write tier; requires step-up unless dry_run=true.",
+      "title": "Extract Form Data to FHIR",
+      "description": "SDC $extract — extract FHIR resources from a completed QuestionnaireResponse into a transaction Bundle. Write tier; requires step-up authorization, including for dry_run=true previews.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -252,12 +253,12 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "openWorldHint": false
-      },
-      "title": "Extract Form Data to FHIR"
+      }
     },
     {
       "name": "fhir_propose_write",
-      "description": "Propose a write \u2014 validates the resource and returns a preview. Does NOT commit. Safe to call without step-up authorization.",
+      "title": "Propose FHIR Write",
+      "description": "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: requires step-up authorization (call fhir_get_token first; pass as _stepUpToken).",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -283,11 +284,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Propose FHIR Write"
+      }
     },
     {
       "name": "fhir_commit_write",
+      "title": "Commit FHIR Write",
       "description": "Commit a previously proposed write. Requires step-up authorization token. This is a destructive operation.",
       "inputSchema": {
         "type": "object",
@@ -313,11 +314,11 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "openWorldHint": false
-      },
-      "title": "Commit FHIR Write"
+      }
     },
     {
       "name": "fhir_stats",
+      "title": "Observation Statistics",
       "description": "Compute statistics (count, min, max, mean) over numeric Observation values. Standard FHIR $stats (since R4). Only supports valueQuantity. Filter by patient and/or code.",
       "inputSchema": {
         "type": "object",
@@ -337,11 +338,79 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
+      }
+    },
+    {
+      "name": "fhir_interpret_labs",
+      "title": "Interpret Lab Results",
+      "description": "Interpret lab Observations against reference ranges — flags each value low/normal/high/critical (HL7 v3 ObservationInterpretation) and returns clinician + consumer summaries. Decision support, not diagnosis. Read-tier.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "observation": {
+            "type": "object",
+            "description": "A single FHIR Observation to interpret"
+          },
+          "bundle": {
+            "type": "object",
+            "description": "A FHIR Bundle of Observations to interpret"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Patient reference (e.g. 'Patient/pt-1') — interpret the tenant's stored Observations for this subject"
+          }
+        },
+        "required": []
       },
-      "title": "Observation Statistics"
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "care_gaps",
+      "title": "Preventive Care Gaps",
+      "description": "Check which preventive-care screenings/immunizations a patient may be due for (blood pressure, cholesterol, colorectal/cervical/breast cancer screening, flu, diabetes A1c), from their own connected records. Decision support based on USPSTF/ACIP/ADA guidelines — not a diagnosis or directive. Response includes _meta.ui.resourceUri pointing to an embeddable review UI.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "description": "Patient reference (e.g. 'Patient/pt-1')"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "guardrail_conformance",
+      "title": "Guardrail Conformance Scorecard",
+      "description": "Run the guardrail conformance self-test on the connected HealthClaw deployment and return the graded scorecard across seven guardrail properties: PHI redaction, immutable audit, step-up auth, human-in-the-loop, tenant isolation, medical disclaimers, and error fidelity. Uses synthetic data only. Set fresh=true to force a new run instead of the cached result.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fresh": {
+            "type": "boolean",
+            "description": "Force a fresh probe run instead of the cached (<=10 min old) result"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
     },
     {
       "name": "fhir_lastn",
+      "title": "Latest Observations",
       "description": "Get the last N observations per code. Standard FHIR $lastn (since R4). Returns most recent observations by storage order.",
       "inputSchema": {
         "type": "object",
@@ -366,11 +435,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Latest Observations"
+      }
     },
     {
       "name": "fhir_permission_evaluate",
+      "title": "Evaluate Access Permission",
       "description": "Evaluate R6 Permission resources for access control decisions. Returns permit/deny based on stored Permission rules. Separates access control (Permission) from consent records (Consent).",
       "inputSchema": {
         "type": "object",
@@ -401,11 +470,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Evaluate Access Permission"
+      }
     },
     {
       "name": "fhir_subscription_topics",
+      "title": "List Subscription Topics",
       "description": "List available SubscriptionTopics for event-driven subscriptions. R6 moves topic-based subscriptions toward Normative. Agents discover what events they can subscribe to.",
       "inputSchema": {
         "type": "object",
@@ -416,12 +485,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "List Subscription Topics"
+      }
     },
     {
       "name": "wearables_sync_status",
-      "description": "List wearable connections (Garmin, Oura, Polar, Suunto, Whoop, Fitbit, Strava, Ultrahuman) for a tenant, with last sync time, observation count, and status. Use this to tell a patient what's connected, when data last arrived, and surface a connection-management UI (via _meta.ui.resourceUri) so they can connect more providers. Data flows into HealthClaw as FHIR Observations with LOINC codes \u2014 agents read it via fhir_search like any other Observation.",
+      "title": "Wearables Sync Status",
+      "description": "List wearable connections (Garmin, Oura, Polar, Suunto, Whoop, Fitbit, Strava, Ultrahuman) for a tenant, with last sync time, observation count, and status. Use this to tell a patient what's connected, when data last arrived, and surface a connection-management UI (via _meta.ui.resourceUri) so they can connect more providers. Data flows into HealthClaw as FHIR Observations with LOINC codes — agents read it via fhir_search like any other Observation.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -436,12 +505,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Wearables Sync Status"
+      }
     },
     {
       "name": "sources_check",
-      "description": "Survey ALL connected health data sources (Fasten, HealthEx, Health Bank One, MEDENT, Flexpa, Epic/Health Skillz, wearables) at once \u2014 returns each source's connection status and the patient's record counts by type. Use when the patient asks what's connected or to check for data across services.",
+      "title": "Check Data Sources",
+      "description": "Survey ALL connected health data sources (Fasten, HealthEx, Health Bank One, MEDENT, Flexpa, Epic/Health Skillz, wearables) at once — returns each source's connection status and the patient's record counts by type. Use when the patient asks what's connected or to check for data across services.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -451,12 +520,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Check Data Sources"
+      }
     },
     {
       "name": "fhir_compiled_truth",
-      "description": "Return the current best understanding of a FHIR resource plus the append-only evidence trail (Provenance entries) of how it got there. Use this before presenting resource-specific facts to a patient \u2014 surfaces curation_state and quality_score so the agent can say not just WHAT the record says but WHY it says it. Redacted, audited. Response includes _meta.ui.resourceUri pointing to an embeddable review UI.",
+      "title": "Compiled Truth Timeline",
+      "description": "Return the current best understanding of a FHIR resource plus the append-only evidence trail (Provenance entries) of how it got there. Use this before presenting resource-specific facts to a patient — surfaces curation_state and quality_score so the agent can say not just WHAT the record says but WHY it says it. Redacted, audited. Response includes _meta.ui.resourceUri pointing to an embeddable review UI.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -478,12 +547,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Compiled Truth Timeline"
+      }
     },
     {
       "name": "curatr_evaluate",
-      "description": "Evaluate a FHIR resource for data quality issues. Checks coding elements against public terminology services (tx.fhir.org for SNOMED/LOINC, NLM for ICD-10-CM, RXNAV for RxNorm) and structural rules. Returns issues in plain language with patient-facing impact descriptions and resolution suggestions. Read-only \u2014 no step-up required.",
+      "title": "Evaluate Data Quality",
+      "description": "Evaluate a FHIR resource for data quality issues. Checks coding elements against public terminology services (tx.fhir.org for SNOMED/LOINC, NLM for ICD-10-CM, RXNAV for RxNorm) and structural rules. Returns issues in plain language with patient-facing impact descriptions and resolution suggestions. Read-only — no step-up required.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -505,12 +574,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": true
-      },
-      "title": "Evaluate Data Quality"
+      }
     },
     {
       "name": "curatr_apply_fix",
-      "description": "Apply patient-approved data quality fixes to a FHIR resource. Creates a linked Provenance record with full attribution. Requires step-up authorization (X-Step-Up-Token) and human confirmation (X-Human-Confirmed: true) for clinical resources like Condition.",
+      "title": "Apply Data Quality Fix",
+      "description": "Apply patient-approved data quality fixes to a FHIR resource. Creates a linked Provenance record with full attribution. Requires step-up authorization (X-Step-Up-Token); in production the token must be audience- and operation-bound to this fix. This tool never asserts human confirmation on the patient's behalf — approval is proved by the token, not by a header.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -555,12 +624,12 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Apply Data Quality Fix"
+      }
     },
     {
       "name": "fhir_get_token",
-      "description": "Get a fresh step-up authorization token for write operations. Call this before fhir_propose_write, fhir_commit_write, or curatr_apply_fix. Tokens expire after 5 minutes. Returns the token string \u2014 pass it as _stepUpToken in subsequent write tool calls.",
+      "title": "Mint Step-Up Token",
+      "description": "Get a fresh step-up authorization token for write operations. Call this before fhir_propose_write, fhir_commit_write, or curatr_apply_fix. Tokens expire after 5 minutes. Returns the token string — pass it as _stepUpToken in subsequent write tool calls.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -577,11 +646,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Mint Step-Up Token"
+      }
     },
     {
       "name": "fhir_seed",
+      "title": "Seed Demo Data",
       "description": "Seed a tenant with a realistic Patient + Observations + Condition bundle for live testing. Use this at the start of a demo session to populate data. Returns created resource IDs and a ready-to-use step_up_token.",
       "inputSchema": {
         "type": "object",
@@ -597,12 +666,12 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Seed Demo Data"
+      }
     },
     {
       "name": "action_propose",
-      "description": "Propose a real-world action (phone call or SMS) on the patient's behalf. Returns a draft (id + script) the patient MUST review before commit. Does not execute anything.",
+      "title": "Propose Real-World Action",
+      "description": "Propose a real-world action (phone call or SMS) on the patient's behalf. Returns a draft (id + script) the patient MUST review before submitting via action_commit. Does not execute anything.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -629,17 +698,54 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": true
-      },
-      "title": "Propose Real-World Action"
+      }
     },
     {
       "name": "rx_transfer_request",
-      "tier": "write",
-      "description": "Draft a prescription-transfer request call to the receiving pharmacy from the patient's active medications (Schedule II refused); commit via action_commit after patient approval."
+      "title": "Request Prescription Transfer",
+      "description": "Draft a prescription-transfer request: assembles the patient's active medications and stages a phone call to the RECEIVING pharmacy asking it to pull the prescriptions from the current pharmacy (how US transfers actually work). Schedule II medications are refused (never transferable — new prescription required). Returns a draft the patient MUST review; submit with action_commit for the patient's own out-of-band confirmation after they explicitly agree — action_commit does not execute the call itself.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "to_pharmacy_name": {
+            "type": "string",
+            "description": "Receiving pharmacy name"
+          },
+          "to_pharmacy_phone": {
+            "type": "string",
+            "description": "Receiving pharmacy phone number"
+          },
+          "from_pharmacy_name": {
+            "type": "string",
+            "description": "Current pharmacy name (optional)"
+          },
+          "from_pharmacy_phone": {
+            "type": "string",
+            "description": "Current pharmacy phone (optional)"
+          },
+          "medication_names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Limit to these medication names (default: all active orders)"
+          }
+        },
+        "required": [
+          "to_pharmacy_name",
+          "to_pharmacy_phone"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      }
     },
     {
       "name": "action_commit",
-      "description": "Execute a previously proposed action AFTER the patient has explicitly approved the draft. Requires step-up authorization (call fhir_get_token first; pass as _stepUpToken). Only call this after the patient says yes.",
+      "title": "Submit Real-World Action for Confirmation",
+      "description": "Submit a previously proposed action for the patient's OWN out-of-band confirmation (their dashboard or Telegram) AFTER they've reviewed and verbally/textually agreed to the draft. Requires step-up authorization (call fhir_get_token first; pass as _stepUpToken). This call does NOT execute anything and never accepts or sends any 'human confirmed' flag — only the patient tapping Approve in their own out-of-band channel can trigger execution. Returns status 'awaiting_confirmation' and is terminal for your turn: do not call action_commit again for the same action_id. Use action_status to check whether the patient has approved yet.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -656,12 +762,12 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "openWorldHint": true
-      },
-      "title": "Commit Real-World Action"
+      }
     },
     {
       "name": "action_status",
-      "description": "Check the status and outcome of an action (proposed/executing/completed/failed). Use after commit to report the result back to the patient.",
+      "title": "Action Status",
+      "description": "Check the status and outcome of an action (proposed/awaiting_confirmation/executing/completed/failed/needs_review/unknown/expired). needs_review means it ran but the outcome could not be confirmed - show the patient the evidence. unknown means the provider MAY have acted - never re-propose the same action. Use after action_commit to see whether the patient has approved yet, and to report the final result back to them.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -678,12 +784,12 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Action Status"
+      }
     },
     {
       "name": "shl_generate",
-      "description": "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required \u2014 pass _stepUpToken), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
+      "title": "Generate SMART Health Link",
+      "description": "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — pass _stepUpToken), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -714,39 +820,11 @@
         "readOnlyHint": false,
         "destructiveHint": false,
         "openWorldHint": true
-      },
-      "title": "Generate SMART Health Link"
-    },
-    {
-      "name": "fhir_interpret_labs",
-      "description": "Interpret lab Observations against reference ranges \u2014 flags each value low/normal/high/critical (HL7 v3 ObservationInterpretation) and returns clinician + consumer summaries. Decision support, not diagnosis. Read-tier.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "observation": {
-            "type": "object",
-            "description": "A single FHIR Observation to interpret"
-          },
-          "bundle": {
-            "type": "object",
-            "description": "A FHIR Bundle of Observations to interpret"
-          },
-          "subject": {
-            "type": "string",
-            "description": "Patient reference (e.g. 'Patient/pt-1') \u2014 interpret the tenant's stored Observations for this subject"
-          }
-        },
-        "required": []
-      },
-      "annotations": {
-        "readOnlyHint": true,
-        "destructiveHint": false,
-        "openWorldHint": false
-      },
-      "title": "Interpret Lab Results"
+      }
     },
     {
       "name": "search",
+      "title": "Search Health Records",
       "description": "ChatGPT-connector-compatible search over the tenant's FHIR records. Query is a FHIR search string (e.g. 'Observation?code=4548-4' or 'Patient?name=smith'); bare resource type works too. Returns compact results: id, title, url. Reads are PHI-redacted and audit-logged server-side.",
       "inputSchema": {
         "type": "object",
@@ -764,11 +842,11 @@
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false
-      },
-      "title": "Search Health Records"
+      }
     },
     {
       "name": "fetch",
+      "title": "Fetch Health Record",
       "description": "ChatGPT-connector-compatible fetch of one FHIR resource by id ('ResourceType/id', as returned by search). Returns the full document (PHI-redacted server-side) with metadata.",
       "inputSchema": {
         "type": "object",
@@ -781,47 +859,6 @@
         "required": [
           "id"
         ]
-      },
-      "annotations": {
-        "readOnlyHint": true,
-        "destructiveHint": false,
-        "openWorldHint": false
-      },
-      "title": "Fetch Health Record"
-    },
-    {
-      "name": "care_gaps",
-      "description": "Check which preventive-care screenings/immunizations a patient may be due for (blood pressure, cholesterol, colorectal/cervical/breast cancer screening, flu, diabetes A1c), from their own connected records. Decision support based on USPSTF/ACIP/ADA guidelines \u2014 not a diagnosis or directive.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "subject": {
-            "type": "string",
-            "description": "Patient reference (e.g. 'Patient/pt-1')"
-          }
-        },
-        "required": []
-      },
-      "annotations": {
-        "readOnlyHint": true,
-        "destructiveHint": false,
-        "openWorldHint": false
-      },
-      "title": "Preventive Care Gaps"
-    },
-    {
-      "name": "guardrail_conformance",
-      "title": "Guardrail Conformance Scorecard",
-      "description": "Run the guardrail conformance self-test on the connected HealthClaw deployment and return the graded scorecard (A-F across PHI redaction, immutable audit, step-up auth, human-in-the-loop, tenant isolation, medical disclaimers). Uses synthetic data only. Set fresh=true to force a new run instead of the cached result.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "fresh": {
-            "type": "boolean",
-            "description": "Force a fresh probe run instead of the cached (<=10 min old) result"
-          }
-        },
-        "required": []
       },
       "annotations": {
         "readOnlyHint": true,

--- a/services/agent-orchestrator/package.json
+++ b/services/agent-orchestrator/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
+    "manifest": "ts-node src/generate-manifest.ts",
     "test": "jest",
     "lint": "tsc --noEmit"
   },

--- a/services/agent-orchestrator/src/generate-manifest.ts
+++ b/services/agent-orchestrator/src/generate-manifest.ts
@@ -1,0 +1,24 @@
+/**
+ * Write `adapters/tools.manifest.json` from the live tool catalogue.
+ *
+ *   cd services/agent-orchestrator && npm run manifest
+ *
+ * `manifest.test.ts` fails CI when the committed file stops matching this
+ * output, so the manifest is a build artifact rather than a file someone
+ * remembers to hand-edit.
+ */
+
+import * as fs from "fs";
+import { MANIFEST_PATH, serializeToolManifest } from "./manifest";
+
+const next = serializeToolManifest();
+const previous = fs.existsSync(MANIFEST_PATH)
+  ? fs.readFileSync(MANIFEST_PATH, "utf-8")
+  : null;
+
+if (previous === next) {
+  console.log(`tools.manifest.json already up to date (${MANIFEST_PATH})`);
+} else {
+  fs.writeFileSync(MANIFEST_PATH, next);
+  console.log(`wrote ${MANIFEST_PATH}`);
+}

--- a/services/agent-orchestrator/src/manifest.test.ts
+++ b/services/agent-orchestrator/src/manifest.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Drift guard for `adapters/tools.manifest.json`.
+ *
+ * The manifest is what OpenAI and Gemini callers see. It was hand-maintained
+ * and drifted: `rx_transfer_request` lost its `inputSchema`, `title` and
+ * `annotations` entirely (so the bridge emitted an empty parameter schema and
+ * every model call failed validation), and `action_commit` still described the
+ * pre-v1.8.0 "executes the action" semantics after commit became
+ * submit-for-approval. Both are the kind of error that only shows up in a
+ * stranger's client.
+ *
+ * These tests make the committed file a build artifact: change a tool, run
+ * `npm run manifest`, or CI fails.
+ */
+
+import * as fs from "fs";
+import {
+  buildToolManifest,
+  MANIFEST_PATH,
+  MANIFEST_SOURCE,
+  serializeToolManifest,
+} from "./manifest";
+
+function committed(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf-8"));
+}
+
+describe("adapters/tools.manifest.json", () => {
+  it("deep-equals freshly generated output", () => {
+    expect(committed()).toEqual(buildToolManifest());
+  });
+
+  it("is byte-identical to the generator's output (run `npm run manifest`)", () => {
+    expect(fs.readFileSync(MANIFEST_PATH, "utf-8")).toBe(serializeToolManifest());
+  });
+
+  it("carries the source label and a tool_count that matches the tool list", () => {
+    const manifest = committed() as { source: string; tool_count: number; tools: unknown[] };
+    expect(manifest.source).toBe(MANIFEST_SOURCE);
+    expect(manifest.tool_count).toBe(manifest.tools.length);
+  });
+
+  it("gives every tool a title, description and non-empty inputSchema", () => {
+    // The S-6 regression in one assertion: an entry without `inputSchema`
+    // becomes `parameters: {"type": "object"}` in healthclaw_bridge.py.
+    const manifest = committed() as {
+      tools: Array<{
+        name: string;
+        title?: string;
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+        annotations?: Record<string, unknown>;
+      }>;
+    };
+    expect(manifest.tools.length).toBeGreaterThan(0);
+    for (const tool of manifest.tools) {
+      expect(typeof tool.title).toBe("string");
+      expect(typeof tool.description).toBe("string");
+      expect(tool.annotations).toBeDefined();
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema!.type).toBe("object");
+      expect(tool.inputSchema).toHaveProperty("properties");
+    }
+  });
+
+  it("includes the privileged tools, because it is the catalogue not a transport view", () => {
+    const names = (committed() as { tools: Array<{ name: string }> }).tools.map((t) => t.name);
+    expect(names).toContain("fhir_get_token");
+    expect(names).toContain("fhir_seed");
+  });
+});

--- a/services/agent-orchestrator/src/manifest.ts
+++ b/services/agent-orchestrator/src/manifest.ts
@@ -1,0 +1,64 @@
+/**
+ * The tool manifest that non-MCP frameworks consume.
+ *
+ * `adapters/tools.manifest.json` feeds `adapters/healthclaw_bridge.py`, which
+ * turns each entry into an OpenAI function tool or a Gemini
+ * FunctionDeclaration. A tool whose entry is missing `inputSchema` is emitted
+ * with `parameters: {"type": "object"}` — the model then calls it with no
+ * arguments and Ajv rejects the call server-side. The failure lands at runtime,
+ * in someone else's client.
+ *
+ * `tests/test_docs_tool_catalogue_drift.py` has claimed since it was written
+ * that the manifest "is generated from the same catalogue the server serves".
+ * Nothing generated it; it was hand-edited, and it drifted. This module is the
+ * generator that makes the claim true, and `manifest.test.ts` fails CI when the
+ * committed file stops matching it.
+ *
+ * Regenerate with `npm run manifest` from `services/agent-orchestrator`.
+ */
+
+import * as path from "path";
+import { FHIRTools, type MCPToolSchema } from "./tools";
+
+/** Label carried in the manifest so a consumer can tell where it came from. */
+export const MANIFEST_SOURCE = "healthclaw-mcp";
+
+/** The committed manifest, resolved from this file (src/ and dist/ are the
+ * same depth below the repository root). */
+export const MANIFEST_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "adapters",
+  "tools.manifest.json"
+);
+
+export interface ToolManifest {
+  source: string;
+  tool_count: number;
+  tools: MCPToolSchema[];
+}
+
+/**
+ * Build the manifest from the live tool catalogue.
+ *
+ * `allowPrivileged: true` on purpose: the manifest is the *catalogue*, not one
+ * transport's view of it. Consumers that need the hosted view subtract
+ * `PRIVILEGED_TOOL_NAMES` themselves — that is exactly what the Python drift
+ * guard does to check the documented "serves N tools" number.
+ *
+ * The base URL is irrelevant to schema generation (no tool is executed here);
+ * it only has to be a well-formed URL for the constructor.
+ */
+export function buildToolManifest(): ToolManifest {
+  const tools = new FHIRTools("http://localhost:5000/r6/fhir", {
+    allowPrivileged: true,
+  }).getMCPToolSchemas();
+  return { source: MANIFEST_SOURCE, tool_count: tools.length, tools };
+}
+
+/** The exact bytes the committed manifest should contain. */
+export function serializeToolManifest(): string {
+  return `${JSON.stringify(buildToolManifest(), null, 2)}\n`;
+}

--- a/services/agent-orchestrator/src/step-up-gate.test.ts
+++ b/services/agent-orchestrator/src/step-up-gate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The declared tier is the step-up gate.
+ *
+ * The gate used to read `tool.tier === "write" && (name === "fhir_commit_write"
+ * || name === "action_commit" || name === "shl_generate")`. The tier looked
+ * like it was doing the work; the name list actually was, and five write-tier
+ * tools were never gated centrally. A tool added with `tier: "write"` inherited
+ * no protection at all — the failure mode is silent, which is the shape the
+ * 2026-08-02 retro is about.
+ *
+ * This suite pins the property rather than the list: every write-tier tool the
+ * registry declares is gated, and the fixture map below must cover exactly the
+ * write-tier set, so adding a write tool without a fixture fails here.
+ */
+
+import { FHIRTools } from "./tools";
+
+jest.mock("node-fetch", () => jest.fn());
+import fetch from "node-fetch";
+const mockFetch = fetch as unknown as jest.Mock;
+
+/** Ajv validation runs before the gate, so each fixture must be schema-valid. */
+const VALID_INPUT: Record<string, Record<string, unknown>> = {
+  questionnaire_extract: { questionnaire_response: { resourceType: "QuestionnaireResponse" } },
+  fhir_propose_write: {
+    resource: { resourceType: "Observation", status: "final" },
+    operation: "create",
+  },
+  fhir_commit_write: {
+    resource: { resourceType: "Observation", status: "final" },
+    operation: "create",
+  },
+  curatr_apply_fix: {
+    resource_type: "Condition",
+    resource_id: "c-1",
+    fixes: [{ field_path: "Condition.code.coding[0].system", new_value: "x" }],
+    patient_intent: "fix my record",
+  },
+  action_propose: {
+    kind: "phone-call",
+    payload: { to: "Dr. Smith", phone: "+15551234567", body: "Requesting referral." },
+  },
+  rx_transfer_request: {
+    to_pharmacy_name: "Corner Pharmacy",
+    to_pharmacy_phone: "+15551230000",
+  },
+  action_commit: { action_id: "act-001" },
+  shl_generate: { label: "Records for the clinic" },
+};
+
+const READ_TIER_SPOT_CHECKS: Record<string, Record<string, unknown>> = {
+  fhir_read: { resource_type: "Patient", resource_id: "p-1" },
+  curatr_evaluate: { resource_type: "Condition", resource_id: "c-1" },
+  action_status: { action_id: "act-001" },
+};
+
+describe("step-up gate follows the declared tier", () => {
+  let tools: FHIRTools;
+  let writeTierNames: string[];
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    tools = new FHIRTools("http://localhost:5000/r6/fhir", { allowPrivileged: true });
+    writeTierNames = tools
+      .getToolSchemas()
+      .filter((t) => t.tier === "write")
+      .map((t) => t.name);
+  });
+
+  it("the fixture map covers exactly the write-tier tools", () => {
+    expect(writeTierNames.slice().sort()).toEqual(Object.keys(VALID_INPUT).sort());
+  });
+
+  it("every write-tier tool refuses without a step-up token, and makes no backend call", async () => {
+    for (const name of writeTierNames) {
+      mockFetch.mockReset();
+      const result = await tools.executeTool(name, VALID_INPUT[name], {});
+      expect({ name, ...result }).toMatchObject({
+        name,
+        error: "Step-up authorization required",
+        requires_step_up: true,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("every write-tier tool refuses when the headers argument is omitted entirely", async () => {
+    for (const name of writeTierNames) {
+      mockFetch.mockReset();
+      const result = await tools.executeTool(name, VALID_INPUT[name]);
+      expect(result).toHaveProperty("requires_step_up", true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("a write-tier tool with a step-up token reaches the backend", async () => {
+    for (const name of writeTierNames) {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ id: "x" }),
+        text: jest.fn().mockResolvedValue("{}"),
+      });
+      await tools.executeTool(name, VALID_INPUT[name], {
+        "x-step-up-token": "tok-1",
+        "x-tenant-id": "tenant-xyz",
+      });
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("read-tier tools are never gated", async () => {
+    for (const [name, input] of Object.entries(READ_TIER_SPOT_CHECKS)) {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ resourceType: "Patient" }),
+        text: jest.fn().mockResolvedValue("{}"),
+      });
+      const result = await tools.executeTool(name, input, {});
+      expect(result).not.toHaveProperty("requires_step_up");
+    }
+  });
+
+  // -- The header the MCP server must never mint --
+  //
+  // curatr_apply_fix used to attach `X-Human-Confirmed: true` to every
+  // upstream call. The MCP client cannot know that a human confirmed a
+  // clinical write; asserting it on the human's behalf is the whole defect,
+  // even though Flask ignores the header on $curatr-apply-fix and requires an
+  // audience-bound, operation-bound, nonce-consumed token instead.
+  it("curatr_apply_fix never sends X-Human-Confirmed upstream", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ issues_fixed: 1 }),
+      text: jest.fn().mockResolvedValue("{}"),
+    });
+
+    await tools.executeTool("curatr_apply_fix", VALID_INPUT.curatr_apply_fix, {
+      "x-step-up-token": "tok-1",
+      "x-tenant-id": "tenant-xyz",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("$curatr-apply-fix");
+    expect(opts.headers).not.toHaveProperty("X-Human-Confirmed");
+    expect(Object.keys(opts.headers).map((k) => k.toLowerCase())).not.toContain(
+      "x-human-confirmed"
+    );
+    expect(JSON.stringify(opts.body || "")).not.toContain("X-Human-Confirmed");
+  });
+});

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -975,7 +975,7 @@ describe("Tool Execution Tests", () => {
       to_pharmacy_phone: "+15551230000",
       from_pharmacy_name: "CVS Oak Ave",
       medication_names: ["Metformin 500 mg"],
-    }, { "x-tenant-id": "t1" });
+    }, { "x-tenant-id": "t1", "x-step-up-token": "tok-1" });
 
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toContain("/r6/actions/rx-transfer/propose");
@@ -994,7 +994,7 @@ describe("Tool Execution Tests", () => {
 
     const result = await tools.executeTool("rx_transfer_request", {
       to_pharmacy_name: "Walgreens", to_pharmacy_phone: "+15551230000",
-    }, {}) as Record<string, unknown>;
+    }, { "x-step-up-token": "tok-1" }) as Record<string, unknown>;
 
     expect(String(result.error)).toContain("422");
   });
@@ -1260,9 +1260,29 @@ describe("Tool Execution Tests", () => {
     }
   });
 
-  // -- propose_write does NOT require step-up --
+  // -- propose_write is write tier, so it IS gated --
+  //
+  // It used to be exempt: the central gate named three tools, and
+  // propose_write was not one of them, even though it declares tier: "write".
+  // Now the declared tier is the gate (see step-up-gate.test.ts), so this
+  // preview call needs a token like every other write-tier tool.
 
-  it("fhir.propose_write does NOT require step-up token", async () => {
+  it("fhir.propose_write requires a step-up token like every write-tier tool", async () => {
+    const result = await tools.executeTool(
+      "fhir_propose_write",
+      {
+        resource: { resourceType: "Observation", status: "final" },
+        operation: "create",
+      },
+      {} // no step-up token
+    );
+
+    expect(result).toHaveProperty("error", "Step-up authorization required");
+    expect(result).toHaveProperty("requires_step_up", true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fhir.propose_write returns the preview once a step-up token is supplied", async () => {
     const validationResponse = {
       resourceType: "OperationOutcome",
       issue: [],
@@ -1275,7 +1295,7 @@ describe("Tool Execution Tests", () => {
         resource: { resourceType: "Observation", status: "final" },
         operation: "create",
       },
-      {} // no step-up token -- should still work
+      { "x-step-up-token": "tok-1" }
     );
 
     expect(result.error).toBeUndefined();
@@ -1291,7 +1311,7 @@ describe("Tool Execution Tests", () => {
     const result = await tools.executeTool(
       "action_propose",
       { kind: "phone-call", payload: { to: "Dr. Smith", phone: "+15551234567", body: "Requesting referral." } },
-      { "x-tenant-id": "tenant-xyz" }
+      { "x-tenant-id": "tenant-xyz", "x-step-up-token": "tok-1" }
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -10,12 +10,12 @@
  * - Adding clinical context to statistical results
  * - Explaining access control decisions
  *
- * Two tiers:
- * - Read-only (no step-up): context.get, fhir.read, fhir.search, fhir.validate,
- *   fhir.stats, fhir.lastn, fhir.permission_evaluate, fhir.subscription_topics,
- *   fhir.compiled_truth, curatr.evaluate
- * - Write (require step-up): fhir.propose_write, fhir.commit_write,
- *   curatr.apply_fix
+ * Two tiers, and the tier is the gate — `executeToolInner` demands an
+ * X-Step-Up-Token for every tool declared `tier: "write"`, with no second list
+ * of names anywhere. Read-tier tools (context.get, fhir.read, fhir.search,
+ * fhir.validate, fhir.stats, fhir.lastn, fhir.permission_evaluate,
+ * fhir.subscription_topics, fhir.compiled_truth, curatr.evaluate, …) are never
+ * gated. A new tool inherits its protection from the one word it declares.
  *
  * All tools include MCP annotations (readOnlyHint, destructiveHint, openWorldHint).
  */
@@ -447,7 +447,7 @@ export class FHIRTools {
         name: "questionnaire_extract",
         title: "Extract Form Data to FHIR",
         description:
-          "SDC $extract — extract FHIR resources from a completed QuestionnaireResponse into a transaction Bundle. Write tier; requires step-up unless dry_run=true.",
+          "SDC $extract — extract FHIR resources from a completed QuestionnaireResponse into a transaction Bundle. Write tier; requires step-up authorization, including for dry_run=true previews.",
         tier: "write",
         handler: ({ input, headers }) =>
           this.extractQuestionnaire(
@@ -471,7 +471,7 @@ export class FHIRTools {
         name: "fhir_propose_write",
         title: "Propose FHIR Write",
         description:
-          "Propose a write — validates the resource and returns a preview. Does NOT commit. Safe to call without step-up authorization.",
+          "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: requires step-up authorization (call fhir_get_token first; pass as _stepUpToken).",
         tier: "write",
         handler: ({ input, headers }) =>
           this.proposeWrite(
@@ -797,7 +797,7 @@ export class FHIRTools {
         name: "curatr_apply_fix",
         title: "Apply Data Quality Fix",
         description:
-          "Apply patient-approved data quality fixes to a FHIR resource. Creates a linked Provenance record with full attribution. Requires step-up authorization (X-Step-Up-Token) and human confirmation (X-Human-Confirmed: true) for clinical resources like Condition.",
+          "Apply patient-approved data quality fixes to a FHIR resource. Creates a linked Provenance record with full attribution. Requires step-up authorization (X-Step-Up-Token); in production the token must be audience- and operation-bound to this fix. This tool never asserts human confirmation on the patient's behalf — approval is proved by the token, not by a header.",
         tier: "write",
         handler: ({ input, headers }) =>
           this.curatrApplyFix(
@@ -1151,8 +1151,12 @@ export class FHIRTools {
       };
     }
 
-    // Enforce step-up for commit_write, action_commit, and shl_generate (releases full record)
-    if (tool.tier === "write" && (toolName === "fhir_commit_write" || toolName === "action_commit" || toolName === "shl_generate")) {
+    // The declared tier IS the gate. This used to be `tier === "write" && (name
+    // is one of three)`, which read like a tier check but was really a name
+    // list — five write-tier tools inherited no central protection, and a tool
+    // added with tier: "write" got none at all. Anything that must not be
+    // gated declares tier: "read"; there is no second, invisible list.
+    if (tool.tier === "write") {
       const stepUpToken = headers?.["x-step-up-token"];
       if (!stepUpToken) {
         return {
@@ -1190,6 +1194,12 @@ export class FHIRTools {
 
     // questionnaire_extract dry-run is read-shaped (Flask gates it with read-auth
     // but no step-up); mint a read token so non-public tenants can preview.
+    //
+    // INERT since the step-up gate became tier-driven: questionnaire_extract is
+    // write tier, so reaching this line means the caller already supplied a
+    // token, and ensureReadToken returns immediately when one is present. Kept
+    // because it is the hook that comes back to life if the dry-run preview is
+    // re-exempted from the gate — see the PR note on that trade-off.
     if (toolName === "questionnaire_extract" && effectiveInput.dry_run === true) {
       await this.ensureReadToken(fwdHeaders);
     }
@@ -1861,15 +1871,16 @@ export class FHIRTools {
     patientIntent: string,
     headers: Record<string, string>
   ): Promise<Record<string, unknown>> {
-    const stepUpToken = headers["X-Step-Up-Token"] || headers["x-step-up-token"];
-    if (!stepUpToken) {
-      return {
-        error: "Step-up authorization required for curatr.apply_fix",
-        requires_step_up: true,
-        message:
-          "Applying fixes to clinical resources requires X-Step-Up-Token and X-Human-Confirmed: true headers.",
-      };
-    }
+    // No local step-up check: executeToolInner gates every write-tier tool,
+    // and curatr_apply_fix is write tier. The check that used to live here
+    // read a differently-cased header than the central gate, which is how two
+    // controls that look like one drift apart.
+    //
+    // Nor does this call mint X-Human-Confirmed. The MCP client cannot know
+    // whether a human confirmed a clinical write; asserting it upstream on the
+    // human's behalf is the guardrail inverted. Flask ignores the header here
+    // and requires an audience-bound, operation-bound, single-use token
+    // instead, so removing it costs nothing and removes a standing lie.
 
     // 30s budget: after applying, Flask re-evaluates the fixed resource via
     // the same external terminology services as $curatr-evaluate
@@ -1879,7 +1890,7 @@ export class FHIRTools {
       `${this.baseUrl}/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}/$curatr-apply-fix`,
       {
         method: "POST",
-        headers: { ...headers, "X-Human-Confirmed": "true" },
+        headers: { ...headers },
         body: JSON.stringify({ fixes, patient_intent: patientIntent }),
       },
       30_000


### PR DESCRIPTION
Three defects in the MCP orchestrator. **One of them was telling every OpenAI/Gemini agent that `action_commit` executes an action** — read that section even if you skip the rest.

## S-6 — the manifest was hand-edited and one tool was unusable

Proven by running the bridge on the committed manifest, not by reading it:

```
OPENAI: {"name":"rx_transfer_request", ..., "parameters": {"type": "object"}}
GEMINI: {"name":"rx_transfer_request", ..., "parameters": {"type": "object"}}
```

`rx_transfer_request` carried only `name`/`description`/`tier` — the sole entry of 29 missing `inputSchema` and the sole one carrying `tier`, the fingerprint of a hand edit. `healthclaw_bridge.py` falls back to `{"type": "object"}`, so the model was told the tool takes no arguments while it actually requires `to_pharmacy_name` and `to_pharmacy_phone`. **Every OpenAI/Gemini call to it failed Ajv validation.**

`tests/test_docs_tool_catalogue_drift.py` claimed the manifest "is generated from the same catalogue the server serves". **No generator existed** — confirmed across `scripts/`, both `package.json`s, and CI. Now `npm run manifest` emits it from `getMCPToolSchemas()`, and a jest test deep-equals the committed file so CI fails on drift. The claim is true for the first time.

### What regeneration exposed — 14 field divergences across 9 tools

The one that matters: **`action_commit` still described pre-v1.8.0 semantics** — title "Commit Real-World Action", description "Execute a previously proposed action". Since v1.8.0 commit only *submits* for out-of-band confirmation. Every agent reading the manifest was told it executes. Now "Submit Real-World Action for Confirmation".

Also stale: `action_status` (missing `awaiting_confirmation`/`needs_review`/`unknown`/`expired` and the never-re-propose rule), `action_propose`, `care_gaps`, `guardrail_conformance`.

## S-8 — `curatr_apply_fix` self-asserted human confirmation

It injected `X-Human-Confirmed: "true"` unconditionally — the client asserting a human confirmed a **clinical write**. Removed. Verified inert server-side (`r6/routes.py:2963` documents it; nothing on that route reads it), so no behavior change, but the shape is exactly the retro's defect on a clinical path. Its redundant local step-up check went too.

## Tier gate — 8 write-tier tools, 3 were gated

The gate was a hardcoded name list ANDed with `tier === "write"`. It now reads the declared tier, so all 8 are covered. (Count verified as **8**, not the 9 the audit claimed.)

### ⚠️ Release-note item — newly require a step-up token

`fhir_propose_write`, `action_propose`, `rx_transfer_request`, `questionnaire_extract` **including `dry_run=true`**.

### ⚠️ Decision needed: the client is now stricter than the server

Four of those are proposal/preview paths whose Flask backends require **no** step-up: `/r6/actions/propose` takes a tenant header only, `/r6/actions/rx-transfer/propose` read-auth only, and `$extract` explicitly skips the gate when `dryRun=true` (`r6/sdc/routes.py:96-104`).

This is fail-safe, not fail-open, and it keeps **one** rule rather than reintroducing per-tool special cases — the constitution's "one control, one property". The cost is the *preview before you mint a token* affordance, and `questionnaire_extract(dry_run=true)` is the one worth a ruling: previewing what will be written is part of the human-approval story. Reverting only that is a single predicate, annotated in place at `tools.ts:1195`.

**My recommendation: keep it uniform.** An argument-dependent exemption is a second encoding of a security decision, which is how the four status dialects happened.

Three tool descriptions became false the moment the gate changed (`fhir_propose_write` said "Safe to call without step-up authorization") and were corrected — a truthful manifest was the point of the first item.

## Gates

- `npx tsc --noEmit` clean; `npm test` **188 passed, 7 suites** (baseline 176 / 5)
- `pytest test_docs_tool_catalogue_drift.py test_site_version_sync.py` → 8 passed; ruff clean
- New: `manifest.test.ts` (5) and `step-up-gate.test.ts` (6), the latter asserting its fixture map covers *exactly* the write-tier set, so adding a write tool without a fixture fails.
- Four existing tests asserting the old ungated behavior were updated — called out rather than buried.

**Known stale, out of lane:** `docs/recipes/any-agent-framework.md` lists four write-tier tools as requiring step-up; it is now stale in the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)