### PR TITLE
fix(brief): a crashed care-gaps engine rendered as 'no screenings due' (#381)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -97,6 +97,32 @@ def _parse_brief_sections(resource: dict) -> dict[str, list[dict]]:
     return out
 
 
+# Mirrors r6.brief.engine.CARE_GAPS_OK. CareAgents talks to HealthClaw over
+# HTTP and imports nothing from it, so the string is repeated rather than
+# shared.
+_CARE_GAPS_OK = "ok"
+
+
+def _parse_care_gaps_status(resource: dict | None) -> str:
+    """Whether the screening review ran, from the brief's care-gaps section.
+
+    Anything short of an explicit "ok" — no brief, no care-gaps section, no
+    marker, an unparseable payload — is not an evaluation, and the page must
+    not render it as "nothing due" (#381). Callers get "" for all of those.
+    """
+    care_gaps_url = _BRIEF_SECTION_PREFIX + "care-gaps"
+    try:
+        for ext in (resource or {}).get("extension", []):
+            if ext.get("url") != care_gaps_url:
+                continue
+            for sub in ext.get("extension", []):
+                if sub.get("url") == "status":
+                    return sub.get("valueString") or ""
+    except (AttributeError, TypeError):
+        pass
+    return ""
+
+
 def create_app(config: Config | None = None,
                client: HealthClawClient | None = None,
                accounts: AccountService | None = None) -> Flask:
@@ -662,7 +688,9 @@ def create_app(config: Config | None = None,
         raw = hc.fetch_appointment_brief(ctx["tenant"])
         sections = _parse_brief_sections(raw) if raw else {}
         return render_template("brief.html", me=ctx["agent"],
-                               agent_id=agent_id, sections=sections)
+                               agent_id=agent_id, sections=sections,
+                               care_gaps_ok=(_parse_care_gaps_status(raw)
+                                             == _CARE_GAPS_OK))
 
     # --- chat API (SSE), scoped to the account's agent -----------------------
 

--- a/careagents/templates/brief.html
+++ b/careagents/templates/brief.html
@@ -75,7 +75,12 @@
   <div class="hub-section">
     <div class="section-head"><h2>Preventive care due</h2></div>
     {% set fields = sections.get('care-gaps', []) %}
-    {% if fields %}
+    {# Three states, not two. An empty list only means "nothing due" when the
+       screening review actually ran, so care_gaps_ok is checked first — an
+       unset value falls through to unavailable, never to reassurance. #}
+    {% if not care_gaps_ok %}
+    <p class="brief-empty">Screening review unavailable — ask your clinician which preventive care you are due for.</p>
+    {% elif fields %}
     <div class="brief-section">
       {% for f in fields %}
       <div class="brief-field">

--- a/r6/brief/engine.py
+++ b/r6/brief/engine.py
@@ -7,6 +7,9 @@ exact record that produced the claim.
 Design rules (enforced by tests):
 1. Unknown is never absent. Empty input lists produce empty section lists,
    not "none" strings. The template decides how to render an empty section.
+   Care gaps go further and carry their own state (see CareGapsSection): for
+   that section an empty list is itself a clinical claim, so it is only made
+   when the screening review actually produced one.
 2. No inference. Every output field projects a literal value from the record.
    The engine never derives a clinical conclusion the record doesn't state.
 3. Read-only. The engine has no write path. It never modifies the input dicts.
@@ -25,6 +28,34 @@ class BriefField:
     source_id: str    # FHIR resource.id — used to build the "View source" link
 
 
+# The care-gaps section has three states, not two: gaps found, no gaps found,
+# and could-not-evaluate. The third one exists because the first two are both
+# answers and the empty list that used to stand in for a failure reads to a
+# patient as "you are up to date on your cancer screenings" (#381). Modelled
+# on r6/labs/interpret.py's _indeterminate(): a result we could not judge
+# carries a reason and is never dressed up as a clean one.
+CARE_GAPS_OK = "ok"
+CARE_GAPS_UNAVAILABLE = "unavailable"
+
+CARE_GAPS_REASON_NO_RESULT = "the screening review did not run"
+CARE_GAPS_REASON_ENGINE_ERROR = "the screening review could not be completed"
+CARE_GAPS_REASON_UNREADABLE = "the screening review returned an unreadable result"
+
+
+@dataclass
+class CareGapsSection:
+    """The care-gaps fields plus whether the screening review ran.
+
+    Deliberately not a bare list. A list carries two states and the third one
+    is the whole point, so callers have to reach through `.fields` — which
+    makes "could not evaluate" impossible to mistake for "nothing is due".
+    `status` defaults to unavailable: the ok state is earned, never assumed.
+    """
+    fields: list[BriefField] = field(default_factory=list)
+    status: str = CARE_GAPS_UNAVAILABLE
+    reason: str = CARE_GAPS_REASON_NO_RESULT
+
+
 @dataclass
 class BriefResult:
     problems: list[BriefField] = field(default_factory=list)
@@ -32,6 +63,10 @@ class BriefResult:
     labs: list[BriefField] = field(default_factory=list)
     care_gaps: list[BriefField] = field(default_factory=list)
     visits: list[BriefField] = field(default_factory=list)
+    # care_gaps alone cannot say whether it is empty because nothing is due or
+    # because nothing ran. These two say which.
+    care_gaps_status: str = CARE_GAPS_UNAVAILABLE
+    care_gaps_reason: str = CARE_GAPS_REASON_NO_RESULT
 
 
 # ---------------------------------------------------------------------------
@@ -209,9 +244,26 @@ def build_labs(observations: list[dict]) -> list[BriefField]:
     return out
 
 
-def build_care_gaps(care_gap_result: dict) -> list[BriefField]:
-    """Open preventive-care gaps from the $care-gaps output."""
-    consumer = care_gap_result.get("consumer") or {}
+def build_care_gaps(care_gap_result: dict) -> CareGapsSection:
+    """Open preventive-care gaps from the $care-gaps output.
+
+    `care_gap_result` is one of two things: a successful evaluation, which is
+    a "consumer" payload carrying a "due" list, or a caller's explicit
+    {"status": "unavailable", "reason": ...} marker. Anything else — {}, a
+    payload with no due list, a non-dict — is unavailable. "Nothing is due"
+    is a clinical claim about cancer screening, and it is only ever repeated
+    from a result that made it.
+    """
+    if not isinstance(care_gap_result, dict) or not care_gap_result:
+        return CareGapsSection(reason=CARE_GAPS_REASON_NO_RESULT)
+    if care_gap_result.get("status") == CARE_GAPS_UNAVAILABLE:
+        return CareGapsSection(
+            reason=care_gap_result.get("reason") or CARE_GAPS_REASON_NO_RESULT)
+
+    consumer = care_gap_result.get("consumer")
+    if not isinstance(consumer, dict) or "due" not in consumer:
+        return CareGapsSection(reason=CARE_GAPS_REASON_UNREADABLE)
+
     due_items = consumer.get("due") or []
     out = []
     for item in due_items:
@@ -223,7 +275,7 @@ def build_care_gaps(care_gap_result: dict) -> list[BriefField]:
             source_type="MeasureReport",
             source_id=item.get("id") or item.get("measure_id", ""),
         ))
