### PR TITLE
fix(care-gaps): the screening question was answered with silence (#389, half one)

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -349,7 +349,20 @@ def _execute_tool(hc: HealthClawClient, tenant: str, name: str,
         })
     if name == "get_care_gaps":
         gaps = hc.care_gaps(tenant)
-        return json.dumps({"consumer_summary": gaps["consumer"]})
+        consumer = gaps.get("consumer") or {}
+        out = {"consumer_summary": consumer}
+        if consumer.get("unevaluated"):
+            # The check produced no lines because it could not run, not
+            # because nothing is outstanding. Those two arrive here looking
+            # identical, and the second was being read out to people as the
+            # first on the busiest button in the product (#389).
+            out["note"] = (
+                "The preventive-care check did not reach a verdict — reason: "
+                f"{consumer['unevaluated']}. Say that plainly, using "
+                "unevaluated_note. Do NOT tell the person they have no "
+                "screenings due, and do not name or infer any screening from "
+                "this result.")
+        return json.dumps(out)
     if name == "search_records":
         rt = args.get("resource_type") or "Condition"
         return json.dumps(_summarize_bundle(

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -12,6 +12,24 @@ _CONSUMER_NOTE = (
     "records may be incomplete, so confirm anything here with your "
     "clinician.")
 
+# Why the consumer list came back empty, in the person's own words. One entry
+# per reason; the reason itself travels as `unevaluated` so a caller can
+# branch on it without matching prose.
+_UNEVALUATED_NOTES = {
+    "no-patient": (
+        "There is no patient record connected here yet, so this check had "
+        "nothing to read. Nothing was examined, and that is not a finding "
+        "that you have no screenings outstanding."),
+    "ambiguous-patient": (
+        "More than one patient record is connected here, so this check could "
+        "not tell whose preventive care to look at. Nothing was examined, "
+        "and that is not a finding that you have no screenings outstanding."),
+    "demographics-unavailable": (
+        "Your date of birth and sex were not available to this check, so it "
+        "could not work out which screenings apply to you. That is not a "
+        "finding that you have no screenings outstanding."),
+}
+
 
 def build_caregaps_summary(results):
     buckets = {"due": 0, "up_to_date": 0, "not_applicable": 0, "indeterminate": 0}
@@ -39,11 +57,37 @@ def _consumer_line(r):
     return None
 
 
-def build_consumer_summary(results):
+def _unevaluated_reason(results, unresolved):
+    """Why there are no consumer lines, or None when the emptiness is a finding.
+
+    An empty list is ambiguous by construction: "we looked and nothing is
+    outstanding" and "we never got far enough to look" render identically,
+    and the second was reaching patients as the first (#389, after #379 and
+    #381). So the reason travels with the emptiness. Same posture as
+    r6/labs/interpret.py `_indeterminate` — say what could not be decided
+    rather than emitting a clean result.
+    """
+    if unresolved:
+        return unresolved
+    if any(r.get("status") == "indeterminate" for r in results):
+        return "demographics-unavailable"
+    return None
+
+
+def build_consumer_summary(results, unresolved=None):
+    """`unresolved` is the subject-resolution failure, if any — the caller
+    knows about it and the engine cannot see it, since an unidentifiable
+    patient produces exactly the same rule results as a healthy one."""
     lines = []
     for r in results:
         if r.get("status") in ("due", "up_to_date"):
             line = _consumer_line(r)
             if line:
                 lines.append(line)
-    return {"lines": lines, "note": _CONSUMER_NOTE}
+    out = {"lines": lines, "note": _CONSUMER_NOTE}
+    if not lines:
+        reason = _unevaluated_reason(results, unresolved)
+        if reason:
+            out["unevaluated"] = reason
+            out["unevaluated_note"] = _UNEVALUATED_NOTES[reason]
+    return out

--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -3,8 +3,10 @@
 
 Registered on r6_blueprint (under /r6/fhir). Read-shaped: tenant-read-
 authenticated + AuditEvent (PHI-free detail). Evaluates preventive-care gaps
-for ?subject=Patient/<id> against the tenant's stored Conditions,
-Observations, Immunizations, and Procedures.
+for ?subject=Patient/<id>, or for the tenant's own Patient when no subject is
+supplied, against the tenant's stored Conditions, Observations, Immunizations,
+and Procedures. The `subjectResolution` parameter reports which of those
+happened, and names the failure when neither could.
 """
 import json
 import logging
@@ -46,6 +48,35 @@ def register_caregaps_routes(blueprint, deps):
                         subject = ref.get("reference") or subject
         return subject
 
+    def _resolve_subject(supplied, tenant_id):
+        """Return (subject_reference, state).
+
+        Both production callers — CareAgents' get_care_gaps and the care-gaps
+        MCP App page — post an empty body with no subject, so `supplied` was
+        None and `_resources_for` compared every stored subject.reference
+        against None. Nothing matched, the evaluator saw an empty record, and
+        the patient was told nothing was due (#389). The tenant already scopes
+        the read, so the tenant's own Patient is the default here as it is
+        elsewhere (r6/actions/review.py `_load_patient`).
+
+        A fallback that cannot land is its OWN outcome and never an empty
+        list. No Patient row and more than one Patient row each return a
+        state, which travels to the caller in the consumer summary — the
+        engine itself cannot tell the difference afterwards, because an
+        unidentifiable patient produces exactly the rule results a healthy
+        one does.
+        """
+        if supplied:
+            return supplied, "supplied"
+        # Two rows is all it takes to know the match is ambiguous.
+        rows = R6Resource.query.filter_by(
+            resource_type="Patient", tenant_id=tenant_id).limit(2).all()
+        if not rows:
+            return None, "no-patient"
+        if len(rows) > 1:
+            return None, "ambiguous-patient"
+        return f"Patient/{rows[0].id}", "tenant-default"
+
     def _patient_for(subject, tenant_id):
         if not subject or not subject.startswith("Patient/"):
             return None
@@ -74,25 +105,39 @@ def register_caregaps_routes(blueprint, deps):
         if auth_err is not None:
             return auth_err[0], auth_err[1]
 
-        subject = _subject_from_request()
-        patient = _patient_for(subject, tenant_id)
-        conditions = _resources_for("Condition", subject, tenant_id)
-        observations = _resources_for("Observation", subject, tenant_id)
-        immunizations = _resources_for("Immunization", subject, tenant_id)
-        procedures = _resources_for("Procedure", subject, tenant_id)
-        as_of = date.today().isoformat()
+        supplied = _subject_from_request()
+        subject, state = _resolve_subject(supplied, tenant_id)
+        unresolved = state if state in ("no-patient", "ambiguous-patient") else None
 
+        # `supplied`, NOT `subject`. Feeding the evaluator the Patient the
+        # fallback just resolved makes every age-gated rule resolve, which
+        # changes WHICH screenings a person is told they are due for. That is
+        # clinical output and it is the second half of #389, gated on CTO
+        # sign-off and Dr. Magan's review — deliberately not this change.
+        # Until then age stays unknown on the fallback path, those rules stay
+        # `indeterminate`, and the consumer summary says why it is empty
+        # instead of reading as "nothing due".
+        patient = _patient_for(supplied, tenant_id)
+
+        # No subject means nothing to compare against, so we do not pretend to
+        # have read anything.
+        def _for(resource_type):
+            return _resources_for(resource_type, subject, tenant_id) if subject else []
+
+        as_of = date.today().isoformat()
         results = evaluate_care_gaps(
-            patient, conditions=conditions, observations=observations,
-            immunizations=immunizations, procedures=procedures, as_of=as_of)
+            patient, conditions=_for("Condition"),
+            observations=_for("Observation"),
+            immunizations=_for("Immunization"), procedures=_for("Procedure"),
+            as_of=as_of)
 
         summary = build_caregaps_summary(results)
-        consumer = build_consumer_summary(results)
+        consumer = build_consumer_summary(results, unresolved=unresolved)
 
         record_audit_event(
             "read", resource_type="Patient", resource_id=None,
             agent_id=request.headers.get("X-Agent-Id"), tenant_id=tenant_id,
-            detail=(f"care-gaps; evaluated={summary['total']} "
+            detail=(f"care-gaps; subject={state} evaluated={summary['total']} "
                     f"due={summary['due']}"))
 
         return jsonify({
@@ -100,6 +145,8 @@ def register_caregaps_routes(blueprint, deps):
             "parameter": [
                 {"name": "summary", "valueString": json.dumps(summary)},
                 {"name": "consumerSummary", "valueString": json.dumps(consumer)},
+                {"name": "subjectResolution",
+                 "valueString": json.dumps({"state": state, "subject": subject})},
                 {"name": "detail", "valueString": json.dumps(results)},
                 {"name": "disclaimer", "valueString": _DISCLAIMER},
             ],

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3427,6 +3427,44 @@ def test_show_lab_timeline_emits_a_card_and_withholds_the_numbers(
     assert "244" not in _json.dumps(out), "the tool handed the model raw values"
 
 
+def test_care_gaps_that_could_not_run_forbids_reporting_no_screenings(
+        cfg, svc, monkeypatch):
+    """The unresolved state has to survive the last hop to the model, or the
+    engine's honesty is thrown away one call short of the person (#389).
+
+    MUTATION: drop the note branch in _execute_tool -> red.
+    """
+    import json as _json
+
+    from careagents.agent import _execute_tool
+
+    class _HC:
+        def care_gaps(self, _tenant):
+            return {"summary": {}, "consumer": {
+                "lines": [], "unevaluated": "no-patient",
+                "unevaluated_note": "nothing was examined"}}
+
+    out = _json.loads(_execute_tool(_HC(), "t", "get_care_gaps", {}, []))
+    assert "no-patient" in out["note"]
+    assert "Do NOT tell the person they have no screenings due" in out["note"]
+
+
+def test_care_gaps_with_real_findings_carries_no_could_not_run_note(cfg, svc):
+    """The note is earned, not boilerplate — a check that ran says nothing
+    about having failed."""
+    import json as _json
+
+    from careagents.agent import _execute_tool
+
+    class _HC:
+        def care_gaps(self, _tenant):
+            return {"summary": {}, "consumer": {
+                "lines": [{"rule_id": "bp-screening", "message": "due"}]}}
+
+    out = _json.loads(_execute_tool(_HC(), "t", "get_care_gaps", {}, []))
+    assert "note" not in out
+
+
 def test_show_lab_timeline_with_no_match_emits_no_card_and_forbids_absence(
         cfg, svc, monkeypatch):
     """MUTATION: emit a card over an empty series -> red (an empty chart reads

--- a/tests/test_caregaps_report.py
+++ b/tests/test_caregaps_report.py
@@ -82,3 +82,43 @@ def test_consumer_summary_note_text():
         "guidelines — not personalized medical advice. Your connected "
         "records may be incomplete, so confirm anything here with your "
         "clinician.")
+
+
+# ─────────────────────────────────────────────
+# Why the list is empty (#389)
+# ─────────────────────────────────────────────
+
+def test_unresolved_subject_travels_with_the_empty_list():
+    """An unresolvable subject is carried, not swallowed. The caller cannot
+    otherwise tell it apart from a clean sheet."""
+    consumer = build_consumer_summary([], unresolved="no-patient")
+    assert consumer["lines"] == []
+    assert consumer["unevaluated"] == "no-patient"
+    assert "not a finding" in consumer["unevaluated_note"]
+
+
+def test_all_indeterminate_rules_are_not_reported_as_nothing_due():
+    """Every rule filtered out for want of age or sex. The list is empty
+    because nothing was decided, which is not the same as nothing being due.
+
+    MUTATION: return the plain {"lines": [], "note": ...} -> red.
+    """
+    consumer = build_consumer_summary(
+        [_result(status="indeterminate", applicable=None),
+         _result(rule_id="mammography", status="not_applicable",
+                 applicable=False)])
+    assert consumer["unevaluated"] == "demographics-unavailable"
+
+
+def test_no_lines_and_no_indeterminate_rules_claims_no_reason():
+    """All rules decided and none outstanding: the emptiness is a finding,
+    so it carries no excuse for itself."""
+    consumer = build_consumer_summary(
+        [_result(status="not_applicable", applicable=False)])
+    assert "unevaluated" not in consumer
+
+
+def test_unevaluated_notes_have_no_banned_words():
+    for reason in ("no-patient", "ambiguous-patient", "demographics-unavailable"):
+        consumer = build_consumer_summary([], unresolved=reason)
+        assert not _BANNED.search(consumer["unevaluated_note"])

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -70,6 +70,98 @@ def test_care_gaps_unknown_patient_is_ok_but_indeterminate(client, tenant_header
 
 
 # ─────────────────────────────────────────────
+# The production call shape: no subject at all
+# ─────────────────────────────────────────────
+
+def test_care_gaps_with_no_subject_uses_the_tenants_own_patient(
+        client, app, tenant_id, tenant_headers):
+    """The shape both production callers actually send (#389).
+
+    CareAgents' get_care_gaps and the care-gaps MCP App page post an empty
+    body with no ?subject=. Every other test in this file passes one, which
+    is why this survived: with subject None the resource filter compares
+    every subject.reference against None, nothing matches, and the evaluator
+    is handed an empty record.
+
+    MUTATION: delete the fallback branch in _resolve_subject (return the
+    supplied subject unconditionally) -> both asserts red.
+    """
+    _seed_patient(app, tenant_id, pid="p-solo")
+    _store(app, {"resourceType": "Condition", "id": "c-dm",
+                 "subject": {"reference": "Patient/p-solo"},
+                 "code": {"coding": [{"system": "http://snomed.info/sct",
+                                      "code": "44054006"}]}}, tenant_id)
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    body = r.get_json()
+    resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
+    assert resolution == {"state": "tenant-default", "subject": "Patient/p-solo"}
+
+    # The tenant's own Condition reached the evaluator: the diabetes rule is
+    # no longer dismissed as "applies to patients with a diabetes diagnosis".
+    # Against subject None it was, because the Condition never matched.
+    detail = json.loads(_resp_param(body, "detail")["valueString"])
+    a1c = next(d for d in detail if d["rule_id"] == "diabetes-a1c")
+    assert a1c["status"] != "not_applicable", (
+        "the tenant's stored Condition did not reach the evaluator")
+
+
+def test_care_gaps_with_no_patient_row_says_so_rather_than_no_gaps(
+        client, tenant_headers):
+    """"Could not look" must not arrive as "looked and found none".
+
+    Third instance of this shape in a week (#379 medications, #381 the
+    brief's care gaps, #390 the intake form), and the one on the highest
+    traffic entry point.
+
+    MUTATION: collapse the unresolved reason (return a bare empty consumer
+    summary) -> red.
+    """
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    body = r.get_json()
+    resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
+    assert resolution == {"state": "no-patient", "subject": None}
+    consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
+    assert consumer["lines"] == []
+    assert consumer["unevaluated"] == "no-patient"
+    assert "no screenings outstanding" in consumer["unevaluated_note"]
+
+
+def test_care_gaps_with_two_patient_rows_is_ambiguous_not_empty(
+        client, app, tenant_id, tenant_headers):
+    """Two Patient rows and no subject: the fallback cannot pick one. That is
+    its own outcome, not a clean sheet.
+
+    MUTATION: take rows[0] instead of reporting ambiguity -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-one")
+    _seed_patient(app, tenant_id, pid="p-two")
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    body = r.get_json()
+    resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
+    assert resolution == {"state": "ambiguous-patient", "subject": None}
+    consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
+    assert consumer["unevaluated"] == "ambiguous-patient"
+
+
+def test_care_gaps_with_a_supplied_subject_reports_that_state(
+        client, app, tenant_id, tenant_headers):
+    """A caller-supplied subject is not the fallback, and says so."""
+    _seed_patient(app, tenant_id, pid="p-named")
+    r = client.get("/r6/fhir/Patient/$care-gaps?subject=Patient/p-named",
+                   headers=tenant_headers)
+    resolution = json.loads(
+        _resp_param(r.get_json(), "subjectResolution")["valueString"])
+    assert resolution == {"state": "supplied", "subject": "Patient/p-named"}
+
+
+# ─────────────────────────────────────────────
 # MCP App page (embedded HTML surface)
 # ─────────────────────────────────────────────
 


### PR DESCRIPTION
Sprint 2, P0. **Half one of #389 only** — read the last section before merging, because this fix leaves the button honest and still non-functional.

## The defect

CareAgents calls `Patient/$care-gaps` with **no `subject`**. There was no fallback, and the resource filter compares `subject.reference == subject` — against `None`. Everything failed the comparison.

So **"Any screenings I'm due for?"** — one of four buttons on the chat's first screen — always reported nothing due. A patient told they have no preventive care outstanding, by a component that never looked. The engine returned 200, well-formed and empty; nothing errored, nothing logged.

Every existing test passes `?subject=`. The only production caller does not. Same shape as #376 (every test asserted validity, none asserted a label) and #387 (a fixture encoding a contract the producer never emits).

## The fix

`_resolve_subject(supplied, tenant_id)` returns `(reference, state)` across four states — `supplied`, `tenant-default`, `no-patient`, `ambiguous-patient`. It follows the existing default in `r6/actions/review.py::_load_patient`, and `.limit(2)` is all it takes to detect ambiguity.

The state reaches the patient through four hops: a `subjectResolution` parameter on the response, `unevaluated` + `unevaluated_note` on the consumer summary **only when `lines` is empty**, and a note in the agent tool result telling the model plainly:

> Do NOT tell the person they have no screenings due, and do not name or infer any screening from this result.

Without lines, the model never sees an empty list it can read as a clean sheet. Audit detail gains `subject=<state>` — four fixed literals, PHI-free.

`_unevaluated_reason` also covers the non-failure case: if any rule came back `indeterminate`, the reason is `demographics-unavailable`. That is the `_indeterminate()` posture from `r6/labs/interpret.py` — the emptiness says *why*.

## READ THIS BEFORE MERGING — the button still does not answer its question

On the fallback path `patient` is still `None` into the evaluator, so age is unknown, all six age-gated rules stay `indeterminate` and get filtered, and `lines` stays empty.

The patient now gets *"your date of birth and sex were not available to this check, so it could not work out which screenings apply to you"* instead of silence read as reassurance. **That is an improvement, not a fix.**

`routes.py:111` deliberately passes `supplied`, not the resolved subject, into `_patient_for` — a resolved Patient held and declined. It is commented in place, and **it will look like a bug to a reviewer.** That is half two of #389: it changes which screenings a patient is told they are due for, which is clinical output needing CTO sign-off and Dr. Magan's review.

A reviewer may reasonably prefer to hold this and ship both halves together. That call is yours.

## Also still broken, stated so nobody reads this as done

- A patient with **real findings plus some unevaluable rules** gets a silent partial: `unevaluated` is set only when `lines` is empty, so two due screenings alongside three indeterminate ones renders as two items with no hint three were skipped. Same shape, narrower.
- `?subject=Patient/<id>` naming a row that does not exist lands in `demographics-unavailable` — honest, but it does not distinguish "we hold no such patient" from "we hold them but not their DOB".
- **#381 (the brief) is untouched.** It calls `evaluate_care_gaps(patient=None, …)` with no subject resolution of its own. It inherits the new key for free, additively, but its own path still does not resolve a patient.
- The care-gaps MCP App ignores the new state and still renders "No screenings evaluated." Not a false absence claim, so left alone.

## Verification

Three mutations, each reverted. Removing the fallback reddens 3 tests. Collapsing the reason reddens 5 across both layers. The agent also **isolated the second assertion** — removing the `subjectResolution` assert and re-running under the first mutation — to prove the resource-reached assertion is independently load-bearing rather than shadowed.

**Not verified against a running HealthClaw.** CareAgents tests fake the client, so the two halves are tested on either side of a fake boundary — the documented repo trap. One live check is worth doing before this reaches the webinar path.

Gates: 2491 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)