### PR TITLE
feat(access): migrate the SMBP step-up gate onto require_grant (slice 3)

### DIFF
--- a/r6/smbp/routes.py
+++ b/r6/smbp/routes.py
@@ -12,8 +12,8 @@ import logging
 from flask import Blueprint, request, jsonify, Response
 
 from r6.models import R6Resource, db
+from r6.access import Scope, Tenant, TenantSource, require_grant
 from r6.audit import record_audit_event
-from r6.stepup import validate_step_up_token
 from r6.smbp.models import SMBPSession
 from r6.smbp.monitoring import build_bp_observation
 from r6.smbp.triage import classify
@@ -79,13 +79,16 @@ def reading():
     if not tenant_id:
         return jsonify(_oo("error", "security", "X-Tenant-Id required")), 400
 
-    step_up = request.headers.get("X-Step-Up-Token")
-    if not step_up:
-        return jsonify(_oo("error", "security",
-                           "reading requires X-Step-Up-Token")), 401
-    valid, _err = validate_step_up_token(step_up, tenant_id)
-    if not valid:
-        return jsonify(_oo("error", "security", "Invalid step-up token")), 401
+    # Access kernel, slice 3 (docs/2026-08-03-access-kernel-spec.md §2.5). The
+    # 401/401 dialect below is the one this route already answered; normalizing
+    # 401 vs 403 across the seven gates is a separate, deliberate decision.
+    # Tenant reading stays as it is — `_tenant()` migrates in slice 9.
+    grant = require_grant(
+        scope=Scope.WRITE,
+        tenant=Tenant(id=tenant_id, source=TenantSource.HEADER),
+        absent_status=401,
+        rejected_status=401,
+    )
 
     body = request.get_json(silent=True) or {}
     try:
@@ -99,13 +102,15 @@ def reading():
 
     triage = classify(systolic, diastolic, body.get("symptoms"))
     obs = build_bp_observation(patient_ref, systolic, diastolic, effective)
+    # grant.tenant_id, not the header: the handler must not be able to write to
+    # a tenant the grant did not authorize (spec §3(e)).
     row = R6Resource(resource_type="Observation",
-                     resource_json=json.dumps(obs), tenant_id=tenant_id)
+                     resource_json=json.dumps(obs), tenant_id=grant.tenant_id)
     db.session.add(row)
     db.session.commit()
     record_audit_event("create", "Observation", row.id,
                        agent_id=request.headers.get("X-Agent-Id"),
-                       tenant_id=tenant_id,
+                       tenant_id=grant.tenant_id,
                        detail="smbp reading band=%s" % triage["band"])
     return jsonify({"observation_id": row.id, "triage": triage}), 201
 

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -906,7 +906,11 @@ def test_outcome_response_is_the_shipped_shape_with_a_status(app):
 #: the one production module allowed to import r6.access. Nothing else may:
 #: a route module importing the kernel means a guard has been migrated, and
 #: that is a later slice with its own PR and its own pin.
-_ADOPTION_ALLOWED = {'main.py'}
+#:
+#: Adoption is a reviewable list. Each entry names the slice that added it:
+#:   main.py            slice 2 — register_error_handlers/install_audit_assertions
+#:   r6/smbp/routes.py  slice 3 — reading()'s step-up gate -> require_grant
+_ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():


### PR DESCRIPTION
The **first real migration** of a live guard onto the kernel. Slices 1–2 added it and registered it; nothing used it until now.

Site chosen per spec §2.5: one call site, the majority 401 dialect, existing matrix rows, and — the point — **not on `r6_blueprint`**, so this proves the kernel's error handler reaches the blueprints the old `before_request` hooks never covered.

## Before / after

```python
# before
step_up = request.headers.get("X-Step-Up-Token")
if not step_up:
    return jsonify(_oo("error", "security", "reading requires X-Step-Up-Token")), 401
valid, _err = validate_step_up_token(step_up, tenant_id)
if not valid:
    return jsonify(_oo("error", "security", "Invalid step-up token")), 401

# after
grant = require_grant(scope=Scope.WRITE,
                      tenant=Tenant(id=tenant_id, source=TenantSource.HEADER),
                      absent_status=401, rejected_status=401)
```

The `validate_step_up_token` import is deleted (protocol rule 8 — migrated code goes with it), and the Observation row and AuditEvent are now scoped to `grant.tenant_id` instead of re-reading the header, so the handler cannot act on a tenant the grant didn't authorize.

Two calls worth checking: **`Scope.WRITE`, not `TENANT_BOUND`** — the old call passed no `require_scope`, and that parameter *defaults to `'write'`* (`r6/stepup.py:175`), so the route already rejected read-scoped tokens; verified on the wire, a `scope="read"` token gets 401 before and after. And **tenant reading is untouched** — `_tenant()` is slice 9's job; adopting `tenant_from_request` here would smuggle a different slice's 400 dialect change into this one.

## ⚠️ One wire change — and it decides slices 4–8

`require_grant` **strips** the token (`r6/access.py:286`). A **valid** token sent with surrounding whitespace now returns 201 where this route returned 401. Confirmed empirically, not inferred.

It is **authority-neutral** — the HMAC must still verify for this tenant, so nobody gets in who wasn't already in — but it is a real change on a security gate, and no test covered it, which is why it took a measurement rather than a test run to find.

**My recommendation: keep the strip.** `r6/read_auth.py:86` **already strips today**. If the kernel didn't, migrating that site in slice 8 would start *rejecting* tokens that work now — a narrowing, and a worse outcome than this widening. Stripping makes seven sites agree instead of leaving two behaviours in one codebase.

The five sites that don't strip today (`r6/routes.py:475, 640, 3032, 3427`, `r6/actions/review.py:63`, plus `r6/agent_runs/routes.py:52`) will inherit this in slices 4–8, so it is worth ruling once here rather than six times over. Filed separately for that decision.

Also: the absent-token diagnostic changes from `"reading requires X-Step-Up-Token"` to the kernel's `"Step-up token required"`. 401 either way, same OperationOutcome shape; grepped — nothing pins the old string.

## Protocol compliance

**The `tests/` diff is the one authorized line** — `_ADOPTION_ALLOWED` gains `'r6/smbp/routes.py'`, with a comment naming which slice added each entry. Nothing else changed. All four `smbp-reading` rows in the guard matrix pass **untouched**, which is the proof that behaviour is unchanged.

`git revert` of this commit produces a tree **byte-identical to `origin/main`**, suite green, no follow-up edit — verified.

## Verification

- Wire behaviour measured across **12 cases** on both `main` and this branch (no headers, tenant-only, empty/garbage/foreign-tenant/expired/read-scoped/whitespace tokens, valid, valid-with-bad-body, unparseable body). Identical except the two documented above.
- **Mutations:** replacing `require_grant` with a hand-built `Grant` reddens 5 tests including all four matrix rows; passing the wrong tenant reddens 3.
- Full suite **2288 passed** — identical to the same base without this commit, measured explicitly. Matrix 172 passed / 0 failed / 0 xpassed. Conformance **Grade A**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)