### PR TITLE
fix(careagents): an import in flight is not an empty chart (#336)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -346,7 +346,13 @@ class AccountService:
             return a.id
 
     def get_agent_context(self, account_id: str, agent_id: str) -> dict | None:
-        """Return {agent, tenant} for an agent the account owns, else None."""
+        """Return {agent, tenant, connection} for an agent the account owns.
+
+        The Connection row is already loaded here to resolve the tenant. It
+        used to be discarded, which left the chat greeting with a record count
+        and no way to tell an empty chart from an import still in flight
+        (#336) — so it is returned rather than fetched a second time.
+        """
         with self.session() as s:
             a = s.query(Agent).filter_by(
                 id=agent_id, account_id=account_id).first()
@@ -355,7 +361,8 @@ class AccountService:
             conn = s.get(Connection, a.connection_id)
             if not conn:
                 return None
-            return {"agent": _agent_dict(a), "tenant": conn.tenant_id}
+            return {"agent": _agent_dict(a), "tenant": conn.tenant_id,
+                    "connection": _conn_dict(conn)}
 
     def get_worker_agent_context(self, agent_id: str) -> dict | None:
         """Resolve an agent for the trusted run worker.
@@ -430,6 +437,7 @@ def _detach(acct: Account) -> _Row:
 def _conn_dict(c: Connection) -> dict:
     return {"id": c.id, "kind": c.kind, "tenant_id": c.tenant_id,
             "label": c.label, "status": c.status, "provider": c.provider,
+            "connected_at": c.connected_at,
             "last_synced_at": c.last_synced_at, "last_count": c.last_count}
 
 

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -27,6 +27,7 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
 from careagents.accounts import (AccountService, AuthError, MailError,
                                  new_binding_code)
 from careagents import advisors, connectors
+from careagents import intake_state
 from careagents import labs_timeline as labs_timeline_mod
 from careagents.agent import GENERIC_FAILURE_TEXT
 from careagents.config import Config
@@ -594,11 +595,15 @@ def create_app(config: Config | None = None,
             conversation_id=conversation_id,
             agent_id=agent_id,
         )
-        summary_counts = None
-        if not past:
-            # First visit: show real record counts so the user immediately sees
-            # the product's value rather than a generic prompt.
-            #
+        conn = ctx.get("connection") or {}
+        pending = conn.get("status") == "pending"
+        totals = None
+        # Count when the greeting will use it, and whenever an import is
+        # outstanding — a `pending` row is the one case where the stored status
+        # may be behind the records, and a returning patient checking whether
+        # anything landed is exactly who must not be told "still arriving"
+        # about a chart that is already here.
+        if not past or pending:
             # _summary=count, NOT len(entry): entry is one page (the server
             # caps it), so len() reported the page size as the total. A real
             # import showed "50 conditions ... 50 lab results" to a person
@@ -612,18 +617,29 @@ def create_app(config: Config | None = None,
                     bundle = hc.search(ctx["tenant"], rt,
                                        {"_summary": "count"})
                     return int(bundle.get("total") or 0)
-                summary_counts = {
+                totals = {
                     "conditions": _total("Condition"),
                     "medications": _total("MedicationRequest"),
                     "labs": _total("Observation"),
                 }
             except (HealthClawError, TypeError, ValueError):
-                pass  # fall back to generic greeting on any error
+                totals = None   # unknown, which is never the same as zero
+        intake = intake_state.classify(
+            totals=totals,
+            connection_status=conn.get("status"),
+            connected_at=conn.get("connected_at"),
+            now=time.time(),
+            provider=conn.get("provider") or conn.get("label"))
+        if pending and intake.state == intake_state.READY:
+            # Records landed while nobody was polling /connect. Settle the
+            # stored status here so the next visit costs no counts.
+            svc.set_connection_status(ctx["tenant"], "active")
         return render_template("chat.html", me=ctx["agent"], persona=p,
                                agent_id=agent_id,
                                conversation_id=conversation_id,
                                past=past,
-                               summary_counts=summary_counts)
+                               intake=intake,
+                               summary_counts=intake.counts)
 
     @app.get("/brief")
     @login_required

--- a/careagents/intake_state.py
+++ b/careagents/intake_state.py
@@ -1,0 +1,83 @@
+"""Which of four things is true about a patient's records — and only one.
+
+Reported live 2026-08-04 (#336). Moments after a Fasten/MEDENT connect, the
+agent greeting said:
+
+    Hi — I'm joe. I found 0 conditions, 0 medications, and 0 lab results in
+    your records.
+
+The import was still running; the connect page had promised records "over the
+next 5-45 minutes". Zero was the expected state. The count was accurate and
+the sentence was false, because "I found 0 conditions in your records" reads
+as *you have no conditions* — a claim about the person's health made from a
+fact about a background job.
+
+Zero-from-empty and zero-from-not-yet-arrived are the same number. Only the
+connection tells them apart, which is why this takes the connection and not
+just the totals.
+
+## Why counts live inside the state
+
+`counts` is populated for :data:`READY` and is `None` everywhere else, and
+:func:`classify` drops them rather than trusting the caller to check. The
+alternative — return the counts always and have each template remember when it
+may print them — is the defect shape `docs/2026-08-02-retro.md` names: a
+control that looks like one thing and quietly does two. A caller cannot render
+a number that does not exist.
+
+Nothing here performs I/O, so the honest-vs-false decision is testable without
+a HealthClaw, an account, or a browser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+NO_CONNECTION = "no-connection"   # nothing to speak about yet
+ARRIVING = "arriving"             # connected, nothing landed, still in window
+OVERDUE = "overdue"               # connected, nothing landed, window passed
+READY = "ready"                   # something landed; counts are speakable
+
+# The window `/connect` itself promises ("over the next 5-45 minutes"). Past
+# it, "your records are still arriving" becomes its own unfounded claim — this
+# app cannot see the import job, so it knows only that nothing has landed. Same
+# family as #310, where a fabricated progress animation stood in for a fact the
+# app did not have.
+ARRIVAL_WINDOW_SECONDS = 45 * 60
+
+
+@dataclass(frozen=True)
+class IntakeState:
+    state: str
+    counts: dict | None
+    provider: str | None
+    minutes_waiting: int | None
+
+
+def classify(*, totals: dict | None, connection_status: str | None,
+             connected_at: float | None, now: float,
+             provider: str | None = None) -> IntakeState:
+    """Decide what may be said about this patient's records.
+
+    ``totals`` is ``None`` when the count was not taken or the lookup failed —
+    which is not the same as zero, and never collapses into it. A failed count
+    means we do not get to say what we would have seen.
+
+    ``connection_status`` is the stored ``pending|active|revoked``. It is a
+    weak signal on its own: it flips to ``active`` only while the connect page
+    is open polling, so a patient who closed the tab keeps a stale ``pending``
+    over a full chart. Records in hand therefore outrank it.
+    """
+    if connection_status is None:
+        return IntakeState(NO_CONNECTION, None, provider, None)
+
+    arrived = bool(totals) and any(int(v or 0) > 0 for v in totals.values())
+    if arrived or connection_status != "pending":
+        return IntakeState(READY, totals, provider, None)
+
+    waiting = None if connected_at is None else max(0.0, now - connected_at)
+    if waiting is not None and waiting > ARRIVAL_WINDOW_SECONDS:
+        return IntakeState(OVERDUE, None, provider, int(waiting // 60))
+    return IntakeState(
+        ARRIVING, None, provider,
+        None if waiting is None else int(waiting // 60))

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -219,6 +219,15 @@ h1 em { font-style: italic; color: var(--clay); }
 .chat-resumed { align-self: center; font-size: 12px; color: var(--muted, #5E5240);
   letter-spacing: .04em; text-transform: uppercase; opacity: .7; }
 
+/* An import still in flight is a fact about a background job, not about the
+   patient — so it reads as a notice from the app and never as the agent
+   speaking about their health (#336). Deliberately NOT .chat-resumed, whose
+   uppercase micro-label styling is for two words, not two sentences. */
+.chat-notice { align-self: stretch; font-size: 13.5px; line-height: 1.5;
+  color: var(--ink); background: var(--card);
+  border: 1px solid var(--hairline); border-left: 3px solid var(--clay);
+  border-radius: 10px; padding: 10px 13px; }
+
 .chips { display: flex; flex-direction: column; gap: 6px; align-self: flex-start; }
 .chip {
   display: inline-flex; align-items: center; gap: 8px;

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -18,6 +18,25 @@
   </div>
 
   <div class="chat-log" id="log">
+    {# An outstanding import is news on every visit, not only the first. The
+       greeting is where a patient looks for "did my records land?", and it
+       used to be computed only for a first visit — so the one person actually
+       watching for arrival was the one person never shown it (#336). #}
+    {% if intake and intake.state in ("arriving", "overdue") %}
+    <div class="chat-notice">
+      {% if intake.state == "arriving" %}
+      Your records{% if intake.provider %} from {{ intake.provider }}{% endif %}
+      haven't arrived yet — imports take 5–45 minutes. Nothing below reflects
+      them.
+      {% else %}
+      Nothing has arrived from your
+      {%- if intake.provider %} {{ intake.provider }}{% endif %} connection
+      {%- if intake.minutes_waiting %} in {{ intake.minutes_waiting }} minutes
+      {%- endif %}. That's longer than an import usually takes. You can retry
+      the connection from your home page.
+      {% endif %}
+    </div>
+    {% endif %}
     {% if past %}
     {# Returning: replay what was actually said rather than greeting them as a
        stranger. The starters are for someone who hasn't asked anything yet. #}

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import time
 
 import pytest
 
@@ -3159,6 +3160,112 @@ def test_a_broken_count_falls_back_to_the_generic_greeting(
     r = c.get(f"/chat?agent={agent_id}")
     assert r.status_code == 200
     assert b"in your records" not in r.data
+
+
+# ---------------------------------------------------------------------------
+# #336: an import in flight is not an empty chart. Reported live — a patient
+# finished a MEDENT connect, opened their agent, and was told "I found 0
+# conditions, 0 medications, and 0 lab results in your records" while the
+# import the connect page had just promised was still running.
+# ---------------------------------------------------------------------------
+def _counting(totals):
+    def search(tenant_id, resource_type, params=None):
+        return {"total": totals.get(resource_type, 0)}
+    return search
+
+
+def _account_id(svc, email="gene@example.com"):
+    from careagents.models import Account
+    with svc.session() as s:
+        return s.query(Account).filter_by(email=email).one().id
+
+
+def test_a_count_is_never_stated_while_an_import_is_in_flight(
+        cfg, svc, monkeypatch):
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+    svc.set_connection_status(tenant, "pending")
+    fake.search = _counting({})
+
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "0 condition" not in page, (
+        "stated a count as a finding about the person while the import that "
+        "would produce it was still running")
+    assert "in your records" not in page
+    assert "haven't arrived yet" in page
+
+
+def test_records_that_landed_while_nobody_polled_are_reported(
+        cfg, svc, monkeypatch):
+    """`status` flips to active only while /connect is open polling. A patient
+    who closed that tab keeps a stale `pending` over a full chart, and must
+    not be told their records are still on the way."""
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+    svc.set_connection_status(tenant, "pending")
+    fake.search = _counting({"Condition": 52, "MedicationRequest": 4,
+                             "Observation": 186})
+
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "52 conditions" in page
+    assert "haven't arrived yet" not in page
+    # and the status settles, so the next visit costs no counts
+    conns = svc.list_home(_account_id(svc))["connections"]
+    assert [x["status"] for x in conns if x["tenant_id"] == tenant] == \
+        ["active"]
+
+
+def test_a_returning_patient_is_told_the_records_still_have_not_landed(
+        cfg, svc, monkeypatch):
+    """The second trap in the same code: counts were computed only when the
+    conversation was empty, so the one person actually watching for arrival —
+    someone who asked a question and came back to check — was the one person
+    never shown the answer."""
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+    svc.set_connection_status(tenant, "pending")
+    fake.log_message(tenant, "user", "did my records land?", agent_id=agent_id)
+    fake.search = _counting({})
+
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "Picking up where you left off" in page   # still a return visit
+    assert "haven't arrived yet" in page
+
+
+def test_past_the_promised_window_we_stop_saying_they_are_coming(
+        cfg, svc, monkeypatch):
+    """"Still arriving" is a claim about a job this app cannot see. Past the
+    window /connect promises, all it knows is that nothing has landed."""
+    from careagents.intake_state import ARRIVAL_WINDOW_SECONDS
+    from careagents.models import Connection
+
+    app, c, fake, agent_id, tenant, conn_id = _chat_app(cfg, svc, monkeypatch)
+    svc.set_connection_status(tenant, "pending")
+    with svc.session() as s:
+        row = s.get(Connection, conn_id)
+        row.connected_at = time.time() - ARRIVAL_WINDOW_SECONDS - 60
+    fake.search = _counting({})
+
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "longer than an import usually takes" in page
+    assert "haven't arrived yet" not in page
+    assert "0 condition" not in page
+
+
+def test_an_unreachable_count_during_an_import_does_not_become_zero(
+        cfg, svc, monkeypatch):
+    """A failed count is not an empty chart — the engine being down must not
+    be reported as the patient having no records."""
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+    svc.set_connection_status(tenant, "pending")
+
+    def search(tenant_id, resource_type, params=None):
+        raise HealthClawError("search failed (503)", 503)
+
+    fake.search = search
+    page = c.get(f"/chat?agent={agent_id}").get_data(as_text=True)
+    assert "0 condition" not in page
+    assert "in your records" not in page
+    # An unreadable count is also not proof the import finished, so the
+    # outstanding-import notice stands rather than quietly disappearing.
+    assert "haven't arrived yet" in page
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_intake_state.py
+++ b/tests/test_intake_state.py
@@ -1,0 +1,125 @@
+"""Zero-from-empty and zero-from-not-yet-arrived are the same number (#336).
+
+A patient completed a Fasten/MEDENT connect, opened their agent, and was told
+"I found 0 conditions, 0 medications, and 0 lab results in your records" while
+the import was still running — the connect page having just promised records
+"over the next 5-45 minutes". The count was accurate and the sentence was
+false: it reads as *you have no conditions*.
+
+These tests pin the rule the fix turns on: a count is only ever speakable once
+something is known to have arrived. Everything else is a statement about the
+import, not about the person.
+"""
+
+from careagents.intake_state import (
+    ARRIVAL_WINDOW_SECONDS,
+    ARRIVING,
+    NO_CONNECTION,
+    OVERDUE,
+    READY,
+    classify,
+)
+
+NOW = 1_754_300_000.0
+SOME = {"conditions": 52, "medications": 9, "labs": 186}
+ZERO = {"conditions": 0, "medications": 0, "labs": 0}
+
+
+def test_zero_while_import_in_flight_is_not_a_finding():
+    """THE bug. Two minutes after connecting, zero means 'not yet'."""
+    st = classify(totals=ZERO, connection_status="pending",
+                  connected_at=NOW - 120, now=NOW, provider="MEDENT")
+    assert st.state == ARRIVING
+    assert st.counts is None, "a count in flight is a claim we cannot make"
+    assert st.provider == "MEDENT"
+
+
+def test_zero_after_a_completed_import_is_a_finding():
+    """State 3 of the issue: the original sentence is correct here, and only
+    here. An empty chart is a real answer once the import is done."""
+    st = classify(totals=ZERO, connection_status="active",
+                  connected_at=NOW - 120, now=NOW, provider="MEDENT")
+    assert st.state == READY
+    assert st.counts == ZERO
+
+
+def test_records_that_arrived_beat_a_stale_pending_status():
+    """`status` only flips to active while the connect page is open polling.
+    Close the tab and it stays 'pending' forever, so records-in-hand has to
+    win — otherwise a real chart is reported as still arriving."""
+    st = classify(totals=SOME, connection_status="pending",
+                  connected_at=NOW - 120, now=NOW, provider="MEDENT")
+    assert st.state == READY
+    assert st.counts == SOME
+
+
+def test_past_the_promised_window_we_stop_claiming_they_are_on_the_way():
+    """"Still arriving" is itself a claim about a job this app cannot see. Past
+    the window /connect promises, we know only that nothing has landed."""
+    st = classify(totals=ZERO, connection_status="pending",
+                  connected_at=NOW - ARRIVAL_WINDOW_SECONDS - 1, now=NOW,
+                  provider="MEDENT")
+    assert st.state == OVERDUE
+    assert st.counts is None
+
+
+def test_the_window_boundary_is_still_arriving():
+    st = classify(totals=ZERO, connection_status="pending",
+                  connected_at=NOW - ARRIVAL_WINDOW_SECONDS, now=NOW)
+    assert st.state == ARRIVING
+
+
+def test_no_connection_at_all():
+    st = classify(totals=None, connection_status=None, connected_at=None,
+                  now=NOW)
+    assert st.state == NO_CONNECTION
+    assert st.counts is None
+
+
+def test_counts_cannot_survive_a_non_ready_state():
+    """The structural guard, not a reminder. A caller that hands counts to a
+    state that must not speak them gets them dropped rather than rendered —
+    'there is nothing to print' beats 'remember not to print it'."""
+    st = classify(totals=SOME, connection_status="pending",
+                  connected_at=NOW - 60, now=NOW)
+    st_forced = classify(totals=ZERO, connection_status="pending",
+                         connected_at=NOW - 60, now=NOW)
+    assert st.counts is not None and st.state == READY   # arrived: fine
+    assert st_forced.counts is None                      # in flight: dropped
+
+
+def test_unknown_totals_never_read_as_zero():
+    """A failed count is not an empty chart. If we could not look, we do not
+    get to say what we would have seen."""
+    st = classify(totals=None, connection_status="pending",
+                  connected_at=NOW - 60, now=NOW)
+    assert st.state == ARRIVING
+    assert st.counts is None
+
+    active = classify(totals=None, connection_status="active",
+                      connected_at=NOW - 60, now=NOW)
+    assert active.state == READY
+    assert active.counts is None, "records are here; how many is unknown"
+
+
+def test_minutes_waiting_is_reported_for_the_waiting_states():
+    st = classify(totals=ZERO, connection_status="pending",
+                  connected_at=NOW - 600, now=NOW)
+    assert st.minutes_waiting == 10
+
+
+def test_a_missing_connected_at_does_not_manufacture_an_overdue():
+    """Rows predating the column have no timestamp. Unknown elapsed time is
+    not a long elapsed time."""
+    st = classify(totals=ZERO, connection_status="pending",
+                  connected_at=None, now=NOW)
+    assert st.state == ARRIVING
+    assert st.minutes_waiting is None
+
+
+def test_a_revoked_connection_still_reports_the_records_it_left_behind():
+    """Disconnect stops new data; it does not erase what already landed."""
+    st = classify(totals=SOME, connection_status="revoked",
+                  connected_at=NOW - 600, now=NOW)
+    assert st.state == READY
+    assert st.counts == SOME


### PR DESCRIPTION
Closes #336.

## The report

A patient finished a Fasten/MEDENT connect, opened their agent, and was told:

> Hi — I'm joe. I found **0 conditions**, **0 medications**, and **0 lab results** in your records.

The import was still running. The connect page had just promised records "over the next 5–45 minutes", so zero was the *expected* state. The count was accurate and the sentence was false: "I found 0 conditions in your records" reads as *you have no conditions*.

## The shape

Zero-from-empty and zero-from-not-yet-arrived are the same number. Only the connection tells them apart, which is why `careagents/intake_state.py` takes both and returns one of four states — and why `get_agent_context` now returns the Connection row it was already loading and throwing away.

`counts` is populated for `READY` and is `None` everywhere else, dropped **by the classifier** rather than by each caller remembering to check. A template cannot render a number that does not exist. The alternative — return the counts always, have every surface remember when it may print them — is the defect shape `docs/2026-08-02-retro.md` names: a control that looks like one thing and quietly does two.

## Three things beyond the headline bug

| | |
|---|---|
| **A stale `pending` must not outrank records in hand** | `status` flips to `active` only while `/connect` is open polling. Close the tab and it stays `pending` over a full chart. Records win, and the status settles so the next visit costs no counts. |
| **Past the promised window, stop claiming they're coming** | "Still arriving" is its own claim about a job this app cannot see — the #310 family. After 45 minutes it says only what it knows: nothing has landed. |
| **A failed count is not an empty chart** | Unknown totals stay `None` and never collapse into zero. |

## The second trap in the same code

Counts were computed only when the conversation was empty (`if not past`). So the one person actually watching for arrival — someone who asked a question and came back to check — was the one person never shown the answer. The notice now renders on every visit while an import is outstanding, and costs zero extra calls once the connection is active.

## Copy, rendered

```
[arriving] Your records from MEDENT haven't arrived yet — imports take 5–45
           minutes. Nothing below reflects them.
[overdue]  Nothing has arrived from your MEDENT connection in 133 minutes.
           That's longer than an import usually takes. You can retry the
           connection from your home page.
```

## Verification

- 11 unit tests on the pure classifier (no HealthClaw, no account, no browser)
- 5 route tests through the real template
- **Mutation-checked**: pinning `connection_status` to `"active"` turns 3 of the 4 new route tests red
- Full suite 2449 passed / 12 skipped / 6 xfailed; ruff, mypy, table-stakes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)