### PR TITLE
fix(careagents): D5, actually landed this time — the sync path leaked str(exc)

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -29,6 +29,30 @@ MAX_TOOL_ROUNDS = 6
 # that person failed until the process restarted.
 MAX_HISTORY_MESSAGES = 40
 
+# The one place patient-facing failure text is decided. Every surface —
+# durable worker, streamed browser chat, SMS/iMessage collapse, the app's
+# empty-event fallbacks — imports these rather than carrying its own copy;
+# four sites had diverging literals, and one of them was yielding str(exc),
+# which showed a patient "model call failed (HTTP 429)" verbatim.
+GENERIC_FAILURE_TEXT = "Something went wrong on our side."
+RATE_LIMITED_TEXT = (
+    "I'm getting more requests than I can answer right now. Nothing is wrong "
+    "with your records — try asking again in a moment.")
+
+
+def failure_text(exc: Exception) -> str:
+    """What the person reads when a turn fails.
+
+    A rate limit is not a defect, and saying "something went wrong on our
+    side" for one is two failures at once: it invites a bug report for a bug
+    that does not exist, and it leaves a patient wondering whether their
+    health records are broken. Everything else stays generic on purpose —
+    exception internals are never patient-facing text.
+    """
+    if isinstance(exc, llm.LLMRateLimited):
+        return RATE_LIMITED_TEXT
+    return GENERIC_FAILURE_TEXT
+
 
 def _trim_history(history: list) -> None:
     """Drop the oldest turns in place, cutting only at a safe boundary.
@@ -342,7 +366,7 @@ def run_turn(cfg, hc: HealthClawClient, tenant: str, system: str,
         try:
             turn = llm.complete(cfg, system, history, TOOLS)
         except llm.LLMError as exc:
-            yield {"type": "error", "text": str(exc)}
+            yield {"type": "error", "text": failure_text(exc)}
             return
 
         if not turn.tool_calls:
@@ -384,7 +408,7 @@ def run_turn(cfg, hc: HealthClawClient, tenant: str, system: str,
             try:
                 final = llm.complete(cfg, system, history, [])
             except llm.LLMError as exc:
-                yield {"type": "error", "text": str(exc)}
+                yield {"type": "error", "text": failure_text(exc)}
                 return
             history.append({"role": "assistant", "content": final.text})
             yield {"type": "text", "text": final.text}
@@ -408,7 +432,7 @@ def run_turn_to_message(cfg, hc: HealthClawClient, tenant: str, system: str,
         if kind == "text" and ev.get("text"):
             parts.append(ev["text"])
         elif kind == "error":
-            return ev.get("text") or "Something went wrong on our side."
+            return ev.get("text") or GENERIC_FAILURE_TEXT
         elif kind == "card" and ev.get("kind") == "review":
             aid = ev.get("action_id", "")
             link = (f"{base}/review/{agent_id}/{aid}"

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -28,6 +28,7 @@ from careagents.accounts import (AccountService, AuthError, MailError,
                                  new_binding_code)
 from careagents import advisors, connectors
 from careagents import labs_timeline as labs_timeline_mod
+from careagents.agent import GENERIC_FAILURE_TEXT
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
 from careagents.personas import DEFAULT_PERSONA, PERSONAS
@@ -662,8 +663,8 @@ def create_app(config: Config | None = None,
         if kind == "agent.text":
             return {"type": "text", "text": payload.get("text") or ""}
         if kind == "agent.error":
-            return {"type": "error", "text": payload.get("text") or (
-                "Something went wrong on our side.")}
+            return {"type": "error",
+                    "text": payload.get("text") or GENERIC_FAILURE_TEXT}
         return None
 
     def _run_belongs_to(run: dict, tenant: str, agent_id: str) -> bool:
@@ -1066,10 +1067,9 @@ def create_app(config: Config | None = None,
                 extras.append(
                     f"Your signed document is ready: {event['url']}")
             elif event.get("type") == "error":
-                parts.append(event.get("text") or (
-                    "Something went wrong on our side."))
+                parts.append(event.get("text") or GENERIC_FAILURE_TEXT)
         reply = "\n\n".join([*parts, *extras]).strip() or (
-            "Something went wrong on our side. Please try again.")
+            GENERIC_FAILURE_TEXT + " Please try again.")
         return jsonify({"run_id": run_id, "status": page.get("status"),
                         "reply": reply})
 

--- a/careagents/worker.py
+++ b/careagents/worker.py
@@ -18,7 +18,9 @@ from datetime import datetime, timezone
 
 from careagents import llm
 from careagents.accounts import AccountService
-from careagents.agent import (MAX_TOOL_ROUNDS, TOOL_LABELS, TOOLS,
+from careagents.agent import (MAX_TOOL_ROUNDS,
+                              TOOL_LABELS, TOOLS,
+                              failure_text as agent_failure_text,
                               _execute_tool, _trim_history)
 from careagents.config import Config
 from careagents.healthclaw import HealthClawClient, HealthClawError
@@ -56,25 +58,11 @@ def _error_class(exc: Exception) -> str:
     return name if name and name[0].isalpha() else "WorkerError"
 
 
-GENERIC_FAILURE_TEXT = "Something went wrong on our side."
-RATE_LIMITED_TEXT = (
-    "I'm getting more requests than I can answer right now. Nothing is wrong "
-    "with your records — try asking again in a moment.")
-
-
-def _failure_text(exc: Exception) -> str:
-    """What the person reads when a run fails.
-
-    A rate limit is not a defect, and saying "something went wrong on our
-    side" for one is two failures at once: it invites a bug report for a bug
-    that does not exist, and it leaves a patient wondering whether their
-    health records are broken. Reported live on 2026-08-04 — a "give me a
-    timeline of my cholesterol results" run died on a provider HTTP 429 and
-    the patient saw only the generic message.
-    """
-    if isinstance(exc, llm.LLMRateLimited):
-        return RATE_LIMITED_TEXT
-    return GENERIC_FAILURE_TEXT
+# One source of truth for patient-facing failure text — careagents/agent.py
+# owns it so the worker, the streamed chat, and the SMS collapse cannot
+# drift apart again. Re-exported here because this module's callers and
+# tests reach it by this path.
+_failure_text = agent_failure_text
 
 
 class LeaseHeartbeat:

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -18,7 +18,7 @@ import types
 import pytest
 import requests
 
-from careagents import llm, worker
+from careagents import agent, llm, worker
 
 
 class _Cfg:
@@ -169,14 +169,14 @@ def test_backoff_grows_and_is_capped():
 def test_the_patient_is_not_told_a_rate_limit_is_our_defect():
     """MUTATION: return the generic text for every exception -> red."""
     text = worker._failure_text(llm.LLMRateLimited("429"))
-    assert text == worker.RATE_LIMITED_TEXT
+    assert text == agent.RATE_LIMITED_TEXT
     assert "went wrong" not in text.lower()
     assert "your records" in text.lower()
 
 
 def test_a_real_defect_still_reads_as_a_defect():
-    assert worker._failure_text(ValueError("boom")) == worker.GENERIC_FAILURE_TEXT
-    assert worker._failure_text(llm.LLMError("HTTP 500")) == worker.GENERIC_FAILURE_TEXT
+    assert worker._failure_text(ValueError("boom")) == agent.GENERIC_FAILURE_TEXT
+    assert worker._failure_text(llm.LLMError("HTTP 500")) == agent.GENERIC_FAILURE_TEXT
 
 
 def test_rate_limited_is_an_llm_error_so_existing_handlers_still_catch_it():
@@ -214,3 +214,48 @@ def test_anthropic_429_is_classified_without_a_second_retry_layer(monkeypatch):
         anthropic_oauth_token="")
     with pytest.raises(llm.LLMRateLimited):
         llm.complete(cfg, "sys", [{"role": "user", "content": "hi"}], [])
+
+
+# --- the synchronous path (run_turn) --------------------------------------
+#
+# The durable worker was fixed first, but the streamed browser chat and the
+# SMS/iMessage collapse go through agent.run_turn — which yielded str(exc)
+# as the error event's text. A patient on those surfaces saw the literal
+# "model call failed (HTTP 429)".
+
+def _turn_events(monkeypatch, exc):
+    from careagents import agent
+
+    def _boom(*_a, **_k):
+        raise exc
+    monkeypatch.setattr(llm, "complete", _boom)
+    return list(agent.run_turn(
+        types.SimpleNamespace(), None, "t", "sys", [], "hi"))
+
+
+def test_the_sync_path_does_not_leak_exception_internals(monkeypatch):
+    """MUTATION: yield str(exc) again -> red."""
+    events = _turn_events(monkeypatch, llm.LLMError("model call failed (HTTP 500)"))
+    assert events == [{"type": "error", "text": agent.GENERIC_FAILURE_TEXT}]
+    assert "HTTP" not in events[0]["text"]
+
+
+def test_the_sync_path_tells_the_truth_about_a_rate_limit(monkeypatch):
+    events = _turn_events(monkeypatch, llm.LLMRateLimited("HTTP 429"))
+    assert events == [{"type": "error", "text": agent.RATE_LIMITED_TEXT}]
+
+
+def test_the_failure_text_has_exactly_one_home():
+    """MUTATION: re-add a local copy anywhere -> red.
+
+    Four sites carried diverging literals of this string; one showed raw
+    exception text. The constant lives in careagents/agent.py and everything
+    else imports it.
+    """
+    import pathlib
+    root = pathlib.Path(worker.__file__).parent
+    owners = [p.name for p in root.glob("*.py")
+              if "Something went wrong" in p.read_text(encoding="utf-8")]
+    assert owners == ["agent.py"], (
+        f"patient-facing failure text is defined in {owners}; only agent.py "
+        "may own it — import GENERIC_FAILURE_TEXT instead")


### PR DESCRIPTION
**This work was reported as shipped and was not.** I pushed it to `fix/llm-retry-and-rate-limit-message` after #345 had already auto-merged, so the commit sat on a dead branch — the exact trap CLAUDE.md warns about, which I quoted earlier the same day:

> Pushing to a branch whose PR already merged is a no-op you will report as a fix. Verify the commit is an ancestor of `origin/main`, not just that the ref moved.

Caught while verifying the CareAgents deploy: `from careagents.agent import RATE_LIMITED_TEXT` raised `ImportError` on the running worker. `git merge-base --is-ancestor` then confirmed the commit never reached main. Recovered by cherry-pick (one import-line conflict, both lines wanted).

## What was missing from production

`agent.run_turn` yielded **`str(exc)`** as the error event's text — so on the streamed browser chat and the SMS/iMessage surfaces a patient saw the literal:

```
model call failed (HTTP 429)
```

#345's honest rate-limit message only ever covered the durable worker path. The two surfaces a patient is most likely to be on were still showing exception internals.

## The change

`careagents/agent.py` now owns `GENERIC_FAILURE_TEXT`, `RATE_LIMITED_TEXT` and `failure_text()`. The worker delegates, `app.py` imports the constant for its empty-event fallbacks, and `run_turn` classifies instead of leaking. Four diverging copies of the string become one.

`test_the_failure_text_has_exactly_one_home` greps the package: re-adding a local copy anywhere goes red.

One `str(exc)` remains on purpose, at `agent.py:393` — that's a *tool* error going to the *model*, which should see what failed. The patient-facing paths are the ones that must never carry it.

Full suite 2433 passed; ruff, mypy and table-stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)