### PR TITLE
fix(mcp): tool descriptions instructed a mechanism that does not exist (#296)

### DIFF
--- a/adapters/tools.manifest.json
+++ b/adapters/tools.manifest.json
@@ -258,7 +258,7 @@
     {
       "name": "fhir_propose_write",
       "title": "Propose FHIR Write",
-      "description": "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: requires step-up authorization (call fhir_get_token first; pass as _stepUpToken).",
+      "description": "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: step-up authorization is required and is supplied by the deployment as an X-Step-Up-Token header. You cannot obtain or pass it yourself. If it is absent this returns requires_step_up; tell the patient authorization is needed rather than attempting another route.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -629,7 +629,7 @@
     {
       "name": "fhir_get_token",
       "title": "Mint Step-Up Token",
-      "description": "Get a fresh step-up authorization token for write operations. Call this before fhir_propose_write, fhir_commit_write, or curatr_apply_fix. Tokens expire after 5 minutes. Returns the token string — pass it as _stepUpToken in subsequent write tool calls.",
+      "description": "Get a fresh step-up authorization token for write operations. Tokens expire after 5 minutes. OPERATOR TOOL: this is withheld from hosted deployments (PRIVILEGED_TOOL_NAMES), and the token it returns travels as the X-Step-Up-Token header set by the caller — it is never an argument to another tool.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -745,7 +745,7 @@
     {
       "name": "action_commit",
       "title": "Submit Real-World Action for Confirmation",
-      "description": "Submit a previously proposed action for the patient's OWN out-of-band confirmation (their dashboard or Telegram) AFTER they've reviewed and verbally/textually agreed to the draft. Requires step-up authorization (call fhir_get_token first; pass as _stepUpToken). This call does NOT execute anything and never accepts or sends any 'human confirmed' flag — only the patient tapping Approve in their own out-of-band channel can trigger execution. Returns status 'awaiting_confirmation' and is terminal for your turn: do not call action_commit again for the same action_id. Use action_status to check whether the patient has approved yet.",
+      "description": "Submit a previously proposed action for the patient's OWN out-of-band confirmation (their dashboard or Telegram) AFTER they've reviewed and verbally/textually agreed to the draft. Requires step-up authorization, supplied by the deployment as an X-Step-Up-Token header; you cannot obtain or pass it yourself. This call does NOT execute anything and never accepts or sends any 'human confirmed' flag — only the patient tapping Approve in their own out-of-band channel can trigger execution. Returns status 'awaiting_confirmation' and is terminal for your turn: do not call action_commit again for the same action_id. Use action_status to check whether the patient has approved yet.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -789,7 +789,7 @@
     {
       "name": "shl_generate",
       "title": "Generate SMART Health Link",
-      "description": "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — pass _stepUpToken), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
+      "description": "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — supplied by the deployment as an X-Step-Up-Token header), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -193,6 +193,63 @@ describe("Tool Schema Tests", () => {
     expect(names).not.toContain("fhir_seed");
   });
 
+  // #296: four tool DESCRIPTIONS instructed a mechanism that does not exist on
+  // a hosted deployment — "call fhir_get_token first; pass as _stepUpToken".
+  // fhir_get_token is withheld from network transports, and no write schema
+  // accepts _stepUpToken; the gate reads the X-Step-Up-Token header. An agent
+  // following that text calls a tool that is not there, then passes an argument
+  // that is dropped. On the write and action rail, a model that "helpfully"
+  // works around a missing tool is improvising on the one surface whose whole
+  // purpose is that it cannot be improvised on.
+  //
+  // These two guards are general, not a string check on the four known lines:
+  // they would have failed on the commit that introduced the defect, and they
+  // fail on the next one written the same way.
+  it("no tool description tells the model to call a withheld tool", () => {
+    const withheld = ["fhir_get_token", "fhir_seed"];
+    const offenders = schemas
+      .filter((tool) => !withheld.includes(tool.name))
+      .flatMap((tool) =>
+        withheld
+          .filter((name) => (tool.description ?? "").includes(name))
+          .map((name) => `${tool.name} names ${name}`),
+      );
+
+    // A withheld tool may still describe ITSELF — an operator reading the
+    // stdio registry needs to know what it is for.
+    expect(offenders).toEqual([]);
+  });
+
+  it("no tool description names an argument its own schema does not accept", () => {
+    // Underscore-prefixed identifiers are the shape a model reads as a
+    // parameter name. Two kinds appear in these descriptions and only one is
+    // a defect, so the allowlist is explicit rather than a looser regex:
+    // `_meta` is a RESPONSE envelope (the MCP Apps `_meta.ui.resourceUri`
+    // pattern), documented on four read tools and correct there. `_stepUpToken`
+    // was an INPUT the model was told to pass, and no schema accepted it.
+    //
+    // Allowlisting by name rather than by phrasing keeps this failing closed:
+    // a newly invented `_whatever` in a description fails here until someone
+    // either declares it in the schema or justifies it on this list.
+    const RESPONSE_ONLY = new Set(["_meta"]);
+    const CANDIDATE = /\b_[A-Za-z][A-Za-z0-9_]*\b/g;
+
+    const offenders = schemas.flatMap((tool) => {
+      const declared = new Set(
+        Object.keys(
+          (tool.inputSchema as { properties?: Record<string, unknown> })
+            ?.properties ?? {},
+        ),
+      );
+      const named = (tool.description ?? "").match(CANDIDATE) ?? [];
+      return named
+        .filter((token) => !declared.has(token) && !RESPONSE_ONLY.has(token))
+        .map((token) => `${tool.name} names ${token}, not in its inputSchema`);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
   it("exposes questionnaire_populate (read) and questionnaire_extract (write)", () => {
     const defs = tools.getToolSchemas();
     const pop = defs.find((t) => t.name === "questionnaire_populate");

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -471,7 +471,7 @@ export class FHIRTools {
         name: "fhir_propose_write",
         title: "Propose FHIR Write",
         description:
-          "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: requires step-up authorization (call fhir_get_token first; pass as _stepUpToken).",
+          "Propose a write — validates the resource and returns a preview. Does NOT commit. Write tier: step-up authorization is required and is supplied by the deployment as an X-Step-Up-Token header. You cannot obtain or pass it yourself. If it is absent this returns requires_step_up; tell the patient authorization is needed rather than attempting another route.",
         tier: "write",
         handler: ({ input, headers }) =>
           this.proposeWrite(
@@ -846,7 +846,7 @@ export class FHIRTools {
         name: "fhir_get_token",
         title: "Mint Step-Up Token",
         description:
-          "Get a fresh step-up authorization token for write operations. Call this before fhir_propose_write, fhir_commit_write, or curatr_apply_fix. Tokens expire after 5 minutes. Returns the token string — pass it as _stepUpToken in subsequent write tool calls.",
+          "Get a fresh step-up authorization token for write operations. Tokens expire after 5 minutes. OPERATOR TOOL: this is withheld from hosted deployments (PRIVILEGED_TOOL_NAMES), and the token it returns travels as the X-Step-Up-Token header set by the caller — it is never an argument to another tool.",
         tier: "read",
         handler: async ({ input, headers, tenantId }) => {
           const tokenTenant = (input.tenant_id as string) || tenantId;
@@ -871,7 +871,7 @@ export class FHIRTools {
             tenant_id: tokenTenant,
             expires_in_seconds: 300,
             _mcp_summary:
-              "Step-up token issued (5-min TTL). Pass it as _stepUpToken in fhir_propose_write, fhir_commit_write, action_commit, shl_generate, or curatr_apply_fix.",
+              "Step-up token issued (5-min TTL). Send it as the X-Step-Up-Token header on subsequent write calls; no write tool accepts it as an argument.",
           };
         },
         annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
@@ -981,7 +981,7 @@ export class FHIRTools {
         name: "action_commit",
         title: "Submit Real-World Action for Confirmation",
         description:
-          "Submit a previously proposed action for the patient's OWN out-of-band confirmation (their dashboard or Telegram) AFTER they've reviewed and verbally/textually agreed to the draft. Requires step-up authorization (call fhir_get_token first; pass as _stepUpToken). This call does NOT execute anything and never accepts or sends any 'human confirmed' flag — only the patient tapping Approve in their own out-of-band channel can trigger execution. Returns status 'awaiting_confirmation' and is terminal for your turn: do not call action_commit again for the same action_id. Use action_status to check whether the patient has approved yet.",
+          "Submit a previously proposed action for the patient's OWN out-of-band confirmation (their dashboard or Telegram) AFTER they've reviewed and verbally/textually agreed to the draft. Requires step-up authorization, supplied by the deployment as an X-Step-Up-Token header; you cannot obtain or pass it yourself. This call does NOT execute anything and never accepts or sends any 'human confirmed' flag — only the patient tapping Approve in their own out-of-band channel can trigger execution. Returns status 'awaiting_confirmation' and is terminal for your turn: do not call action_commit again for the same action_id. Use action_status to check whether the patient has approved yet.",
         tier: "write",
         handler: ({ input, headers }) =>
           this.commitAction(input.action_id as string, headers),
@@ -1015,7 +1015,7 @@ export class FHIRTools {
         name: "shl_generate",
         title: "Generate SMART Health Link",
         description:
-          "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — pass _stepUpToken), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
+          "Generate a SMART Health Link (shlink:/ QR payload) sharing the patient's record with a clinic. Fetches the guardrailed share-bundle from HealthClaw (step-up required — supplied by the deployment as an X-Step-Up-Token header), encrypts it client-side (the SHL server never sees plaintext), uploads ciphertext, and returns the shlink URI, viewer link, and the patient's private manage link. ALWAYS get the patient's explicit consent before generating, and deliver the manage link ONLY to the patient.",
         tier: "write",
         handler: ({ input, headers }) => this.generateShl(input, headers),
         annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },


### PR DESCRIPTION
Closes #296.

## The defect

Five tool **descriptions** — the text a model reads to decide how to call a tool — told it:

> "call `fhir_get_token` first; pass as `_stepUpToken`"

Both halves are false on a hosted deployment.

| Claim | Reality |
|---|---|
| `fhir_get_token` is callable | It's in `PRIVILEGED_TOOL_NAMES` and never appears in a network transport's `tools/list`. Only `src/stdio.ts` builds `FHIRTools` with `allowPrivileged: true`; `src/index.ts`, which serves hosted agents, does not. |
| `_stepUpToken` is an argument | No write schema declares it. The gate reads the `X-Step-Up-Token` **header** (`tools.ts:1161`). |

So an agent following the text calls a tool that isn't there, then passes an argument that's silently dropped.

**This is the write and action rail.** Best case the agent reports it can't proceed and the patient is stuck. Worse, a model that "helpfully" works around a missing tool is improvising on the one surface whose entire purpose is that it cannot be improvised on.

The auto-mint path doesn't rescue it either: `ensureReadToken` returns early unless `allowPrivileged`, so on exactly the deployment where the descriptions are wrong, nothing supplies the header behind the agent's back.

## The fix

Descriptions now state the real mechanism: step-up arrives as a header set by the deployment, the agent can neither obtain nor pass it, and an absent one returns `requires_step_up` — so tell the patient rather than looking for another route. The issue named four sites; `fhir_propose_write:474` carried the same text and is fixed too.

## The guards — general, not a string check on five known lines

The issue asked for these, and they'd have failed on the commit that introduced the defect:

1. No description names a tool in `PRIVILEGED_TOOL_NAMES`. (A withheld tool may still describe *itself* — an operator reading the stdio registry needs that.)
2. No description names an underscore-identifier absent from its own `inputSchema`.

**Guard 2 caught a false-positive class on its first run**, which is worth recording: `_meta` appears in four read-tool descriptions as a *response* envelope — the MCP Apps `_meta.ui.resourceUri` pattern — and is correct there. My first regex conflated "underscore identifier" with "argument". It's allowlisted by name rather than by phrasing, so a newly invented `_whatever` still fails closed until someone declares it or justifies it on the list.

**Mutation-verified**: restoring the original `action_commit` description reddens **both** guards independently.

## Gates

`adapters/tools.manifest.json` regenerated (its byte-identical guard caught the staleness, as designed). Node 192 passed / 7 suites · tsc clean · Python 2469 passed, 12 skipped, 5 xfailed · ruff clean · table stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)