-    return out
+    return CareGapsSection(fields=out, status=CARE_GAPS_OK, reason="")
 
 
 def build_visits(encounters: list[dict]) -> list[BriefField]:
@@ -261,13 +313,18 @@ def generate_brief(
     """Generate a structured appointment brief from FHIR resource lists.
 
     All inputs may be empty lists / empty dicts. Empty inputs produce empty
-    section lists — never error strings. The unknown-never-absent rule is
-    enforced: this function never returns a string like 'none' or 'no records'.
+    section lists — never error strings. The unknown-never-absent rule holds
+    for the wording *and* for the shape: no section says 'none' or 'no
+    records', and the care-gaps section reports whether it ran at all, so an
+    empty list there is never read back as reassurance (#381).
     """
+    gaps = build_care_gaps(care_gap_result)
     return BriefResult(
         problems=build_problems(conditions),
         medications=build_medications(medication_requests),
         labs=build_labs(observations),
-        care_gaps=build_care_gaps(care_gap_result),
+        care_gaps=gaps.fields,
         visits=build_visits(encounters),
+        care_gaps_status=gaps.status,
+        care_gaps_reason=gaps.reason,
     )

--- a/r6/brief/routes.py
+++ b/r6/brief/routes.py
@@ -16,7 +16,13 @@ from flask import request, jsonify
 
 from r6.models import R6Resource
 from r6.audit import record_audit_event
-from r6.brief.engine import generate_brief, BriefResult, BriefField
+from r6.brief.engine import (
+    generate_brief,
+    BriefResult,
+    BriefField,
+    CARE_GAPS_UNAVAILABLE,
+    CARE_GAPS_REASON_ENGINE_ERROR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,26 +54,43 @@ def _field_to_dict(f: BriefField) -> dict:
 
 
 def _brief_to_extension(result: BriefResult) -> list[dict]:
-    def _section(name: str, fields: list[BriefField]) -> dict:
+    def _section(name: str, fields: list[BriefField],
+                 extra: list[dict] | None = None) -> dict:
         return {
             "url": f"https://healthclaw.io/fhir/StructureDefinition/brief-section-{name}",
             "extension": [
                 {"url": "field", "valueString": json.dumps(_field_to_dict(f))}
                 for f in fields
-            ],
+            ] + (extra or []),
         }
+
+    # Care gaps ship their state alongside their fields. Without it a client
+    # sees an empty list and has no way to tell "nothing due" from "the
+    # screening review never ran" (#381).
+    care_gap_state = [{"url": "status", "valueString": result.care_gaps_status}]
+    if result.care_gaps_reason:
+        care_gap_state.append(
+            {"url": "reason", "valueString": result.care_gaps_reason})
 
     return [
         _section("problems", result.problems),
         _section("medications", result.medications),
         _section("labs", result.labs),
-        _section("care-gaps", result.care_gaps),
+        _section("care-gaps", result.care_gaps, care_gap_state),
         _section("visits", result.visits),
     ]
 
 
 def _care_gap_result(conditions: list[dict], observations: list[dict]) -> dict:
-    """Run care-gaps evaluation; return empty result on any failure."""
+    """Run care-gaps evaluation; on failure say so rather than returning {}.
+
+    The brief must not 500 when the screening rules break, but the old empty
+    dict was worse than the crash: it reached the patient's page as an empty
+    "preventive care due" section, which reads as a clean bill of health from
+    a component that never ran (#381). The marker keeps the failure named all
+    the way through. The reason is a fixed string — exception text can carry
+    record content, and audit/log detail stays PHI-free.
+    """
     try:
         from r6.caregaps.evaluate import evaluate_care_gaps
         from r6.caregaps.report import build_consumer_summary
@@ -79,8 +102,11 @@ def _care_gap_result(conditions: list[dict], observations: list[dict]) -> dict:
         )
         consumer = build_consumer_summary(results)
         return {"consumer": consumer}
