### PR TITLE
feat(terminology): opt-in runtime lookup for codes the static table lacks

### DIFF
--- a/r6/terminology.py
+++ b/r6/terminology.py
@@ -20,14 +20,27 @@ label up here — rather than trusting the string the upstream sent — restores
 readability without reopening the leak, because nothing patient-specific can
 enter through a table keyed by code.
 
-Deliberately a plain dict
--------------------------
-Not a terminology service, not a network call, not a cache. A dict lookup cannot
-time out, cannot fail in production, and can be read and corrected by anyone.
-Unknown codes are LEFT UNLABELLED on purpose: the honest "a record is here that
-I could not read" fallback in the agent is far better than a confident guess,
-and `unlabelled_codes()` reports what is missing so the map can grow from
-evidence rather than speculation.
+A plain dict, consulted first
+-----------------------------
+The table below is still a plain dict, and it still answers without a network
+call, a timeout, or a cache. Every read hits it first.
+
+It used to be the ONLY source, on the reasoning that a dict cannot fail in
+production. That reasoning was right and is unchanged; what changed is the
+evidence about coverage. Measured against a live MEDENT import on 2026-08-04:
+**1 of 15 distinct ICD-10-CM codes and 0 of 11 SNOMED codes carried a label**,
+so the agent named one condition and called the other 25 unreadable. A
+121-entry hand-curated map cannot cover a real EHR export.
+
+So a MISS — and only a miss — may now consult `r6/terminology_resolver.py`,
+which is opt-in per deployment, budgeted so it cannot slow a read, and returns
+None on every failure. Read its module docstring before changing it; the three
+properties it must not lose are written down there.
+
+Unknown codes are still LEFT UNLABELLED rather than guessed: the honest "a
+record is here that I could not read" fallback in the agent is far better than
+a confident invention, and `unlabelled_codes()` reports what is missing so the
+static map can still grow from evidence.
 
 Coverage is primary-care-weighted (the records consumers actually connect):
 common chemistry and hematology panels, vitals, the widespread chronic
@@ -37,6 +50,8 @@ conditions, and high-frequency maintenance medications.
 from __future__ import annotations
 
 import collections
+
+from r6 import terminology_resolver as _resolver_mod
 
 # System URIs, canonical form.
 LOINC = "http://loinc.org"
@@ -216,15 +231,30 @@ def canonical_system(system: str | None) -> str:
 def lookup(system: str | None, code: str | None) -> str | None:
     """The server's label for a code, or None if we don't know it.
 
-    None is a valid, useful answer: the caller says "a record is here I could
+    Static table first, then the opt-in runtime resolver on a miss. None is
+    still a valid, useful answer: the caller says "a record is here I could
     not read" rather than inventing a name.
+
+    The resolver is reached through the MODULE attribute, not a bound import,
+    so a test can replace `r6.terminology_resolver.resolve` by path and have
+    this see it.
     """
     if not code:
         return None
-    label = _LABELS.get((canonical_system(system), str(code).strip()))
-    if label is None:
-        _MISSES[(canonical_system(system), str(code).strip())] += 1
-    return label
+    key = (canonical_system(system), str(code).strip())
+    label = _LABELS.get(key)
+    if label is not None:
+        return label
+
+    try:
+        label = _resolver_mod.resolve(*key)
+    except Exception:  # noqa: BLE001 — a label is never worth failing a read
+        label = None
+    if label is not None:
+        return label
+
+    _MISSES[key] += 1
+    return None
 
 
 def unlabelled_codes(limit: int = 50) -> list[tuple[tuple[str, str], int]]:

