### PR TITLE
fix(prod-watch): report an outage as an outage, and make --json parseable (#272, #270)

### DIFF
--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -2,8 +2,12 @@
 """Production watch — is the live product actually working right now?
 
     python scripts/prod_watch.py                  # all deployments
-    python scripts/prod_watch.py --json           # machine-readable
+    python scripts/prod_watch.py --json           # machine-readable on stdout
     python scripts/prod_watch.py --expect-sha a1b2c3d,4f5e6d7   # pin the build
+
+Under `--json` the human report moves to stderr and stdout carries the payload
+alone, so `--json | jq` works (#270). Without it, the human report keeps stdout
+to itself.
 
 Exit codes, so a scheduled job can open the right issue:
 
@@ -67,6 +71,17 @@ _SHA_RE = re.compile(r"[0-9a-f]{7,40}")
 
 results: list[tuple[str, bool, str]] = []
 
+# Where the human report goes. `--json` moves it to stderr so stdout carries
+# the payload and nothing else — the flag was documented as machine-readable
+# while printing JSON after the ANSI-coloured lines on the same stream, so
+# piping it into a parser failed (#270). Resolved at print time rather than
+# captured at import, so redirecting stdout around a call still works.
+_human_to_stderr = False
+
+
+def _human():
+    return sys.stderr if _human_to_stderr else sys.stdout
+
 # The build check's verdict, kept separately from `results`, because an exit
 # code is one scalar and the two alarms it drives are not. Without this the
 # workflow had to infer "is the build stale?" from a code an unrelated outage
@@ -81,7 +96,8 @@ build_info: dict = {"deployed": None, "built_at": None, "built": None,
 def check(name: str, ok: bool, detail: str = "") -> bool:
     results.append((name, ok, detail))
     mark = f"{G} OK {X}" if ok else f"{R}FAIL{X}"
-    print(f"{mark} {name}" + (f" {D}— {detail}{X}" if detail else ""))
+    print(f"{mark} {name}" + (f" {D}— {detail}{X}" if detail else ""),
+          file=_human())
     return ok
 
 
@@ -91,7 +107,7 @@ def report(name: str, detail: str) -> None:
     Deliberately NOT recorded as a passing check: this script's whole claim is
     that every line it prints was actually verified.
     """
-    print(f"{Y}INFO{X} {name} {D}— {detail}{X}")
+    print(f"{Y}INFO{X} {name} {D}— {detail}{X}", file=_human())
 
 
 def _stamp(ts) -> str:
@@ -182,9 +198,14 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # --- the consumer app ----------------------------------------------------
     r = get(f"{CAREAGENTS}/healthz", timeout)
     body = {}
+    # Whether the deployment actually told us anything, as opposed to us
+    # defaulting on its behalf. The build check below reads its one field from
+    # this body and may only speak when this is True — see #272.
+    healthz_read = False
     if getattr(r, "status_code", None) in (200, 503):
         try:
             body = r.json() or {}
+            healthz_read = True
         except ValueError:
             pass
     # /healthz round-trips the database, so this catches an app that booted but
@@ -198,34 +219,49 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # deployments were running code older than PR #241 while this script
     # reported 9/9 green. This asks the one question the others cannot.
     stale = False
-    deployed = str(body.get("build") or "unknown").lower()
-    built = _stamp(body.get("built_at"))
-    marker = deployed + (f" built {built}" if built else "")
-    build_info.update(deployed=deployed, built_at=body.get("built_at"),
-                      built=built or None)
-    if not expect_sha:
-        # No expected set means no honest assertion to make, so make none.
-        report(BUILD_CHECK, f"{marker} (informational — no --expect-sha given)")
+    if not healthz_read:
+        # Nothing was read, so there is no marker to have a verdict about, and
+        # `deployed` below would be this script's own "unknown" default —
+        # indistinguishable from a genuinely unmarked build. Asserting on it
+        # told whoever read the alarm at 03:00 to redeploy when the deployment
+        # was simply DOWN (#272): a verdict about a field the run never read,
+        # which is the exact thing #258 exists to prevent. The readiness check
+        # above already reports the outage, and its remedy is the right one.
+        report(BUILD_CHECK,
+               f"not asserted — /healthz was not readable "
+               f"({getattr(r, 'status_code', r)}), so no build marker was read")
     else:
-        # Deployed sha is short; the expected set is full sha. A build still
-        # rolling out matches an hours-old commit and passes; "unknown" and
-        # anything "-dirty" match nothing, which is the intent.
-        #
-        # Shape-check first. `startswith` alone means a build reporting "4"
-        # prefix-matches every expected sha and passes. _build.py gates the
-        # marker on its way out; this gates it on the way in, because the one
-        # thing a monitor must not do is accept the field it is auditing.
-        ok = (bool(_SHA_RE.fullmatch(deployed))
-              and any(full.startswith(deployed) for full in expect_sha))
-        stale = not check(
-            BUILD_CHECK, ok,
-            marker if ok else
-            f"deployed build {deployed}"
-            + (f" (built {built})" if built else "")
-            + f" is not one of the {len(expect_sha)} commit(s) this run "
-            f"accepts (tip {expect_sha[0][:7]}). CareAgents does not "
-            "auto-deploy — redeploy per RELEASING.md §4.")
-        build_info.update(asserted=True, ok=ok)
+        deployed = str(body.get("build") or "unknown").lower()
+        built = _stamp(body.get("built_at"))
+        marker = deployed + (f" built {built}" if built else "")
+        build_info.update(deployed=deployed, built_at=body.get("built_at"),
+                          built=built or None)
+        if not expect_sha:
+            # No expected set means no honest assertion to make, so make none.
+            report(BUILD_CHECK,
+                   f"{marker} (informational — no --expect-sha given)")
+        else:
+            # Deployed sha is short; the expected set is full sha. A build
+            # still rolling out matches an hours-old commit and passes;
+            # "unknown" and anything "-dirty" match nothing, which is the
+            # intent.
+            #
+            # Shape-check first. `startswith` alone means a build reporting "4"
+            # prefix-matches every expected sha and passes. _build.py gates the
+            # marker on its way out; this gates it on the way in, because the
+            # one thing a monitor must not do is accept the field it is
+            # auditing.
+            ok = (bool(_SHA_RE.fullmatch(deployed))
+                  and any(full.startswith(deployed) for full in expect_sha))
+            stale = not check(
+                BUILD_CHECK, ok,
+                marker if ok else
+                f"deployed build {deployed}"
+                + (f" (built {built})" if built else "")
+                + f" is not one of the {len(expect_sha)} commit(s) this run "
+                f"accepts (tip {expect_sha[0][:7]}). CareAgents does not "
+                "auto-deploy — redeploy per RELEASING.md §4.")
+            build_info.update(asserted=True, ok=ok)
 
     r = get(f"{CAREAGENTS}/", timeout)
     html = getattr(r, "text", "") or ""
@@ -290,16 +326,17 @@ def run(timeout: float, expect_sha: list[str]) -> int:
 
     failed = [n for n, ok, _ in results if not ok]
     hard = [n for n in failed if n != BUILD_CHECK]
-    print()
+    print(file=_human())
     if failed:
-        print(f"{R}{len(failed)} check(s) failing:{X} " + ", ".join(failed))
+        print(f"{R}{len(failed)} check(s) failing:{X} " + ", ".join(failed),
+              file=_human())
     # A stale build is not an outage. Reporting it as one would train the
     # reader to ignore the outage alarm.
     if hard:
         return 1
     if stale:
         return 2
-    print(f"{G}all {len(results)} checks passing{X}")
+    print(f"{G}all {len(results)} checks passing{X}", file=_human())
     return 0
 
 
@@ -307,12 +344,15 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--timeout", type=float, default=20.0)
     ap.add_argument("--json", action="store_true",
-                    help="emit machine-readable results")
+                    help="emit machine-readable results on stdout, and send "
+                         "the human report to stderr so stdout can be piped "
+                         "into a parser")
     ap.add_argument("--json-out", metavar="PATH",
-                    help="write the same machine-readable results to PATH, "
-                         "leaving stdout human-readable. The scheduled run "
-                         "uses this to drive its two alarms from the checks "
-                         "themselves rather than from one exit code.")
+                    help="write the same machine-readable results to PATH. "
+                         "stdout keeps the human report unless --json is also "
+                         "given. The scheduled run uses this to drive its two "
+                         "alarms from the checks themselves rather than from "
+                         "one exit code.")
     ap.add_argument("--expect-sha", action="append", default=[], metavar="SHA",
                     help="full commit sha the CareAgents build may have been "
                          "built from; repeatable or comma-separated. The "
@@ -321,6 +361,12 @@ def main() -> int:
                          "still accepted. Omit it and the deployed build is "
                          "reported but not asserted.")
     args = ap.parse_args()