-    except Exception:
-        return {}
+    except Exception as exc:
+        logger.warning("appointment brief: care-gaps evaluation failed (%s)",
+                       type(exc).__name__)
+        return {"status": CARE_GAPS_UNAVAILABLE,
+                "reason": CARE_GAPS_REASON_ENGINE_ERROR}
 
 
 def register_brief_routes(blueprint, deps):

--- a/tests/test_brief_engine.py
+++ b/tests/test_brief_engine.py
@@ -20,6 +20,9 @@ from r6.brief.engine import (
     build_visits,
     BriefResult,
     BriefField,
+    CARE_GAPS_OK,
+    CARE_GAPS_UNAVAILABLE,
+    CARE_GAPS_REASON_ENGINE_ERROR,
 )
 
 
@@ -158,8 +161,9 @@ class TestFullRecords:
 
     def test_care_gaps_populated(self):
         gaps = build_care_gaps(self.CARE_GAPS)
-        assert len(gaps) == 1
-        assert "Colorectal" in gaps[0].label
+        assert gaps.status == CARE_GAPS_OK
+        assert len(gaps.fields) == 1
+        assert "Colorectal" in gaps.fields[0].label
 
     def test_visits_populated(self):
         visits = build_visits(self.ENCOUNTERS)
@@ -264,3 +268,53 @@ class TestPartialRecords:
         assert result.problems[0].source_id == "cond-abc"
         assert result.medications[0].source_id == "med-xyz"
         assert result.labs[0].source_id == "obs-123"
