### PR TITLE
fix(terminology): the RxNorm lookup could never return a drug name

### DIFF
--- a/r6/curatr.py
+++ b/r6/curatr.py
@@ -30,7 +30,12 @@ TX_FHIR_ORG = "https://tx.fhir.org/r4"
 NLM_ICD10_API = (
     "https://clinicaltables.nlm.nih.gov/api/icd10cm/v3/search"
 )
-RXNAV_API = "https://rxnav.nlm.nih.gov/REST/rxcui.json"
+# /REST/rxcui.json searches BY NAME (?name=). Passing ?rxcui= to it is a
+# parameter error and RXNav answers HTTP 400 — which this code did from the
+# day it was written, so every RxNorm lookup returned None ("could not check")
+# and nothing ever looked broken. The per-concept properties endpoint below is
+# the one that takes an rxcui, and it returns the drug NAME.
+RXNAV_PROPERTIES_API = "https://rxnav.nlm.nih.gov/REST/rxcui/{rxcui}/properties.json"
 TERMINOLOGY_TIMEOUT = 5  # seconds
 
 # Code systems that are deprecated / retired
@@ -687,21 +692,42 @@ class CuratrEngine:
 
     def _validate_rxnorm(self, code: str) -> Optional[dict]:
         """
-        Validate an RxNorm RXCUI via RXNAV REST API.
-        Returns {'valid': bool, 'display': None, 'message': str|None}.
+        Look up an RxNorm RXCUI via the RXNav properties endpoint.
+        Returns {'valid': bool, 'display': str|None, 'message': str|None}.
+
+        `display` is the drug name, and returning it is the point. This method
+        used to hardcode it to None because it was written as a validity check
+        for the quality scan, where "is this a real code?" is the only
+        question. `terminology_resolver.resolve` reuses it to LABEL a code, so
+        a patient asking "what medications am I on?" was told their record
+        could not be read while four correctly-coded rows sat in it — the
+        upstream display having been stripped by redaction, as designed, with
+        nothing to put back.
+
+        RXNav answers 200 with `{}` for a code that is not a concept. That is
+        an authoritative "no" and is reported as valid=False. A non-200 or a
+        transport error stays None — "could not check" — because
+        terminology_resolver caches an authoritative verdict and must never
+        cache a blip (#344 D2).
         """
         try:
+            # Override the session's Accept. It is set once to
+            # application/fhir+json for tx.fhir.org, and RXNav answers a FHIR
+            # Accept with HTTP 406 Not Acceptable — a third way this lookup
+            # returned None that no unit test could see, because a mocked
+            # session has no opinion about headers.
             resp = self._session.get(
-                RXNAV_API,
-                params={"rxcui": code},
+                RXNAV_PROPERTIES_API.format(rxcui=code),
+                headers={"Accept": "application/json"},
                 timeout=self.timeout,
             )
             if resp.status_code != 200:
                 return None