+
+    # Assigned unconditionally, not only under --json: this is module state,
+    # and a second main() in one process must not inherit the first one's
+    # stream.
+    global _human_to_stderr
+    _human_to_stderr = args.json
 
     # Order matters: the first sha is reported as the tip. De-duplicated so a
     # tip that also appears in the last-24h list is not counted twice.

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -73,6 +73,10 @@ def _isolate(monkeypatch):
     # than papering over it here.
     prod_watch.results.clear()
     prod_watch.build_info.update(_FRESH_BUILD_INFO)
+    # Same reason, for the stream --json redirects (#270): main() assigns it
+    # unconditionally, but a test that calls run() directly after one would
+    # otherwise find its human output on stderr.
+    monkeypatch.setattr(prod_watch, "_human_to_stderr", False)
     monkeypatch.setattr(prod_watch, "get", _fake_get())
     yield
     prod_watch.results.clear()
@@ -186,18 +190,25 @@ def test_json_and_json_out_cannot_disagree(monkeypatch, capsys, tmp_path):
         json.loads(out.read_text())
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "DEFECT (pre-existing, and the one F5 leaned on): --json is documented as "
-    "'machine-readable' and --json-out as the flag that leaves 'stdout "
-    "human-readable', but --json prints the JSON *after* the ANSI-coloured "
-    "human lines on the same stream, so the documented machine-readable mode "
-    "cannot be parsed. Repro: "
-    "python scripts/prod_watch.py --json | python -m json.tool"))
 def test_the_documented_machine_readable_mode_is_machine_readable(monkeypatch,
                                                                   capsys):
