### PR TITLE
docs: the integrator recipe under-reported which tools need a step-up token

### DIFF
--- a/docs/recipes/any-agent-framework.md
+++ b/docs/recipes/any-agent-framework.md
@@ -26,10 +26,22 @@ a tool-schema shim.
   - `HealthClawClient(mcp_base_url, tenant_id, step_up_token).call(name, args)` →
     relays to `/mcp/rpc`, carrying `X-Tenant-Id` / `X-Step-Up-Token`.
 
-Read-tier tools need only `X-Tenant-Id` (public tenants) or a tenant-bound token;
-write-tier tools (`fhir_commit_write`, `action_commit`, `shl_generate`, `questionnaire_extract`)
-require `X-Step-Up-Token`. Mint one with `fhir_get_token` or
-`POST /r6/fhir/internal/step-up-token`.
+Read-tier tools need only `X-Tenant-Id` (public tenants) or a tenant-bound
+token. **Every** write-tier tool requires `X-Step-Up-Token` — the gate reads the
+tool's declared `tier`, so the list below is the tier, not a second list that
+can drift out of step with it:
+
+`action_commit`, `action_propose`, `curatr_apply_fix`, `fhir_commit_write`,
+`fhir_propose_write`, `questionnaire_extract`, `rx_transfer_request`,
+`shl_generate`.
+
+Mint a token with `fhir_get_token` or `POST /r6/fhir/internal/step-up-token`.
+
+Two of these will surprise you if you used an older build. `questionnaire_extract`
+needs a token **even with `dry_run=true`**, and the `*_propose` tools need one
+even though they only draft — the client gates on tier rather than on what the
+server happens to require per argument, so there is one rule to reason about
+instead of a per-tool exception list.
 
 ## OpenAI (Agents SDK / Chat Completions)
 

--- a/tests/test_write_tier_docs_match_code.py
+++ b/tests/test_write_tier_docs_match_code.py
@@ -1,0 +1,73 @@
+"""The documented write-tier tool list must match the tier declared in code.
+
+`docs/recipes/any-agent-framework.md` told integrators which tools need
+`X-Step-Up-Token`. It listed four. The gate then moved from a hardcoded name
+list to the declared `tier` (#328), which made it eight — and the doc was left
+stale in the *other* direction: it now under-reported which tools need a token,
+so an integrator following it would build a client that 400s on four tools.
+
+That is the same drift class as the tool manifest, which claimed to be
+generated and was not. The answer there was a generator plus a test; the answer
+here is this test. A prose list that restates a value the code owns needs
+something holding the two together, or it is only accurate on the day it is
+written.
+
+Scope: this checks the doc does not CONTRADICT the code. It cannot check that
+the surrounding prose is true.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+TOOLS_TS = REPO_ROOT / 'services' / 'agent-orchestrator' / 'src' / 'tools.ts'
+RECIPE = REPO_ROOT / 'docs' / 'recipes' / 'any-agent-framework.md'
+
+# `name: "x", ... tier: "write"` within one registration object. Non-greedy up
+# to the next `}` keeps it inside a single entry.
+_WRITE_TIER = re.compile(r'name:\s*"([a-z_]+)"[^}]*?tier:\s*"write"', re.S)
+
+
+def _write_tier_tools() -> set[str]:
+    return set(_WRITE_TIER.findall(TOOLS_TS.read_text(encoding='utf-8')))
+
+
+def test_the_registry_still_declares_write_tier_tools():
+    """Guards the guard: a regex that matches nothing would pass everything."""
+    tools = _write_tier_tools()
+    assert len(tools) >= 5, (
+        f'only {len(tools)} write-tier tools found in tools.ts — the pattern '
+        'has probably stopped matching, which would make the next assertion '
+        'vacuous')
+
+
+def test_every_write_tier_tool_is_named_in_the_integrator_recipe():
+    """MUTATION: delete a tool name from the recipe's list -> red.
+
+    An integrator who builds against a short list ships a client that 400s on
+    the tools it omitted.
+    """
+    doc = RECIPE.read_text(encoding='utf-8')
+    missing = sorted(t for t in _write_tier_tools() if f'`{t}`' not in doc)
+    assert not missing, (
+        'these tools are tier:"write" in tools.ts but are not named in '
+        f'{RECIPE.relative_to(REPO_ROOT)}: {", ".join(missing)}. A client '
+        'built from that doc will be refused when it calls them without a '
+        'step-up token.')
+
+
+def test_the_recipe_does_not_promise_a_write_tool_needs_no_token():
+    """The specific false claim that shipped: naming a write-tier tool as an
+    example of something safe to call without step-up.
+
+    MUTATION: re-add 'Safe to call without step-up' next to a write tool -> red.
+    """
+    doc = RECIPE.read_text(encoding='utf-8').lower()
+    for tool in sorted(_write_tier_tools()):
+        for phrase in ('safe to call without step-up',
+                       f'{tool} does not require'):
+            assert phrase not in doc, (
+                f'the recipe tells integrators {tool!r} needs no step-up '
+                'token, but it is declared tier:"write"')


### PR DESCRIPTION
Flagged as out-of-lane by the #328 work and picked up here.

## The drift

#328 moved the MCP step-up gate from a hardcoded name list to the declared `tier`, taking the gated set from **3 to 8**. `docs/recipes/any-agent-framework.md` still listed four names — stale in the direction that costs an integrator real time: build a client from that list and it is refused on four tools with no hint why.

## The fix

All eight are listed, and the prose now says the gate reads the **tier** — so it describes the rule rather than restating a set that can drift from it.

Two surprises are called out explicitly, because an older build teaches them wrong:
- `questionnaire_extract` needs a token **even with `dry_run=true`**
- the `*_propose` tools need one even though they only draft

## The guard

`tests/test_write_tier_docs_match_code.py` holds the doc and `tools.ts` together. This is the same drift class as the tool manifest that claimed to be generated and wasn't — the answer there was a generator plus a test, and a prose list restating a value the code owns needs the same treatment or it is accurate only on the day it is written.

**Verified both directions:** 3 pass on the corrected doc; the name-coverage test goes red against the stale one.

It is honest about its reach — it checks the doc does not *contradict* the code, and cannot check the surrounding prose is true. It also guards itself: a regex that stopped matching would make the real assertion vacuous, so the match count is asserted first.

Full suite **2291 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)