+
+
+# ---------------------------------------------------------------------------
+# Case 4: care gaps — the third state (#381)
+# ---------------------------------------------------------------------------
+
+class TestCareGapsThirdState:
+    """"The screening review raised" and "you have no open screening gaps"
+    must not produce the same section. An empty list reads to a patient as
+    "you are up to date on your cancer screenings", so the ok state has to be
+    earned by a result that actually says it."""
+
+    def test_caller_reported_failure_is_unavailable(self):
+        section = build_care_gaps({"status": CARE_GAPS_UNAVAILABLE,
+                                   "reason": CARE_GAPS_REASON_ENGINE_ERROR})
+        assert section.status == CARE_GAPS_UNAVAILABLE
+        assert section.reason == CARE_GAPS_REASON_ENGINE_ERROR
+        assert section.fields == []
+
+    def test_missing_result_is_unavailable_not_no_gaps(self):
+        assert build_care_gaps({}).status == CARE_GAPS_UNAVAILABLE
+        assert build_care_gaps(None).status == CARE_GAPS_UNAVAILABLE  # type: ignore[arg-type]
+
+    def test_consumer_payload_without_a_due_list_is_unavailable(self):
+        # A payload we cannot read is not an answer. Reporting "nothing due"
+        # off a shape that never carried the due items is the #381 defect.
+        section = build_care_gaps({"consumer": {"note": "some disclaimer"}})
+        assert section.status == CARE_GAPS_UNAVAILABLE
+        assert section.fields == []
+
+    def test_successful_empty_evaluation_is_ok(self):
+        section = build_care_gaps({"consumer": {"due": []}})
+        assert section.status == CARE_GAPS_OK
+        assert section.fields == []
+        assert section.reason == ""
+
+    def test_unavailable_and_no_gaps_are_distinguishable(self):
+        failed = generate_brief([], [], [], [], {})
+        evaluated = generate_brief([], [], [], [], {"consumer": {"due": []}})
+        assert failed.care_gaps == evaluated.care_gaps == []
+        assert failed.care_gaps_status != evaluated.care_gaps_status
+        assert failed.care_gaps_status == CARE_GAPS_UNAVAILABLE
+        assert evaluated.care_gaps_status == CARE_GAPS_OK
+
+    def test_reason_is_carried_to_the_brief(self):
+        result = generate_brief([], [], [], [], {
+            "status": CARE_GAPS_UNAVAILABLE,
+            "reason": CARE_GAPS_REASON_ENGINE_ERROR,
+        })
+        assert result.care_gaps_reason == CARE_GAPS_REASON_ENGINE_ERROR

