### PR TITLE
fix(careagents): the resend cooldown reported a send that never happened (#262), and pin the pool settings (#221)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -11,6 +11,7 @@ import base64
 import hashlib
 import hmac
 import logging
+import math
 import secrets
 import time
 from contextlib import contextmanager
@@ -75,7 +76,14 @@ class AccountService:
     def _hash(code: str) -> str:
         return hashlib.sha256(code.encode()).hexdigest()
 
-    def start_email_code(self, email: str, purpose: str = "verify") -> None:
+    def start_email_code(self, email: str, purpose: str = "verify") -> int:
+        """Mint and send a one-time code.
+
+        Returns 0 when a code was actually sent, otherwise the whole seconds
+        until another may be requested. The cooldown branch is not a failure —
+        the person still holds a live code — but it is not a send either, and
+        the caller must not report one it never observed (#262).
+        """
         email = email.strip().lower()
         if "@" not in email or len(email) > 255:
             raise AuthError("Enter a valid email address.")
@@ -88,9 +96,14 @@ class AccountService:
                       .filter_by(email=email, used=False)
                       .filter(EmailToken.exp >= now())
                       .order_by(EmailToken.exp.desc()).first())
-            if recent is not None and (recent.exp - now()) > (
-                    CODE_TTL - RESEND_COOLDOWN):
-                return
+            if recent is not None:
+                # exp is mint-time + CODE_TTL, so whatever the code has left
+                # beyond its post-cooldown life is the cooldown that remains.
+                remaining = ((recent.exp - now())
+                             - (CODE_TTL - RESEND_COOLDOWN))
+                if remaining > 0:
+                    # Round up: never tell someone to retry a moment early.
+                    return max(1, math.ceil(remaining))
             # One live code at a time: retire any prior unused codes so an
             # attacker can't accumulate many simultaneously-valid guesses.
             s.query(EmailToken).filter_by(
@@ -107,6 +120,7 @@ class AccountService:
                     email=email, used=False).update({"used": True})
             raise MailError(
                 "We couldn't send your code just now. Please try again.")
+        return 0
 
     def verify_email_code(self, email: str, code: str) -> Account:
         email = email.strip().lower()

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -197,7 +197,7 @@ def create_app(config: Config | None = None,
         email = (request.get_json(silent=True) or {}).get("email", "")
         purpose = "verify"
         try:
-            svc.start_email_code(email, purpose)
+            retry_after = svc.start_email_code(email, purpose)
         except AuthError as exc:
             return jsonify({"error": str(exc)}), 400
         except MailError as exc:
@@ -205,6 +205,22 @@ def create_app(config: Config | None = None,
             # door, and a silent failure leaves the person watching an empty
             # inbox with no idea whether to wait or retry.
             return jsonify({"error": str(exc), "sent": False}), 502
+        if retry_after:
+            # The cooldown suppressed the send (#262). 200, not 4xx: the
+            # request was handled correctly and the person still holds a live
+            # code, so the UI still advances to code entry. But claiming
+            # "sent" here is the lie — it strands whoever's first email never
+            # arrived, telling them to wait for something nobody sent.
+            #
+            # Not an enumeration oracle: this branch turns only on whether a
+            # code was requested for this address moments ago — a state the
+            # requester just created themselves — never on whether an account
+            # exists. start_email_code touches ca_email_tokens alone; accounts
+            # are created at verify. The genuine-send and cooldown responses
+            # are byte-identical for an address with an account and one
+            # without.
+            return jsonify({"sent": False, "reason": "cooldown",
+                            "retry_after": retry_after})
         return jsonify({"sent": True})
 
     @app.post("/api/auth/verify")

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -195,6 +195,20 @@ def make_engine(url: str):
         # quiet period is followed by intermittent "server closed the
         # connection" 500s on the next request — check the connection before
         # handing it out, and retire it well before the server would.
+        #
+        # The numbers: 300s is half of the 600s that PgBouncer's
+        # server_idle_timeout defaults to (Railway does not document its own
+        # idle window, so we sit well under the common default rather than
+        # guess at it). A connection is therefore retired on our side before
+        # either the pooler or the server can drop it.
+        #
+        # Note what pool_recycle does NOT buy: pre_ping pings on *every*
+        # checkout, not only stale ones, so recycling does not reduce the
+        # per-checkout round trip. What it buys is that the ping almost always
+        # succeeds — the expensive discard-and-reconnect path stays rare — and
+        # it covers the one race pre_ping cannot, a connection that dies in the
+        # gap between a successful ping and the query. One round trip per
+        # checkout is the cost; the alternative is a 500 nobody can retry into.
         pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 300}
     engine = create_engine(url, connect_args=connect_args, future=True,
                            **pool_kwargs)

--- a/careagents/static/auth.js
+++ b/careagents/static/auth.js
@@ -61,6 +61,18 @@
     if (!res.ok) return fail(res.d.error || "Couldn't send a code.");
     pendingEmail = email;
     $("code-email").textContent = email;
+    // Within the resend cooldown the server sends nothing (#262). The code
+    // from a moment ago is still live, so we still ask for it — we just don't
+    // claim a send we didn't get, which is what strands someone whose first
+    // email never arrived.
+    const held = res.d.sent === false;
+    $("code-lede").textContent = held
+      ? "We sent a code moments ago to"
+      : "We sent an 8-digit code to";
+    $("code-note").textContent = held
+      ? `Check your inbox and spam folder. You can request a new one in ${res.d.retry_after} seconds.`
+      : "";
+    $("code-note").hidden = !held;
     show("step-code"); $("code").focus();
   });
   $("back-btn").addEventListener("click", () => { clear(); show("step-start"); });

