### PR TITLE
feat(careagents): 'recorded but not coded at the source' for source-uncoded records

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -184,12 +184,35 @@ def _summarize_bundle(bundle: dict, limit: int = 12,
         else:
             # A record exists but carries no readable label. Say so explicitly
             # and pass the raw code through: dropping the name key entirely
-            # made the record look like nothing, and the model then reported
-            # the condition as ABSENT (#207). Unreadable is not absent.
-            coding = (code.get("coding") or [{}])[0]
-            raw = coding.get("code")
-            item["name"] = (f"unlabeled record, code {raw}" if raw
-                            else "unlabeled record")
+            # made the model report the condition as ABSENT (#207).
+            # Unreadable is not absent.
+            #
+            # Two distinct situations hide here, and they deserve different
+            # sentences because they have different remedies:
+            #
+            # - A code is present but our label table doesn't know it. That is
+            #   OUR gap; "unlabeled record, code X" is accurate and the code
+            #   gives the person something to look up or ask about.
+            # - Nothing codeable ever existed. Live example (MEDENT,
+            #   2026-08-04): an AllergyIntolerance whose only coding carried
+            #   free text — which redaction rightly strips, because real
+            #   feeds put patient names there. No table can ever fix that
+            #   row. Calling it "unreadable to me" sounds like our failure
+            #   and tells the person nothing; "recorded but not coded at the
+            #   source" is what actually happened and points at the fix
+            #   (ask the clinic to code it / confirm details at the visit).
+            raw = next((c.get("code") for c in (code.get("coding") or [])
+                        if isinstance(c, dict) and c.get("code")), None)
+            if raw:
+                item["name"] = f"unlabeled record, code {raw}"
+            else:
+                item["name"] = "recorded but not coded at the source"
+                item["uncoded"] = True
+                item["note"] = (
+                    "The source system sent this record as free text with no "
+                    "standard code, and free text is removed for privacy. It "
+                    "is still a real record — never treat it as absent; "
+                    "suggest confirming the details with the clinician.")
             item["unreadable"] = True
         if res.get("status"):
             item["status"] = res["status"]

--- a/tests/test_uncoded_wording.py
+++ b/tests/test_uncoded_wording.py
@@ -1,0 +1,76 @@
+"""Wording for records that were never coded at the source.
+
+Live example (MEDENT tenant, 2026-08-04): the one AllergyIntolerance carries a
+single coding with ONLY free text — no system, no code. Redaction rightly
+strips the text (real feeds put patient names there), so nothing codeable
+remains, and no label table will ever fix that row. The agent called it
+"unreadable to me", which sounds like our failure and gives the person
+nothing to act on.
+
+Two situations, two sentences:
+- code present, label unknown  -> "unlabeled record, code X"   (our table gap)
+- nothing codeable ever existed -> "recorded but not coded at the source"
+
+Both keep unreadable=True: whatever the sentence, the record is never absent
+(#207, and SAFETY_CORE's never-infer-absence rule — for allergies especially,
+"no known allergies" may only come from a human attestation).
+"""
+from __future__ import annotations
+
+from careagents.agent import _summarize_bundle
+
+
+def _bundle(*resources):
+    return {"entry": [{"resource": r} for r in resources]}
+
+
+def _allergy_no_code():
+    # The live MEDENT shape after redaction: coding existed, carried only
+    # display, display stripped -> an empty coding dict.
+    return {"resourceType": "AllergyIntolerance", "status": "active",
+            "code": {"coding": [{}]}}
+
+
+def test_a_source_uncoded_record_gets_the_honest_sentence():
+    """MUTATION: collapse both cases back to 'unlabeled record' -> red."""
+    items = _summarize_bundle(_bundle(_allergy_no_code()))
+    assert items[0]["name"] == "recorded but not coded at the source"
+    assert items[0]["uncoded"] is True
+    assert items[0]["unreadable"] is True
+    assert "never treat it as absent" in items[0]["note"]
+
+
+def test_a_record_with_no_code_field_at_all_gets_the_same_sentence():
+    items = _summarize_bundle(_bundle(
+        {"resourceType": "AllergyIntolerance", "status": "active"}))
+    assert items[0]["name"] == "recorded but not coded at the source"
+
+
+def test_a_known_gap_still_names_the_code():
+    """Our-table-gap wording is unchanged: the code is real and actionable."""
+    items = _summarize_bundle(_bundle(
+        {"resourceType": "Condition",
+         "code": {"coding": [{"system": "http://snomed.info/sct",
+                              "code": "9014002"}]}}))
+    assert items[0]["name"] == "unlabeled record, code 9014002"
+    assert "uncoded" not in items[0]
+    assert items[0]["unreadable"] is True
+
+
+def test_a_code_in_a_later_coding_entry_is_still_found():
+    """MUTATION: look only at coding[0] -> red. Real concepts often lead
+    with a text-only coding followed by the coded one."""
+    items = _summarize_bundle(_bundle(
+        {"resourceType": "Condition",
+         "code": {"coding": [{}, {"system": "http://snomed.info/sct",
+                                  "code": "9014002"}]}}))
+    assert items[0]["name"] == "unlabeled record, code 9014002"
+
+
+def test_a_labelled_record_is_untouched():
+    items = _summarize_bundle(_bundle(
+        {"resourceType": "Condition",
+         "code": {"text": "Hyperlipidemia", "coding": []}}))
+    assert items[0]["name"] == "Hyperlipidemia"
+    assert "unreadable" not in items[0]
+    assert "uncoded" not in items[0]


### PR DESCRIPTION
Shakeout gate S4 (docs/2026-08-04-plan-live-data-shakeout.md). Part of #343. **Stacked on #347** (same `_summarize_bundle` region); retargets to main when #347 merges.

## The live row

The MEDENT tenant's single `AllergyIntolerance` has `code.coding = [{display-only}]` — no system, no code. Redaction correctly strips the free text (real feeds put patient names there), nothing codeable remains, and **no label table will ever fix that row**. The agent's "unreadable to me" sounds like our failure and gives the patient nothing to act on.

## Two situations, two sentences

| situation | sentence | why |
|---|---|---|
| code present, label unknown | `unlabeled record, code X` | our table gap; the code is real and actionable |
| nothing codeable ever existed | `recorded but not coded at the source` + note | the source's gap; the remedy is asking the clinic, not waiting for us |

Both keep `unreadable: True` — never-infer-absence (#207, SAFETY_CORE) is unchanged, and for allergies specifically, "no known allergies" may only ever come from a human attestation. The note carries the instruction in the payload, the same trick as the truncation marker: this is the one place the model can tell the cases apart, so the guidance travels with the data rather than relying on the system prompt.

Bonus robustness a test forced: the raw code is now found in **any** coding entry, not just `coding[0]` — real concepts often lead with a text-only coding followed by the coded one.

5 tests. Full suite 2376 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)