### PR TITLE
fix(ingest): a record we refused is not a record we skipped (#293, #306)

### DIFF
--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -51,6 +51,30 @@ _DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.
 # truncated or replaced.
 _RESOURCE_ID_PATTERN = re.compile(r'^[A-Za-z0-9\-\.]{1,255}$')
 
+# `_ingest_one` outcomes that mean WE REFUSED DATA, as opposed to `skipped`,
+# which means "a resource type this store does not keep" — routine, expected,
+# and not news. Both call sites used to collapse the two, so a real export
+# carrying an id outside the charset would be dropped, counted as a skip, and
+# reported as a successful import with nothing to page on (#293).
+REFUSED_OUTCOMES = frozenset({'invalid_id', 'forbidden'})
+
+
+def log_refusal(log, where: str, tenant_id: str, resource: dict,
+                result: str) -> None:
+    """Record that a resource was refused — never WHICH resource.
+
+    The refused id is the one field that must not appear. It is refused
+    precisely because it fell outside `[A-Za-z0-9-.]`, and the shapes that
+    fail that test in the wild are names, dates and MRNs. Logging it to
+    explain the refusal would publish the thing the refusal exists to stop.
+
+    One function rather than two call sites, because that invariant is what
+    diverges: three callers of `_ingest_one` already handle failure three
+    different ways (#306).
+    """
+    log.warning('%s refused a resource: tenant=%s type=%s reason=%s',
+                where, tenant_id, resource.get('resourceType', '?'), result)
+
 
 def _is_fasten_download_host(url: str) -> bool:
     """True only when *url* is an https link whose host is fastenhealth.com or
@@ -98,6 +122,7 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
 
         ingested = 0
         skipped = 0
+        refused = 0
         failed = 0
         curatr_eligible_ids: list[tuple[str, str]] = []  # (resource_type, resource_id)
 
@@ -133,6 +158,10 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
                                 rt = resource.get('resourceType', '')
                                 if rt in _CURATR_ELIGIBLE and rid:
                                     curatr_eligible_ids.append((rt, rid))
+                            elif result in REFUSED_OUTCOMES:
+                                refused += 1
+                                log_refusal(logger, f'Fasten job {job.task_id}',
+                                            tenant_id, resource, result)
                             else:
                                 skipped += 1
                         except json.JSONDecodeError:
@@ -176,12 +205,14 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
                 outcome='success',
                 detail=(
                     f'job={job.task_id} '
-                    f'ingested={ingested} skipped={skipped} failed={failed}'
+                    f'ingested={ingested} skipped={skipped} '
+                    f'refused={refused} failed={failed}'
                 ),
             )
             logger.info(
-                'Fasten job %s complete: ingested=%d skipped=%d failed=%d',
-                job.task_id, ingested, skipped, failed,
+                'Fasten job %s complete: ingested=%d skipped=%d '
+                'refused=%d failed=%d',
+                job.task_id, ingested, skipped, refused, failed,
             )
 
             # Optional: run Curatr quality scan on clinical resources. Best

--- a/r6/shc/routes.py
+++ b/r6/shc/routes.py
@@ -44,6 +44,7 @@ from datetime import datetime, timezone
 from flask import Blueprint, request, jsonify, current_app
 from markupsafe import escape
 
+from models import db
 from r6.access import TenantRejected, TenantSource, tenant_from_request
 from r6.audit import record_audit_event
 
@@ -245,31 +246,55 @@ def ingest():
 
 # ── Background ingest ─────────────────────────────────────────────────────────
 
-def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str) -> None:
-    from r6.fasten.ingester import _ingest_one  # reuse existing ingest logic
+def _ingest_bundle(app, entries: list, tenant_id: str, source: str,
+                   job_id: str) -> dict:
+    """Ingest a bundle in the background. Returns the outcome counts.
+
+    Returned rather than only logged so the counts are assertable — the
+    silence around a refusal was the defect (#293), and a count no test can
+    read is the next version of it.
+    """
+    import r6.fasten.ingester as ingester
 
     with app.app_context():
-        ingested = skipped = failed = 0
+        ingested = skipped = refused = failed = 0
         curatr_eligible_ids: list[tuple[str, str]] = []
 
         for resource in entries:
             try:
-                result, rid = _ingest_one(resource, tenant_id)
+                result, rid = ingester._ingest_one(resource, tenant_id)
                 if result == 'ok':
                     ingested += 1
                     rt = resource.get('resourceType', '')
                     if rt in _CURATR_ELIGIBLE and rid:
                         curatr_eligible_ids.append((rt, rid))
+                elif result in ingester.REFUSED_OUTCOMES:
+                    refused += 1
+                    ingester.log_refusal(logger, f'SHC job {job_id}',
+                                         tenant_id, resource, result)
                 else:
                     skipped += 1
             except Exception as exc:
                 failed += 1
+                # CRITICAL: roll back the failed flush so the session isn't
+                # poisoned. Without this, one bad resource makes every
+                # SUBSEQUENT resource fail with "transaction has been rolled
+                # back", wedging the rest of the batch — found live on the
+                # Fasten path 2026-07-08, where a single over-length id cost
+                # all 250 resources. This path is the one that never got the
+                # fix (#306, S-4).
+                try:
+                    db.session.rollback()
+                except Exception:
+                    pass
                 # Log the exception CLASS only — str(exc) on a DBAPIError
                 # serialises the failing statement and bound parameters (the
                 # FHIR record), leaking PHI into logs (#306, S-4).
                 logger.warning('SHC ingest error (job=%s): %s',
                                job_id, type(exc).__name__)
 
+        counts = {'ingested': ingested, 'skipped': skipped,
+                  'refused': refused, 'failed': failed}
         record_audit_event(
             event_type='shc_import_complete',
             agent_id=f'shc-{source}',
@@ -277,12 +302,14 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
             outcome='success',
             detail=(
                 f'job={job_id} source={source} '
-                f'ingested={ingested} skipped={skipped} failed={failed}'
+                f'ingested={ingested} skipped={skipped} '
+                f'refused={refused} failed={failed}'
             ),
         )
         logger.info(
-            'SHC job %s complete: source=%s ingested=%d skipped=%d failed=%d',
-            job_id, source, ingested, skipped, failed,
+            'SHC job %s complete: source=%s ingested=%d skipped=%d '
+            'refused=%d failed=%d',
+            job_id, source, ingested, skipped, refused, failed,
         )
 
         curatr_issues = 0
@@ -306,6 +333,11 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
             ]
             if skipped:
                 msg_lines.append(f'• {skipped} skipped')
+            # A refusal is data the person did NOT get. Folding it into
+            # "skipped" told them a record they are missing was a record we
+            # were never going to store.
+            if refused:
+                msg_lines.append(f'• {refused} refused (unreadable id)')
             if failed:
                 msg_lines.append(f'• {failed} failed')
             if curatr_issues:
@@ -314,3 +346,5 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str, job_id: str)
             notify_tenant(tenant_id, '\n'.join(msg_lines))
         except Exception as exc:
             logger.warning('SHC notify push failed: %s', type(exc).__name__)
+
+        return counts

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -167,3 +167,183 @@ def test_resource_id_pattern_is_a_charset_control_not_a_length_control():
     width = R6Resource.__table__.c.id.type.length
     assert pat.fullmatch("a" * width)
     assert not pat.fullmatch("a" * (width + 1))
+
+
+# ---------------------------------------------------------------------------
+# #293 / #306: a record we REFUSED is not a record we chose to skip, and the
+# SHC path never got the rollback the Fasten path was patched for on
+# 2026-07-08. Both call sites collapsed every non-'ok' outcome into `skipped`
+# with no log line, so a real export carrying an id outside the FHIR charset
+# would be dropped and the import would report success.
+# ---------------------------------------------------------------------------
+def _bundle(*resources):
+    return {"resourceType": "Bundle",
+            "entry": [{"resource": r} for r in resources]}
+
+
+def test_shc_ingest_rolls_back_so_one_bad_entry_does_not_wedge_the_batch(
+        app, tenant_id, monkeypatch):
+    """The 2026-07-08 incident, on the path that never got the fix: a failed
+    flush poisons the session, so every LATER entry fails too — one bad
+    resource silently costs the rest of the import.
+
+    Two assertions, deliberately. The surviving-row assertion is the real
+    one, and it is only meaningful on the Postgres lane — SQLite does not
+    poison a session the way Postgres does, which is the same reason this
+    whole file exists and why CI runs it against real Postgres. The
+    rollback-was-called assertion is the one that holds everywhere, so a
+    future edit that deletes the line fails on both lanes rather than
+    quietly only on the one nobody runs locally.
+    """
+    from models import db
+    from r6.shc import routes as shc
+
+    calls = {"n": 0}
+    rollbacks = {"n": 0}
+    real = __import__(
+        "r6.fasten.ingester", fromlist=["_ingest_one"])._ingest_one
+    real_rollback = db.session.rollback
+
+    def flaky(resource, tid, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("flush failed on entry 1")
+        return real(resource, tid, **kw)
+
+    def counting_rollback():
+        rollbacks["n"] += 1
+        return real_rollback()
+
+    monkeypatch.setattr("r6.fasten.ingester._ingest_one", flaky)
+    monkeypatch.setattr(db.session, "rollback", counting_rollback)
+
+    obs = {"resourceType": "Observation", "id": "shc-good-1",
+           "status": "final", "code": {"coding": [{"code": "x"}]}}
+    shc._ingest_bundle(app, [dict(obs), dict(obs, id="shc-good-2")],
+                       tenant_id, "flexpa", "job1")
+
+    assert calls["n"] == 2, "the batch stopped after the failure"
+    assert rollbacks["n"] >= 1, (
+        "the failed entry left the session un-rolled-back — the exact "
+        "failure r6/fasten/ingester.py was patched for on 2026-07-08")
+    survived = R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation",
+        id="shc-good-2").first()
+    assert survived is not None, "entry 2 was lost to a poisoned session"
+
+
+def test_a_refused_resource_is_counted_and_logged_apart_from_a_skip(
+        app, tenant_id, caplog):
+    """`skipped` means 'a type we do not store' — routine. `invalid_id` and
+    `forbidden` mean 'data we refused'. Collapsing them hid the only signal
+    that a real export had been silently truncated."""
+    import logging
+
+    from r6.shc import routes as shc
+
+    good = {"resourceType": "Observation", "id": "shc-ok-1",
+            "status": "final", "code": {"coding": [{"code": "x"}]}}
+    unsupported = {"resourceType": "NotAResourceWeStore", "id": "x1"}
+    refused = {"resourceType": "Observation", "id": "has spaces/and-slash"}
+
+    with caplog.at_level(logging.WARNING):
+        counts = shc._ingest_bundle(
+            app, [good, unsupported, refused], tenant_id, "flexpa", "job2")
+
+    assert counts["ingested"] == 1
+    assert counts["skipped"] == 1, "an unsupported type is a routine skip"
+    assert counts["refused"] == 1, "refusing data is its own outcome"
+
+    refusal_logs = [r.getMessage() for r in caplog.records
+                    if "refused" in r.getMessage()]
+    assert refusal_logs, "a refusal has to be findable without a DB dive"
+    joined = " ".join(refusal_logs)
+    assert "invalid_id" in joined and "Observation" in joined
+    assert "has spaces" not in joined, (
+        "the refused id was logged — that field carries names and MRNs in "
+        "the wild, which is why it is the one thing that must not appear")
+
+
+def test_the_import_summary_reports_refusals(app, tenant_id):
+    """A count nobody can see is not a signal. The audit detail carries it,
+    PHI-free, so a silent truncation shows up without a log dive."""
+    from r6.shc import routes as shc
+
+    seen = {}
+
+    def capture(**kw):
+        seen.update(kw)
+
+    import r6.shc.routes as shcmod
+    original = shcmod.record_audit_event
+    shcmod.record_audit_event = capture
+    try:
+        shc._ingest_bundle(
+            app, [{"resourceType": "Observation", "id": "bad id!"}],
+            tenant_id, "flexpa", "job3")
+    finally:
+        shcmod.record_audit_event = original
+
+    assert "refused=1" in seen.get("detail", "")
+    assert "bad id" not in seen.get("detail", "")
+
+
+def test_the_fasten_path_refuses_the_same_way_the_shc_path_does(app, caplog):
+    """Three callers of `_ingest_one` already handle failure three different
+    ways (#306). Both ingest paths are pinned to one refusal vocabulary here
+    so a fix applied to one does not quietly skip the other — which is how
+    the SHC path went two years without the rollback the Fasten path got."""
+    import json as _json
+    import logging
+    from unittest.mock import patch
+
+    from models import db
+    from r6.fasten.ingester import stream_ingest
+    from r6.fasten.models import FastenJob
+
+    lines = [
+        _json.dumps({"resourceType": "Observation", "id": "fasten-ok-1",
+                     "status": "final", "code": {"coding": [{"code": "x"}]}}),
+        _json.dumps({"resourceType": "NotAResourceWeStore", "id": "nope"}),
+        _json.dumps({"resourceType": "Observation",
+                     "id": "Jane Doe 1980-01-01 MRN 12345"}),
+    ]
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            return iter(lines)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with app.app_context():
+        job = FastenJob(task_id="refusal-job", org_connection_id="c1",
+                        tenant_id="test-tenant", status="pending")
+        db.session.add(job)
+        db.session.commit()
+        job_id = job.id
+
+        with patch("r6.fasten.ingester.httpx.stream",
+                   return_value=_Resp()), caplog.at_level(logging.WARNING):
+            stream_ingest(app, job_id,
+                          ["https://download.example.invalid/e.ndjson"],
+                          "test-tenant")
+
+        db.session.expire_all()
+        done = db.session.get(FastenJob, job_id)
+        assert done.ingested_resources == 1
+        assert done.skipped_resources == 1, (
+            "2 means the refused resource was folded back into the routine "
+            "skips — the collapse this fixes")
+
+    joined = caplog.text
+    assert "refused a resource" in joined and "invalid_id" in joined
+    assert "Jane Doe" not in joined and "MRN" not in joined, (
+        "the refused id reached the log — it is refused precisely because "
+        "it looks like this")


### PR DESCRIPTION
Closes #293. Closes #306.

Two defects on the same five lines, both about **silence**.

## #293 — refusals were counted as skips

`_ingest_one` distinguishes:

| outcome | meaning |
|---|---|
| `skipped` | a resource type this store does not keep — routine, expected, not news |
| `invalid_id` / `forbidden` | **data we refused** |

Both call sites (`r6/fasten/ingester.py`, `r6/shc/routes.py`) collapsed every non-`ok` outcome into `skipped`, with no log line. A real export carrying an id outside the FHIR charset would be dropped, counted as a routine skip, and reported as a **successful import** — with nothing to page on.

The charset is spec-conformant, so a violation is unlikely. That is not the problem. The problem is that if it happens we would not find out, and the 2026-07-08 Epic export documented in `tests/test_ingest_resilience.py` is the standing proof that real feeds violate assumptions we were confident about. That incident's own commit message warned of exactly this:

> silent data loss on real patient records — `invalid_id` skips, not a crash

We fixed the ceiling. We did not fix the silence that made it invisible.

### Never the id

Refusals are logged with the tenant and the resource type, and **never the id**. The id is refused *precisely because* it fell outside `[A-Za-z0-9-.]`, and the shapes that fail that test in the wild are names, dates and MRNs — logging it to explain the refusal would publish the thing the refusal exists to stop. That invariant lives in one shared `log_refusal()`, not at each call site, because divergence is the documented failure mode here: three callers of `_ingest_one`, three different failure strategies.

Counts now reach three places that were blind to them: the audit `detail`, the log line, and the patient's Telegram import summary — where a refusal is data they did **not** get, not a record we were never going to store.

## #306 — the SHC path never got the rollback

A failed entry left the SQLAlchemy session poisoned, so every subsequent entry in the batch failed too. This is the exact defect the Fasten path was patched for on 2026-07-08, where a single over-length id cost all 250 resources. That fix carries a comment documenting the incident; the SHC path, six files away, never got it.

(The raw-exception-logging half of #306 was already fixed on main — this closes the rollback half.)

## Verification

- **Mutation-checked**: emptying `REFUSED_OUTCOMES` reddens 3 tests; deleting the SHC rollback reddens 1.
- The surviving-row assertion is only meaningful on the **Postgres lane** — SQLite does not poison a session, which is why this file exists and why CI runs it against real Postgres. The rollback is therefore *also* pinned structurally, so a future edit that deletes the line fails on both lanes rather than quietly only on the one nobody runs locally.
- `_ingest_bundle` now returns its counts rather than only logging them: a count no test can read is the next version of the same defect.
- Full suite 2453 passed / 12 skipped / 6 xfailed; ruff, mypy, table-stakes clean.

## Not in scope

The audit's shared `ingest_entries()` extraction (Product asked for the patch now, the extraction later) and #286's blank-id semantics decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)