### PR TITLE
fix(ci): the ios-zoom rule flagged every font-size, not form controls

### DIFF
--- a/scripts/check_table_stakes.py
+++ b/scripts/check_table_stakes.py
@@ -148,6 +148,38 @@ CDN_ASSET = re.compile(
 SMALL_INPUT_FONT = re.compile(
     r"font-size\s*:\s*(\d+(?:\.\d+)?)px", re.I)
 
+# iOS zooms the page when a FORM CONTROL is focused whose font-size is under
+# 16px. It does not zoom for static text, so the rule only fires inside a rule
+# whose selector reaches a control. Matching every font-size (which is what it
+# used to do, despite the name and the message both saying "inputs") banned
+# every new caption, axis label and helper line in the product — 13px body
+# copy has always been fine and is used throughout the existing stylesheet.
+INPUTISH_SELECTOR = re.compile(
+    r"\b(input|select|textarea|button|\[contenteditable)|"
+    r"[.#][\w-]*(input|field|search|combo|entry|form-control)[\w-]*",
+    re.I)
+
+
+def _enclosing_selector(whole_file: str, line_number: int) -> str:
+    """The selector of the CSS rule containing this line, best effort.
+
+    Walks back to the nearest `{` and returns the text before it, including a
+    preceding line so multi-line selector lists still resolve. Returns "" when
+    the line is not inside a rule (an inline `style=` attribute, say), which
+    the caller handles by looking at the line itself.
+    """
+    lines = whole_file.splitlines()
+    for idx in range(min(line_number, len(lines)) - 1, -1, -1):
+        line = lines[idx]
+        if "{" in line:
+            selector = line.split("{", 1)[0]
+            if idx and not selector.strip():
+                selector = lines[idx - 1]
+            return selector
+        if "}" in line:
+            return ""          # left the rule without finding its opening
+    return ""
+
 MOTION = re.compile(r"\b(transition|animation)\s*:", re.I)
 
 
@@ -171,10 +203,13 @@ def check_style(path: str, lines: list[tuple[int, str]],
 
         m = SMALL_INPUT_FONT.search(raw)
         if m and float(m.group(1)) < 16:
-            out.append(Finding(
-                path, num, "ios-zoom-font-size",
-                f"{m.group(1)}px — iOS zooms the page below 16px on inputs",
-                raw.strip()[:100]))
+            context = raw + " " + _enclosing_selector(whole_file, num)
+            if INPUTISH_SELECTOR.search(context):
+                out.append(Finding(
+                    path, num, "ios-zoom-font-size",
+                    f"{m.group(1)}px on a form control — iOS zooms the page "
+                    "when one under 16px is focused",
+                    raw.strip()[:100]))
 
     if any(MOTION.search(raw) for _, raw in lines):
         if "prefers-reduced-motion" not in whole_file:

--- a/tests/test_table_stakes.py
+++ b/tests/test_table_stakes.py
@@ -96,8 +96,45 @@ def test_cdn_asset_is_flagged_because_the_csp_blocks_it():
         _style('<script src="https://cdn.example.com/x.js"></script>'))
 
 
-def test_small_input_font_is_flagged_for_ios_zoom():
-    assert "ios-zoom-font-size" in _rules(_style("  font-size: 14px;"))
+def test_small_font_on_a_form_control_is_flagged_for_ios_zoom():
+    """Updated with the rule. This previously asserted that ANY font-size
+    under 16px was flagged, which is not what iOS does and not what the rule
+    or its message claimed: Safari zooms when a FORM CONTROL under 16px is
+    focused. Flagging every declaration banned each new caption and axis
+    label, while the existing stylesheet is full of 13-14px body copy.
+    """
+    css = "input.tenant {\n  font-size: 14px;\n}"
+    assert "ios-zoom-font-size" in _rules(
+        check_style("a.css", [(2, "  font-size: 14px;")], css))
+
+
+def test_the_selector_is_found_across_a_multi_line_selector_list():
+    css = "textarea,\nselect {\n  font-size: 13px;\n}"
+    assert "ios-zoom-font-size" in _rules(
+        check_style("a.css", [(3, "  font-size: 13px;")], css))
+
+
+def test_an_inline_style_on_an_input_is_flagged():
+    line = '<input class="x" style="font-size:13px">'
+    assert "ios-zoom-font-size" in _rules(_style(line))
+
+
+def test_small_font_on_static_text_is_not_flagged():
+    """MUTATION: drop the selector check -> red.
+
+    iOS does not zoom for static text. A rule that says otherwise makes every
+    caption, axis label and helper line a CI failure — which is how a guard
+    stops being read as signal.
+    """
+    css = ".spark-axis {\n  font-size: 10px;\n}"
+    assert "ios-zoom-font-size" not in _rules(
+        check_style("a.css", [(2, "  font-size: 10px;")], css))
+
+
+def test_a_16px_control_is_fine():
+    css = "input {\n  font-size: 16px;\n}"
+    assert "ios-zoom-font-size" not in _rules(
+        check_style("a.css", [(2, "  font-size: 16px;")], css))
 
 
 def test_motion_without_the_media_query_is_flagged():


### PR DESCRIPTION
Found while building #358 — the lint job failed on three CSS lines that are correct.

## The rule did not do what it says

```python
SMALL_INPUT_FONT = re.compile(r"font-size\s*:\s*(\d+(?:\.\d+)?)px", re.I)
...
f"{m.group(1)}px — iOS zooms the page below 16px on inputs"
```

The constant is named `SMALL_INPUT_FONT`, the message says **"on inputs"**, and the pattern matches **every** `font-size`. iOS Safari zooms the page when a **form control under 16px is focused**; it does not zoom for static text.

So the rule rejected a chart's axis label at 10px and a caption at 13px. Meanwhile `careagents.css` is full of 13-14px body copy that passes only because the check looks at *added* lines — the existing product would fail its own rule.

**A guard that fails on correct code is one people learn to route around**, which costs more than the defect it was aimed at. That's the reason to fix it rather than bump three numbers to 16px and ship an ugly chart.

## The fix

Resolve the enclosing selector — walk back to the rule's opening brace, including a preceding line so multi-line selector lists (`textarea,\nselect {`) still resolve — and fire only when the selector reaches a control (`input`, `select`, `textarea`, `button`, `[contenteditable`, or a class/id like `.search-field`). The raw line is checked too, so an inline `style="font-size:13px"` on an `<input>` is still caught.

## Tests

`test_small_input_font_is_flagged_for_ios_zoom` asserted the old behaviour, so **it is updated in this PR** rather than left to go red on main — the §6 rule. Four cases added:

- a form control under 16px → **flagged**
- a multi-line selector list → **flagged** (the walk-back would otherwise miss it)
- an inline `style=` on an input → **flagged**
- static text at 10px → **not flagged**, the mutation guard for the whole change

Full suite 2410 passed; ruff, mypy and table-stakes all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)