### PR TITLE
fix(security): destructure the step-up tuple, and use the reason (#307)

### DIFF
--- a/r6/agent_runs/routes.py
+++ b/r6/agent_runs/routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hmac
+import logging
 import os
 import re
 
@@ -40,6 +41,8 @@ agent_runs_blueprint = Blueprint(
     url_prefix="/command-center/api/runs",
 )
 
+logger = logging.getLogger(__name__)
+
 _ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 _EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
 _ERROR_CLASS = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,127}$")
@@ -50,7 +53,18 @@ def _tenant_authorized(tenant_id: str) -> bool:
     if session.get(TENANT_SESSION_KEY) == tenant_id:
         return True
     token = request.headers.get("X-Step-Up-Token", "")
-    return bool(token and validate_step_up_token(token, tenant_id)[0])
+    if not token:
+        return False
+    # Destructure both halves (#307). `[0]` returned the correct boolean, but
+    # it sits one keystroke from `if validate_step_up_token(...)`, which is a
+    # silent auth bypass because a 2-tuple is always truthy — including
+    # `(False, 'expired')`. The reason is the other half of the fix: a refusal
+    # nobody can name is a refusal nobody can diagnose.
+    valid, error = validate_step_up_token(token, tenant_id)
+    if not valid:
+        logger.info("agent-runs step-up refused: tenant=%s reason=%s",
+                    tenant_id, error)
+    return valid
 
 
 def _internal_authorized() -> bool:

--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -263,9 +263,15 @@ def _require_session_or_stepup():
             or request.headers.get("X-Tenant-Id")
             or DEFAULT_TENANT
         )
-        valid, _ = validate_step_up_token(step_up, tenant)
+        # Both halves used, not just destructured (#307). Throwing the reason
+        # away made every refusal here indistinguishable — a misconfigured
+        # STEP_UP_SECRET, an expired token and a token for someone else's
+        # tenant all produced the same silent 401.
+        valid, error = validate_step_up_token(step_up, tenant)
         if valid:
             return None
+        logger.info("command-center step-up refused: tenant=%s reason=%s",
+                    tenant, error)
     return jsonify({"error": "authentication required"}), 401
 
 

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -1356,3 +1356,33 @@ def test_postgres_deadline_fences_concurrent_stale_worker_mutation(
             conversation_id=run.conversation_id,
             request_id=f"run:{run_id}:assistant",
         ).count() == 0
+
+
+def test_a_refused_step_up_names_its_reason(client, caplog):
+    """#307's second half. Destructuring `valid, _` satisfies the letter of
+    the rule and still throws away the only thing that distinguishes a
+    misconfigured secret from an expired token from a token minted for
+    someone else's tenant — all three used to produce the same silent 401.
+
+    MUTATION: change the call site back to `valid, _ = ...` and drop the log
+    line. This goes red; the source-level `[0]` guard in
+    tests/test_write_guard_matrix.py cannot see that regression.
+    """
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        response = client.post(
+            "/command-center/api/runs",
+            headers={"X-Tenant-Id": TENANT,
+                     "X-Step-Up-Token": "not-even-a-token"},
+            json={"tenant_id": TENANT, "message_id": "m-refused-1"},
+        )
+
+    assert response.status_code == 401
+    blob = " ".join(record.getMessage() for record in caplog.records)
+    assert "step-up refused" in blob, "the refusal was not recorded at all"
+    assert "Malformed step-up token" in blob, (
+        "the refusal was recorded without the reason — which is the half of "
+        "#307 that destructuring alone does not fix")
+    assert "not-even-a-token" not in blob, (
+        "the rejected token itself was logged")

--- a/tests/test_write_guard_matrix.py
+++ b/tests/test_write_guard_matrix.py
@@ -1307,17 +1307,17 @@ def test_shc_ingest_never_logs_a_raw_exception(app, caplog, monkeypatch):
         "the SHC ingest failure path logged the raw exception text")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#307: r6/agent_runs/routes.py:53 indexes the "
-           "validate_step_up_token tuple ([0]) instead of destructuring it, "
-           "and r6/command_center/routes.py:266 discards the reason. "
-           "CLAUDE.md names destructuring a non-negotiable because a "
-           "truthiness test on the tuple is a silent auth bypass.")
 def test_no_write_path_indexes_the_step_up_tuple():
     """validate_step_up_token is always destructured, never indexed.
 
-    MUTATION (once fixed): rewrite any destructured call site as
+    Was a strict xfail for #307 and is now enforced: both offenders are
+    fixed (`r6/agent_runs/routes.py` indexed `[0]`, `r6/command_center/
+    routes.py` destructured and dropped the reason). The pin flips in the
+    same PR as the fix — a strict xfail left in place after its defect is
+    gone fails as "unexpectedly passing", which reads as a broken test
+    rather than a closed finding.
+
+    MUTATION: rewrite any destructured call site as
     `validate_step_up_token(token, tenant)[0]`. This goes red.
 
     Observed at the source, deliberately: `[0]` returns the correct boolean


### PR DESCRIPTION
Closes #307.

Two sites contradicted a stated non-negotiable (CLAUDE.md: *"`validate_step_up_token` returns `(bool, str)` — destructure both. A truthiness test on the tuple is a silent auth bypass."*).

| site | what it did | why it matters |
|---|---|---|
| [r6/agent_runs/routes.py](r6/agent_runs/routes.py) | `validate_step_up_token(...)[0]` | Correct **today** — index 0 is the bool. But it sits one keystroke from `if validate_step_up_token(...)`, which always passes: a 2-tuple is truthy, including `(False, 'expired')`. And it reads as though it had been reviewed. |
| [r6/command_center/routes.py](r6/command_center/routes.py) | `valid, _ = ...` | Destructures, then throws the reason away. A misconfigured `STEP_UP_SECRET`, an expired token, and a token minted for another tenant all produced the same silent 401. |

Both now destructure **and use** the reason. The reason strings are a closed set of literals in `r6/stepup.py`, so nothing caller-controlled reaches a log line — and the rejected token is never logged.

## The pin flips in this PR

`test_no_write_path_indexes_the_step_up_tuple` was a `strict=True` xfail naming these two sites. Fixing them without flipping it would fail CI as **XPASS(strict)**, which reads as a broken test rather than a closed finding — the trap written up in `docs/agent-task-guide.md` §6. The xfail marker is removed and the docstring records why.

## The guard the source check can't provide

That source-level guard greps for `[0]`. It cannot see a regression from `valid, error` back to `valid, _` — which is exactly half of what #307 is about. So "use the reason" gets its own behavioral test at the HTTP boundary, asserting a refusal is logged, that it names *which* refusal, and that the token itself is not.

**Mutation-verified**: reverting to `valid, _` and dropping the log line reddens it.

## Not in scope

`r6.access.require_grant` removes the tuple entirely by raising, and is where both sites should end up. That is the kernel migration, gated on #334 — this PR does what the issue asked for in the meantime.

Full suite 2435 passed / 12 skipped / **5 xfailed** (was 6 — the flipped pin); ruff, mypy, table-stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)