### PR TITLE
feat(careagents): the chat answers a timeline question with a chart

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 
-from careagents import llm
+from careagents import labs_timeline, llm
 from careagents.healthclaw import HealthClawClient, HealthClawError
 
 MAX_TOOL_ROUNDS = 6
@@ -59,6 +59,19 @@ TOOLS = [
      "description": ("Recent lab results with plain-language reference-range "
                      "interpretation (what's normal, what's flagged)."),
      "parameters": {"type": "object", "properties": {}, "required": []}},
+    {"name": "show_lab_timeline",
+     "description": ("Show a CHART of how a lab value has changed over time. "
+                     "Use for any 'timeline', 'trend', 'over time', 'history' "
+                     "or 'has it improved' question about a lab (cholesterol, "
+                     "LDL, HDL, triglycerides, A1c, glucose). The chart "
+                     "appears in the conversation, so describe what it shows "
+                     "rather than listing every number."),
+     "parameters": {"type": "object", "properties": {
+         "topic": {"type": "string",
+                   "description": ("What the person asked about, e.g. "
+                                   "'cholesterol' or 'a1c'. Omit to show "
+                                   "every lab series on file.")},
+     }, "required": []}},
     {"name": "get_care_gaps",
      "description": ("Preventive screenings and immunizations that are due "
                      "or coming due (USPSTF/ACIP/ADA guidance)."),
@@ -88,6 +101,7 @@ TOOLS = [
 TOOL_LABELS = {
     "get_health_summary": "Reading your records — redacted view",
     "get_labs": "Interpreting your labs",
+    "show_lab_timeline": "Charting your results over time",
     "get_care_gaps": "Checking preventive care gaps",
     "search_records": "Searching your records",
     "start_intake_form": "Preparing your intake form",
@@ -255,6 +269,33 @@ def _execute_tool(hc: HealthClawClient, tenant: str, name: str,
         labs = hc.interpret_labs(tenant)
         return json.dumps({"consumer_summary": labs["consumer"],
                            "disclaimer": labs["disclaimer"][:200]})
+    if name == "show_lab_timeline":
+        topic = str(args.get("topic") or "")
+        labs = hc.interpret_labs(tenant)
+        keys = labs_timeline.keys_for_topic(topic)
+        series = labs_timeline.build_series(labs.get("bundle") or {}, keys)
+        if series:
+            events.append({"type": "card", "kind": "lab-timeline",
+                           "topic": topic})
+        # The model gets SHAPE, not the readings: how many series, how many
+        # points, whether a trend is even plottable. The chart carries the
+        # numbers. Handing them over too would invite the model to restate
+        # every value and, worse, to narrate a direction from a single point.
+        return json.dumps({
+            "chart_shown": bool(series),
+            "series": [{"name": s["name"], "readings": len(s["readings"]),
+                        "trend_plottable": s["trend_plottable"]}
+                       for s in series],
+            "note": ("A chart is now visible to the person. Describe what it "
+                     "shows in one or two sentences and invite a question; do "
+                     "not list every value. A series with trend_plottable "
+                     "false has a single reading — say so, and never describe "
+                     "it as rising or falling."
+                     if series else
+                     "No lab series matched in the CONNECTED records. That is "
+                     "not the same as the person never having had this test — "
+                     "say so, and do not report it as absent."),
+        })
     if name == "get_care_gaps":
         gaps = hc.care_gaps(tenant)
         return json.dumps({"consumer_summary": gaps["consumer"]})

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -27,6 +27,7 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
 from careagents.accounts import (AccountService, AuthError, MailError,
                                  new_binding_code)
 from careagents import advisors, connectors
+from careagents import labs_timeline as labs_timeline_mod
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS
@@ -813,6 +814,34 @@ def create_app(config: Config | None = None,
             pass
         return jsonify({"status": status.get("status"),
                         "delivery_link": outcome.get("delivery_link")})
+
+    @app.get("/api/labs/timeline")
+    @login_required
+    def labs_timeline():
+        """Per-analyte lab series for the chat's timeline card.
+
+        Same-origin and session-authenticated on purpose. The equivalent MCP
+        App is served by HealthClaw, and embedding it here would mean either
+        a cross-origin iframe with no credentials (a guaranteed 401) or a
+        step-up token in a URL. Neither is worth it: this process already
+        holds the credentials, so it fetches server-side and the browser
+        never sees one.
+        """
+        acct = current_account()
+        agent_id = request.args.get("agent", "")
+        ctx = svc.get_agent_context(acct.id, agent_id)
+        if not ctx:
+            return jsonify({"error": "unknown agent"}), 404
+        try:
+            labs = hc.interpret_labs(ctx["tenant"])
+        except HealthClawError:
+            return jsonify({"error": "labs unavailable"}), 502
+        keys = labs_timeline_mod.keys_for_topic(request.args.get("topic"))
+        return jsonify({
+            "series": labs_timeline_mod.build_series(labs.get("bundle") or {},
+                                                     keys),
+            "disclaimer": labs.get("disclaimer") or "",
+        })
 
     # --- review relay (credential-injecting proxy, agent-scoped) -------------
 

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -172,7 +172,12 @@ class HealthClawClient:
         if r.status_code != 200:
             raise HealthClawError(f"$interpret failed ({r.status_code})",
                                   r.status_code)
-        out = {"summary": {}, "consumer": {}, "disclaimer": ""}
+        # `bundle` carries the ANNOTATED Observations — each already redacted,
+        # audited and flagged by the engine. The timeline card builds its
+        # series from these rather than issuing a second, differently-shaped
+        # read, so the chart and the agent's prose can never disagree about a
+        # value or a flag.
+        out = {"summary": {}, "consumer": {}, "disclaimer": "", "bundle": {}}
         for p in (r.json() or {}).get("parameter", []):
             if p.get("name") == "summary":
                 out["summary"] = json.loads(p.get("valueString") or "{}")
@@ -180,6 +185,8 @@ class HealthClawClient:
                 out["consumer"] = json.loads(p.get("valueString") or "{}")
             elif p.get("name") == "disclaimer":
                 out["disclaimer"] = p.get("valueString") or ""
+            elif p.get("name") == "return":
+                out["bundle"] = p.get("resource") or {}
         return out
 
     def care_gaps(self, tenant: str) -> dict:

--- a/careagents/labs_timeline.py
+++ b/careagents/labs_timeline.py
@@ -1,0 +1,149 @@
+"""Group interpreted Observations into per-analyte time series.
+
+Reported live 2026-08-04: "give me a timeline of my cholesterol results"
+produced eight tool calls and then an error. Prose is the wrong shape for the
+question — four numbers across four dates is a picture — so the chat answers
+it with a chart, and this builds the series behind it.
+
+Input is the engine's `Observation/$interpret` response, so every reading has
+already been redacted, audited, tenant-scoped, and interpreted against the
+reference ranges in `r6/labs/interpret.py`. Nothing here re-derives a clinical
+verdict; `flag` is carried through verbatim.
+
+## The duplication, named
+
+`templates/mcp_apps/lab_trends.html` groups the same way in JavaScript,
+because it talks to the engine directly from a browser and cannot import this.
+Two implementations of one concept is a drift risk, so the ANALYTES table is
+pinned across both by `tests/test_labs_timeline.py` — if either side gains or
+loses a code, that test fails. A shared constant we cannot share in code is at
+least a shared constant we refuse to let diverge.
+"""
+
+from __future__ import annotations
+
+LOINC = "http://loinc.org"
+
+# An analyte is a SET of codes. The same test arrives under different LOINCs
+# from different labs, and plotting only one of them draws a confident line
+# through part of the data — the shape of #343, one level up. Order is display
+# order.
+ANALYTES = [
+    {"key": "total-cholesterol", "name": "Total cholesterol",
+     "codes": ["2093-3"]},
+    {"key": "ldl", "name": "LDL cholesterol", "codes": ["13457-7", "18262-6"]},
+    {"key": "hdl", "name": "HDL cholesterol", "codes": ["2085-9"]},
+    {"key": "triglycerides", "name": "Triglycerides", "codes": ["2571-8"]},
+    {"key": "a1c", "name": "Hemoglobin A1c", "codes": ["4548-4", "17856-6"]},
+    {"key": "glucose", "name": "Glucose", "codes": ["2345-7"]},
+]
+
+# Free-text search terms -> analyte keys, so "how's my cholesterol?" narrows to
+# the lipid panel instead of dumping every series into the chat.
+_TOPICS = {
+    "cholesterol": ["total-cholesterol", "ldl", "hdl", "triglycerides"],
+    "lipid": ["total-cholesterol", "ldl", "hdl", "triglycerides"],
+    "ldl": ["ldl"],
+    "hdl": ["hdl"],
+    "triglyceride": ["triglycerides"],
+    "a1c": ["a1c"],
+    "hemoglobin a1c": ["a1c"],
+    "diabetes": ["a1c", "glucose"],
+    "glucose": ["glucose"],
+    "sugar": ["glucose", "a1c"],
+}
+
+
+def keys_for_topic(topic: str | None) -> list[str] | None:
+    """Analyte keys a free-text topic names, or None for 'everything'.
+
+    None is deliberately distinct from []: "no topic given" means show what
+    there is, while "a topic that matches nothing" must not silently widen
+    into every series the person has.
+    """
+    if not topic:
+        return None
+    needle = str(topic).strip().lower()
+    if not needle:
+        return None
+    hits: list[str] = []
+    for term, keys in _TOPICS.items():
+        if term in needle:
+            for key in keys:
+                if key not in hits:
+                    hits.append(key)
+    return hits
+
+
+def _loinc_of(resource: dict) -> str | None:
+    for coding in ((resource.get("code") or {}).get("coding") or []):
+        if isinstance(coding, dict) and coding.get("system") == LOINC \
+                and coding.get("code"):
+            return str(coding["code"])
+    return None
+
+
+def _flag_of(resource: dict) -> str:
+    """The ENGINE's interpretation code, or IND when it did not assign one.
+
+    Never computed here. A second opinion on a reference range is how a
+    patient ends up seeing a different verdict from the one we audited.
+    """
+    for concept in (resource.get("interpretation") or []):
+        for coding in ((concept or {}).get("coding") or []):
+            if isinstance(coding, dict) and coding.get("code"):
+                return str(coding["code"])
+    return "IND"
+
+
+def _date_of(resource: dict) -> str:
+    raw = resource.get("effectiveDateTime") or resource.get("issued") or ""
+    return str(raw)[:10]
+
+
+def build_series(interpret_bundle: dict,
+                 keys: list[str] | None = None) -> list[dict]:
+    """Per-analyte series from an $interpret return Bundle, oldest first.
+
+    Only analytes with at least one numeric reading appear: an empty panel
+    tells the person nothing and invites the model to narrate an absence it
+    cannot support.
+    """
+    entries = (interpret_bundle or {}).get("entry") or []
+    wanted = None if keys is None else set(keys)
+
+    series = []
+    for analyte in ANALYTES:
+        if wanted is not None and analyte["key"] not in wanted:
+            continue
+        codes = set(analyte["codes"])
+        readings = []
+        for entry in entries:
+            resource = (entry or {}).get("resource") or {}
+            if _loinc_of(resource) not in codes:
+                continue
+            quantity = resource.get("valueQuantity") or {}
+            value = quantity.get("value")
+            # No number, no point. Defaulting a missing value to 0 would put
+            # a clinical claim nobody made onto a chart.
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                continue
+            readings.append({
+                "date": _date_of(resource),
+                "value": value,
+                "unit": quantity.get("unit") or "",
+                "flag": _flag_of(resource),
+            })
+        if not readings:
+            continue
+        readings.sort(key=lambda r: r["date"])
+        series.append({
+            "key": analyte["key"],
+            "name": analyte["name"],
+            "unit": next((r["unit"] for r in readings if r["unit"]), ""),
+            "readings": readings,
+            # One reading has no direction. The surface must not draw a line
+            # through it, and the model must not narrate a trend from it.
+            "trend_plottable": len([r for r in readings if r["date"]]) >= 2,
+        })
+    return series

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -495,3 +495,29 @@ button.linkish { background: none; border: 0; color: var(--clay-deep);
   padding: 14px 0; margin: 0; }
 .brief-disclaimer { font-size: 12.5px; color: var(--ink-soft);
   border-top: 1px solid var(--hairline); padding-top: 16px; }
+
+/* --- lab timeline card ---------------------------------------------------
+   Rendered inline in the conversation, not in an iframe: an iframe of the
+   engine's MCP App would carry no credentials, and iOS will not scroll an
+   iframe's internals anyway (the Fasten dialog taught that one twice). */
+.card.timeline { max-width: 100%; border-color: var(--sage);
+  box-shadow: 0 4px 20px rgba(95,125,98,.16); }
+.card.timeline p { margin-bottom: 0; }
+.timeline-series { margin-top: 14px; }
+.timeline-series:first-child { margin-top: 4px; }
+.timeline-name { font-size: 13px; color: var(--ink-soft); margin-bottom: 4px;
+  font-weight: 600; }
+.spark { width: 100%; height: 150px; display: block; overflow: visible; }
+.spark-grid { stroke: var(--hairline); stroke-width: 1; }
+.spark-line { fill: none; stroke: var(--sage); stroke-width: 2;
+  stroke-linejoin: round; stroke-linecap: round; }
+.spark-axis { fill: var(--ink-soft); font-size: 10px; }
+.spark-pt { stroke: var(--card); stroke-width: 2; fill: var(--sage); }
+/* Flag colours follow the ENGINE's interpretation code — never recomputed
+   here. H/L is worth a look; HH/LL is critical; IND means the engine did not
+   assign one, which must not read as "normal". */
+.spark-pt.H, .spark-pt.L { fill: #C98A1E; }
+.spark-pt.HH, .spark-pt.LL { fill: var(--clay-deep); }
+.spark-pt.IND { fill: #9A8F7D; }
+.muted { color: var(--ink-soft); }
+.muted.small { font-size: 12px; margin-top: 10px; }

--- a/careagents/static/chat.js
+++ b/careagents/static/chat.js
@@ -84,6 +84,130 @@
     log.appendChild(c); scroll();
   }
 
+  // --- lab timeline ------------------------------------------------------
+  // Rendered inline, NOT as an iframe of HealthClaw's lab-trends MCP App.
+  // That app is same-origin to the engine and authenticates with a step-up
+  // token; embedded here it would either 401 or need a credential in a URL.
+  // The server fetches with the credentials it already holds and hands back
+  // series only.
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function svgEl(name, attrs) {
+    const node = document.createElementNS(SVG_NS, name);
+    for (const key in attrs) node.setAttribute(key, attrs[key]);
+    return node;
+  }
+
+  function drawSeries(series) {
+    const W = 520, H = 150, padL = 40, padR = 10, padT = 12, padB = 22;
+    const pts = series.readings.filter((r) => r.date);
+    const svg = svgEl("svg", {
+      class: "spark", viewBox: "0 0 " + W + " " + H,
+      preserveAspectRatio: "none", role: "img",
+      "aria-label": series.name + " over time"
+    });
+
+    const values = pts.map((p) => p.value);
+    let lo = Math.min.apply(null, values), hi = Math.max.apply(null, values);
+    if (hi === lo) { hi = lo + 1; lo = lo - 1; }
+    const span = (hi - lo) * 0.15; lo -= span; hi += span;
+    const times = pts.map((p) => new Date(p.date + "T00:00:00Z").getTime());
+    const t0 = Math.min.apply(null, times);
+    const t1 = Math.max.apply(null, times) === t0
+      ? t0 + 1 : Math.max.apply(null, times);
+    const x = (t) => padL + ((t - t0) / (t1 - t0)) * (W - padL - padR);
+    const y = (v) => padT + ((hi - v) / (hi - lo)) * (H - padT - padB);
+
+    [0, 0.5, 1].forEach((frac) => {
+      const gy = padT + frac * (H - padT - padB);
+      svg.appendChild(svgEl("line", {
+        class: "spark-grid", x1: padL, x2: W - padR, y1: gy, y2: gy }));
+      const label = svgEl("text", { class: "spark-axis", x: 2, y: gy + 3 });
+      label.textContent = (hi - frac * (hi - lo)).toFixed(0);
+      svg.appendChild(label);
+    });
+
+    // A single reading has no direction: draw the point, never a line.
+    if (series.trend_plottable) {
+      svg.appendChild(svgEl("path", {
+        class: "spark-line",
+        d: pts.map((p, i) => (i ? "L" : "M") + x(times[i]).toFixed(1) +
+          " " + y(p.value).toFixed(1)).join(" ")
+      }));
+    }
+    pts.forEach((p, i) => {
+      const dot = svgEl("circle", {
+        class: "spark-pt " + (p.flag || "IND"),
+        cx: x(times[i]).toFixed(1), cy: y(p.value).toFixed(1), r: 4 });
+      const title = document.createElementNS(SVG_NS, "title");
+      title.textContent = p.date + ": " + p.value + " " + (p.unit || "") +
+        " (" + (p.flag || "IND") + ")";
+      dot.appendChild(title);
+      svg.appendChild(dot);
+    });
+
+    [[t0, "start"], [t1, "end"]].forEach((pair) => {
+      const label = svgEl("text", {
+        class: "spark-axis", x: x(pair[0]), y: H - 5,
+        "text-anchor": pair[1] === "end" ? "end" : "start" });
+      label.textContent = new Date(pair[0]).toISOString().slice(0, 10);
+      svg.appendChild(label);
+    });
+    return svg;
+  }
+
+  async function addLabTimelineCard(topic) {
+    const c = el("div", "card timeline");
+    c.appendChild(el("h4", null, "Your results over time"));
+    const body = el("div", "timeline-body");
+    body.appendChild(el("p", "muted", "Loading your readings…"));
+    c.appendChild(body);
+    log.appendChild(c); scroll();
+
+    let data;
+    try {
+      const url = "/api/labs/timeline?agent=" + encodeURIComponent(AGENT) +
+        (topic ? "&topic=" + encodeURIComponent(topic) : "");
+      const res = await fetch(url, { headers: { "Accept": "application/json" } });
+      if (!res.ok) throw new Error(String(res.status));
+      data = await res.json();
+    } catch (e) {
+      body.textContent = "";
+      body.appendChild(el("p", "muted",
+        "Couldn't load the chart just now — your records are fine, this " +
+        "view isn't. Ask again in a moment."));
+      return;
+    }
+
+    body.textContent = "";
+    const series = (data && data.series) || [];
+    if (!series.length) {
+      // Never "you have no results": this reads the CONNECTED record.
+      body.appendChild(el("p", "muted",
+        "No readings for that test in the records connected here. That's " +
+        "not the same as never having had one."));
+      return;
+    }
+    series.forEach((s) => {
+      const panel = el("div", "timeline-series");
+      const count = s.readings.length;
+      panel.appendChild(el("div", "timeline-name",
+        s.name + " · " + count + " reading" + (count === 1 ? "" : "s") +
+        (s.unit ? " · " + s.unit : "")));
+      panel.appendChild(drawSeries(s));
+      if (!s.trend_plottable) {
+        panel.appendChild(el("p", "muted",
+          "Only one reading on file — not enough to show a trend."));
+      }
+      body.appendChild(panel);
+    });
+    if (data.disclaimer) {
+      body.appendChild(el("p", "muted small", data.disclaimer));
+    }
+    scroll();
+  }
+
   function watchForm(actionId) {
     if (pollers[actionId]) return;
     pollers[actionId] = setInterval(async () => {
@@ -130,6 +254,8 @@
           addReviewCard(ev.action_id, ev.review_url);
         else if (ev.type === "card" && ev.kind === "pdf")
           addPdfCard(ev.url);
+        else if (ev.type === "card" && ev.kind === "lab-timeline")
+          addLabTimelineCard(ev.topic || "");
         else if (ev.type === "text") {
           typing.remove(); addAgentText(ev.text);
         } else if (ev.type === "error") {

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3159,3 +3159,110 @@ def test_a_broken_count_falls_back_to_the_generic_greeting(
     r = c.get(f"/chat?agent={agent_id}")
     assert r.status_code == 200
     assert b"in your records" not in r.data
+
+
+# ---------------------------------------------------------------------------
+# Lab timeline card (#357 follow-up): the chat answers a "timeline" question
+# with a chart, fetched same-origin with credentials this process already has.
+# ---------------------------------------------------------------------------
+def _interpret_payload():
+    def _obs(code, value, date, flag="N"):
+        return {"resource": {
+            "resourceType": "Observation",
+            "code": {"coding": [{"system": "http://loinc.org", "code": code}]},
+            "effectiveDateTime": date,
+            "valueQuantity": {"value": value, "unit": "mg/dL"},
+            "interpretation": [{"coding": [{"code": flag}]}]}}
+    return {"summary": {}, "consumer": {}, "disclaimer": "Decision support.",
+            "bundle": {"entry": [_obs("2093-3", 244, "2026-03-01", "H"),
+                                 _obs("2093-3", 210, "2025-01-01"),
+                                 _obs("4548-4", 6.1, "2026-02-01")]}}
+
+
+def test_the_timeline_endpoint_returns_series_for_the_signed_in_agent(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn = _chat_app(cfg, svc, monkeypatch)
+    fake.interpret_labs = lambda t: _interpret_payload()
+
+    body = c.get(f"/api/labs/timeline?agent={agent_id}").get_json()
+    names = [s["name"] for s in body["series"]]
+    assert "Total cholesterol" in names and "Hemoglobin A1c" in names
+    assert body["disclaimer"] == "Decision support."
+
+
+def test_the_timeline_endpoint_narrows_to_the_topic_asked_about(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn = _chat_app(cfg, svc, monkeypatch)
+    fake.interpret_labs = lambda t: _interpret_payload()
+
+    body = c.get(
+        f"/api/labs/timeline?agent={agent_id}&topic=cholesterol").get_json()
+    assert [s["name"] for s in body["series"]] == ["Total cholesterol"]
+
+
+def test_the_timeline_endpoint_refuses_an_agent_you_do_not_own(
+        cfg, svc, monkeypatch):
+    """MUTATION: drop the get_agent_context check -> red. The agent id comes
+    from the query string; it selects the TENANT whose labs are returned."""
+    app, c, fake, agent_id, tenant, _conn = _chat_app(cfg, svc, monkeypatch)
+    assert c.get("/api/labs/timeline?agent=someone-elses").status_code == 404
+
+
+def test_the_timeline_endpoint_requires_a_session(cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn = _chat_app(cfg, svc, monkeypatch)
+    anon = app.test_client()
+    assert anon.get(f"/api/labs/timeline?agent={agent_id}").status_code in (302, 401)
+
+
+def test_the_timeline_endpoint_degrades_rather_than_500ing(
+        cfg, svc, monkeypatch):
+    def _boom(_t):
+        raise HealthClawError("interpret failed (503)", 503)
+    app, c, fake, agent_id, tenant, _conn = _chat_app(cfg, svc, monkeypatch)
+    fake.interpret_labs = _boom
+    assert c.get(f"/api/labs/timeline?agent={agent_id}").status_code == 502
+
+
+def test_show_lab_timeline_emits_a_card_and_withholds_the_numbers(
+        cfg, svc, monkeypatch):
+    """The chart carries the values. Handing them to the model too invites it
+    to restate every number and to narrate a direction from a single point.
+
+    MUTATION: return the readings in the tool result -> red.
+    """
+    import json as _json
+
+    from careagents.agent import _execute_tool
+
+    class _HC:
+        def interpret_labs(self, _tenant):
+            return _interpret_payload()
+
+    events = []
+    out = _json.loads(_execute_tool(_HC(), "t", "show_lab_timeline",
+                                    {"topic": "cholesterol"}, events))
+    assert events == [{"type": "card", "kind": "lab-timeline",
+                       "topic": "cholesterol"}]
+    assert out["chart_shown"] is True
+    assert out["series"] == [{"name": "Total cholesterol", "readings": 2,
+                              "trend_plottable": True}]
+    assert "244" not in _json.dumps(out), "the tool handed the model raw values"
+
+
+def test_show_lab_timeline_with_no_match_emits_no_card_and_forbids_absence(
+        cfg, svc, monkeypatch):
+    """MUTATION: emit a card over an empty series -> red (an empty chart reads
+    as 'nothing there'), and the note must forbid reporting absence."""
+    import json as _json
+
+    from careagents.agent import _execute_tool
+
+    class _HC:
+        def interpret_labs(self, _tenant):
+            return {"bundle": {"entry": []}, "disclaimer": ""}
+
+    events = []
+    out = _json.loads(_execute_tool(_HC(), "t", "show_lab_timeline", {}, events))
+    assert events == []
+    assert out["chart_shown"] is False
+    assert "not the same as" in out["note"]

--- a/tests/test_labs_timeline.py
+++ b/tests/test_labs_timeline.py
@@ -1,0 +1,173 @@
+"""Series building for the chat's lab-timeline card.
+
+Reported live 2026-08-04: "give me a timeline of my cholesterol results" made
+eight tool calls and then errored. Prose was the wrong shape for the question.
+
+The series carries clinical numbers into a chart, so what these pin is not
+"does it group" but the honesty properties: no invented values, no invented
+direction, no invented absence, and no second opinion on a reference range.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+from careagents.labs_timeline import ANALYTES, build_series, keys_for_topic
+
+LOINC = "http://loinc.org"
+TEMPLATE = (pathlib.Path(__file__).resolve().parent.parent
+            / "templates" / "mcp_apps" / "lab_trends.html")
+
+
+def _obs(code, value, date="2026-01-01", unit="mg/dL", flag="N", **kw):
+    res = {"resourceType": "Observation",
+           "code": {"coding": [{"system": LOINC, "code": code}]},
+           "effectiveDateTime": date}
+    if value is not None:
+        res["valueQuantity"] = {"value": value, "unit": unit}
+    if flag:
+        res["interpretation"] = [{"coding": [{"code": flag}]}]
+    res.update(kw)
+    return {"resource": res}
+
+
+def _bundle(*entries):
+    return {"resourceType": "Bundle", "entry": list(entries)}
+
+
+# --- grouping ------------------------------------------------------------
+
+def test_readings_are_grouped_by_analyte_oldest_first():
+    series = build_series(_bundle(
+        _obs("2093-3", 244, "2026-03-01"),
+        _obs("2093-3", 210, "2025-01-01"),
+        _obs("2085-9", 48, "2025-06-01")))
+    names = [s["name"] for s in series]
+    assert names == ["Total cholesterol", "HDL cholesterol"]
+    assert [r["date"] for r in series[0]["readings"]] == \
+        ["2025-01-01", "2026-03-01"]
+
+
+def test_an_analyte_is_a_code_set():
+    """MUTATION: match only the first LDL code -> red.
+
+    The same test arrives under different LOINCs from different labs; matching
+    one draws a confident line through part of the data (#343, one level up).
+    """
+    series = build_series(_bundle(
+        _obs("13457-7", 130, "2025-01-01"),
+        _obs("18262-6", 118, "2026-01-01")))
+    assert len(series) == 1
+    assert len(series[0]["readings"]) == 2
+
+
+def test_an_analyte_with_no_readings_is_omitted():
+    series = build_series(_bundle(_obs("2093-3", 200)))
+    assert [s["key"] for s in series] == ["total-cholesterol"]
+
+
+# --- honesty -------------------------------------------------------------
+
+def test_a_reading_without_a_number_is_skipped_never_zeroed():
+    """MUTATION: default a missing value to 0 -> red.
+
+    A 0 plotted on a cholesterol chart is a clinical claim nobody made.
+    """
+    series = build_series(_bundle(
+        _obs("2093-3", None, "2025-01-01"),
+        _obs("2093-3", 244, "2026-01-01")))
+    assert [r["value"] for r in series[0]["readings"]] == [244]
+
+
+def test_a_boolean_is_not_mistaken_for_a_number():
+    """bool is a subclass of int in Python — True would plot as 1."""
+    series = build_series(_bundle(_obs("2093-3", True, "2025-01-01")))
+    assert series == []
+
+
+def test_one_reading_is_not_plottable_as_a_trend():
+    """MUTATION: always report trend_plottable -> red. One point has no
+    direction, and the surface must not draw a line through it."""
+    series = build_series(_bundle(_obs("2093-3", 244)))
+    assert series[0]["trend_plottable"] is False
+
+
+def test_two_dated_readings_are_plottable():
+    series = build_series(_bundle(
+        _obs("2093-3", 244, "2025-01-01"), _obs("2093-3", 210, "2026-01-01")))
+    assert series[0]["trend_plottable"] is True
+
+
+def test_undated_readings_are_kept_but_do_not_make_a_trend():
+    """A reading we cannot place in time is still a reading. It must not be
+    dropped (that would report absence), nor counted toward a trend line."""
+    series = build_series(_bundle(
+        _obs("2093-3", 244, ""), _obs("2093-3", 210, "")))
+    assert len(series[0]["readings"]) == 2
+    assert series[0]["trend_plottable"] is False
+
+
+def test_the_engines_flag_is_carried_through_never_recomputed():
+    """MUTATION: derive the flag from the value here -> red.
+
+    A second opinion on a reference range is how a patient sees a different
+    verdict from the one we audited.
+    """
+    series = build_series(_bundle(_obs("2093-3", 244, flag="HH")))
+    assert series[0]["readings"][0]["flag"] == "HH"
+
+
+def test_a_reading_with_no_interpretation_is_indeterminate_not_normal():
+    """MUTATION: default the flag to N -> red. 'The engine did not judge
+    this' must never render as 'this is fine'."""
+    series = build_series(_bundle(_obs("2093-3", 244, flag=None)))
+    assert series[0]["readings"][0]["flag"] == "IND"
+
+
+# --- topic narrowing -----------------------------------------------------
+
+def test_a_cholesterol_question_narrows_to_the_lipid_panel():
+    keys = keys_for_topic("how has my cholesterol changed?")
+    assert set(keys) == {"total-cholesterol", "ldl", "hdl", "triglycerides"}
+    assert "a1c" not in keys
+
+
+def test_no_topic_means_everything_but_an_unmatched_topic_means_nothing():
+    """MUTATION: return None for an unmatched topic -> red.
+
+    None ("show what there is") and [] ("nothing matched") are different
+    answers. Collapsing them means asking about one test silently dumps every
+    series the person has.
+    """
+    assert keys_for_topic("") is None
+    assert keys_for_topic(None) is None
+    assert keys_for_topic("my knee") == []
+
+    everything = build_series(_bundle(_obs("2093-3", 200), _obs("4548-4", 6.1)),
+                              keys_for_topic(""))
+    assert len(everything) == 2
+    assert build_series(_bundle(_obs("2093-3", 200)),
+                        keys_for_topic("my knee")) == []
+
+
+# --- the duplication we cannot remove ------------------------------------
+
+def test_the_analyte_table_matches_the_mcp_app():
+    """MUTATION: add a code on either side only -> red.
+
+    templates/mcp_apps/lab_trends.html groups the same way in JavaScript
+    because it talks to the engine straight from a browser and cannot import
+    this module. Two implementations of one concept drift; a constant we
+    cannot share in code is at least one we refuse to let diverge.
+    """
+    src = TEMPLATE.read_text(encoding="utf-8")
+    block = re.search(r"var PANELS = \[(.*?)\];", src, re.S)
+    assert block, "PANELS not found in the MCP App"
+    js = {}
+    for name, codes in re.findall(
+            r'name:\s*"([^"]+)",\s*codes:\s*\[([^\]]*)\]', block.group(1)):
+        js[name] = {c.strip().strip('"') for c in codes.split(",") if c.strip()}
+    py = {a["name"]: set(a["codes"]) for a in ANALYTES}
+    assert js == py, (
+        "the chat card and the MCP App disagree about which LOINC codes make "
+        "up an analyte; one surface will silently plot fewer readings")


### PR DESCRIPTION
Follow-up to #357. That PR gave MCP clients the rich trend view; this gives the CareAgents chat the same answer inline, so "give me a timeline of my cholesterol results" finally gets the shape it asked for.

## The embed decision, made deliberately

**Rendered inline, not as an iframe of HealthClaw's `lab-trends` app.** That app is same-origin to the engine and authenticates with a step-up token; embedded cross-origin from CareAgents it would either 401 or need a credential in a URL. Neither is acceptable, and this process already holds the credentials — so it fetches server-side (`GET /api/labs/timeline`, session-authenticated, agent-ownership checked) and the browser receives *series only*.

Secondary reason, learned the hard way: iOS will not scroll an iframe's internals. The Fasten dialog taught that twice.

## The model gets shape, not numbers

`show_lab_timeline` emits a card event and returns only *how many series, how many points, whether a trend is plottable*. **The chart carries the values.** Handing them to the model as well invites it to restate every number, and — worse — to narrate a direction from a single point. A test asserts the raw values never appear in the tool result.

## Honesty properties, each with its mutation

- a reading with no number is **skipped, never zeroed** — a `0` on a cholesterol chart is a clinical claim nobody made
- **a bool is not a number** — `bool` subclasses `int` in Python, so `True` would have plotted as `1`
- **one reading is never a trend**, in the data (`trend_plottable`) and in the drawing (no line through a single point)
- an unmatched topic returns `[]`, not `None` — collapsing "nothing matched" into "show everything" means asking about one test silently dumps every series the person has
- the engine's `interpretation` flag is carried **verbatim**, and a missing one is `IND`, not `N` — *"the engine did not judge this"* must never render as *"this is fine"*
- an empty result says the **connected** record has none, never that the person has none

## The duplication I could not remove

`templates/mcp_apps/lab_trends.html` groups by analyte in JavaScript because it talks to the engine straight from a browser and cannot import `careagents/labs_timeline.py`. Two implementations of one concept drift, so `test_the_analyte_table_matches_the_mcp_app` parses the template's `PANELS` and compares it to `ANALYTES` — add or drop a LOINC on either side and it goes red. A constant we cannot share in code is at least one we refuse to let diverge.

20 new tests. Full suite 2426 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)