### PR TITLE
fix(careagents): a #contained medication reference still blamed the source

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -258,11 +258,17 @@ def _summarize_bundle(bundle: dict, limit: int = 12,
                         if isinstance(c, dict) and c.get("code")), None)
             if raw:
                 item["name"] = f"unlabeled record, code {raw}"
-            elif lookup_reason in ("unavailable", "not-attempted"):
+            elif lookup_reason in ("unavailable", "not-attempted",
+                                  "not-a-ref"):
                 # We did not learn anything about this record's coding, so we
                 # say nothing about it. "The source sent free text" below is a
                 # finding; asserting it here would be inventing one — the
                 # defect PR #376 fixed, reached by a different route.
+                #
+                # "not-a-ref" belongs here too: a #contained or urn:uuid:
+                # target is ordinary FHIR that we decline to chase, so we
+                # learn nothing about its coding either. Routing it to the
+                # sentence below was the fourth way into the same falsehood.
                 item["name"] = "a medication I could not look up just now"
                 item["note"] = (
                     "The name is stored behind a reference this turn could "

--- a/tests/test_medication_deref.py
+++ b/tests/test_medication_deref.py
@@ -231,3 +231,34 @@ def test_a_medication_with_no_label_still_earns_the_source_sentence():
 
     assert items[0]["uncoded"] is True
     assert items[0]["name"] == "recorded but not coded at the source"
+
+
+def test_a_contained_or_uuid_reference_never_claims_the_source_sent_free_text():
+    """The fourth route to the false sentence, missed by #379.
+
+    `resolve` returns "not-a-ref" for any reference that is not
+    `Medication/<id>` — which includes `#contained` and `urn:uuid:` targets.
+    Both are ordinary FHIR: a contained Medication and a bundle-local one.
+
+    We decline to chase those, so we learn nothing about how the source coded
+    them — exactly the state "unavailable" and "not-attempted" describe. They
+    were routed to the source-blame wording instead, which asserts a finding
+    about the upstream feed from a branch that never looked.
+
+    A MedicationRequest with an INLINE uncoded concept and no reference at all
+    is different: there `lookup_reason` is None, we did see the concept, and
+    it genuinely had no code. That case keeps the source sentence, and
+    test_a_medication_with_no_label_still_earns_the_source_sentence guards it.
+    """
+    hc = _StubHC({})
+    resolver = _medication_resolver(hc, "t1")
+
+    for ref in ("#med-1", "urn:uuid:1e2d3c4b-0000-0000-0000-000000000001"):
+        items = _summarize_bundle(
+            {"entry": [_med_request("mr1", ref=ref)]},
+            limit=10, resolve_ref=resolver)
+        assert items[0]["unreadable"] is True, ref
+        assert not items[0].get("uncoded"), (
+            f"{ref} was reported as uncoded at the source, but we never "
+            "looked at it")
+    assert hc.reads == [], "a non-Medication reference was fetched"


### PR DESCRIPTION
Follow-on to #379, found by Product's honesty sweep. **My own fix missed a route.**

`resolve` returns `"not-a-ref"` for any reference that is not `Medication/<id>` — which includes `#contained` and `urn:uuid:` targets. Both are ordinary FHIR: a contained Medication, and a bundle-local one. We decline to chase them, so we learn nothing about how the source coded them, which is exactly the state `unavailable` and `not-attempted` describe.

They were routed to the source-blame wording instead — *"The source system sent this record as free text"* — a claim about the upstream feed from a branch that never looked.

**The lesson, since this is the second time:** #379 closed the routes I had enumerated, not the property. Enumerating cases is how you miss the fourth one. #376 had three stacked faults for the same reason.

An inline uncoded concept with **no reference at all** keeps the source sentence — there `lookup_reason` is `None`, we did see the concept, and it genuinely had no code. Guarded separately by `test_a_medication_with_no_label_still_earns_the_source_sentence`.

Mutation-verified: dropping `"not-a-ref"` from the tuple reddens the new test. Gates: 2482 passed · ruff · table stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)