### PR TITLE
docs: record the Q1-Q3 shakeout rulings, next to the code they govern

### DIFF
--- a/docs/2026-08-04-shakeout-rulings.md
+++ b/docs/2026-08-04-shakeout-rulings.md
@@ -1,0 +1,115 @@
+# Rulings — 2026-08-04 shakeout questions Q1–Q3
+
+Three design questions were raised by the hard review of the 2026-08-04 work
+(PRs #342, #344, #345). All three are now settled. This file is the record;
+each ruling also lives next to the code it governs, because a decision that
+only exists in a dated document is a decision the next person will re-litigate.
+
+---
+
+## Q1 — `Observation/$interpret` with no input: keep it
+
+**Question.** #342 made "no subject, no body" mean *interpret this tenant's
+whole stored record*. Convenient for clients, but implicit: the request does
+not say what it reads. Commit to it, or force clients to be explicit and
+deprecate the fallback?
+
+**Ruling: KEEP.** It is committed API surface, not an accident of the fix.
+
+**Why this is defensible rather than merely convenient.** The operation is
+already tenant-scoped by construction — the caller passed tenant read-auth
+before reaching the handler, and the fallback selects `WHERE tenant_id = ?`.
+"Everything I am allowed to see" is therefore the *only* thing the empty form
+could sensibly mean; there is no wider set for it to accidentally reach. That
+is what makes an implicit default safe here and would not make it safe on,
+say, a write path or a cross-tenant search.
+
+**What the ruling obliges us to maintain**, now pinned in the handler
+docstring and by tests:
+
+1. **Nothing supplied ≠ something unusable.** A junk body — a bare array, an
+   unparseable payload, a `Parameters` whose subject will not resolve — is
+   `ignored`, never a fallback. A malformed request must not widen into the
+   widest possible read. (This was D1, fixed in #342.)
+2. **The fallback is bounded** by `STORED_OBSERVATION_CAP`, matching the
+   search route's `_count` ceiling, so no surface can quietly read more than
+   another.
+3. **The response says how much it interpreted** (`summary.total`), which is
+   also what makes shakeout row S1 measurable from the audit trail.
+
+**Not covered by this ruling:** the `?subject=` branch still loads every
+Observation the tenant owns into memory before filtering. Same defect class,
+different branch, tracked separately — capping it would truncate callers who
+get everything today.
+
+---
+
+## Q2 — Terminology lookup: public endpoints now, self-hosted later
+
+**Question.** Enabling `TERMINOLOGY_LOOKUP_ENABLED` sends `(system, code)`
+pairs to NLM / RxNav / tx.fhir.org. Never patient data, but it discloses the
+*set of clinical codes present in the deployment*. Acceptable for launch, or
+does self-hosting come first?
+
+**Ruling: enable the public endpoints now; move to a self-hosted terminology
+server afterwards.** The disclosure is narrow and the alternative — an agent
+that can name 1 of 26 conditions — is a worse product failure than the
+disclosure is a privacy failure.
+
+**The disclosure, stated precisely, so "narrow" is not doing unexamined work:**
+
+- What leaves: a code system URI and a code. Nothing else — no tenant, no
+  patient, no agent id, no free text, and (per the resolver's design) never
+  an upstream `display`.
+- What an observer learns: that *somewhere in this deployment* a record
+  carries e.g. `L40.9`. Not whose, not how many, not when relative to any
+  person — the per-process cache means each distinct code is asked **once**,
+  so query volume carries no per-patient signal either.
+- What an observer does **not** learn: any linkage between codes, any
+  identifier, or anything at all about a specific individual.
+
+**Conditions attached to this ruling:**
+
+1. It stays a per-deployment switch. A deployment that cannot accept the
+   disclosure leaves it unset and behaves exactly as before.
+2. **Self-hosting is scheduled work, not an aspiration** — tracked as its own
+   issue, and the change is a base-URL swap in `r6/curatr.py` because the
+   routing already exists.
+3. If the code set itself ever becomes sensitive for a particular tenant
+   (a small population where a rare code is identifying), that tenant is a
+   reason to self-host sooner, not a reason to re-argue this ruling.
+
+---
+
+## Q3 — Sustained throttling: fail fast and honestly
+
+**Question.** Under sustained provider rate limiting, keep #345's
+fail-fast-with-an-honest-message, or park the run as `waiting` and complete
+it when capacity returns?
+
+**Ruling (delegated to the implementer, so the reasoning is recorded here):
+FAIL FAST. Do not build queue-and-resume before Aug 18.**
+
+**Three reasons, in order of weight:**
+
+1. **A parked run is a worse experience than an honest one at demo time.**
+   An answer that silently arrives ninety seconds later, after the presenter
+   has moved on, lands in the wrong place in the conversation. "I'm busy, ask
+   again in a moment" hands control back to the person, immediately.
+2. **Queue-and-resume is a new run state reaching the UI**, with its own
+   notification path and its own failure modes, landing two weeks before a
+   demo. #345's retry already absorbs the common case (a single 429 clearing
+   within seconds); what remains is *sustained* throttling, which parking
+   would not fix either — it would only hide it.
+3. **The honest message is already correct behaviour**, not a placeholder.
+   Being throttled is not a defect, and the system now says so.
+
+**What this ruling requires instead:** throttling must be *visible* to us
+even though it is not a defect. `scripts/shakeout_live.py` counts
+`LLMRateLimited` runs and reports them on the scorecard as information
+rather than failure — so "the provider throttles us occasionally" and "the
+provider is throttling us constantly" cannot look identical.
+
+**Revisit this ruling if** the scorecard shows rate-limited runs as a
+material share of traffic. At that point the answer is probably provider
+capacity or concurrency control, not parking — but the data decides.

--- a/r6/labs/routes.py
+++ b/r6/labs/routes.py
@@ -57,6 +57,16 @@ def register_labs_routes(blueprint, deps):
         observations and told patients their labs were not in their records
         while the tenant held hundreds.
 
+        COMMITTED BEHAVIOUR, not an accident of that fix (ruling Q1,
+        docs/2026-08-04-shakeout-rulings.md). The empty form means "interpret
+        everything I am allowed to see", and it is safe to leave implicit
+        only because the caller already passed tenant read-auth and this
+        selects WHERE tenant_id = ? — there is no wider set it could reach.
+        Do not make the same argument for a write path or a cross-tenant
+        search. Three obligations come with the ruling and are enforced
+        below and in tests: junk input is ignored rather than widened, the
+        fallback is capped, and the response reports how much it interpreted.
+
         "Nothing supplied" is deliberately NOT the same as "something
         unusable". A junk body (a bare array, a Parameters with an
         unparseable subject) still counts as ignored input rather than

--- a/scripts/shakeout_live.py
+++ b/scripts/shakeout_live.py
@@ -103,7 +103,15 @@ def check_s3_medication_reads(cur, tenant: str) -> tuple[str, str]:
 
 
 def check_s5_run_health(cur, tenant: str) -> tuple[str, str]:
-    """S5: recent runs complete, and failures carry an honest class."""
+    """S5: recent runs complete, and failures carry an honest class.
+
+    Throttling is reported but does not fail the row (ruling Q3,
+    docs/2026-08-04-shakeout-rulings.md). Fail-fast-and-honest was chosen
+    over parking a run, and the price of that choice is that throttling must
+    stay VISIBLE — otherwise "the provider throttles us occasionally" and
+    "the provider is throttling us constantly" look identical from here, and
+    the ruling's revisit condition could never be observed.
+    """
     cur.execute("""
         SELECT status, coalesce(error_class, ''), count(*)
         FROM agent_runs WHERE tenant_id = %s
@@ -115,11 +123,18 @@ def check_s5_run_health(cur, tenant: str) -> tuple[str, str]:
     total = sum(r[2] for r in rows)
     defects = {r[1]: r[2] for r in rows if r[1] in DEFECT_ERROR_CLASSES}
     completed = sum(r[2] for r in rows if r[0] == "completed")
+    throttled = sum(r[2] for r in rows if r[1] == "LLMRateLimited")
+    note = ""
+    if throttled:
+        share = throttled * 100 // max(total, 1)
+        note = (f"; {throttled}/{total} ({share}%) rate-limited — reported, "
+                "not a defect. Revisit Q3 if this share is material")
     if defects:
         return "FAIL", (f"{sum(defects.values())}/{total} runs failed with a "
                         f"defect-class error: {defects} — read the worker log "
-                        "before assuming a provider blip")
-    return "PASS", f"{completed}/{total} runs completed; no defect-class failures"
+                        f"before assuming a provider blip{note}")
+    return "PASS", (f"{completed}/{total} runs completed; no defect-class "
+                    f"failures{note}")
 
 
 def check_s8_tool_rounds(cur, tenant: str) -> tuple[str, str]:

--- a/tests/test_shakeout_live.py
+++ b/tests/test_shakeout_live.py
@@ -68,6 +68,28 @@ def test_s5_fails_on_a_defect_class_and_ignores_honest_throttling():
     assert shakeout.check_s5_run_health(throttled, "t")[0] == "PASS"
 
 
+def test_throttling_is_reported_even_though_it_passes():
+    """MUTATION: drop the rate-limited note -> red.
+
+    Ruling Q3 chose fail-fast over parking a run; the price is that
+    throttling must stay visible. Without the count, 'throttled twice ever'
+    and 'throttled constantly' read identically, and the ruling's own
+    revisit condition could never be observed.
+    """
+    cur = _Cur(all_=[("completed", "", 3), ("failed", "LLMRateLimited", 2)])
+    verdict, detail = shakeout.check_s5_run_health(cur, "t")
+    assert verdict == "PASS"
+    assert "2/5" in detail and "40%" in detail
+    assert "not a defect" in detail
+
+
+def test_a_clean_card_says_nothing_about_throttling():
+    """No rate limits means no noise — the note must be conditional."""
+    cur = _Cur(all_=[("completed", "", 4)])
+    _verdict, detail = shakeout.check_s5_run_health(cur, "t")
+    assert "rate-limited" not in detail
+
+
 def test_s8_fails_on_the_loop_shape_that_preceded_the_429():
     assert shakeout.check_s8_tool_rounds(_Cur(one=(8,)), "t")[0] == "FAIL"
     assert shakeout.check_s8_tool_rounds(_Cur(one=(4,)), "t")[0] == "PASS"


### PR DESCRIPTION
Your answers to the three review questions, written down where they will actually be read. Each ruling lives in `docs/2026-08-04-shakeout-rulings.md` **and** next to the code it governs — a decision that exists only in a dated document is one the next person re-litigates.

## Q1 — keep the implicit whole-record `$interpret`

Committed API surface, not an accident of #342. The docstring now records *why* it is safe to leave implicit: the caller already passed tenant read-auth and the fallback selects `WHERE tenant_id = ?`, so "everything I am allowed to see" is the only thing the empty form could mean — **and explicitly warns not to make the same argument for a write path or a cross-tenant search**, which is where that reasoning stops holding.

Three obligations come with the ruling, all already enforced: junk input is ignored rather than widened (D1), the fallback is capped, and the response reports how much it interpreted (which is what makes S1 measurable).

## Q2 — public endpoints now, self-hosted later

Recorded with the disclosure stated precisely, so "narrow" isn't doing unexamined work:

- **What leaves:** a code system URI and a code. Nothing else.
- **What an observer learns:** that somewhere in this deployment a record carries e.g. `L40.9`. Not whose, not how many, not when — the per-process cache asks each distinct code **once**, so query volume carries no per-patient signal either.
- **What they don't learn:** any linkage, identifier, or anything about an individual.

Weighed against an agent that can name 1 of 26 conditions, that trade is defensible. Conditions attached: it stays a per-deployment switch, self-hosting is scheduled work rather than an aspiration, and a tenant whose code set is itself identifying (small population, rare code) is a reason to self-host *sooner*, not to reopen the ruling.

## Q3 — fail fast (my call, so the reasoning is on the record)

**Do not build queue-and-resume before Aug 18.** A parked run that answers ninety seconds later lands after the presenter has moved on; "ask again in a moment" hands control back immediately. Queue-and-resume is a new run state reaching the UI with its own notification path, two weeks out. And #345's retry already absorbs the common case — what remains is *sustained* throttling, which parking would hide rather than fix.

**The price of that choice is visibility**, so the scorecard now reports rate-limited runs as a share of traffic (`2/5 (40%) rate-limited — reported, not a defect`). Without it, "throttled twice ever" and "throttled constantly" read identically and the ruling's own revisit condition could never be observed. Two tests pin it, including that a clean card stays quiet.

Full suite 2381 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)