### PR TITLE
fix(labs): $interpret with an empty body interpreted nothing

### DIFF
--- a/r6/labs/routes.py
+++ b/r6/labs/routes.py
@@ -19,6 +19,10 @@ from r6.labs.report import (
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on the no-input fallback below. Matches the search route's
+# _count ceiling so one surface cannot quietly read more than the other.
+STORED_OBSERVATION_CAP = 200
+
 _DISCLAIMER = ("Advisory decision support, not a diagnosis. Reference ranges are "
                "adult population defaults and vary by lab, age, sex, and clinical "
                "context. The performing lab's own reference range takes precedence.")
@@ -31,11 +35,37 @@ def register_labs_routes(blueprint, deps):
     def _tenant():
         return (request.headers.get("X-Tenant-Id") or "").strip() or None
 
+    def _stored_observations(tenant_id):
+        """The tenant's own Observations, newest first, capped."""
+        rows = (R6Resource.query
+                .filter_by(resource_type="Observation", tenant_id=tenant_id)
+                .order_by(R6Resource.last_updated.desc())
+                .limit(STORED_OBSERVATION_CAP)
+                .all())
+        return [row.to_fhir_json() for row in rows]
+
     def _observations_from_request(tenant_id):
-        """Return (observations, ignored_count). Tolerates malformed input."""
-        body = request.get_json(silent=True) or {}
-        if not isinstance(body, dict):
-            body = {}
+        """Return (observations, ignored_count). Tolerates malformed input.
+
+        Four inputs, in precedence order: an explicit ?subject (or Parameters
+        subject), a Bundle, a single Observation, or NOTHING — in which case
+        the tenant's own stored Observations are interpreted.
+
+        That last branch is the one CareAgents uses: get_labs posts an empty
+        body and no subject (careagents/healthclaw.py:interpret_labs). It
+        previously matched no branch at all, so the agent interpreted zero
+        observations and told patients their labs were not in their records
+        while the tenant held hundreds.
+
+        "Nothing supplied" is deliberately NOT the same as "something
+        unusable". A junk body (a bare array, a Parameters with an
+        unparseable subject) still counts as ignored input rather than
+        falling through to the whole record set — a malformed request must
+        not silently widen into a full read.
+        """
+        raw = request.get_json(silent=True)
+        body = raw if isinstance(raw, dict) else {}
+        supplied = raw is not None and raw != {}
         subject = request.args.get("subject")
         if body.get("resourceType") == "Parameters":
             for p in body.get("parameter", []):
@@ -60,8 +90,10 @@ def register_labs_routes(blueprint, deps):
                     ignored += 1
         elif body.get("resourceType") == "Observation":
             observations.append(body)
-        elif body:
+        elif supplied:
             ignored += 1
+        else:
+            observations = _stored_observations(tenant_id)
         return observations, ignored
 
     def _patient_for(obs, tenant_id, cache):

--- a/tests/test_labs_routes.py
+++ b/tests/test_labs_routes.py
@@ -1,6 +1,8 @@
 # tests/test_labs_routes.py
 import json
 
+from r6.labs.routes import STORED_OBSERVATION_CAP as _STORED_CAP
+
 
 def _obs(loinc, value, unit):
     return {"resourceType": "Observation", "status": "final",
@@ -72,3 +74,101 @@ def test_interpret_parameters_subject_string_is_graceful(client, tenant_headers)
               "parameter": [{"name": "subject", "valueReference": "Patient/x"}]}
     r = client.post("/r6/fhir/Observation/$interpret", headers=tenant_headers, json=params)
     assert r.status_code == 200
+
+
+# --- the CareAgents call shape -------------------------------------------
+#
+# careagents/healthclaw.py:interpret_labs posts an EMPTY body and no ?subject:
+#
+#     self.http.post(f"{self.fhir}/Observation/$interpret", json={}, ...)
+#
+# Reported live: an agent greeted the user with "I found ... 50 lab results"
+# and then answered "What do my labs say?" with "I don't see any recent blood
+# work results". Both statements came from the same tenant in the same minute.
+# The greeting counts a Observation search; get_labs posts this empty body,
+# which matched no branch of _observations_from_request and interpreted
+# nothing. The tenant held 186 Observations, 179 with a valueQuantity and 4
+# carrying LOINC 2093-3 (total cholesterol) — a code the interpreter knows.
+
+def _stored_obs(app, tenant_id, rid, loinc, value, unit):
+    from r6.models import R6Resource, db
+    with app.app_context():
+        db.session.add(R6Resource(
+            resource_type="Observation",
+            resource_json=json.dumps({
+                "resourceType": "Observation", "id": rid, "status": "final",
+                "code": {"coding": [{"system": "http://loinc.org",
+                                     "code": loinc}]},
+                "subject": {"reference": "Patient/p1"},
+                "valueQuantity": {"value": value, "unit": unit}}),
+            resource_id=rid, tenant_id=tenant_id))
+        db.session.commit()
+
+
+def test_empty_body_interprets_the_tenants_stored_observations(
+        app, client, tenant_headers, tenant_id):
+    """MUTATION: drop the no-input fallback -> total 0 -> red.
+
+    This is the exact call CareAgents makes. Before the fix it returned
+    total=0 with records sitting in the tenant, and the agent told the
+    patient their cholesterol results were not there.
+    """
+    _stored_obs(app, tenant_id, "chol-1", "2093-3", 244, "mg/dL")
+    _stored_obs(app, tenant_id, "k-1", "2823-3", 4.2, "mmol/L")
+
+    r = client.post("/r6/fhir/Observation/$interpret",
+                    headers=tenant_headers, json={})
+
+    assert r.status_code == 200
+    summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
+    assert summary["total"] == 2, (
+        "an empty $interpret body interpreted nothing while the tenant held "
+        "stored Observations — this is the live get_labs bug")
+    assert "2093-3" not in json.dumps(summary), "summary must not echo raw codes"
+
+
+def test_no_body_at_all_interprets_the_tenants_stored_observations(
+        app, client, tenant_headers, tenant_id):
+    """A POST with no JSON body at all must behave like an empty one."""
+    _stored_obs(app, tenant_id, "chol-2", "2093-3", 244, "mg/dL")
+    r = client.post("/r6/fhir/Observation/$interpret", headers=tenant_headers)
+    assert r.status_code == 200
+    summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
+    assert summary["total"] == 1
+
+
+def test_the_stored_fallback_is_bounded(app, client, tenant_headers, tenant_id):
+    """MUTATION: remove the cap -> red.
+
+    The fallback reads every Observation the tenant owns. Unbounded, one chat
+    message would load a full import into memory; the live tenant already
+    holds 186 and an Epic tenant holds far more.
+    """
+    for i in range(_STORED_CAP + 5):
+        _stored_obs(app, tenant_id, f"cap-{i}", "2823-3", 4.2, "mmol/L")
+    r = client.post("/r6/fhir/Observation/$interpret",
+                    headers=tenant_headers, json={})
+    summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
+    assert summary["total"] == _STORED_CAP
+
+
+def test_an_explicit_body_still_wins_over_the_stored_fallback(
+        app, client, tenant_headers, tenant_id):
+    """The fallback must not silently widen an explicit request."""
+    _stored_obs(app, tenant_id, "stored-1", "2823-3", 4.2, "mmol/L")
+    r = client.post("/r6/fhir/Observation/$interpret", headers=tenant_headers,
+                    json={"resourceType": "Bundle", "type": "collection",
+                          "entry": [{"resource": _obs("2345-7", 520, "mg/dL")}]})
+    summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
+    assert summary["total"] == 1 and summary["critical"] == 1
+
+
+def test_the_stored_fallback_is_tenant_scoped(
+        app, client, tenant_headers, tenant_id):
+    """The fallback selects by tenant; another tenant's rows must not appear."""
+    _stored_obs(app, "someone-elses-tenant", "theirs-1", "2093-3", 244, "mg/dL")
+    _stored_obs(app, tenant_id, "mine-1", "2823-3", 4.2, "mmol/L")
+    r = client.post("/r6/fhir/Observation/$interpret",
+                    headers=tenant_headers, json={})
+    summary = json.loads(_resp_param(r.get_json(), "summary")["valueString"])
+    assert summary["total"] == 1


### PR DESCRIPTION
## The report

A patient's agent said, in the same minute, on the same tenant:

> Hi — I'm Rob. I found 50 conditions, 4 medications, and **50 lab results** in your records.

and then, asked "What do my labs say?":

> I don't see any recent blood work results (like a lipid panel or A1c) right now.

## Root cause

`careagents/healthclaw.py:interpret_labs` posts an empty body and no subject:

```python
r = self.http.post(f"{self.fhir}/Observation/$interpret", json={}, headers=..., timeout=...)
```

`_observations_from_request` had four branches — `?subject`, `Bundle`, a single `Observation`, and `elif body: ignored += 1`. An empty dict is falsy, so **the CareAgents call matched none of them** and returned `([], 0)`. `get_labs` has therefore always interpreted zero observations.

The greeting came from a different path (`hc.search(tenant, "Observation")`), which is why the two numbers disagreed.

## Verified against production

Tenant `ca-f674235b99` (MEDENT import, 2026-08-04):

| | |
|---|---|
| Observations | 186 |
| …with a `valueQuantity` | 179 |
| …coded with LOINC | 186 |
| …carrying LOINC `2093-3` (total cholesterol) | **4** |

`2093-3` is already in `LOINC_RANGES`. The data and the interpreter were both fine; nothing was ever handed over.

## The fix

No input now falls back to the tenant's own stored Observations, newest first, capped at `STORED_OBSERVATION_CAP = 200` — the same ceiling the search route clamps `_count` to, so one surface cannot quietly read more than the other.

**"Nothing supplied" is kept distinct from "something unusable."** A bare array, or a `Parameters` whose subject won't parse, still counts as ignored input rather than falling through to the whole record set. A malformed request must not silently widen into a full read, and the pre-existing graceful-degradation tests still pin that.

## Tests

Five new, each with its mutation noted in the docstring:

- `test_empty_body_interprets_the_tenants_stored_observations` — the exact CareAgents call shape; red before this change
- `test_no_body_at_all_interprets_the_tenants_stored_observations`
- `test_the_stored_fallback_is_bounded` — 205 stored, 200 interpreted
- `test_an_explicit_body_still_wins_over_the_stored_fallback`
- `test_the_stored_fallback_is_tenant_scoped`

Full suite: 2330 passed, 12 skipped, 6 xfailed. `uv run ruff check .` clean.

## Deliberately not in this PR

The `?subject` branch loads **every** Observation the tenant owns into memory and filters in Python. Same defect class, different branch, and capping it would truncate callers who get everything today — so it gets its own PR rather than riding along with a fix.

This does **not** close the bigger problem the same session surfaced: the agent still cannot name medications, allergies, or most conditions, because `r6/terminology.py` carries roughly 140 hand-curated labels and a real MEDENT import is not covered by them. That is being measured and filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)