### PR TITLE
fix(security): the rate limit was opt-out via a caller-chosen header (#339)

### DIFF
--- a/r6/rate_limit.py
+++ b/r6/rate_limit.py
@@ -6,13 +6,16 @@ Production deployments should use Redis-backed rate limiting.
 """
 
 import hashlib
+import hmac
 import logging
 import os
 import threading
 import time
 from typing import Any
-from flask import g, request, jsonify
+from flask import g, request, jsonify, session
+from r6.read_auth import TENANT_SESSION_KEY
 from r6.runtime_config import resolve_app_env
+from r6.stepup import validate_step_up_token
 
 logger = logging.getLogger(__name__)
 
@@ -86,20 +89,72 @@ def _client_ip():
     return request.remote_addr or 'unknown'
 
 
+def _tenant_claim_is_authenticated(tenant_id):
+    """True iff this request PROVED the tenant it claims.
+
+    Deliberately narrow, and deliberately not `authorize_tenant_read`: that
+    helper returns the tenant unchanged when READ_AUTH_ENABLED is unset, which
+    would hand the bucket key straight back to an unauthenticated header on
+    any deployment that has not flipped the flag. A rate limiter must not
+    inherit a rollout switch.
+
+    Any failure to verify answers False — an unverifiable claim is treated
+    exactly like no claim at all.
+
+    The internal check here is STRICTER than `internal_secret_authorized()`,
+    which answers True outside production when no secret is configured. That
+    dev-open default is right for operator surfaces (it keeps local work and
+    the test harness usable) and wrong here: it would silently restore
+    header-keying on every non-production deployment, and — worse — make this
+    guard untestable, since the suite runs with no secret set. A limiter that
+    is only armed in production is a limiter nobody can prove works.
+    """
+    mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
+    if mint_secret and hmac.compare_digest(
+            request.headers.get('X-Internal-Secret', ''), mint_secret):
+        return True
+    if session.get(TENANT_SESSION_KEY) == tenant_id:
+        return True
+    auth = (request.headers.get('Authorization') or '').strip()
+    bearer = auth[7:].strip() if auth.lower().startswith('bearer ') else ''
+    token = (request.headers.get('X-Step-Up-Token') or '').strip() or bearer
+    if not token:
+        return False
+    try:
+        # Destructure BOTH values — a truthiness test on this tuple is always
+        # True and is a documented auth-bypass shape in this codebase.
+        valid, _error = validate_step_up_token(token, tenant_id,
+                                               require_scope=None)
+    except Exception:  # noqa: BLE001 — never fail a request from the limiter
+        return False
+    return bool(valid)
+
+
 def rate_limit_key():
     """
     Resolve the bucket key for the current request.
 
-    Prefers the X-Tenant-Id header so authenticated traffic is throttled per
-    tenant. When no tenant header is present (e.g. provider webhook callbacks
-    at /r6/actions/callback/<provider>, which carry no tenant), key by client
-    IP instead of dumping every untenanted request into one shared 'anonymous'
-    bucket — that shared bucket would let one source exhaust the limit for all
-    untenanted callers. The IP key is prefixed so it can never collide with a
-    real tenant id.
+    Per tenant ONLY when the request proved that tenant; otherwise per client
+    IP. X-Tenant-Id is caller-chosen, so keying on it unconditionally meant
+    the limit was opt-out: measured on a live deployment (#339), 150 requests
+    with a constant tenant header got 30 throttled, and the same 150 with a
+    varying header got ZERO throttled while opening 150 buckets. The limiter
+    both failed to limit and became its own memory-growth vector.
+
+    Authenticated per-tenant keying is kept because it is the useful case and
+    is now safe: a caller that proved the tenant cannot forge a different one.
+    It also protects the legitimate high-volume caller — CareAgents reads
+    /r6/fhir for many tenants from a single egress IP, and collapsing that to
+    one IP bucket would throttle real users to fix an attacker.
+
+    Untenanted traffic (provider webhook callbacks at
+    /r6/actions/callback/<provider>) keys by IP for the original reason: a
+    shared 'anonymous' bucket would let one source exhaust the limit for
+    every other untenanted caller. The IP key stays prefixed so it can never
+    collide with a real tenant id.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
-    if tenant_id:
+    tenant_id = (request.headers.get('X-Tenant-Id') or '').strip()
+    if tenant_id and _tenant_claim_is_authenticated(tenant_id):
         return tenant_id
     return f'ip:{_client_ip()}'
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -117,10 +117,29 @@ def test_payload_cap_configured_at_least_5mb(client):
 # ---------------------------------------------------------------------------
 # 4. Rate-limit keying: IP fallback when no tenant header
 # ---------------------------------------------------------------------------
-def test_rate_limit_key_uses_tenant_when_present(app):
+def test_rate_limit_key_uses_tenant_when_the_claim_is_PROVEN(app):
+    """Updated by #339. This test previously asserted that a bare
+    X-Tenant-Id header selected the bucket — which was the vulnerability,
+    not the feature: the header is caller-chosen, so the limit was opt-out.
+
+    Per-tenant keying survives, but only for a caller that proved the tenant.
+    """
     from r6.rate_limit import rate_limit_key
-    with app.test_request_context('/r6/actions/x', headers={'X-Tenant-Id': 'acme'}):
+    from r6.stepup import generate_step_up_token
+
+    token = generate_step_up_token('acme')
+    with app.test_request_context('/r6/actions/x', headers={
+            'X-Tenant-Id': 'acme', 'X-Step-Up-Token': token}):
         assert rate_limit_key() == 'acme'
+
+
+def test_an_unproven_tenant_header_does_not_select_the_bucket(app):
+    """MUTATION: key on the header again -> red. This is #339 itself."""
+    from r6.rate_limit import rate_limit_key
+    with app.test_request_context(
+            '/r6/actions/x', headers={'X-Tenant-Id': 'acme'},
+            environ_base={'REMOTE_ADDR': '203.0.113.9'}):
+        assert rate_limit_key() == 'ip:203.0.113.9'
 
 
 def test_rate_limit_key_falls_back_to_ip(app):
@@ -207,3 +226,86 @@ def test_all_model_tables_registered_in_metadata():
                      "wearable_connections" if "wearable_connections" in tables else "wearable_connection"):
         assert any(expected.rstrip('s') in t for t in tables), (expected, tables)
     assert "fasten_connections" in tables
+
+
+# ---------------------------------------------------------------------------
+# 4b. #339 — the limiter must not be opt-out via a caller-chosen header
+# ---------------------------------------------------------------------------
+def _flood(app, headers_for, n=150, ip='198.51.100.4'):
+    """Send n requests through the keying+counting path; return throttled count."""
+    from r6 import rate_limit
+
+    rate_limit._rate_limits.clear()
+    throttled = 0
+    for i in range(n):
+        with app.test_request_context('/r6/fhir/Patient',
+                                      headers=headers_for(i),
+                                      environ_base={'REMOTE_ADDR': ip}):
+            allowed, _remaining, _reset = rate_limit.check_rate_limit(
+                rate_limit.rate_limit_key(), max_requests=30, window_seconds=60)
+            if not allowed:
+                throttled += 1
+    return throttled
+
+
+def test_varying_the_tenant_header_no_longer_evades_the_limit(app):
+    """MUTATION: revert rate_limit_key to the header -> red.
+
+    MEASURED on the live deployment before this fix (#339): 150 requests with
+    a constant tenant header -> 30 throttled; the same 150 with a VARYING
+    header -> 0 throttled, and 150 buckets opened. The limiter both failed to
+    limit and became its own memory-growth vector. Both halves are asserted
+    here so neither can regress silently.
+    """
+    from r6 import rate_limit
+
+    constant = _flood(app, lambda i: {'X-Tenant-Id': 'acme'})
+    assert constant > 0, "the limiter did not fire at all — check the fixture"
+
+    varying = _flood(app, lambda i: {'X-Tenant-Id': f'acme-{i}'})
+    assert varying > 0, (
+        "varying a caller-chosen header still evades the rate limit (#339)")
+    assert len(rate_limit._rate_limits) == 1, (
+        "each forged tenant id still opened its own bucket — the limiter is "
+        "a memory-growth vector as well as ineffective")
+
+
+def test_a_proven_tenant_still_gets_its_own_bucket(app):
+    """The fix must not collapse legitimate multi-tenant traffic from one
+    egress IP (CareAgents reads /r6/fhir for every tenant from one host)."""
+    from r6 import rate_limit
+    from r6.stepup import generate_step_up_token
+
+    rate_limit._rate_limits.clear()
+    for tenant in ('t-one', 't-two', 't-three'):
+        token = generate_step_up_token(tenant)
+        with app.test_request_context('/r6/fhir/Patient', headers={
+                'X-Tenant-Id': tenant, 'X-Step-Up-Token': token},
+                environ_base={'REMOTE_ADDR': '198.51.100.9'}):
+            rate_limit.check_rate_limit(rate_limit.rate_limit_key(),
+                                        max_requests=30)
+    assert set(rate_limit._rate_limits) == {'t-one', 't-two', 't-three'}
+
+
+def test_a_token_for_a_DIFFERENT_tenant_does_not_prove_this_one(app):
+    """MUTATION: validate the token without binding it to the claimed tenant
+    -> red. Holding one valid token would otherwise re-open the evasion."""
+    from r6.rate_limit import rate_limit_key
+    from r6.stepup import generate_step_up_token
+
+    token = generate_step_up_token('tenant-i-own')
+    with app.test_request_context('/r6/fhir/Patient', headers={
+            'X-Tenant-Id': 'someone-elses-tenant', 'X-Step-Up-Token': token},
+            environ_base={'REMOTE_ADDR': '198.51.100.7'}):
+        assert rate_limit_key() == 'ip:198.51.100.7'
+
+
+def test_a_garbage_token_degrades_to_ip_and_never_raises(app):
+    """The limiter runs as a before_request hook: a malformed token must
+    key by IP, not 500 the request."""
+    from r6.rate_limit import rate_limit_key
+    for bad in ('', 'not-a-token', 'a.b.c', 'x' * 5000):
+        with app.test_request_context('/r6/fhir/Patient', headers={
+                'X-Tenant-Id': 'acme', 'X-Step-Up-Token': bad},
+                environ_base={'REMOTE_ADDR': '198.51.100.8'}):
+            assert rate_limit_key() == 'ip:198.51.100.8'


### PR DESCRIPTION
Closes #339.

## Measured, on the live deployment

```
150 requests, constant X-Tenant-Id  ->  30 throttled
150 requests, varying  X-Tenant-Id  ->   0 throttled, 150 buckets opened
```

`rate_limit_key()` returned `X-Tenant-Id` whenever present. The header is caller-chosen, so **the limit was opt-out** — and each forged id opened its own bucket, making the limiter a memory-growth vector as well as ineffective.

## The fix

Per-tenant keying **only when the request proved the tenant** — a matching internal secret, an authenticated session, or a step-up token bound to *that* tenant. Otherwise the key is the client IP, which the caller cannot forge (`_client_ip` already takes the rightmost `X-Forwarded-For` hop for exactly this reason).

**Keeping proven per-tenant keying isn't a compromise — it protects real users.** CareAgents reads `/r6/fhir` for every tenant from a single egress IP. Collapsing that to one IP bucket would throttle legitimate traffic in order to inconvenience an attacker.

## Two deliberate strictnesses

- **Not `authorize_tenant_read`.** It returns the tenant unchanged when `READ_AUTH_ENABLED` is unset — which would hand the bucket key straight back to an unauthenticated header on any deployment that hasn't flipped the flag. A rate limiter must not inherit a rollout switch.
- **Not `internal_secret_authorized()`.** Its dev-open default (True outside production when no secret is set) is right for operator surfaces and wrong here: it would restore header-keying on every non-production deployment and — worse — make this guard **untestable**, since the suite runs with no secret configured. A limiter that's only armed in production is one nobody can prove works. That's also why the existing tests "passed" against my first draft.

## Tests

5 new, red-green verified (3 fail against the vulnerable code):

- the measured evasion, asserting **both halves** — that throttling now fires *and* that only one bucket opens
- proven multi-tenant traffic from one IP still gets separate buckets
- **a valid token for a *different* tenant does not prove this one** — otherwise holding any one token re-opens the evasion
- garbage tokens degrade to IP keying and never raise (this runs as a `before_request` hook; a malformed token must not 500 the request)

`test_rate_limit_key_uses_tenant_when_present` asserted the vulnerable behaviour, so **it is updated in this PR** rather than left to go red on main — the rule from `docs/agent-task-guide.md` §6 that three security PRs skipped last week.

Full suite 2386 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)