--- a/r6/terminology_resolver.py
+++ b/r6/terminology_resolver.py
@@ -1,0 +1,207 @@
+"""Runtime resolution for codes the static label table does not carry.
+
+Why this exists
+---------------
+``r6/terminology.py`` was deliberately a plain dict — "not a terminology
+service, not a network call, not a cache" — because a dict cannot time out and
+cannot fail in production. That reasoning still holds for the read path, and
+nothing here changes it: the dict is still consulted first and still answers
+without touching the network.
+
+What changed is evidence. Measured against a live MEDENT import on 2026-08-04
+(tenant with 52 Conditions, 26 distinct codes): **1 of 15 distinct ICD-10-CM
+codes and 0 of 11 SNOMED codes had a label**. The one hit was E78.5, and it
+produced the agent's entire answer — it reported "High Cholesterol" as the
+patient's key health focus because that was the only row the table could
+translate. A hand-curated table of 121 labels cannot cover a real EHR export,
+and the honest "a record is here I could not read" fallback, applied to 25 of
+26 conditions, is not a product.
+
+So the miss path — and only the miss path — now consults the public
+terminology services ``r6/curatr.py`` already talks to.
+
+Three properties this must never lose
+-------------------------------------
+1. **It cannot break a read.** Every failure mode — disabled, over budget,
+   unknown system, timeout, malformed response, unexpected exception —
+   returns ``None``, which is exactly what the static table returned before.
+   The caller's existing "unreadable record" path handles it.
+
+2. **It cannot make a read slow.** A cold cache with 26 unknown codes and a
+   5s timeout each would add minutes to a chat message. Work is capped per
+   request (``PER_REQUEST_MAX_LOOKUPS``) and by wall clock
+   (``PER_REQUEST_BUDGET_SECONDS``); past either, misses stay misses and are
+   resolved on a later request. A partially-labelled answer now beats a
+   complete one after a timeout.
+
+3. **It cannot leak PHI.** Only ``(system, code)`` is sent. No tenant, no
+   patient, no agent id, no free text. A code's meaning is a property of the
+   code, not of the patient — the same argument that justifies the static
+   table.
+
+The privacy cost, stated plainly
+--------------------------------
+This is a disclosure, just a narrow one. Querying NLM or tx.fhir.org reveals
+which clinical codes exist somewhere in this deployment — not whose they are,
+but the set is clinical information that previously never left the box. It is
+therefore **opt-in**: with ``TERMINOLOGY_LOOKUP_ENABLED`` unset, this module
+does nothing at all and behaviour is byte-identical to before. Deployments
+that cannot accept that disclosure should point ``r6/curatr.py`` at a
+self-hosted terminology server instead of enabling this against public ones.
+
+The cache is per-process and in-memory
+--------------------------------------
+Deliberately not a database table. A cache write during a read would share the
+caller's SQLAlchemy session, and a failed write that rolled it back would
+discard the caller's work — the exact defect shape of #202. A dict cannot do
+that. The cost is that each process re-resolves after a restart, which the
+budget already makes survivable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+from flask import has_request_context, request
+
+from r6 import curatr as _curatr_mod
+
+logger = logging.getLogger(__name__)
+
+ENABLED_ENV = "TERMINOLOGY_LOOKUP_ENABLED"
+_TRUE_VALUES = frozenset({"1", "true", "yes"})
+
+# Per-request ceilings. Both are deliberately small: this runs inside a
+# patient-facing read, and a label is a nicety while a timely answer is not.
+PER_REQUEST_MAX_LOOKUPS = 8
+PER_REQUEST_BUDGET_SECONDS = 0.4
+
+# Systems r6/curatr.py knows how to route. Anything else is an immediate miss
+# rather than a wasted round trip.
+RESOLVABLE_SYSTEMS = frozenset({
+    "http://hl7.org/fhir/sid/icd-10-cm",
+    "http://hl7.org/fhir/sid/icd-10",
+    "http://www.nlm.nih.gov/research/umls/rxnorm",
+    "http://snomed.info/sct",
+    "http://loinc.org",
+})
+
+# (system, code) -> label, or None for a resolved miss. Negative entries are
+# cached too: an unknown code must not be re-queried on every message.
+_CACHE: dict[tuple[str, str], str | None] = {}
+_CACHE_LOCK = threading.Lock()
+
+_ENGINE = None
+_ENGINE_LOCK = threading.Lock()
+
+
+def enabled() -> bool:
+    """Whether runtime lookup is switched on for this deployment."""
+    return os.environ.get(ENABLED_ENV, "").strip().lower() in _TRUE_VALUES
+
+
+def _engine():
+    """One CuratrEngine per process; it owns a pooled requests session."""
+    global _ENGINE
+    if _ENGINE is None:
+        with _ENGINE_LOCK:
+            if _ENGINE is None:
+                _ENGINE = _curatr_mod.CuratrEngine()
+    return _ENGINE
+
+
+_BUDGET_KEY = "r6.terminology_budget"
+
+
+def _budget_state():
+    """Per-request (lookups_used, deadline), or None outside a request.
+
+    Outside a request context there is no budget to enforce — that path is
+    scripts and tests, not a patient waiting on a message.
+
+    Stored on ``request.environ`` rather than ``flask.g`` on purpose. ``g`` is
+    scoped to the APP context, not the request: whenever an app context
+    outlives several requests — a worker, a CLI command, a test that pushes
+    one itself — a ``g``-based budget is spent once and never refills, and
+    every later request silently stops resolving. ``environ`` is created per
+    request by the server, so it cannot leak between them.
+    """
+    if not has_request_context():
+        return None
+    environ = request.environ
+    state = environ.get(_BUDGET_KEY)
+    if state is None:
+        state = {"used": 0, "deadline": time.monotonic() + PER_REQUEST_BUDGET_SECONDS}
+        environ[_BUDGET_KEY] = state
+    return state
+
+
+def _budget_allows() -> bool:
+    state = _budget_state()
+    if state is None:
+        return True
+    if state["used"] >= PER_REQUEST_MAX_LOOKUPS:
+        return False
+    return time.monotonic() < state["deadline"]
+
+
+def _budget_spend() -> None:
+    state = _budget_state()
+    if state is not None:
+        state["used"] += 1
+
+
+def resolve(system: str, code: str) -> str | None:
+    """A label for this code from a terminology service, or None.
+
+    None is always a valid answer and is what every failure returns. Callers
+    treat it exactly as they treated a static-table miss.
+    """
+    if not enabled():
+        return None
+    if not system or not code:
+        return None
+    if system not in RESOLVABLE_SYSTEMS:
+        return None
+
+    key = (system, code)
+    with _CACHE_LOCK:
+        if key in _CACHE:
+            return _CACHE[key]
+
+    if not _budget_allows():
+        # Not cached as a miss: the code is unresolved because we ran out of
+        # room, not because the terminology server said no. Caching it here
+        # would make one slow request poison the label forever.
+        return None
+
+    _budget_spend()
+    label = None
+    try:
+        result = _engine()._lookup_code(system, code)
+        if isinstance(result, dict) and result.get("valid"):
+            display = result.get("display")
+            if isinstance(display, str) and display.strip():
+                label = display.strip()[:512]
+    except Exception:  # noqa: BLE001 — a label is never worth failing a read
+        logger.debug("terminology lookup failed for %s (system %s)",
+                     code, system, exc_info=True)
+        return None
+
+    with _CACHE_LOCK:
+        _CACHE[key] = label
+    return label
+
+
+def cache_size() -> int:
+    with _CACHE_LOCK:
+        return len(_CACHE)
+
+
+def reset_cache() -> None:
+    """Drop the process cache. For tests and for a deliberate refresh."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/tests/test_terminology_resolver.py
+++ b/tests/test_terminology_resolver.py
@@ -1,0 +1,217 @@
+"""Guards for the opt-in runtime terminology resolver.
+
+The resolver exists because a hand-curated table of 121 labels covered 1 of 15
+distinct ICD-10-CM codes on a real MEDENT import. It sits on the PHI read path,
+so the properties that matter are not "does it find labels" but "can it ever
+break, slow, or widen a read". Each test below pins one of those.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from r6 import terminology, terminology_resolver
+
+ICD10 = "http://hl7.org/fhir/sid/icd-10-cm"
+SNOMED = "http://snomed.info/sct"
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    terminology_resolver.reset_cache()
+    terminology.reset_unlabelled()
+    monkeypatch.setenv(terminology_resolver.ENABLED_ENV, "true")
+    yield
+    terminology_resolver.reset_cache()
+
+
+def _never_called(*_args, **_kwargs):
+    raise AssertionError("the terminology service must not have been called")
+
+
+class _Recorder:
+    """Stands in for CuratrEngine._lookup_code and counts calls."""
+
+    def __init__(self, result=None, raises=None, delay=0.0):
+        self.calls: list[tuple[str, str]] = []
+        self._result = result
+        self._raises = raises
+        self._delay = delay
+
+    def __call__(self, system, code):
+        self.calls.append((system, code))
+        if self._delay:
+            time.sleep(self._delay)
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+def _install(monkeypatch, recorder):
+    class _Engine:
+        _lookup_code = staticmethod(recorder)
+
+    monkeypatch.setattr(terminology_resolver, "_engine", lambda: _Engine())
+
+
+# --- the switch ----------------------------------------------------------
+
+def test_disabled_by_default_makes_no_call(monkeypatch):
+    """MUTATION: drop the enabled() guard -> red.
+
+    An unset env var must mean byte-identical behaviour to before this module
+    existed. Nobody's clinical codes start leaving the box on a deploy.
+    """
+    monkeypatch.delenv(terminology_resolver.ENABLED_ENV, raising=False)
+    _install(monkeypatch, _never_called)
+    assert terminology_resolver.resolve(ICD10, "L40.9") is None
+
+
+def test_enabled_resolves_a_code_the_static_table_lacks(monkeypatch):
+    rec = _Recorder({"valid": True, "display": "Psoriasis, unspecified"})
+    _install(monkeypatch, rec)
+    assert terminology.lookup(ICD10, "L40.9") == "Psoriasis, unspecified"
+    assert rec.calls == [(ICD10, "L40.9")]
+
+
+def test_the_static_table_still_wins_and_makes_no_call(monkeypatch):
+    """A hit in the dict must never reach the network."""
+    _install(monkeypatch, _never_called)
+    assert terminology.lookup(ICD10, "E78.5") is not None
+
+
+# --- it cannot break a read ----------------------------------------------
+
+def test_an_exception_is_swallowed_and_reads_as_unlabelled(monkeypatch):
+    """MUTATION: let the exception propagate -> red.
+
+    A terminology outage must degrade to "unreadable record", never to a 500
+    on a patient's chat message.
+    """
+    _install(monkeypatch, _Recorder(raises=RuntimeError("tx down")))
+    assert terminology.lookup(ICD10, "L40.9") is None
+
+
+def test_a_malformed_response_reads_as_unlabelled(monkeypatch):
+    for bad in (None, {}, {"valid": False, "display": "x"},
+                {"valid": True, "display": None},
+                {"valid": True, "display": "   "}, "not-a-dict"):
+        terminology_resolver.reset_cache()
+        _install(monkeypatch, _Recorder(bad))
+        assert terminology_resolver.resolve(ICD10, "L40.9") is None, bad
+
+
+def test_an_unroutable_system_is_never_sent(monkeypatch):
+    """curatr can only route five systems; the rest are an immediate miss."""
+    _install(monkeypatch, _never_called)
+    assert terminology_resolver.resolve(
+        "http://example.org/private-codes", "abc") is None
+
+
+# --- it cannot slow a read -----------------------------------------------
+
+def test_a_resolved_code_is_cached_and_queried_once(monkeypatch):
+    rec = _Recorder({"valid": True, "display": "Psoriasis, unspecified"})
+    _install(monkeypatch, rec)
+    for _ in range(5):
+        terminology_resolver.resolve(ICD10, "L40.9")
+    assert len(rec.calls) == 1
+
+
+def test_an_unknown_code_is_negatively_cached(monkeypatch):
+    """MUTATION: cache only successful lookups -> red.
+
+    Without negative caching, every unknown code costs a round trip on every
+    message forever — the common case on a real import.
+    """
+    rec = _Recorder({"valid": False, "display": None})
+    _install(monkeypatch, rec)
+    for _ in range(5):
+        terminology_resolver.resolve(ICD10, "ZZ.9")
+    assert len(rec.calls) == 1
+
+
+def test_lookups_are_capped_per_request(app, monkeypatch):
+    """MUTATION: remove PER_REQUEST_MAX_LOOKUPS -> red.
+
+    26 unknown codes on a cold cache must not become 26 round trips inside one
+    patient-facing request.
+    """
+    rec = _Recorder({"valid": True, "display": "something"})
+    _install(monkeypatch, rec)
+    with app.test_request_context("/"):
+        for i in range(terminology_resolver.PER_REQUEST_MAX_LOOKUPS + 6):
+            terminology_resolver.resolve(ICD10, f"X{i}.0")
+    assert len(rec.calls) == terminology_resolver.PER_REQUEST_MAX_LOOKUPS
+
+
+def test_the_wall_clock_budget_stops_further_lookups(app, monkeypatch):
+    """MUTATION: drop the deadline check -> red.
+
+    A service that is up but slow is the dangerous case: the call-count cap
+    alone still permits 8 x timeout inside one request.
+    """
+    monkeypatch.setattr(terminology_resolver, "PER_REQUEST_BUDGET_SECONDS", 0.05)
+    rec = _Recorder({"valid": True, "display": "something"}, delay=0.06)
+    _install(monkeypatch, rec)
+    with app.test_request_context("/"):
+        for i in range(6):
+            terminology_resolver.resolve(ICD10, f"Y{i}.0")
+    assert len(rec.calls) == 1
+
+
+def test_a_budget_exhausted_code_is_not_cached_as_a_miss(app, monkeypatch):
+    """Running out of budget is OUR limit, not the server's answer.
+
+    Caching it would let one slow request blank a label permanently.
+    """
+    monkeypatch.setattr(terminology_resolver, "PER_REQUEST_MAX_LOOKUPS", 0)
+    rec = _Recorder({"valid": True, "display": "Psoriasis, unspecified"})
+    _install(monkeypatch, rec)
+    with app.test_request_context("/"):
+        assert terminology_resolver.resolve(ICD10, "L40.9") is None
+    assert terminology_resolver.cache_size() == 0
+
+    monkeypatch.setattr(terminology_resolver, "PER_REQUEST_MAX_LOOKUPS", 8)
+    assert terminology_resolver.resolve(ICD10, "L40.9") == "Psoriasis, unspecified"
+
+
+def test_the_budget_is_per_request_not_per_process(app, monkeypatch):
+    """MUTATION: hold the budget in a module global -> red."""
+    monkeypatch.setattr(terminology_resolver, "PER_REQUEST_MAX_LOOKUPS", 2)
+    rec = _Recorder({"valid": True, "display": "something"})
+    _install(monkeypatch, rec)
+    for req in range(3):
+        with app.test_request_context("/"):
+            for i in range(4):
+                terminology_resolver.resolve(ICD10, f"R{req}-{i}")
+    assert len(rec.calls) == 6
+
+
+# --- it cannot leak ------------------------------------------------------
+
+def test_only_the_system_and_code_are_sent(monkeypatch):
+    """The whole safety argument is that a code's meaning is not patient-specific.
+
+    If anything else ever reaches the wire, that argument fails.
+    """
+    rec = _Recorder({"valid": True, "display": "Psoriasis, unspecified"})
+    _install(monkeypatch, rec)
+    terminology_resolver.resolve(SNOMED, "9014002")
+    assert rec.calls == [(SNOMED, "9014002")]
+
+
+def test_label_codings_still_refuses_to_carry_upstream_display(monkeypatch):
+    """The resolver must not become a way for upstream text to survive.
+
+    A coding arrives with a PHI-bearing display (redaction is what removes it);
+    whatever ends up on the resource must come from the resolver, never from
+    the value that was already there.
+    """
+    _install(monkeypatch, _Recorder({"valid": True, "display": "Psoriasis, unspecified"}))
+    concept = {"coding": [{"system": ICD10, "code": "L40.9",
+                           "display": "Psoriasis for Jane Secret"}]}
+    terminology.label_codings(concept)
+    assert concept["coding"][0]["display"] == "Psoriasis, unspecified"
+    assert "Jane Secret" not in str(concept)


### PR DESCRIPTION
Closes the main defect in #343.

## Measured, not assumed

Against the live MEDENT tenant (52 Conditions, 26 distinct codes):

| system | distinct codes | labelled by `r6/terminology.py` |
|---|---|---|
| ICD-10-CM | 15 | **1** |
| SNOMED CT | 11 | **0** |

The single hit is `E78.5`. It produced the agent's *entire* answer — "High Cholesterol is your key health focus" — because it was the only row the table could translate. The other 25 conditions came back as "records I cannot read clearly", including the three the patient quoted back at us: `L40.9`, `R73.03`, `R07.9`.

`r6/terminology.py` holds 121 labels total, and **zero** SNOMED entries despite declaring SNOMED as a system constant. A hand-curated map cannot cover a real EHR export.

## What this does

On a **miss only**, `lookup()` consults the public terminology services `r6/curatr.py` already routes to — NLM for ICD-10-CM, RxNav for RxNorm, tx.fhir.org for SNOMED and LOINC. The static dict is still consulted first and still answers without touching the network.

This sits on the PHI read path, so the tests pin what it must never do rather than what it finds.

**It cannot break a read.** Disabled, over budget, unroutable system, timeout, malformed response, unexpected exception — every one returns `None`, which is exactly what a static miss returned. The agent's existing "a record is here I could not read" path handles it unchanged.

**It cannot slow a read.** 26 unknown codes at a 5s timeout would add minutes to one chat message. Work is capped at 8 lookups *and* 400ms per request; past either, misses stay misses and resolve on a later request. Budget exhaustion is deliberately **not** cached — that is our limit, not the server's answer, and caching it would let one slow request blank a label permanently.

**It cannot leak.** Only `(system, code)` crosses the wire. No tenant, no patient, no agent id, no free text — the same argument that justifies the static table: a code's meaning is a property of the code, not of the patient.

## The privacy cost, stated plainly

This is still a disclosure, just a narrow one: querying NLM or tx.fhir.org reveals which clinical codes exist somewhere in this deployment. Not whose they are, but the set is clinical information that previously never left the box.

So it is **opt-in**. With `TERMINOLOGY_LOOKUP_ENABLED` unset, this module does nothing and behaviour is byte-identical to before. Deployments that cannot accept that disclosure should point `curatr` at a self-hosted terminology server rather than enable this against public ones. I'd suggest we do exactly that before turning it on for anything beyond a demo tenant.

## Two design choices a test forced

**The budget lives on `request.environ`, not `flask.g`.** `g` is scoped to the *app* context, not the request. `test_the_budget_is_per_request_not_per_process` failed on the first implementation: an app context outliving several requests spends the budget once and never refills it, so every later request silently stops resolving. `environ` is created per request by the server and cannot leak between them.

**The cache is an in-process dict, not a table.** A cache write during a read would share the caller's SQLAlchemy session, and a failed write rolling it back would discard the caller's work — the exact defect shape of #202. A dict cannot do that. The cost is re-resolution after a restart, which the budget makes survivable.

## Tests

14 new in `tests/test_terminology_resolver.py`, grouped by the property each defends, with the killing mutation in each docstring. Including `test_label_codings_still_refuses_to_carry_upstream_display`, which pins that the resolver has not become a back door for upstream `display` to survive redaction — a coding arrives carrying "Psoriasis for Jane Secret" and must leave carrying the resolver's label.

Full suite: 2344 passed, 12 skipped, 6 xfailed. `uv run ruff check .` clean. Conformance still Grade A.

## Still open in #343 after this

- `medicationReference` is never dereferenced, so medication names stay unreadable even with labels working
- an uncoded resource should say "recorded but not coded at the source", not "unreadable to me"
- no guideline-grounded advice path exists for a *diagnosed condition*, which is why the agent fell back to persona filler once it named hyperlipidemia

🤖 Generated with [Claude Code](https://claude.com/claude-code)