### PR TITLE
fix(careagents): "could not look it up" is not "the source sent free text"

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -154,16 +154,28 @@ def _medication_resolver(hc: HealthClawClient, tenant: str):
     None and the item stays unreadable-not-absent; per-call memo so one ref
     costs one read; capped so a junk bundle cannot fan out.
     """
-    memo: dict[str, str | None] = {}
+    memo: dict[str, tuple[str | None, str]] = {}
 
-    def resolve(ref) -> str | None:
+    def resolve(ref) -> tuple[str | None, str]:
+        """Return (label, reason).
+
+        The reason is the point. This used to return a bare label, so four
+        different outcomes arrived at the caller as one `None` and the caller
+        explained all of them to the patient as "the source sent free text"
+        — a claim about the upstream feed, made by a branch that had learned
+        nothing about the upstream feed. PR #376 fixed one cause of that
+        sentence; this stops the remaining three from producing it.
+        """
         if not isinstance(ref, str) or not ref.startswith("Medication/"):
-            return None
+            return None, "not-a-ref"
         if ref in memo:
             return memo[ref]
         if len(memo) >= MAX_MEDICATION_DEREFS:
-            return None
+            # Never looked at. Anything said about how the source coded it
+            # would be invented.
+            return None, "not-attempted"
         label = None
+        reason = "no-label"
         try:
             med = hc.read(tenant, "Medication", ref.split("/", 1)[1])
             code = med.get("code") or {}
@@ -174,10 +186,11 @@ def _medication_resolver(hc: HealthClawClient, tenant: str):
                 label = label.strip() or None
             else:
                 label = None
+            reason = "resolved" if label else "no-label"
         except HealthClawError:
-            pass
-        memo[ref] = label
-        return label
+            reason = "unavailable"
+        memo[ref] = (label, reason)
+        return label, reason
 
     return resolve
 
@@ -212,11 +225,13 @@ def _summarize_bundle(bundle: dict, limit: int = 12,
         code = res.get("code") or res.get("medicationCodeableConcept") or {}
         text = code.get("text") or " ".join(
             c.get("display", "") for c in (code.get("coding") or [])[:1])
+        lookup_reason = None
         if not text and resolve_ref is not None:
             # No inline code — the name may live behind medicationReference.
             ref = (res.get("medicationReference") or {}).get("reference")
             if ref:
-                text = resolve_ref(ref) or ""
+                text, lookup_reason = resolve_ref(ref)
+                text = text or ""
         if text:
             item["name"] = text.strip()
         else:
@@ -243,6 +258,18 @@ def _summarize_bundle(bundle: dict, limit: int = 12,
                         if isinstance(c, dict) and c.get("code")), None)
             if raw:
                 item["name"] = f"unlabeled record, code {raw}"
+            elif lookup_reason in ("unavailable", "not-attempted"):
+                # We did not learn anything about this record's coding, so we
+                # say nothing about it. "The source sent free text" below is a
+                # finding; asserting it here would be inventing one — the
+                # defect PR #376 fixed, reached by a different route.
+                item["name"] = "a medication I could not look up just now"
+                item["note"] = (
+                    "The name is stored behind a reference this turn could "
+                    "not read, so it is missing for a reason on OUR side, not "
+                    "the clinic's. Do not describe how the source recorded "
+                    "it. It is still a real record — never treat it as "
+                    "absent; offer to try again.")
             else:
                 item["name"] = "recorded but not coded at the source"
                 item["uncoded"] = True

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -392,6 +392,24 @@ class LiveMCPProbeClient:
 
 # --- Guardrail probes ----------------------------------------------------------
 
+# LOINC 2093-3 -> "Cholesterol (total)" in r6/terminology.py's static table,
+# so the positive relabel check below needs no terminology server.
+_EXPECTED_LABEL = "Cholesterol (total)"
+_UPSTREAM_JUNK = "UPSTREAM-DISPLAY-MUST-NOT-SURVIVE"
+
+
+def _synthetic_labelled_obs() -> dict:
+    """An Observation whose upstream display is junk we expect to LOSE, and
+    whose code we expect the server to label from its own table."""
+    return {
+        "resourceType": "Observation",
+        "status": "final",
+        "code": {"coding": [{"system": "http://loinc.org", "code": "2093-3",
+                             "display": _UPSTREAM_JUNK}]},
+        "valueQuantity": {"value": 188, "unit": "mg/dL"},
+    }
+
+
 def _create_synthetic(client, ctx) -> tuple[Optional[str], object]:
     status, body, _ = client.request(
         "POST", "/Patient", ctx.write_headers(), _synthetic_patient())
@@ -434,6 +452,39 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
         Check("phone number stripped (search)", _PHONE not in sblob),
         Check("street address stripped (search)", _STREET not in sblob),
     ]
+
+    # A POSITIVE check, and the only one in this file. Every assertion above
+    # is "a bad string is ABSENT", which a broken labeller passes HARDER — it
+    # strictly shrinks the response. That is not hypothetical: the RxNorm
+    # lookup returned None for its entire life (#376) and every guardrail
+    # check here stayed green while a patient was told their medications were
+    # unreadable. The grade said A about the wrong property.
+    #
+    # Redaction removes the upstream `display`; r6/terminology.py must put a
+    # server-derived one back, keyed by code. LOINC 2093-3 is in the static
+    # table, so this needs no network and no feature flag — it fails when the
+    # relabel step stops running, which is the half of the contract nothing
+    # else measures.
+    status, body, _ = client.request(
+        "POST", "/Observation", ctx.write_headers(), _synthetic_labelled_obs())
+    oid = body.get("id") if isinstance(body, dict) else None
+    if not oid:
+        r.checks.append(Check("labelled observation created", False,
+                              f"create returned {status}"))
+    else:
+        status, obody, otext = client.request(
+            "GET", f"/Observation/{oid}", ctx.read_headers())
+        oblob = otext or json.dumps(obody or {})
+        r.checks += [
+            Check("a recognised code is re-labelled after redaction",
+                  status == 200 and _EXPECTED_LABEL in oblob,
+                  f"status {status}; expected {_EXPECTED_LABEL!r}"),
+            # The other half of the same contract: the label must be OURS.
+            # Asserting only that a display exists would pass if redaction
+            # stopped running and the feed's own text survived.
+            Check("the upstream display did not survive",
+                  _UPSTREAM_JUNK not in oblob),
+        ]
     r.note = f"Patient/{pid}"
     return r
 

--- a/tests/test_medication_deref.py
+++ b/tests/test_medication_deref.py
@@ -148,8 +148,86 @@ def test_only_medication_references_are_chased():
     are argued for Medication only; a Patient/ ref must never be fetched."""
     hc = _StubHC({})
     resolve = _resolver(hc)