--- a/tests/test_brief_routes.py
+++ b/tests/test_brief_routes.py
@@ -1,0 +1,88 @@
+"""Route tests for the AppointmentBrief endpoint.
+
+#381: when the care-gaps evaluation raises, the brief must carry an explicit
+"unavailable" state. The old behaviour returned {} and produced a care-gaps
+section indistinguishable from a clean bill of health — a patient reading it
+was told they were up to date on colorectal, cervical and breast cancer
+screening by a component that never ran.
+
+NOTE the URL. r6_blueprint is mounted at /r6/fhir and the handler adds a
+second "/fhir", so the route registers at /r6/fhir/fhir/AppointmentBrief
+while its only client (careagents/healthclaw.py) requests
+/r6/fhir/AppointmentBrief. That mismatch is a separate defect, untouched
+here; these tests exercise the path the app actually serves.
+"""
+
+from r6.brief.engine import (
+    CARE_GAPS_OK,
+    CARE_GAPS_REASON_ENGINE_ERROR,
+    CARE_GAPS_UNAVAILABLE,
+)
+
+_URL = "/r6/fhir/fhir/AppointmentBrief"
+_SECTION_PREFIX = "https://healthclaw.io/fhir/StructureDefinition/brief-section-"
+
+
+def _section(body, name):
+    for ext in body.get("extension", []):
+        if ext.get("url") == _SECTION_PREFIX + name:
+            return ext
+    return None
+
+
+def _sub(section, url):
+    for e in section.get("extension", []):
+        if e.get("url") == url:
+            return e.get("valueString")
+    return None
+
+
+def _fields(section):
+    return [e for e in section.get("extension", []) if e.get("url") == "field"]
+
+
+def test_care_gaps_engine_failure_is_marked_unavailable(client, tenant_headers,
+                                                        monkeypatch):
+    def _boom(**kwargs):
+        raise RuntimeError("screening rule table is corrupt")
+
+    monkeypatch.setattr("r6.caregaps.evaluate.evaluate_care_gaps", _boom)
+
+    r = client.get(_URL, headers=tenant_headers)
+    assert r.status_code == 200  # a brief that 500s is worse than a named gap
+
+    gaps = _section(r.get_json(), "care-gaps")
+    assert gaps is not None
+    assert _sub(gaps, "status") == CARE_GAPS_UNAVAILABLE
+    assert _sub(gaps, "reason") == CARE_GAPS_REASON_ENGINE_ERROR
+    # The failure is named, not silently rendered as an answered-and-empty
+    # section: no consumer may read this as "no gaps".
+    assert _sub(gaps, "status") != CARE_GAPS_OK
+    assert _fields(gaps) == []
+
+
+def test_care_gaps_section_always_carries_a_status(client, tenant_headers):
+    """Every brief states whether the screening review ran.
+
+    Without the marker a parser has only the field list to go on, which is
+    the two-state shape #381 is about.
+    """
+    r = client.get(_URL, headers=tenant_headers)
+    assert r.status_code == 200
+    gaps = _section(r.get_json(), "care-gaps")
+    assert _sub(gaps, "status") in (CARE_GAPS_OK, CARE_GAPS_UNAVAILABLE)
+
+
+def test_other_sections_are_unchanged(client, tenant_headers):
+    """The status marker is care-gaps only — the other four sections keep
+    carrying nothing but fields."""
+    r = client.get(_URL, headers=tenant_headers)
+    body = r.get_json()
+    for name in ("problems", "medications", "labs", "visits"):
+        section = _section(body, name)
+        assert section is not None
+        assert all(e.get("url") == "field" for e in section["extension"])
+
+
+def test_brief_requires_a_tenant(client):
+    assert client.get(_URL).status_code == 400

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2040,6 +2040,100 @@ def test_brief_unknown_agent_redirects(app, svc, monkeypatch):
     assert c.get("/brief?agent=nope").status_code == 302
 
 
