### PR TITLE
fix(careagents): the first-visit greeting counted a page, not the record

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -596,16 +596,26 @@ def create_app(config: Config | None = None,
         if not past:
             # First visit: show real record counts so the user immediately sees
             # the product's value rather than a generic prompt.
+            #
+            # _summary=count, NOT len(entry): entry is one page (the server
+            # caps it), so len() reported the page size as the total. A real
+            # import showed "50 conditions ... 50 lab results" to a person
+            # with 52 and 186 — two different numbers both wrong, and both
+            # capped at exactly the page limit, which is how it read as
+            # plausible for six weeks on demo-sized data. Same pattern as
+            # HealthClawClient.record_count, and PHI-free for the same
+            # reason: only totals cross, never resources.
             try:
-                conditions = hc.search(ctx["tenant"], "Condition")
-                medications = hc.search(ctx["tenant"], "MedicationRequest")
-                observations = hc.search(ctx["tenant"], "Observation")
+                def _total(rt: str) -> int:
+                    bundle = hc.search(ctx["tenant"], rt,
+                                       {"_summary": "count"})
+                    return int(bundle.get("total") or 0)
                 summary_counts = {
-                    "conditions": len(conditions.get("entry", [])),
-                    "medications": len(medications.get("entry", [])),
-                    "labs": len(observations.get("entry", [])),
+                    "conditions": _total("Condition"),
+                    "medications": _total("MedicationRequest"),
+                    "labs": _total("Observation"),
                 }
-            except HealthClawError:
+            except (HealthClawError, TypeError, ValueError):
                 pass  # fall back to generic greeting on any error
         return render_template("chat.html", me=ctx["agent"], persona=p,
                                agent_id=agent_id,

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -34,7 +34,10 @@
       <p>Hi — I'm {{ me.name }}. I found
       <strong>{{ summary_counts.conditions }} condition{{ 's' if summary_counts.conditions != 1 else '' }}</strong>,
       <strong>{{ summary_counts.medications }} medication{{ 's' if summary_counts.medications != 1 else '' }}</strong>,
-      and <strong>{{ summary_counts.labs }} lab result{{ 's' if summary_counts.labs != 1 else '' }}</strong>
+      {# "test results & measurements", not "lab results": this counts every
+         Observation — vitals and wearable readings included — and the number
+         is now a true total, so the label has to be true too. #}
+      and <strong>{{ summary_counts.labs }} test result{{ 's' if summary_counts.labs != 1 else '' }} &amp; measurement{{ 's' if summary_counts.labs != 1 else '' }}</strong>
       in your records. Want me to walk through what they show?</p>
     </div>
     <div class="starters" id="starters">

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3102,3 +3102,56 @@ def test_connection_action_buttons_are_styled_and_thumb_sized():
         assert sel in _CSS, sel
     shared = _CSS.split(".conn-refresh, .conn-disconnect, .conn-delete {")[1]
     assert "min-height: 44px" in shared.split("}")[0]
+
+
+def test_the_first_visit_greeting_counts_totals_not_the_first_page(
+        cfg, svc, monkeypatch):
+    """MUTATION: count len(entry) again -> red.
+
+    A searchset's `entry` is one PAGE (the server caps it at 50), so
+    len(entry) reported the page size as the person's total. A real import
+    greeted its patient with "50 conditions ... 50 lab results" when the true
+    numbers were 52 and 186 — both wrong, both capped at exactly the page
+    limit, which is why it read as plausible on demo-sized data for six
+    weeks. The greeting must ask for `_summary=count` and use `total`,
+    the same contract as HealthClawClient.record_count.
+    """
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+
+    seen = []
+    real_totals = {"Condition": 52, "MedicationRequest": 4, "Observation": 186}
+
+    def search(tenant_id, resource_type, params=None):
+        seen.append((resource_type, dict(params or {})))
+        if (params or {}).get("_summary") == "count":
+            return {"total": real_totals.get(resource_type, 0)}
+        # A full page of 50 — what len(entry) used to mistake for the total.
+        return {"total": real_totals.get(resource_type, 0),
+                "entry": [{"resource": {"resourceType": resource_type}}] * 50}
+
+    fake.search = search
+
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "52 conditions" in page
+    assert "4 medications" in page
+    assert "186 test results" in page
+    assert "50 condition" not in page
+    for _rt, params in seen:
+        assert params.get("_summary") == "count", (
+            "the greeting pulled a full page just to count it — resources "
+            "crossed the boundary where only totals should")
+
+
+def test_a_broken_count_falls_back_to_the_generic_greeting(
+        cfg, svc, monkeypatch):
+    """A counting failure must degrade to the generic greeting, not 500
+    the first page a new user ever sees."""
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+
+    def search(tenant_id, resource_type, params=None):
+        raise HealthClawError("search failed (503)", 503)
+
+    fake.search = search
+    r = c.get(f"/chat?agent={agent_id}")
+    assert r.status_code == 200
+    assert b"in your records" not in r.data


### PR DESCRIPTION
Shakeout row S8 support (docs/2026-08-04-plan-live-data-shakeout.md); the greeting half of #336's dishonesty.

## The bug

```python
"conditions": len(conditions.get("entry", [])),   # ← one PAGE, capped at 50
```

A searchset's `entry` is a page. The live tenant saw **"50 conditions … 50 lab results"** when the true numbers are **52 and 186** — both wrong, both capped at exactly the page limit. That's also why it survived six weeks: on demo-sized data (< 50 of everything), page size *equals* total, so the demo tenant was structurally incapable of catching it. Same oracle problem as the terminology table.

## The fix

`_summary=count` + `total` — the identical contract `HealthClawClient.record_count` already uses, PHI-free for the same reason: only totals cross the boundary, never resources. The test pins both properties:

- totals are reported (52/4/186, not 50/4/50), **and**
- every greeting search carries `_summary=count` — pulling a full page just to count it would move resources across a boundary where only numbers should travel.

The label changes with the number: **"test results & measurements"**, not "lab results" — the count is every Observation, vitals and wearable readings included, and a number that just became true deserves a label that is too.

A counting failure still degrades to the generic greeting rather than 500ing the first page a new user ever sees (second test).

Red-green verified: the totals test fails against the pre-fix code. Careagents suite 149 passed, ruff clean.

## Explicitly out of scope

#336's other half — greeting while an import is in flight says "0 conditions" with no "import in progress" qualifier — is a state-awareness feature (needs the FastenJob status), not a counting fix, and stays open on #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