-    assert resolve("Patient/p1") is None
-    assert resolve("Observation/o1") is None
-    assert resolve(None) is None
-    assert resolve({"reference": "Medication/m1"}) is None
+    # resolve now returns (label, reason) so the caller can tell "we could not
+    # look" from "we looked and there is no name" (2026-08-05). A non-
+    # Medication ref is neither: it is a ref we decline to chase at all.
+    for ref in ("Patient/p1", "Observation/o1", None,
+                {"reference": "Medication/m1"}):
+        assert resolve(ref) == (None, "not-a-ref"), ref
     assert hc.reads == []
+
+
+# ---------------------------------------------------------------------------
+# "Could not look it up" is not "the source sent free text" (2026-08-05).
+#
+# PR #376 fixed a case where four correctly-coded medications were reported
+# unreadable, and the agent volunteered a confident FALSE explanation to the
+# patient: "The source system sent these as free-text notes rather than
+# standardized codes." That sentence came from the note below, which is a
+# claim about the upstream feed made by a branch that never learned anything
+# about the upstream feed.
+#
+# #376 closed the RxNorm cause. The same false sentence is still reachable
+# from three others, because `resolve_ref(ref) or ""` collapses them all:
+#
+#   - the deref cap (MAX_MEDICATION_DEREFS) was hit — we never looked
+#   - the Medication read failed — we looked and could not tell
+#   - the Medication genuinely carries no label — the only case the sentence
+#     is true for
+#
+# A patient on more than ten medications gets the false sentence for the
+# overflow. A patient during a backend blip gets it for everything.
+# ---------------------------------------------------------------------------
+def _names(items):
+    return [i.get("name") for i in items]
+
+
+def test_a_read_failure_never_claims_the_source_sent_free_text():
+    hc = _StubHC({}, fail=True)
+    resolver = _medication_resolver(hc, "t1")
+
+    items = _summarize_bundle(
+        {"entry": [_med_request("mr1", ref="Medication/m1")]},
+        limit=10, resolve_ref=resolver)
+
+    assert items[0]["unreadable"] is True, "unreadable-not-absent still holds"
+    assert not items[0].get("uncoded"), (
+        "a failed read was reported as a fact about the source feed")
+    assert "not coded at the source" not in (items[0].get("name") or "")
+    assert "free text" not in (items[0].get("note") or "").lower()
+
+
+def test_the_deref_cap_never_claims_the_source_sent_free_text():
+    """The overflow rows were never looked at. Saying anything about how the
+    source coded them is inventing a finding."""
+    meds = {f"m{i}": {"resourceType": "Medication", "id": f"m{i}",
+                      "code": {"text": f"Drug {i}"}}
+            for i in range(MAX_MEDICATION_DEREFS + 3)}
+    hc = _StubHC(meds)
+    resolver = _medication_resolver(hc, "t1")
+    entries = [_med_request(f"mr{i}", ref=f"Medication/m{i}")
+               for i in range(MAX_MEDICATION_DEREFS + 3)]
+
+    items = _summarize_bundle({"entry": entries}, limit=50,
+                              resolve_ref=resolver)
+
+    overflow = [i for i in items if not i.get("name", "").startswith("Drug")]
+    assert overflow, "the cap did not engage; this test proves nothing"
+    for item in overflow:
+        assert not item.get("uncoded"), (
+            "a row we never read was reported as uncoded at the source")
+
+
+def test_a_medication_with_no_label_still_earns_the_source_sentence():
+    """The one case the sentence is true for must keep it — otherwise this
+    fix trades a false explanation for no explanation."""
+    hc = _StubHC({"m1": {"resourceType": "Medication", "id": "m1",
+                         "code": {}}})
+    resolver = _medication_resolver(hc, "t1")
+
+    items = _summarize_bundle(
+        {"entry": [_med_request("mr1", ref="Medication/m1")]},
+        limit=10, resolve_ref=resolver)
+
+    assert items[0]["uncoded"] is True
+    assert items[0]["name"] == "recorded but not coded at the source"