+# --- care gaps: the third state (#381) ------------------------------------
+#
+# "The screening review did not run" and "you have no screenings due" are
+# different sentences, and the second one is a clinical claim. The page must
+# never make it on the first one's behalf.
+
+_CARE_GAPS_SECTION = ("https://healthclaw.io/fhir/StructureDefinition/"
+                      "brief-section-care-gaps")
+_UNAVAILABLE_COPY = b"Screening review unavailable"
+_NO_GAPS_COPY = b"no preventive care items"
+
+
+def _brief_with_care_gaps(status, fields=()):
+    return {
+        "resourceType": "Basic",
+        "extension": [{
+            "url": _CARE_GAPS_SECTION,
+            "extension": (
+                [{"url": "field", "valueString": f} for f in fields]
+                + [{"url": "status", "valueString": status}]
+            ),
+        }],
+    }
+
+
+def _agent_for_brief(c, svc, monkeypatch):
+    _login(c, svc, monkeypatch)
+    conn_id = c.post("/api/connections/sample").get_json()["id"]
+    return c.post("/api/agents", json={"name": "Ada", "persona": "direct",
+                                       "connection_id": conn_id}
+                  ).get_json()["id"]
+
+
+def test_brief_care_gaps_unavailable_is_not_rendered_as_no_gaps(app, svc,
+                                                                monkeypatch):
+    c = app.test_client()
+    agent_id = _agent_for_brief(c, svc, monkeypatch)
+    monkeypatch.setattr(FakeClient, "fetch_appointment_brief",
+                        lambda self, tenant: _brief_with_care_gaps("unavailable"))
+
+    resp = c.get(f"/brief?agent={agent_id}")
+    assert resp.status_code == 200
+    assert _UNAVAILABLE_COPY in resp.data
+    assert _NO_GAPS_COPY not in resp.data
+
+
+def test_brief_care_gaps_evaluated_and_empty_says_no_items(app, svc, monkeypatch):
+    c = app.test_client()
+    agent_id = _agent_for_brief(c, svc, monkeypatch)
+    monkeypatch.setattr(FakeClient, "fetch_appointment_brief",
+                        lambda self, tenant: _brief_with_care_gaps("ok"))
+
+    resp = c.get(f"/brief?agent={agent_id}")
+    assert resp.status_code == 200
+    assert _NO_GAPS_COPY in resp.data
+    assert _UNAVAILABLE_COPY not in resp.data
+
+
+def test_brief_care_gaps_evaluated_with_gaps_lists_them(app, svc, monkeypatch):
+    c = app.test_client()
+    agent_id = _agent_for_brief(c, svc, monkeypatch)
+    field = ('{"label":"Colorectal cancer screening","value":"May be due",'
+             '"sourceType":"MeasureReport","sourceId":"gap-1"}')
+    monkeypatch.setattr(
+        FakeClient, "fetch_appointment_brief",
+        lambda self, tenant: _brief_with_care_gaps("ok", fields=[field]))
+
+    resp = c.get(f"/brief?agent={agent_id}")
+    assert b"Colorectal cancer screening" in resp.data
+    assert _NO_GAPS_COPY not in resp.data
+    assert _UNAVAILABLE_COPY not in resp.data
+
+
+def test_brief_missing_care_gaps_marker_is_not_reassurance(app, svc, monkeypatch):
+    """An unmarked brief — an older engine, a truncated payload, no brief at
+    all — is not an evaluation, so it cannot say "nothing due"."""
+    c = app.test_client()
+    agent_id = _agent_for_brief(c, svc, monkeypatch)
+    monkeypatch.setattr(FakeClient, "fetch_appointment_brief",
+                        lambda self, tenant: None)
+
+    resp = c.get(f"/brief?agent={agent_id}")
+    assert _UNAVAILABLE_COPY in resp.data
+    assert _NO_GAPS_COPY not in resp.data
+
+
+def test_parse_care_gaps_status_defaults_to_not_ok():
+    from careagents.app import _parse_care_gaps_status
+    assert _parse_care_gaps_status(_brief_with_care_gaps("ok")) == "ok"
+    assert _parse_care_gaps_status(_brief_with_care_gaps("unavailable")) != "ok"
+    assert _parse_care_gaps_status({}) != "ok"
+    assert _parse_care_gaps_status(None) != "ok"
+
+
 def test_parse_brief_sections_extracts_fields():
     """_parse_brief_sections correctly deserializes section extensions."""
     from careagents.app import _parse_brief_sections