--- a/careagents/templates/auth.html
+++ b/careagents/templates/auth.html
@@ -28,7 +28,11 @@
 
     <!-- Step: code -->
     <div id="step-code" hidden>
-      <p class="setup-sub">We sent an 8-digit code to <b id="code-email"></b>.</p>
+      <!-- The lede is set from JS: within the resend cooldown nothing was
+           sent just now, and saying otherwise is #262. -->
+      <p class="setup-sub"><span id="code-lede">We sent an 8-digit code to</span>
+        <b id="code-email"></b>.</p>
+      <p class="setup-sub" id="code-note" hidden></p>
       <label class="field-label" for="code">Code</label>
       <input class="field code-input" id="code" inputmode="numeric"
              maxlength="8" placeholder="••••••••" autocomplete="one-time-code">

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -50,9 +50,9 @@ test.beforeEach(async ({ page }) => {
 
 /**
  * Unique per test. Reusing an address breaks reruns: within RESEND_COOLDOWN
- * (30s, careagents/accounts.py:35) start_email_code returns early and mints
- * nothing, while /api/auth/email still answers {"sent": true} — so no new
- * code would ever reach the log.
+ * (30s, careagents/accounts.py:35) start_email_code mints nothing and
+ * /api/auth/email answers {"sent": false, "reason": "cooldown"} (#262) — so
+ * no new code would ever reach the log.
  */
 const uniqueEmail = () =>
   `e2e-${Date.now()}-${Math.floor(Math.random() * 1e4)}@example.test`;

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -208,6 +208,61 @@ def test_review_submit_reports_a_failed_confirmation(cfg, svc, monkeypatch):
     assert "not" in body["message"].lower() or "couldn't" in body["message"]
 
 
+# --- engine pool settings (#221) ---------------------------------------------
+# Honest scope: these assert what make_engine hands to create_engine. They do
+# NOT prove that a dropped connection is recovered — that needs a real server
+# whose connection you can kill mid-pool, which this suite has no way to do.
+# What they buy is a fence around settings that are invisible in review and
+# whose absence only shows up as intermittent 500s after an idle period.
+
+def _engine_kwargs(url, monkeypatch):
+    """Capture the kwargs make_engine passes to create_engine for `url`.
+
+    The spy returns a real in-memory SQLite engine so create_all() and
+    _ensure_columns() still run — a Postgres URL must be assertable without a
+    Postgres server.
+    """
+    import careagents.models as models
+    seen = {}
+    real = models.create_engine
+
+    def _spy(engine_url, **kwargs):
+        seen.update(kwargs)
+        return real("sqlite:///:memory:",
+                    connect_args={"check_same_thread": False}, future=True)
+
+    monkeypatch.setattr(models, "create_engine", _spy)
+    models.make_engine(url)
+    return seen
+
+
+def test_postgres_engine_is_built_with_pre_ping_and_recycle(monkeypatch):
+    """MUTATION: drop either key from make_engine's pool_kwargs and this fails.
+
+    Managed Postgres closes idle connections; a pooled one handed out after a
+    quiet period fails on first use. pool_recycle must stay under the pooler's
+    idle timeout (see the comment in models.py for why 300).
+    """
+    kwargs = _engine_kwargs("postgresql://u:p@db:5432/care", monkeypatch)
+    assert kwargs.get("pool_pre_ping") is True
+    assert kwargs.get("pool_recycle") == 300
+    assert kwargs["pool_recycle"] < 600, "must retire before the pooler does"
+
+
+def test_sqlite_engine_is_given_no_pool_options(monkeypatch):
+    """The gate is the URL scheme. This suite runs on sqlite:///:memory:, where
+    a pre-ping is meaningless — there is no server to have closed anything."""
+    kwargs = _engine_kwargs("sqlite:///:memory:", monkeypatch)
+    assert "pool_pre_ping" not in kwargs
+    assert "pool_recycle" not in kwargs
+
+
+def test_a_real_sqlite_engine_has_pre_ping_off(monkeypatch):
+    """Guards the guard: the spy above could pass while the real engine differs."""
+    from careagents.models import make_engine
+    assert make_engine("sqlite:///:memory:").pool._pre_ping is False
+
+
 # --- chat persistence (#222) --------------------------------------------------
 
 def _turn(client, agent_id, message, request_id=None, conversation_id=None):
@@ -1797,6 +1852,79 @@ def test_email_resend_cooldown_suppresses_duplicate_send(svc, monkeypatch):
     assert len(codes) == 1
 
 
+def test_start_email_code_reports_the_seconds_left_on_the_cooldown(
+        svc, monkeypatch):
+    """MUTATION: `return` (rather than the seconds left) on the cooldown branch
+    and this fails — that bare return is what left the route with nothing to
+    distinguish a send from a suppression (#262)."""
+    from careagents.accounts import RESEND_COOLDOWN
+    import careagents.mail as mailmod
+    codes = []
+    monkeypatch.setattr(mailmod, "send_code", _sink_code(codes))
+    assert svc.start_email_code("secs@example.com") == 0, "a real send waits 0"
+    retry_after = svc.start_email_code("secs@example.com")
+    assert isinstance(retry_after, int)
+    assert 0 < retry_after <= RESEND_COOLDOWN
+    assert len(codes) == 1, "the cooldown must still suppress the send"
+
+
+def test_auth_email_does_not_claim_a_send_the_cooldown_suppressed(
+        app, monkeypatch):
+    """The front door: taps resend, is told it sent, waits for an email nobody
+    sent (#262). The cooldown stays — only the claim goes."""
+    import careagents.mail as mailmod
+    codes = []
+    monkeypatch.setattr(mailmod, "send_code", _sink_code(codes))
+    c = app.test_client()
+
+    first = c.post("/api/auth/email", json={"email": "honest@example.com"})
+    assert first.status_code == 200
+    assert first.get_json() == {"sent": True}
+
+    second = c.post("/api/auth/email", json={"email": "honest@example.com"})
+    # 200, not 4xx: nothing went wrong and the code they hold is still live,
+    # so the UI still advances to code entry.
+    assert second.status_code == 200
+    body = second.get_json()
+    assert body["sent"] is False
+    assert body["reason"] == "cooldown"
+    assert isinstance(body["retry_after"], int) and body["retry_after"] > 0
+    assert len(codes) == 1, "the cooldown must still suppress the send"
+
+
+def test_email_code_response_never_reveals_whether_an_account_exists(
+        app, svc, monkeypatch):
+    """The flow deliberately answers the same for a stranger and a member; a
+    truthful cooldown state must not become an enumeration oracle.
+
+    Both branches turn only on ca_email_tokens — a state the requester just
+    created — so an attacker learns nothing about ca_accounts either way.
+    """
+    import careagents.mail as mailmod
+    monkeypatch.setattr(mailmod, "send_code", _sink_code([]))
+    _make_account(svc, monkeypatch, "member@example.com")
+    monkeypatch.setattr(mailmod, "send_code", _sink_code([]))
+    c = app.test_client()
+
+    def _probe(email):
+        # The member's own code was consumed by verify, so both addresses
+        # start from the same place: no live token.
+        first = c.post("/api/auth/email", json={"email": email})
+        second = c.post("/api/auth/email", json={"email": email})
+        return ((first.status_code, first.get_json()),
+                (second.status_code, second.get_json()))
+
+    member_send, member_cooldown = _probe("member@example.com")
+    stranger_send, stranger_cooldown = _probe("stranger@example.com")
+
+    assert member_send == stranger_send
+    # retry_after is a clock reading, not an account fact — compare the rest.
+    assert member_cooldown[0] == stranger_cooldown[0]
+    assert (member_cooldown[1].keys() == stranger_cooldown[1].keys())
+    assert member_cooldown[1]["sent"] == stranger_cooldown[1]["sent"] is False
+    assert member_cooldown[1]["reason"] == stranger_cooldown[1]["reason"]
+
+
 def test_gated_pages_redirect_or_401_without_session(app):
     c = app.test_client()
     assert c.get("/home").status_code == 302
@@ -3072,6 +3200,40 @@ _CA = _pathlib.Path(__file__).resolve().parents[1] / "careagents"
 _HOME_JS = (_CA / "static" / "home.js").read_text()
 _HOME_HTML = (_CA / "templates" / "home.html").read_text()
 _CSS = (_CA / "static" / "careagents.css").read_text()
+_AUTH_JS = (_CA / "static" / "auth.js").read_text()
+_AUTH_HTML = (_CA / "templates" / "auth.html").read_text()
+
+
+def test_auth_js_reads_the_sent_flag_before_saying_a_code_was_sent():
+    """MUTATION: delete the `res.d.sent === false` branch -> red.
+
+    Same honest scope as the guards below: source-level, executes no JS. The
+    server can answer truthfully and the screen still say "We sent a code" —
+    the lie #262 is about lives in the copy, so the copy is what needs a
+    fence.
+    """
+    assert "res.d.sent === false" in _AUTH_JS, "cooldown state never read"
+    assert "res.d.retry_after" in _AUTH_JS, "the wait is never shown"
+    # Both ledes must exist, and the cooldown one must not claim a fresh send.
+    assert '"We sent an 8-digit code to"' in _AUTH_JS
+    assert '"We sent a code moments ago to"' in _AUTH_JS
+
+
+def test_auth_js_never_builds_markup_from_strings():
+    """The email address and a server-supplied number reach the DOM here."""
+    for sink in ("innerHTML", "outerHTML", "insertAdjacentHTML", "document.write"):
+        assert sink not in _AUTH_JS, sink
+
+
+def test_auth_dialog_selector_contract():
+    """auth.js addresses these by id; a template rename would break the copy at
+    runtime only, with no server-side signal."""
+    for sel in ('id="code-lede"', 'id="code-note"', 'id="code-email"',
+                'id="step-code"', 'id="email-btn"', 'id="verify-btn"'):
+        assert sel in _AUTH_HTML, sel
+    # The lede ships as the truthful default and is overwritten per response;
+    # a hardcoded "We sent" outside the span would survive the JS.
+    assert "We sent an 8-digit code to</span>" in _AUTH_HTML
 
 
 def test_hub_js_uses_no_blocking_browser_dialogs():


### PR DESCRIPTION
Sprint 1, P1 rows 8 and 10 from `docs/2026-08-05-prioritized-backlog.md`.

## #221 was stale — and the finding is the useful part

The two-line fix has been on `main` since **`ccf82fe`** (2026-08-01): `pool_pre_ping=True, pool_recycle=300`, gated on the URL scheme. Verified as an ancestor of `origin/main`, and present in `careagents/models.py` today.

**Nothing pinned it.** A tidy-up could have dropped either setting and the only signal would have been intermittent 500s after idle — the exact symptom the issue was filed for. This adds the tests and the numeric justification, and deliberately leaves the deployed values alone; changing a live value without evidence is churn.

`#221 should be closed as already-fixed.`

### It also corrected my brief

I wrote that "a pre-ping costs a round trip per checkout, and recycling before the server's idle timeout avoids most of them." That is not how SQLAlchemy behaves — `pool_pre_ping` pings on **every** checkout, so `pool_recycle` does not reduce the ping count at all.

What recycle actually buys: the ping almost always *succeeds*, keeping the expensive discard-and-reconnect path rare, and it covers the one race pre-ping cannot close — a connection that dies between a successful ping and the query. The correct version is now in the comment rather than my wrong one.

300s is half PgBouncer's 600s `server_idle_timeout` default. Railway doesn't document its own window, so the comment says we sit under the common default rather than inventing a number.

## #262 — the front door reported a send that did not happen

`start_email_code` returned early on the resend cooldown and the route reported success anyway. Someone who never received the first email taps resend, is told it was sent, and waits for an email nobody sent.

Now returns whole seconds remaining (`0` on a genuine send):

| case | response |
|---|---|
| genuine send | `200 {"sent": true}` |
| cooldown | `200 {"sent": false, "reason": "cooldown", "retry_after": N}` |

**200, not 4xx, deliberately** — nothing went wrong and the code from a moment ago is still live, so the UI still advances to code entry and asks for it. `res.ok` stays true, so the existing `fail()` path is untouched.

The cooldown's security behaviour is byte-for-byte unchanged: it still suppresses the send and still refuses to reset the per-code attempt counter.

### Enumeration is preserved, and pinned

The cooldown branch turns **only** on whether a live row exists in `ca_email_tokens` for that address — state the requester created seconds earlier. `start_email_code` never reads `ca_accounts` at all; accounts are created at *verify*. So probing a stranger's address yields `sent: true` then `cooldown` identically to a real one.

`test_email_code_response_never_reveals_whether_an_account_exists` asserts genuine-send responses are equal and cooldown responses match on status, key set, `sent` and `reason`. `retry_after` is compared structurally only — it is a clock reading, not an account fact.

## Mutations

Seven, each fencing a layer independently:

| Mutant | Result |
|---|---|
| drop `pool_pre_ping` | red |
| drop `pool_recycle` | red |
| `pool_recycle=900` (above the 600s pooler timeout) | red |
| service returns `None` on cooldown (the original bug) | red |
| route ignores `retry_after`, always `sent: true` | red |
| `auth.js` ignores the `sent` flag | red |
| clean tree | 12 passed |

The route mutant leaves the enumeration test green — correct, since that test is about symmetry, not honesty.

## Stated honestly

- **No resend button exists** on the code-entry screen. The new copy says "you can request a new one in N seconds", reachable only via "← use a different email" and re-submitting (which works — the field retains its value). A real resend button is the natural follow-up, and was not in scope.
- **Playwright was not run** — it needs a booted server and was outside the stated gates. The e2e spec's comment describing the old `{"sent": true}` behaviour was corrected, since this change made it false.
- `careagents/` is outside mypy's `files` list, so the `-> int` signature change was verified by grep on the single production caller, not by mypy.

Gates: 2490 passed, 12 skipped, 3 xfailed · ruff · table stakes clean. Both branches also exercised against a real in-process app, not only fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)