### PR TITLE
fix(r6): refuse a non-object JSON body instead of 500ing (#330)

### DIFF
--- a/r6/health_compliance.py
+++ b/r6/health_compliance.py
@@ -79,6 +79,13 @@ def require_human_confirmation(resource):
     Returns True for high-risk clinical writes that require a
     separate confirmation header (X-Human-Confirmed: true).
     """
+    # A body that is not a JSON object cannot name a resourceType, so it is
+    # not a clinical write this gate can identify. Say so instead of crashing:
+    # this runs in a before_request hook ahead of EVERY handler, so an
+    # AttributeError here is a 500 on any malformed body (#330). The request is
+    # still rejected — by the handler, which owns what a valid body looks like.
+    if not isinstance(resource, dict):
+        return False
     rt = resource.get('resourceType', '')
     if rt in CLINICAL_RESOURCE_TYPES:
         return True

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -460,7 +460,10 @@ def create_resource(resource_type):
     if too_deep:
         return _operation_outcome('error', 'invalid',
                                   'Request body nesting is too deep'), 400
-    if not body:
+    # isinstance, not truthiness: `[1]`, `42` and `"text"` are all truthy and
+    # all lack .get(), so a bare `if not body` lets them through to an
+    # AttributeError and a 500 (#330).
+    if not isinstance(body, dict):
         return _operation_outcome('error', 'invalid', 'Request body must be valid JSON'), 400
 
     if body.get('resourceType') != resource_type:
@@ -1218,7 +1221,7 @@ def ingest_context():
     if too_deep:
         return _operation_outcome('error', 'invalid',
                                   'Request body nesting is too deep'), 400
-    if not body or body.get('resourceType') != 'Bundle':
+    if not isinstance(body, dict) or body.get('resourceType') != 'Bundle':
         return _operation_outcome('error', 'invalid',
                                   'Request body must be a FHIR Bundle'), 400
 
@@ -1460,7 +1463,7 @@ def import_stub():
     R4/R5 import stub: accept Bundle + annotate "needs transform".
     """
     body = request.get_json(silent=True)
-    if not body or body.get('resourceType') != 'Bundle':
+    if not isinstance(body, dict) or body.get('resourceType') != 'Bundle':
         return _operation_outcome('error', 'invalid',
                                   'Request body must be a FHIR Bundle'), 400
 

--- a/r6/smbp/routes.py
+++ b/r6/smbp/routes.py
@@ -48,6 +48,9 @@ def enroll():
         return jsonify(_oo("error", "invalid",
                            "request body nesting is too deep")), 400
     body = body or {}
+    if not isinstance(body, dict):
+        return jsonify(_oo("error", "invalid",
+                           "request body must be a JSON object")), 400
     patient_ref = body.get("patient_ref")
     if not patient_ref:
         return jsonify(_oo("error", "invalid", "patient_ref required")), 400

--- a/tests/test_non_dict_body_refused.py
+++ b/tests/test_non_dict_body_refused.py
@@ -1,0 +1,85 @@
+"""A JSON body that is not an object must be refused, not crash the worker.
+
+Sibling of the depth bound shipped for #312, and found while fixing it. Same
+outcome — an unauthenticated caller turns a malformed body into a 500 — but a
+different mechanism, so the depth guard does not cover it: the payload is not
+deep, it is the wrong *type*. ``[1]`` is a few bytes and needs only a tenant
+header.
+
+The first crash is not in any handler. ``require_human_confirmation``
+(``r6/health_compliance.py``) calls ``.get()`` on the parsed body from inside
+``enforce_human_in_loop``, a ``before_request`` hook that runs ahead of EVERY
+non-exempt POST/PUT on ``r6_blueprint``. That is the same hook that made the
+per-handler guards unreachable in #312, and it is why this file asserts through
+the HTTP boundary rather than calling the handlers.
+
+The hook returning False for a non-dict body is not a gate being skipped. It
+says "this is not a clinical write I can identify", which is true — a list has
+no ``resourceType``. The request is still refused, by the handler that owns
+what a valid body looks like. ``propose_action`` already had this shape; these
+sites did not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# (method, path) for every write path reachable with only a tenant header.
+WRITE_PATHS = [
+    ('post', '/r6/fhir/Patient'),
+    ('post', '/r6/fhir/Bundle/$ingest-context'),
+    ('post', '/r6/smbp/enroll'),
+    ('post', '/r6/actions/propose'),
+]
+
+# Bodies that parse as JSON but are not objects. A handler reading .get() on
+# any of these raises AttributeError, which Flask turns into a 500.
+NON_DICT_BODIES = ['[1]', '"a string"', '42', 'true', '[]', 'null']
+
+
+@pytest.mark.parametrize('method,path', WRITE_PATHS,
+                         ids=[p for _, p in WRITE_PATHS])
+@pytest.mark.parametrize('body', NON_DICT_BODIES)
+def test_a_non_object_body_is_refused_not_crashed(client, method, path, body):
+    """MUTATION: drop the isinstance check in require_human_confirmation
+    (r6/health_compliance.py) -> the two /r6/fhir/ rows go red with a 500.
+
+    Any 5xx here is an unauthenticated caller crashing a worker.
+    """
+    response = getattr(client, method)(
+        path, data=body,
+        headers={'X-Tenant-Id': 'test-tenant',
+                 'Content-Type': 'application/json'})
+    assert response.status_code < 500, (
+        f'{method.upper()} {path} answered {response.status_code} for a '
+        f'non-object body {body!r}; a malformed body must be refused, not '
+        'raise')
+
+
+def test_the_human_in_the_loop_hook_tolerates_a_non_dict_body():
+    """The hook runs before every handler, so it must not be the crash site.
+
+    MUTATION: remove the isinstance guard from require_human_confirmation
+    -> AttributeError instead of a clean False.
+    """
+    from r6.health_compliance import require_human_confirmation
+
+    for body in ([1], 'text', 42, None, [], True):
+        assert require_human_confirmation(body) is False, (
+            f'the hook claimed {body!r} needs human confirmation')
+
+
+def test_a_clinical_dict_still_requires_human_confirmation():
+    """The tolerance above must not become a bypass.
+
+    A real clinical resource still trips the gate — otherwise "not a dict, so
+    no confirmation needed" would have widened into "no confirmation needed".
+
+    MUTATION: return False unconditionally -> red.
+    """
+    from r6.health_compliance import require_human_confirmation
+
+    assert require_human_confirmation(
+        {'resourceType': 'Observation', 'status': 'final'}) is True
+    assert require_human_confirmation({'resourceType': 'Consent'}) is True
+    assert require_human_confirmation({'resourceType': 'Patient'}) is False


### PR DESCRIPTION
Closes #330. Sibling of the depth bound shipped for #312 and found while fixing it: same outcome — an unauthenticated caller turns a malformed body into a 500 — but a different mechanism, so the depth guard did not cover it. `[1]` is a few bytes and is the wrong **type**, not too deep. A tenant header is all it takes.

## The first crash was not in a handler

`require_human_confirmation` called `.get()` on the parsed body from inside `enforce_human_in_loop` — the `before_request` hook that runs ahead of **every** non-exempt POST/PUT on `r6_blueprint`. That is the same hook that made per-handler guards unreachable in #312. Fixing it covers `create_resource` and every other `r6_blueprint` write at once.

## Four sites

| Site | Change |
|---|---|
| `r6/health_compliance.py` | the hook returns `False` for a non-dict body |
| `r6/routes.py` `create_resource` | `if not body` → `if not isinstance(body, dict)` |
| `r6/routes.py` `ingest_context` | same shape |
| `r6/smbp/routes.py` `enroll` | same shape |

Truthiness was the bug in `create_resource`: `[1]`, `42` and `"text"` are all truthy and none has `.get()`.

**The hook returning `False` is not a gate being skipped.** It says "this is not a clinical write I can identify" — true, since a list has no `resourceType` — and the request is still refused by the handler that owns what a valid body looks like. A test pins that a real clinical dict still trips the gate, so the tolerance cannot widen into a bypass.

`propose_action` already had this check and was the only one of the five that did; the others now match it.

## Verification

Re-ran the repro myself, `[1]` with only a tenant header:

| Path | before | after |
|---|---|---|
| `POST /r6/fhir/Patient` | **500** | 400 |
| `POST /Bundle/$ingest-context` | **500** | 400 |
| `POST /r6/smbp/enroll` | **500** | 400 |
| `POST /r6/actions/propose` | 400 | 400 |

The test parametrizes six non-object bodies across four paths and asserts no 5xx — **13 failures on `main`, 0 here**. Full suite **2288 passed**; matrix 172 passed / 0 failed / 0 xpassed; conformance **Grade A**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)