### PR TITLE
fix(scripts): the shakeout card's first live run found two defects in itself

### DIFF
--- a/scripts/shakeout_live.py
+++ b/scripts/shakeout_live.py
@@ -54,6 +54,13 @@ G, R, Y, D, X = "\033[92m", "\033[91m", "\033[93m", "\033[2m", "\033[0m"
 # truthfully-reported non-defect after PR #345.
 DEFECT_ERROR_CLASSES = ("LLMError",)
 
+# S5 looks at a WINDOW, not all history. Scored over all time, a single
+# already-fixed failure fails the card forever, and a card that cannot return
+# to green stops being read — which is how a real regression gets missed. The
+# first live run hit exactly this: one pre-#345 LLMError from a provider 429,
+# fixed hours earlier, still failing the row.
+RUN_HEALTH_WINDOW_HOURS = 24
+
 
 def _connect(uri: str):
     import psycopg2  # deferred: the container has it; a laptop may not
@@ -73,9 +80,9 @@ def _one(cur, sql: str, params: tuple):
 def check_s1_labs_interpreted(cur, tenant: str) -> tuple[str, str]:
     """S1: the most recent labs $interpret actually interpreted something."""
     row = _one(cur, """
-        SELECT detail, recorded_at FROM audit_events
+        SELECT detail, recorded FROM audit_events
         WHERE tenant_id = %s AND detail LIKE 'labs $interpret;%%'
-        ORDER BY recorded_at DESC LIMIT 1
+        ORDER BY recorded DESC LIMIT 1
     """, (tenant,))
     if row is None:
         return "SKIP", "no $interpret call recorded yet — ask 'what do my labs say?' first"
@@ -114,12 +121,14 @@ def check_s5_run_health(cur, tenant: str) -> tuple[str, str]:
     """
     cur.execute("""
         SELECT status, coalesce(error_class, ''), count(*)
-        FROM agent_runs WHERE tenant_id = %s
+        FROM agent_runs
+        WHERE tenant_id = %s AND created_at > now() - make_interval(hours => %s)
         GROUP BY status, error_class
-    """, (tenant,))
+    """, (tenant, RUN_HEALTH_WINDOW_HOURS))
     rows = cur.fetchall()
     if not rows:
-        return "SKIP", "no agent runs for this tenant yet"
+        return "SKIP", (f"no agent runs in the last {RUN_HEALTH_WINDOW_HOURS}h "
+                        "— ask the agent something first")
     total = sum(r[2] for r in rows)
     defects = {r[1]: r[2] for r in rows if r[1] in DEFECT_ERROR_CLASSES}
     completed = sum(r[2] for r in rows if r[0] == "completed")
@@ -133,8 +142,8 @@ def check_s5_run_health(cur, tenant: str) -> tuple[str, str]:
         return "FAIL", (f"{sum(defects.values())}/{total} runs failed with a "
                         f"defect-class error: {defects} — read the worker log "
                         f"before assuming a provider blip{note}")
-    return "PASS", (f"{completed}/{total} runs completed; no defect-class "
-                    f"failures{note}")
+    return "PASS", (f"{completed}/{total} runs in {RUN_HEALTH_WINDOW_HOURS}h "
+                    f"completed; no defect-class failures{note}")
 
 
 def check_s8_tool_rounds(cur, tenant: str) -> tuple[str, str]:

--- a/tests/test_shakeout_live.py
+++ b/tests/test_shakeout_live.py
@@ -131,8 +131,6 @@ def test_the_manual_rows_state_what_the_script_cannot_see():
 # this executes them; on SQLite it still catches a wrong column or table name,
 # which is the class of defect that shipped.
 
-import pytest  # noqa: E402
-
 from models import db  # noqa: E402
 
 

--- a/tests/test_shakeout_live.py
+++ b/tests/test_shakeout_live.py
@@ -115,3 +115,102 @@ def test_the_manual_rows_state_what_the_script_cannot_see():
     for probe in ("labs", "conditions", "medications", "allergies",
                   "cholesterol", "another tenant"):
         assert probe in shakeout.MANUAL_ROWS