### PR DESCRIPTION
Sprint 1, P0-1. Closes #381.

## The defect

`_care_gap_result` swallowed every failure into `{}`, which `build_care_gaps` read as an empty `due` list, which rendered as an **empty care-gaps section** in the pre-appointment brief.

"The screening engine raised" and "you have no open screening gaps" were byte-identical to the patient.

#376 lost a medication *name* — the patient could tell something was missing. This loses a **recommendation to act**, and it looks like good news. Someone reading "no screenings due" has been told they are current on colorectal, cervical and breast cancer screening, blood pressure and A1c, by a component that never ran. They take that document to an appointment.

## The fix

A third state, `unavailable`, on a `CareGapsSection(fields, status, reason)` — the `_indeterminate()` shape from `r6/labs/interpret.py`, the one place in this repo that already refuses to let "could not judge" look like "normal". Renders as:

> Screening review unavailable — ask your clinician which preventive care you are due for.

Two choices that want explicit sign-off:

1. **`status` defaults to `unavailable`; "nothing due" now requires positive evidence** — a `consumer` payload actually carrying a `due` list. Absence no longer earns reassurance by default. That is the constitutional never-infer-absence rule restored at the level where it was defeated: a data shape, not a wording.
2. **`build_care_gaps` no longer returns a list.** Callers reach through `.fields`, so a caller that ignores the status gets a `TypeError` rather than quietly reassuring the patient.

Also fixed by consequence: the `raw is None` path (brief fetch fails entirely) previously rendered the same false reassurance with *no data behind it at all*.

## Two defects found underneath, filed separately

**The AppointmentBrief endpoint has never been reachable.** `r6_blueprint` mounts at `/r6/fhir` and `r6/brief/routes.py` adds a second `/fhir`, so it registers at `/r6/fhir/fhir/AppointmentBrief` while `careagents/healthclaw.py` requests `/r6/fhir/AppointmentBrief`. Verified against the live URL map. **The brief page has never populated in production** — which is why the false reassurance was reaching patients through the `None` path rather than the exception path.

**The care-gaps section cannot produce a gap on the live path.** `build_consumer_summary` returns `{"lines", "note"}` — there is no `due` key, which is what `build_care_gaps` reads. Verified. The existing engine test passed because its fixture built `{"consumer": {"due": items}}`, a shape the real producer never emits.

**Product decision inside this PR:** because of the second defect, the live section now renders "Screening review unavailable" rather than "We found no preventive care items". That is the truthful statement for a component that currently cannot find any item, and shipping the honest state beats preserving a reassurance — but it is a happy-path copy change and Product owns copy. Reverting is one line in the success predicate.

## Consumers checked

`generate_brief`, `_brief_to_extension` (other four sections untouched, pinned by a test), `_parse_brief_sections`, the `/brief` route, `brief.html` (unavailable checked first; an unset value falls to unavailable, never to reassurance). Grepped `care_gaps`/`care-gaps`/`careGaps` across Python, JS, TS, HTML and JSON — the MCP server and the care-gaps MCP App consume `Patient/$care-gaps` directly, not the brief.

## Mutations

| Mutant | Result |
|---|---|
| `_care_gap_result` back to `return {}` | red on the *reason* assertion |
| `build_care_gaps` back to two states | 6 red |
| template's third branch removed | 2 red |

Noted honestly: under the first mutant the *status* assertion stays green, because the engine's fail-safe catches `{}` independently. The reason is what distinguishes the layers.

## Not verified

Nothing was run against a live HealthClaw + CareAgents pair. The CareAgents tests fake the HealthClaw client, so they prove the marker is parsed and rendered; the route tests cover the emit side against the real Flask app. Both halves are pinned — the wire between them is not.

Gates: 2496 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)