-            data = resp.json()
-            rxcuis = data.get("idGroup", {}).get("rxnormId", [])
-            if rxcuis:
-                return {"valid": True, "display": None, "message": None}
+            properties = (resp.json() or {}).get("properties") or {}
+            name = properties.get("name")
+            if isinstance(name, str) and name.strip():
+                return {"valid": True, "display": name.strip(),
+                        "message": None}
             return {
                 "valid": False,
                 "display": None,

--- a/tests/test_terminology_resolver.py
+++ b/tests/test_terminology_resolver.py
@@ -215,3 +215,161 @@ def test_label_codings_still_refuses_to_carry_upstream_display(monkeypatch):
     terminology.label_codings(concept)
     assert concept["coding"][0]["display"] == "Psoriasis, unspecified"
     assert "Jane Secret" not in str(concept)
+
+
+# ---------------------------------------------------------------------------
+# The RxNorm path never returned a name (found live 2026-08-05).
+#
+# A patient asked "what medications am I on?" and their agent answered "I
+# cannot read the specific names of these medications ... they've been
+# redacted for your privacy." That sentence was true and the cause was ours:
+# four Medication rows carried correct RxNorm codings, redaction stripped the
+# upstream display as designed, and nothing put a label back.
+#
+# Two independent faults, either of which alone is enough to lose every drug
+# name:
+#
+#   1. The request went to /REST/rxcui.json?rxcui=<code>. That endpoint
+#      searches BY NAME (?name=); passing rxcui= is the wrong parameter and
+#      RXNav answers HTTP 400 "Path or Query Parameter error". Verified against
+#      the live service. It has done so since the call was written, so curatr's
+#      RxNorm validation has never once succeeded either — it returned None,
+#      which reads as "could not check", so nothing ever looked wrong.
+#   2. Even on success the method hardcoded "display": None. It was written as
+#      a VALIDITY checker for curatr's quality scan, where the question is
+#      "is this a real code?", and terminology_resolver.resolve() reuses it
+#      expecting a name it could never return.
+#
+# The fix uses /REST/rxcui/<code>/properties.json, which returns
+# {"properties": {"name": "atorvastatin 40 MG Oral Tablet", ...}}, and reports
+# an unknown code as {} with HTTP 200 — so absent properties means "not a
+# concept", not "lookup failed".
+# ---------------------------------------------------------------------------
+class _RxResp:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def _engine_with(monkeypatch, responses):
+    """A CuratrEngine whose HTTP session replays `responses` by URL."""
+    from r6.curatr import CuratrEngine
+
+    engine = CuratrEngine()
+    seen = []
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        seen.append(url)
+        for fragment, resp in responses.items():
+            if fragment in url:
+                return resp
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(engine._session, "get", fake_get)
+    return engine, seen
+
+
+def test_a_valid_rxcui_returns_the_drug_name(monkeypatch):
+    """The whole point: a name the patient can read."""
+    engine, seen = _engine_with(monkeypatch, {
+        "/rxcui/617311/properties.json": _RxResp(
+            200, {"properties": {"rxcui": "617311",
+                                 "name": "atorvastatin 40 MG Oral Tablet"}}),
+    })
+
+    result = engine._lookup_code(
+        "http://www.nlm.nih.gov/research/umls/rxnorm", "617311")
+
+    assert result == {"valid": True,
+                      "display": "atorvastatin 40 MG Oral Tablet",
+                      "message": None}
+    assert not any("rxcui.json" in url for url in seen), (
+        "went back to the name-search endpoint, which answers HTTP 400 for a "
+        "rxcui= parameter")
+
+
+def test_rxnav_is_asked_for_json_not_fhir_json(monkeypatch):
+    """The third fault, and the one no mock could have caught.
+
+    CuratrEngine sets `Accept: application/fhir+json` once on the shared
+    session, which is correct for tx.fhir.org. RXNav answers that Accept with
+    HTTP 406 Not Acceptable. Found only by calling the live service — a mocked
+    session has no opinion about headers, so every unit test passed while the
+    real call returned None.
+    """
+    from r6.curatr import CuratrEngine
+
+    engine = CuratrEngine()
+    sent = {}
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        sent["headers"] = headers or {}
+        return _RxResp(200, {"properties": {"name": "atorvastatin 40 MG"}})
+
+    monkeypatch.setattr(engine._session, "get", fake_get)
+    engine._lookup_code("http://www.nlm.nih.gov/research/umls/rxnorm", "617311")
+
+    assert sent["headers"].get("Accept") == "application/json", (
+        "RXNav was asked with the session's FHIR Accept header, which it "
+        "refuses with 406"
+    )
+
+
+def test_an_unknown_rxcui_is_reported_invalid_not_unavailable(monkeypatch):
+    """RXNav answers 200 with {} for a code that is not a concept.
+
+    That is an authoritative 'no', and it must not be collapsed into None —
+    None means 'we could not check', which is what every RxNorm lookup has
+    silently returned until now.
+    """
+    engine, _ = _engine_with(monkeypatch, {
+        "/rxcui/99999999/properties.json": _RxResp(200, {}),
+    })
+
+    result = engine._lookup_code(
+        "http://www.nlm.nih.gov/research/umls/rxnorm", "99999999")
+
+    assert result is not None, "an authoritative 'not a concept' became 'unknown'"
+    assert result["valid"] is False
+    assert result["display"] is None
+
+
+def test_a_transport_failure_stays_unavailable(monkeypatch):
+    """A 404 or an exception is 'could not check', which is NOT 'invalid'.
+
+    Same distinction as D2 in #344: only an authoritative verdict may be
+    cached, so returning valid=False here would poison the label permanently.
+    """
+    engine, _ = _engine_with(monkeypatch, {
+        "/rxcui/617311/properties.json": _RxResp(404, "Path or Query error"),
+    })
+    assert engine._lookup_code(
+        "http://www.nlm.nih.gov/research/umls/rxnorm", "617311") is None
+
+
+def test_the_resolver_now_produces_a_label_for_a_medication_code(monkeypatch):
+    """End to end through resolve(), which is what the read path calls.
+
+    MUTATION: restore `"display": None` in _validate_rxnorm. This goes red
+    while every validity assertion above stays green — which is exactly how
+    the defect survived: the code was 'working' at the only thing it was
+    tested for.
+    """
+    from r6 import terminology_resolver as resolver
+
+    engine, _ = _engine_with(monkeypatch, {
+        "/rxcui/314076/properties.json": _RxResp(
+            200, {"properties": {"name": "lisinopril 10 MG Oral Tablet"}}),
+    })
+    monkeypatch.setattr(resolver, "_engine", lambda: engine)
+    monkeypatch.setenv("TERMINOLOGY_LOOKUP_ENABLED", "true")
+    resolver.reset_cache()
+
+    label = resolver.resolve(
+        "http://www.nlm.nih.gov/research/umls/rxnorm", "314076")
+
+    assert label == "lisinopril 10 MG Oral Tablet"


### PR DESCRIPTION
Found by running E2 against live data. Follow-on to #282/#344. **Patient-facing.**

## The report

A patient asked *"what medications am I on?"* and their agent answered:

> I cannot read the specific names of these medications right now. The source system sent these as free-text notes rather than standardized codes, so they've been redacted for your privacy.

Every clause of that is wrong except the last, and the last one is our doing. The record holds four `Medication` rows, **each carrying a correct RxNorm coding**. Redaction stripped the upstream display exactly as designed, nothing put a label back, and the agent inferred from a name-shaped hole that the source had sent free text.

Worth noting *why* the sentence was so plausible: #348 added honest wording for records that genuinely arrive uncoded, and this record hit that branch by accident. A good honesty fix ended up narrating a different bug.

## Three independent faults

Each one alone loses every drug name.

| # | Fault | Effect |
|---|---|---|
| 1 | **Wrong endpoint.** `/REST/rxcui.json?rxcui=<code>` searches *by name* (`?name=`); an `rxcui=` parameter is an error | RXNav answers **HTTP 400**, always has |
| 2 | **No name requested.** `"display": None` hardcoded | Even on success, no label exists to return |
| 3 | **Wrong Accept header.** The shared session sets `application/fhir+json` for tx.fhir.org | RXNav refuses it with **HTTP 406** |

Fault 1 means **curatr's RxNorm validation has never once succeeded** since the call was written. It returned `None`, which reads as "could not check" rather than "broken", so nothing ever looked wrong.

Fault 3 was invisible to every unit test, because a mocked session has no opinion about headers. It only surfaced by calling the live service *after* the first two were fixed — which is the lesson worth keeping from this one.

## The fix

`/REST/rxcui/<code>/properties.json` with an explicit JSON `Accept`, returning `properties.name`.

RXNav answers `200` with `{}` for a code that is not a concept — an authoritative **no** (`valid=False`) — while a non-200 or transport error stays `None`, "could not check". That distinction is load-bearing: `terminology_resolver` caches authoritative verdicts and must never cache a blip (#344 D2).

## Verification

Against **live RXNav**, using the four codes from the real record: **4/4 now return readable names**, and an unknown code correctly reports `valid=False`. Names are not reproduced here — this repo is public.

**Mutation-verified:** restoring `"display": None` reddens the two label tests while *every validity test stays green*. That asymmetry is exactly how this survived — the code worked at the one thing it was tested for.

Gates: 2474 passed, 12 skipped, 5 xfailed · ruff · mypy · table stakes clean.

## What this does not fix

- The **allergy** answer is correct as-is: that record genuinely carries free text with no code, so #348's "recorded but not coded at the source" is the honest answer and stays.
- `MedicationStatement` is still not a supported ingest type. Many EHRs send the patient's med list that way; worth its own decision.
- The scorecard requires `--tenant` with no discovery mode, which is why it took three tries to find the tenant the agent actually runs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)