+    """#270: --json printed the payload after the ANSI-coloured human lines on
+    the same stream, so the mode documented as 'machine-readable' died on
+    `prod_watch.py --json | python -m json.tool`.
+
+    Closed by sending the human report to stderr under --json. stdout is then
+    the payload and nothing else — parsed here as a WHOLE stream, not from the
+    first `{`, because slicing to a brace is what let the defect hide.
+    """
     monkeypatch.setattr(sys, "argv", ["prod_watch.py", "--json"])
     prod_watch.main()
-    json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["checks"], "the payload is the real one, not an empty stub"
+    # Option 2 of #270, not option 1: the human report moves, it does not
+    # disappear. Someone watching a terminal still sees every check.
+    assert prod_watch.BUILD_CHECK in captured.err
+    assert "mcp (locked): alive" in captured.err
 
 
 def test_a_refused_run_writes_no_status_file_at_all(monkeypatch, capsys,
@@ -371,26 +382,32 @@ def test_the_workflow_only_reads_fields_the_script_actually_writes(
     assert top and build, "the regexes must actually be matching something"
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "DEFECT (LOW, self-healing): when /healthz is UNREACHABLE, get() returns "
-    "an exception name, body stays {}, and `deployed` defaults to 'unknown' — "
-    "indistinguishable from a real unmarked build. The build check then "
-    "asserts ok=False and the stale alarm fires 'deployed build is stale ... "
-    "CareAgents does not auto-deploy — redeploy per RELEASING.md §4', "
-    "prescribing a redeploy for what is an outage. It is the branch's own "
-    "principle inverted: this asserts a verdict about a field it never read. "
-    "The outage alarm fires alongside it and the stale issue closes on the "
-    "next healthy run, so it misdirects rather than lies. Fix: only assert "
-    "the build when /healthz was actually read; otherwise report() it. "
-    "Repro: point prod_watch.get at a stub returning 'ConnectionError' for "
-    "/healthz and run with --expect-sha."))
-def test_an_unreachable_endpoint_is_not_reported_as_a_stale_build(monkeypatch):
+def test_an_unreachable_endpoint_is_not_reported_as_a_stale_build(monkeypatch,
+                                                                  capsys):
+    """#272: an unreachable /healthz made get() return an exception name, left
+    `body` empty, and let `deployed` default to 'unknown' — indistinguishable
+    from a genuinely unmarked build. The build check then asserted ok=False and
+    the stale alarm told whoever read it at 03:00 to 'redeploy per RELEASING.md
+    §4' while CareAgents was DOWN: a verdict about a field the run never read.
+
+    Closed by gating the assertion on /healthz having actually been read, and
+    report()-ing the build otherwise — the same not-asserted path a run with no
+    --expect-sha already takes.
+    """
     def unreachable(url, timeout, **kw):
         if url.endswith("/healthz"):
             return "ConnectionError"
         return _fake_get()(url, timeout, **kw)
 
     monkeypatch.setattr(prod_watch, "get", unreachable)