### PR DESCRIPTION
Follow-on to #376, and the first fix for the pattern behind #365 / #369 / #376: **a guardrail producing nothing that gets read as an answer.**

## The same false sentence, three more ways to reach it

#376 fixed a case where correctly-coded medications came back unreadable and the agent told the patient:

> The source system sent these as free-text notes rather than standardized codes, so they've been redacted for your privacy.

That came from a `note` in `careagents/agent.py`. #376 closed **one** of the four routes to it. `_medication_resolver.resolve` returned a bare label, so four outcomes arrived as one `None`:

| outcome | what we actually knew |
|---|---|
| deref cap hit | we never looked |
| Medication read failed | we looked and could not tell |
| Medication carries no label | **the only case the sentence is true for** |
| not a Medication ref | we declined to chase it |

`text = resolve_ref(ref) or ""` collapsed them, and the caller then made a claim about the upstream feed from a branch that had learned nothing about the upstream feed.

**A patient on more than ten medications gets the false sentence for the overflow. A patient during a backend blip gets it for everything.**

`resolve` now returns `(label, reason)`. The wording branch is three-way: unavailable/unattempted says the name could not be read on *our* side, sets no `uncoded` flag, and instructs the model not to describe how the source recorded it. The genuinely-uncoded case keeps its sentence — now earned rather than assumed.

## The conformance harness measured only half its contract

Every check in `probe_phi_redaction` asserts a bad string is **absent**. A broken labeller passes those *harder* — it strictly shrinks the response.

That is not hypothetical. The RxNorm lookup returned `None` for its entire life, and the guardrail grade stayed **A** the whole time, while a patient was told their medications were unreadable. The badge was honest about the wrong property.

This adds the file's first **positive** check, as a pair:

- a recognised LOINC code **is** re-labelled after redaction
- the upstream display **did not** survive

Neither alone is enough: the first passes if redaction stops running, the second passes if labelling stops. Together they pin both halves. It uses LOINC `2093-3` from the static table, so no network and no feature flag.

## Mutation results

| Mutation | Result |
|---|---|
| Collapse the three-way branch back to two | both new medication tests red |
| Stub out `label_codings` (the #376 shape) | **conformance red** — where before it would have been greener |

## Found while probing, filed separately

A **CREATE** response echoes the caller's own upstream `display` back unredacted, unlike a read. Lower severity — the caller is receiving content it just sent — but it is an inconsistency in a property we state without qualification, and it belongs in its own issue rather than widened into this one.

Gates: 2481 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean · conformance Grade A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)