### PR TITLE
docs: publish two traps that each cost a day

### DIFF
--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -175,6 +175,21 @@ auditor.
 - **A stale branch can silently drop work.** If your branch predates a squash
   merge of the same feature, merging can revert files. Rebase onto current
   `origin/main` and confirm the files you expect are present before pushing.
+- **A request body is parsed before your handler runs.** `enforce_human_in_loop`
+  (`r6/health_compliance.py`) is a `before_request` hook on `r6_blueprint`, and
+  it parses every non-exempt POST/PUT body ahead of every handler. A guard you
+  add *inside* a handler is therefore unreachable for anything the parse itself
+  raises. This produced two unauthenticated 500 levers — a deep-nesting
+  `RecursionError` and a non-object body `AttributeError` — and both times the
+  handler-level fix looked correct, passed review, and changed nothing. If you
+  are hardening a write path against a malformed body, check what runs *above*
+  the handler first.
+- **A strict-xfail row in `tests/test_write_guard_matrix.py` goes red when you
+  FIX the defect it pins.** That is deliberate: a fix must not land while the
+  table still describes the route as broken. The consequence is that a fix PR
+  updates its own matrix row in the *same* PR. Three security PRs skipped that
+  and left `main` red for a day, each of them individually green. The matrix
+  must report **0 failed and 0 xpassed** — an XPASS is a failure, not a pass.
 
 ---
 


### PR DESCRIPTION
Two lessons from this week that belong to everyone, moved into `docs/agent-task-guide.md` §6 rather than left in a local working file. CLAUDE.md's own rule is that anything living only there is a bug.

**A request body is parsed before your handler runs.** `enforce_human_in_loop` is a `before_request` hook on `r6_blueprint` and parses every non-exempt POST/PUT body ahead of every handler — so a guard added *inside* a handler is unreachable for anything the parse itself raises. This produced two unauthenticated 500 levers (a deep-nesting `RecursionError`, #312, and a non-object body `AttributeError`, #330), and **both times the handler-level fix looked correct, passed review, and changed nothing.**

**A strict-xfail row in the write-guard matrix goes red when you *fix* the defect it pins.** That's deliberate — a fix must not land while the table still describes the route as broken. The consequence is that a fix PR updates its own matrix row in the *same* PR. Three security PRs skipped that and left `main` red for a day, each of them individually green against `main` as it stood.

Docs only. Full suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)