-    prod_watch.run(1.0, [TIP])
+    # 1, not 2: this is an outage, and the outage alarm is the one whose remedy
+    # is right. Exit 2 would have routed it to the stale-build alarm.
+    assert prod_watch.run(1.0, [TIP]) == 1
     assert prod_watch.build_info["asserted"] is False, (
         "a build that was never read has not been asserted about")
+    assert _named(prod_watch.BUILD_CHECK) == [], "must not count as a check"
+    assert prod_watch.build_info["deployed"] is None, (
+        "'unknown' here is this script's own default, not the deployment's")
+    # The misdirection itself: no redeploy prescribed for an outage.
+    out = capsys.readouterr().out
+    assert "RELEASING.md" not in out and "auto-deploy" not in out


### PR DESCRIPTION
Closes #272. Closes #270.

Both are labelled LOW. They are worth more than that label, because I used `prod_watch` tonight as the confirmation gate for a production deploy — **a monitor that misdiagnoses is worse than no monitor, because it is believed.**

## #272 — an outage was reported as a stale build

When `/healthz` was unreachable, `body` stayed `{}` and `deployed` fell back to `"unknown"` — indistinguishable from a genuinely unmarked build. The build check then asserted a verdict about a field it never read, and printed a redeploy prescription:

```
FAIL careagents: running the current build — deployed build unknown is not one of the 1
commit(s) this run accepts ... CareAgents does not auto-deploy — redeploy per RELEASING.md §4.
```

So at 03:00 it told you to redeploy while the real problem was that CareAgents was **down**. That inverts the principle #258 exists for: do not report something you did not verify.

Now a `healthz_read` flag gates the assertion. Unread means informational, the same path a run with no `--expect-sha` already takes, and `deployed` stays `None` rather than recording the script's own `"unknown"` default as if it were an observation. The readiness check still fails, so the run still exits 1 — **the outage alarm fires, the stale-build alarm does not.**

## #270 — the documented machine-readable mode was not machine-readable

`--json` printed JSON after the ANSI human lines on the same stream, so `prod_watch.py --json | python -m json.tool` failed. Now `--json` sends the human report to **stderr** and JSON to **stdout**: both still visible in a terminal, and the flag does what its help text claims. Default mode is unchanged, so the scheduled workflow's `> result.txt 2>&1` path still captures the full report.

## Both strict-xfail pins flipped in this PR

`test_an_unreachable_endpoint_is_not_reported_as_a_stale_build` and `test_the_documented_machine_readable_mode_is_machine_readable` were `strict=True` xfails. Left in place they'd fail as XPASS(strict), which reads as a broken test rather than a closed finding — `docs/agent-task-guide.md` §6, and a trap that has cost this repo real time.

The #270 test now parses the **whole** stream rather than slicing from the first `{` — slicing to a brace is precisely what let the defect hide.

## Mutation checks

| Fix | Mutation | Result |
|---|---|---|
| #272 | assert on the unreachable path again | red, printing the old redeploy prescription |
| #270 | human report back on stdout under `--json` | red, `JSONDecodeError` |

## Live verification

```
$ uv run python scripts/prod_watch.py --json | python3 -m json.tool | head
{ "ok": true, "hard_ok": true, "checks": [ { "name": "healthclaw: alive", ... 
```

Human report still on stderr in the same run, all 10 checks visible.

## Stated honestly

- **The unreachable path was not proven against a genuinely down deployment.** Production stayed healthy; #272's new branch is proven by the stubbed test and the mutation check only. I did not take CareAgents down to confirm it live.
- **One live behaviour change worth knowing:** during a CareAgents outage the stale-build alarm no longer fires, so a stale-build issue open from before an outage now stays open and silent through it rather than collecting a misleading comment. That is the intended semantics — only an observed pass closes an alarm — but it is a change.
- `.github/workflows/prod-watch.yml` untouched; it doesn't pass `--json` and reads `build.asserted`/`build.ok` from `--json-out`, both still written.
- No check changed *what* it checks. `--expect-sha` semantics untouched.

Gates: 2471 passed, 12 skipped, **3 xfailed** (was 5 — the two flipped pins) · ruff · mypy · table stakes clean. I re-ran them myself on the branch and confirmed the `--json` pipe parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)