### PR TITLE
fix(access): the audit assertion observes the row, not the call (#321)

### DIFF
--- a/docs/2026-08-03-access-kernel-spec.md
+++ b/docs/2026-08-03-access-kernel-spec.md
@@ -553,7 +553,7 @@ After 11k, and only then: add the grep guard that fails if
 
 | # | Content | Notes |
 |---|---|---|
-| 12 | `audit()` adopted per blueprint, `record_audit_event` kept as a shim | `install_audit_assertions` is already registered (slice 2) and is inert for unmigrated sites, because only `audit()` writes the `g` marker. So the guard arrives with the first migrated site automatically. |
+| 12 | `audit()` adopted per blueprint, `record_audit_event` kept as a shim | `install_audit_assertions` is already registered (the #321 fix) and is inert for unmigrated sites — but NOT because only `audit()` writes the `g` marker: since #321 any `AuditEventRecord` flush writes it. It is inert because `record_audit_event` commits, and a commit clears the marker. So the guard arrives with the first migrated site automatically. |
 | 12x | `install_read_audit_assertion` | Its own PR. Goes red on the five S-9 paths on arrival. That redness is the pin, and the fix is a separate PR after it. |
 | 13 | Retire `record_audit_event`'s ambient commit (`r6/audit.py:92`) | Last of the audit work, after every writer owns its commit. Postgres lane matters most here. |
 | 14 | `fhir_response` / `outcome_response` / `unredacted_response` | Read paths first, per blueprint. S-11 (`r6/routes.py:719-723`) is a behavior FIX, so it ships alone with its own pin, not inside a shaping migration. |

--- a/main.py
+++ b/main.py
@@ -271,16 +271,18 @@ def _register_request_hooks(flask_app: Flask) -> None:
     # the URL is the credential, and the route must work with no headers).
     # Behaviourally inert today: nothing raises StepUpDenied or calls audit()
     # yet, since the kernel is still adopted by no production module.
-    # Neither audit assertion is installed here. install_read_audit_assertion
-    # goes red on the five unaudited-404 paths (S-9). install_audit_assertions
-    # has a demonstrated false-positive class (see #321): audit() sets its
-    # pending marker unconditionally, but only real session activity clears
-    # it, so any caller whose writer wrote nothing trips it with no row
-    # pending. Installing a control that fires when its property is NOT
-    # violated is how controls get silenced. Both wait for their own slice.
-    from r6.access import register_error_handlers
+    # install_audit_assertions is registered here (#321), before any audit()
+    # adoption rather than with it — a guard that arrives alongside the
+    # migration it guards protected nobody. Testing-mode only: it fails a
+    # request that flushed an AuditEvent and returned without resolving the
+    # transaction. It does NOT catch a flush that is rolled back behind a 2xx;
+    # docs/2026-08-03-audit-assertion-ruling.md lists that gap and six others.
+    # install_read_audit_assertion stays unregistered: it goes red on the five
+    # unaudited-404 paths (S-9), and that redness is its own slice (12x).
+    from r6.access import install_audit_assertions, register_error_handlers
 
     register_error_handlers(flask_app)
+    install_audit_assertions(flask_app)
 
     @flask_app.context_processor
     def inject_fasten_public_key():

--- a/r6/access.py
+++ b/r6/access.py
@@ -36,6 +36,7 @@ from r6 import fhir_proxy as _fhir_proxy_mod
 from r6 import health_compliance as _compliance_mod
 from r6 import redaction as _redaction_mod
 from r6 import stepup as _stepup_mod
+from r6.models import AuditEventRecord
 from r6.read_auth import TENANT_SESSION_KEY
 
 logger = logging.getLogger(__name__)
@@ -411,17 +412,17 @@ def _render_tenant_rejected(exc: TenantRejected):
 # §1.3 Audit
 # ---------------------------------------------------------------------------
 
-#: flask.g attribute set by audit() and CLEARED when the session commits or
-#: rolls back. Set means "an audit row is flushed into a transaction nobody has
-#: resolved yet" — the state install_audit_assertions refuses to let a request
-#: end in.
+#: flask.g attribute set when an AuditEventRecord goes through a flush, and
+#: CLEARED when the session commits or rolls back that transaction. Set means
+#: "an audit row is flushed into a transaction nobody has resolved yet" — the
+#: state install_audit_assertions refuses to let a request end in.
 #:
 #: The spec words this condition as "db.session.new or db.session.dirty is
 #: non-empty at teardown". Measured, that condition can never fire: flush()
 #: moves the AuditEvent out of session.new into the persistent identity map,
 #: so both sets are empty for exactly the request this control exists to
-#: catch. A marker cleared by the commit/rollback events is the same property
-#: with a signal that actually observes it. See the PR body.
+#: catch. Reading session.new from inside after_flush is the same property
+#: with a signal that actually observes it. See _install_marker_listeners.
 _AUDIT_PENDING = '_hc_access_audit_pending'
 
 #: flask.g attribute recording that audit() ran at least once in this request,
@@ -473,7 +474,10 @@ def audit(
     sanitizer that silently drops PHI is worse than a reviewer who sees the
     string. Composition of the detail line stays where the facts are.
 
-    Records the flush on ``g`` for install_audit_assertions.
+    Records that an audit was emitted on ``g`` for
+    install_read_audit_assertion. The PENDING marker install_audit_assertions
+    reads is not set here — it is set by the flush that carries the row, so a
+    call that wrote nothing leaves nothing pending (#321).
     """
     tenant_id = tenant.id if isinstance(tenant, Tenant) else tenant
     _install_marker_listeners()
@@ -489,8 +493,15 @@ def audit(
         outcome_detail_code=outcome_detail_code,
     )
     if has_app_context():
-        setattr(g, _AUDIT_PENDING, True)
         setattr(g, _AUDIT_EMITTED, True)
+
+
+def _set_pending_marker(session_, _flush_context, *_args) -> None:
+    """An AuditEventRecord is going to the database in an open transaction."""
+    if not has_app_context():
+        return
+    if any(isinstance(obj, AuditEventRecord) for obj in session_.new):
+        setattr(g, _AUDIT_PENDING, True)
 
 
 def _clear_pending_marker(*_args) -> None:
@@ -499,8 +510,35 @@ def _clear_pending_marker(*_args) -> None:
         g.pop(_AUDIT_PENDING, None)
 
 
+def _clear_on_soft_rollback(_session, previous_transaction=None) -> None:
+    """after_soft_rollback also fires for a SAVEPOINT, which resolves nothing.
+
+    A nested rollback leaves the audit row pending in the OUTER transaction, so
+    clearing on it is a false negative — and it is the exact path
+    record_audit_event takes when the audit write fails (r6/audit.py:105), the
+    function slices 12 and 13 migrate away from.
+
+    Do NOT write this as session.in_transaction(): inside after_commit the
+    session still reports a transaction, so that variant breaks the commit
+    cases. previous_transaction.nested is the discriminator.
+    """
+    if previous_transaction is not None and previous_transaction.nested:
+        return
+    _clear_pending_marker()
+
+
 def _install_marker_listeners() -> None:
-    """Attach the commit/rollback listeners that clear the pending marker.
+    """Attach the session listeners that set and clear the pending marker.
+
+    Set and clear run on the same mechanism on purpose. The marker follows the
+    ROW — an AuditEventRecord in a flush — not the call to audit(). Keying it
+    to the call makes a faked writer that wrote nothing fail its request, with
+    the assertion firing when its property was never violated (#321).
+
+    session.new is read inside after_flush, where SQLAlchemy still holds it in
+    its pre-flush state. At teardown it is empty for exactly the request this
+    control exists to catch, which is why the spec's original condition could
+    never fire.
 
     Idempotent and once per process: SQLAlchemy session events are global, so
     installing per app would stack one listener per Flask app the suite makes.
@@ -509,8 +547,9 @@ def _install_marker_listeners() -> None:
     if _marker_listeners_installed:
         return
     from sqlalchemy import event
+    event.listen(db.session, 'after_flush', _set_pending_marker)
     event.listen(db.session, 'after_commit', _clear_pending_marker)
-    event.listen(db.session, 'after_soft_rollback', _clear_pending_marker)
+    event.listen(db.session, 'after_soft_rollback', _clear_on_soft_rollback)
     _marker_listeners_installed = True
 
 
@@ -548,13 +587,20 @@ def install_audit_assertions(app) -> None:
 
     Installed as a teardown_request, active only when app.config['TESTING']
     or HC_ASSERT_AUDIT_COMMITTED is set. It fires when g still carries the
-    pending marker at teardown — the signature of a handler that called
-    audit() and then returned without commit() or rollback(). A rollback path
+    pending marker at teardown — the signature of a handler that flushed an
+    AuditEvent and returned without commit() or rollback(). An outer rollback
     clears the marker and passes, correctly: a refused write should carry no
-    audit row.
+    audit row. A SAVEPOINT rollback does not clear it, because it resolves
+    nothing.
 
     Without this, moving 41 sites from an ambient commit to a caller-owned
     commit is 41 chances to drop an audit row behind a 201.
+
+    WHAT IT DOES NOT CATCH (see docs/2026-08-03-audit-assertion-ruling.md for
+    the full list of seven): a handler that flushes an audit row, rolls the
+    transaction back, and still answers 2xx. The marker clears and this passes,
+    though the audit row is gone from behind a success. That needs a second
+    control, not a change to this one.
     """
     _install_marker_cleanup(app)
     _install_marker_listeners()

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -675,6 +675,117 @@ def test_the_assertion_is_off_when_neither_testing_nor_the_env_var_is_set(
     db.session.rollback()
 
 
+def test_a_faked_writer_that_wrote_nothing_does_not_trip_the_assertion(
+        app, tenant_id, monkeypatch):
+    """#321: the marker follows the ROW, not the call to audit().
+
+    Faking r6.audit.add_audit_event is how the migration's own tests are
+    written. Under the old design audit() set the marker unconditionally and
+    nothing cleared it, so a writer that wrote nothing failed the request with
+    no row pending — a control firing when its property is NOT violated.
+
+    MUTATION: set _AUDIT_PENDING in audit() again -> red.
+    """
+    monkeypatch.setattr('r6.audit.add_audit_event',
+                        lambda event_type, **kwargs: None)
+    _audit_routes(app, tenant_id)
+    install_audit_assertions(app)
+    assert app.test_client().post('/kernel/flush-only').status_code == 201
+
+
+def test_a_faked_writer_after_a_real_query_does_not_trip_the_assertion(
+        app, tenant_id, monkeypatch):
+    """The regression for the rejected in_transaction() gate.
+
+    Every production handler reads the database before it audits, so a gate on
+    transaction state fires on a faked writer in every one of them. The row is
+    the discriminator; an open transaction is not.
+    """
+    from r6.models import AuditEventRecord
+
+    monkeypatch.setattr('r6.audit.add_audit_event',
+                        lambda event_type, **kwargs: None)
+
+    @app.route('/kernel/read-then-audit', methods=['POST'])
+    def read_then_audit():
+        AuditEventRecord.query.filter_by(tenant_id=tenant_id).count()
+        audit(tenant=tenant_id, event_type='create', detail='faked writer')
+        return '', 201
+
+    install_audit_assertions(app)
+    assert app.test_client().post('/kernel/read-then-audit').status_code == 201
+
+
+def test_a_row_flushed_without_going_through_audit_still_fails_the_request(
+        app, tenant_id):
+    """The marker is set by the flush, so it covers the shipped writer too.
+
+    MUTATION: gate _set_pending_marker on audit() having run -> red.
+    """
+    from r6.audit import add_audit_event
+
+    @app.route('/kernel/raw-writer', methods=['POST'])
+    def raw_writer():
+        add_audit_event('create', tenant_id=tenant_id, detail='raw')
+        return '', 201
+
+    install_audit_assertions(app)
+    with pytest.raises(AuditAssertionError):
+        app.test_client().post('/kernel/raw-writer')
+    db.session.rollback()
+
+
+def test_a_pending_row_that_is_not_an_audit_row_is_none_of_its_business(
+        app, tenant_id):
+    """The marker follows an AuditEventRecord, not any flush.
+
+    Without this the guard quietly widens into "no request leaves ANY pending
+    write", which is a property it was never asked to assert and which fires
+    on every unmigrated write handler. That widening is how a control stops
+    meaning what its name says (docs/2026-08-02-retro.md).
+
+    MUTATION: set the marker for every flush in _set_pending_marker -> red.
+    """
+    from r6.models import R6Resource
+
+    @app.route('/kernel/flush-a-plain-row', methods=['POST'])
+    def flush_a_plain_row():
+        db.session.add(R6Resource(
+            'Observation', '{"resourceType": "Observation"}',
+            resource_id='kernel-1', tenant_id=tenant_id))
+        db.session.flush()
+        return '', 201
+
+    install_audit_assertions(app)
+    assert app.test_client().post('/kernel/flush-a-plain-row').status_code == 201
+    db.session.rollback()
+
+
+def test_rolling_back_a_savepoint_does_not_satisfy_the_assertion(
+        app, tenant_id):
+    """A SAVEPOINT rollback leaves the audit row pending in the OUTER
+    transaction, so it must not clear the marker.
+
+    This is not hypothetical: record_audit_event's failure path
+    (r6/audit.py:105) rolls back exactly this savepoint, and that is the
+    function slices 12 and 13 migrate away from. A guard with a masking path
+    through the code being migrated is not a guard.
+
+    MUTATION: drop the `previous_transaction.nested` check in
+    _clear_on_soft_rollback -> red.
+    """
+    @app.route('/kernel/flush-then-savepoint-rollback', methods=['POST'])
+    def flush_then_savepoint_rollback():
+        audit(tenant=tenant_id, event_type='create', detail='pending')
+        db.session.begin_nested().rollback()
+        return '', 201
+
+    install_audit_assertions(app)
+    with pytest.raises(AuditAssertionError):
+        app.test_client().post('/kernel/flush-then-savepoint-rollback')
+    db.session.rollback()
+
+
 # ---------------------------------------------------------------------------
 # §1.3.1 install_read_audit_assertion
 # ---------------------------------------------------------------------------
@@ -1234,16 +1345,16 @@ def test_the_app_factory_registers_both_kernel_handlers():
     assert TenantRejected in registered, 'TenantRejected handler not registered'
 
 
-def test_neither_audit_assertion_is_installed_yet():
-    """Slice 2 registers the error handlers only.
+def test_the_audit_assertion_is_installed_and_the_read_one_is_not():
+    """#321 is fixed, so install_audit_assertions ships BEFORE the first
+    audit() adoption — a guard that arrives with the migration it guards is a
+    guard nobody was protected by.
 
-    install_read_audit_assertion goes red on the five unaudited-404 paths
-    (S-9). install_audit_assertions has a demonstrated false-positive class
-    (#321): audit() sets its pending marker unconditionally while only real
-    session activity clears it, so a caller whose writer wrote nothing trips
-    it with no row pending. A control that fires when its property is NOT
-    violated is one someone eventually silences, so neither ships until it
-    holds.
+    install_read_audit_assertion still ships nowhere. It goes red on the five
+    unaudited-404 paths (S-9) on arrival, and that redness is its own slice
+    (spec §2.7, 12x).
+
+    MUTATION: delete the install_audit_assertions call in main.py -> red.
     """
     import main
     flask_app = main.create_app({
@@ -1251,8 +1362,11 @@ def test_neither_audit_assertion_is_installed_yet():
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
         'LEGACY_BOOT_ON_CREATE': False,
     })
-    installed = [f.__name__ for fns in flask_app.teardown_request_funcs.values()
+    teardowns = [f.__name__ for fns in flask_app.teardown_request_funcs.values()
                  for f in fns]
-    assert not any('read_audit' in n or 'audit_committed' in n
-                   for n in installed), (
-        f'an audit assertion is registered too early: {installed}')
+    assert any('audit_committed' in n for n in teardowns), (
+        f'install_audit_assertions is not registered: {teardowns}')
+    after = [f.__name__ for fns in flask_app.after_request_funcs.values()
+             for f in fns]
+    assert not any('read_audited' in n for n in teardowns + after), (
+        f'install_read_audit_assertion is registered too early: {after}')


### PR DESCRIPTION
Implements the CTO ruling (#335). **Unblocks slices 12–13**, which move 41 call sites off `record_audit_event`'s ambient commit.

## The fix

`audit()` no longer sets the pending marker. An `after_flush` listener sets it, and only when an `AuditEventRecord` is in `session.new` *inside the flush* — where it is still populated. Set and clear now run on the same mechanism, which is what removes the false positive: a faked writer never flushes a row, so nothing is ever marked pending.

The subtle one, straight from the ruling: **`after_soft_rollback` now skips nested transactions.** A savepoint rollback was clearing the marker while the row was still pending, and `record_audit_event`'s own failure path (`r6/audit.py:105`) takes exactly that route.

`install_audit_assertions` is now registered in `main.py`. `install_read_audit_assertion` remains registered nowhere — it goes red on the five unaudited-404 paths and is its own slice.

## The ruling's mutation (b) killed nothing — so a fifth test exists

Making the `after_flush` listener set the marker for **every** flush left the whole 2295-test suite green. No existing test flushes a non-audit row and returns without committing, so the ruling's four tests could not see it.

Dev added `test_a_pending_row_that_is_not_an_audit_row_is_none_of_its_business` rather than report an unkilled mutation. Without it the guard can silently widen into "no request leaves *any* pending write" — a different property, and one that would fire on every unmigrated write handler. **I re-ran both mutations myself** and confirmed each is now caught by exactly one test.

## What this control still does NOT catch

Stated because the value is in knowing the boundary, not in the green tick. The load-bearing gap: **flush → rollback → 2xx.** A handler that flushes an audit row, rolls back, and still answers 201 loses the record behind a success, and this assertion passes it — the rollback clears the marker. That is the failure the guard's own docstring describes. It needs a second control (ruling follow-up A), not a tweak to this one.

Six more, briefly: requests only (no CLI, worker or background thread); test-time only, production unprotected by design; one session; failing requests skipped; content unchecked (a row landed — nothing about tenant, accuracy, or PHI in `detail`); and **the ambient commit is invisible to it** — `after_commit` clears the marker whether the caller committed deliberately or `record_audit_event` committed on its behalf, so it does nothing to detect what slice 13 removes.

Net: it asserts *no request leaves an audit row flushed into an unresolved transaction*, and nothing broader. Worth having before slice 12's 41 call sites; not an audit-completeness check.

## Verification

- Full suite **2296 passed**, 0 failed · matrix **172 passed, 0 failed, 0 xpassed** · conformance **Grade A** · ruff clean
- Three mutations, full suite each: the nested check, the unconditional listener, and unregistering the installer — each reddens exactly one test
- Spec §2.7's stated reason for slice-12 inertness corrected: not "only `audit()` writes the marker" but "`record_audit_event` commits, and a commit clears it"

**Known stale, not fixed here:** `main.py:272-273` and `r6/access.py`'s module docstring still say the kernel is "adopted by nothing" — untrue since #333 and #337. Folding that into the next slice rather than touching files another agent held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)