+
+
+# ---------------------------------------------------------------------------
+# The SQL itself
+# ---------------------------------------------------------------------------
+# Everything above stubs the cursor and ignores the SQL, which is right for
+# verdict logic and blind to the thing that actually broke: the first live run
+# of this script crashed with UndefinedColumn, because audit_events has
+# `recorded`, not `recorded_at`. Every unit test passed while the query could
+# not execute at all — the repo's standing trap (a fake proves the call is
+# MADE, not that it is ACCEPTED) in its purest form.
+#
+# So: run the real statements against a real database. On the Postgres CI lane
+# this executes them; on SQLite it still catches a wrong column or table name,
+# which is the class of defect that shipped.
+
+import pytest  # noqa: E402
+
+from models import db  # noqa: E402
+
+
+def _sqlite_params(sql: str) -> str:
+    """psycopg2 %s -> sqlite ?, and %% -> % for LIKE patterns."""
+    return sql.replace("%%", "\x00").replace("%s", "?").replace("\x00", "%")
+
+
+def test_every_check_query_actually_executes(app):
+    """MUTATION: rename any queried column (e.g. `recorded` -> `recorded_at`)
+    -> red. This is the defect that reached production.
+
+    Each check is called with a cursor wired to the real test database, so a
+    column or table that does not exist raises here instead of at 3am against
+    the live record.
+    """
+    import sqlite3
+
+    executed = []
+
+    class _RealCur:
+        """Adapts psycopg2-style SQL onto the test database session."""
+
+        def __init__(self):
+            self._rows = []
+
+        def execute(self, sql, params=None):
+            executed.append(sql)
+            bind = db.engine
+            is_sqlite = bind.dialect.name == "sqlite"
+            statement = _sqlite_params(sql) if is_sqlite else sql
+            if is_sqlite:
+                # now() / make_interval are Postgres-only; the point of this
+                # test on SQLite is name resolution, so neutralise the clause
+                # while leaving every identifier intact.
+                statement = statement.replace(
+                    "created_at > now() - make_interval(hours => ?)",
+                    "created_at IS NOT NULL AND ? IS NOT NULL")
+            raw = bind.raw_connection()
+            try:
+                cur = raw.cursor()
+                cur.execute(statement, tuple(params or ()))
+                self._rows = cur.fetchall()
+                cur.close()
+            except sqlite3.OperationalError as exc:
+                raise AssertionError(
+                    f"shakeout query does not match the schema: {exc}\n{sql}"
+                ) from exc
+            finally:
+                raw.close()
+
+        def fetchone(self):
+            return self._rows[0] if self._rows else None
+
+        def fetchall(self):
+            return self._rows
+
+    with app.app_context():
+        for name, check in shakeout.CHECKS:
+            verdict, detail = check(_RealCur(), "some-tenant")
+            assert verdict in ("PASS", "FAIL", "SKIP"), (name, verdict)
+
+    assert len(executed) >= len(shakeout.CHECKS), (
+        "a check returned without running its query — it cannot have "
+        "measured anything")
+
+
+def test_run_health_is_windowed_not_all_time():
+    """MUTATION: drop the window -> red.
+
+    Scored over all history, one already-fixed failure fails the card
+    forever, and a card that cannot return to green stops being read. The
+    first live run hit exactly this: a single pre-#345 LLMError from a
+    provider 429, fixed hours earlier, still failing the row.
+    """
+    assert shakeout.RUN_HEALTH_WINDOW_HOURS > 0
+    cur = _Cur(all_=[("completed", "", 2)])
+    _verdict, detail = shakeout.check_s5_run_health(cur, "t")
+    assert str(shakeout.RUN_HEALTH_WINDOW_HOURS) in detail, (
+        "the card must say the score is windowed, or a reader will take it "
+        "as all-time")


### PR DESCRIPTION
First run of `shakeout_live.py` against the live tenant, minutes after the resolver went live:

```
FAIL  S1 labs interpreted: check crashed: UndefinedColumn
SKIP  S3 medication deref audited: no audited Medication reads yet
FAIL  S5 run health honest: 1/3 runs failed with a defect-class error: {'LLMError': 1}
PASS  S8 tool rounds bounded: worst run used 6 model round(s) (budget 6)
PASS  ingest not stranded: no stranded ingest jobs
```

Both FAILs were bugs in the card, not the product.

## S1 — the query could never have run

`audit_events` has **`recorded`**, not `recorded_at`. Eight unit tests passed against a stubbed cursor that ignores the SQL entirely, so nothing ever checked that the statement was executable. That is the repo's standing trap — *a fake proves the call is MADE, not that it is ACCEPTED* — in its purest form, and I wrote it into a brand-new file the same day I quoted the rule.

**So the fix is not the column name.** `test_every_check_query_actually_executes` now runs every check against the real test database via a cursor adapter, so a wrong column or table raises in CI instead of at 3am against the live record. Red-green verified by reintroducing the exact defect (`recorded` → `recorded_at`) and watching it go red.

## S5 — a card that can never return to green

The query scored **all history**, so the single pre-#345 `LLMError` — the provider 429 from the incident this whole thread started with, fixed hours earlier — failed the row permanently. A scorecard that cannot go green stops being read, and that is precisely how a real regression gets missed later.

Now windowed to `RUN_HEALTH_WINDOW_HOURS = 24`, and the detail line **says** it is windowed rather than letting a reader take it as all-time.

## What the card got right

S8 and the ingest row are genuine passes, and S3's SKIP is accurate — #347 is merged but the deref hasn't been exercised yet, and the row says exactly what to do about it. The two rows that were built to catch live shapes both worked; the two that failed were mine.

Full suite 2386 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)