### PR TITLE
fix(intake): 'No allergies found in your records' sat above the attestation that must never be inferred (#390)

### DIFF
--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -8,6 +8,10 @@ Two routes on the actions blueprint:
        row with a confirm/remove decision PLUS the explicit, UNCHECKED
        "No known allergies (patient confirmed)" checkbox; each condition
        confirmable. Provenance ("from your records") on populated items.
+       A patient we could NOT resolve renders as an unread record, never as
+       an empty one — the absence line sits directly above the attestation,
+       so claiming it from a lookup that never ran walks the patient into
+       affirming it (#390). See IntakeContent.
 
   POST /r6/actions/<id>/review  — the SERVER-SIDE SAFETY GATE. It RE-POPULATES
        the questionnaire from the tenant's FHIR (never trusting the client
@@ -28,6 +32,7 @@ per-item + allergy-attestation check, not single-use.
 """
 import json
 import logging
+from dataclasses import dataclass, field
 
 from flask import render_template, request
 
@@ -54,6 +59,68 @@ _CONTENT_TYPES = (
     ('AllergyIntolerance', 'patient'),
     ('Condition', 'subject'),
 )
+
+# The intake content has three states, not two: rows we found, a record we
+# read that holds none, and a patient we could not resolve at all. The third
+# exists because the first two are both ANSWERS, and the empty list that used
+# to stand in for a failure renders as "No allergies found in your records"
+# directly above the no-known-allergies attestation (#390) — walking a
+# skimming patient into agreeing with a sentence a lookup emptied. "No known
+# allergies" is never inferred; neither is the context the patient reads
+# before affirming it.
+#
+# Modelled on r6/labs/interpret.py's _indeterminate(): a result we could not
+# produce carries a REASON and is never dressed up as a clean one.
+CONTENT_OK = 'ok'
+CONTENT_UNRESOLVED = 'unresolved'
+
+CONTENT_REASON_NO_PATIENT = 'no patient record has reached this account yet'
+CONTENT_REASON_UNKNOWN_SUBJECT = (
+    'the form names a patient record this account does not hold')
+CONTENT_REASON_UNANCHORED = (
+    'part of the record refers to a patient we could not identify')
+
+
+@dataclass
+class IntakeContent:
+    """The FHIR content behind the review page, plus whether we resolved the
+    patient it is supposed to belong to.
+
+    Deliberately not a bare list. An empty list carries two meanings and the
+    difference between them is the whole point, so callers reach through
+    `.resources` and cannot mistake "could not resolve" for "nothing on
+    file". `status` defaults to unresolved — ok is earned, never assumed.
+    """
+    resources: list = field(default_factory=list)
+    status: str = CONTENT_UNRESOLVED
+    reason: str = CONTENT_REASON_NO_PATIENT
+
+    @property
+    def resolved(self):
+        return self.status == CONTENT_OK
+
+
+_URN_UUID_PREFIX = 'urn:uuid:'
+
+
+def _referenced_patient_id(reference):
+    """The Patient id a subject/patient reference points at, or None.
+
+    Two shapes resolve. The relative `Patient/<id>` form, and the
+    `urn:uuid:<id>` form a transaction Bundle uses for entries that reference
+    each other by fullUrl — which is how bundles arrive, and which the literal
+    string compare this replaced could never match (#390). Anything else (an
+    absolute URL, another resource type) resolves to None: the caller then
+    treats the record as unread rather than guessing whose it is.
+    """
+    if not isinstance(reference, str):
+        return None
+    ref = reference.strip()
+    if ref.startswith(_URN_UUID_PREFIX):
+        return ref[len(_URN_UUID_PREFIX):] or None
+    if ref.startswith('Patient/'):
+        return ref.split('/', 1)[1] or None
+    return None
 
 
 def _require_step_up(tenant_id):
@@ -100,7 +167,10 @@ def _resolve_questionnaire(action, tenant_id):
 
 def _load_patient(tenant_id, subject_ref=None):
     if subject_ref:
-        ident = subject_ref.split('/')[-1]
+        # `urn:uuid:<id>` first (a Bundle's own fullUrl reference), then the
+        # last path segment, which covers `Patient/<id>` and an absolute URL.
+        ident = (_referenced_patient_id(subject_ref)
+                 or subject_ref.split('/')[-1])
         row = R6Resource.query.filter_by(
             resource_type='Patient', id=ident, tenant_id=tenant_id).first()
         return row.to_fhir_json() if row else None
@@ -109,33 +179,65 @@ def _load_patient(tenant_id, subject_ref=None):
     return row.to_fhir_json() if row else None
 
 
-def _gather_content(tenant_id, patient):
-    content = []
-    if patient:
-        content.append(patient)
+def _gather_content(tenant_id, patient, subject_ref=None):
+    """The patient's FHIR content, and whether we resolved the patient at all.
+
+    An unresolved patient is NOT an empty record, and the difference is the
+    whole return type (see IntakeContent). Only a resolved, genuinely empty
+    record may be rendered as an absence (#390).
+    """
     if not (patient and patient.get('id')):
-        return content
-    ref = 'Patient/%s' % patient['id']
+        return IntakeContent(
+            reason=(CONTENT_REASON_UNKNOWN_SUBJECT if subject_ref
+                    else CONTENT_REASON_NO_PATIENT))
+
+    patient_id = patient['id']
+    ref = 'Patient/%s' % patient_id
+    content = [patient]
+    unanchored = False
     for resource_type, subject_field in _CONTENT_TYPES:
         for row in R6Resource.query.filter_by(
                 resource_type=resource_type, tenant_id=tenant_id).all():
             resource = row.to_fhir_json()
-            if (resource.get(subject_field) or {}).get('reference') == ref:
+            reference = (resource.get(subject_field) or {}).get('reference')
+            if _referenced_patient_id(reference) == patient_id:
+                # Canonicalize a resolved urn onto the relative form so the
+                # populate engine, which matches `Patient/<id>` alone, sees
+                # it. to_fhir_json() hands back a fresh dict each call, so
+                # this rewrites the copy the page renders — never the store.
+                resource[subject_field] = dict(resource[subject_field],
+                                               reference=ref)
                 content.append(resource)
-    return content
+            elif isinstance(reference, str) \
+                    and reference.startswith(_URN_UUID_PREFIX):
+                # A Bundle entry whose fullUrl reference names no id we hold:
+                # the ingester minted a fresh id for a patient that arrived
+                # without one, so this record can no longer be tied to
+                # anybody. We are holding clinical data we cannot read, which
+                # is the one thing the page must not report as "none found".
+                unanchored = True
+
+    if unanchored:
+        return IntakeContent(resources=content,
+                             reason=CONTENT_REASON_UNANCHORED)
+    return IntakeContent(resources=content, status=CONTENT_OK, reason='')
 
 
 def _draft_qr(action, tenant_id):
     """Populate the action's questionnaire from the tenant's FHIR -> draft QR.
     Deterministic: population order fixes the med/allergy/condition row indices
-    used by both the rendered page and the POST gate."""
+    used by both the rendered page and the POST gate.
+
+    Returns the content marker alongside the QR — an empty QR alone cannot say
+    whether the record is empty or unread, and the page has to say which."""
     questionnaire = _resolve_questionnaire(action, tenant_id)
     subject_ref = (action.payload.get('subject') or {}).get('reference') \
         if isinstance(action.payload.get('subject'), dict) else None
     patient = _load_patient(tenant_id, subject_ref)
-    content = _gather_content(tenant_id, patient)
-    qr, _issues = populate_questionnaire(questionnaire, patient, content)
-    return questionnaire, patient, qr
+    content = _gather_content(tenant_id, patient, subject_ref)
+    qr, _issues = populate_questionnaire(questionnaire, patient,
+                                         content.resources)
+    return questionnaire, patient, qr, content
 
 
 def _section_repeats(draft_qr, section_link_id, item_link_id):
@@ -224,18 +326,23 @@ def review_form(action_id):
     if action is None:
         return _error(404, 'Unknown action')
 
-    _questionnaire, _patient, draft_qr = _draft_qr(action, tenant_id)
+    _questionnaire, _patient, draft_qr, content = _draft_qr(action, tenant_id)
     demographics = _demographics(draft_qr)
     meds, allergies, conditions = _view_rows(draft_qr)
 
     record_audit_event(
         'read', resource_type='ProposedAction', resource_id=action.id,
         agent_id=request.headers.get('X-Agent-Id'), tenant_id=tenant_id,
-        detail='review page rendered',
+        # The reasons are fixed strings from this module, never record text,
+        # so the detail stays PHI-free. Without this, the state that renders
+        # the unreadable notice is invisible in production.
+        detail=('review page rendered' if content.resolved else
+                'review page rendered; record unreadable: %s' % content.reason),
     )
     html = render_template(
         'action_review.html', action_id=action_id, demographics=demographics,
         meds=meds, allergies=allergies, conditions=conditions,
+        record_readable=content.resolved, record_reason=content.reason,
         step_up_token=request.headers.get('X-Step-Up-Token', ''),
         tenant_id=tenant_id)
     return html, 200
@@ -268,7 +375,7 @@ def review_submit(action_id):
 
     # RE-POPULATE from FHIR: the server, not the client, decides which rows
     # exist and must be acted on. This is what makes the gate un-craftable.
-    _questionnaire, patient, draft_qr = _draft_qr(action, tenant_id)
+    _questionnaire, patient, draft_qr, _content = _draft_qr(action, tenant_id)
     med_rows = _section_repeats(draft_qr, 'medications', 'medications.item')
     allergy_rows = _section_repeats(draft_qr, 'allergies', 'allergies.item')
     condition_rows = _section_repeats(draft_qr, 'conditions',

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -33,8 +33,10 @@
             <dd class="col-sm-8">{{ value }}</dd>
             {% endfor %}
           </dl>
-          {% else %}
+          {% elif record_readable %}
           <p class="text-muted mb-0">No demographic details found in your records.</p>
+          {% else %}
+          <p class="text-muted mb-0">We could not read your records, so nothing has been filled in here.</p>
           {% endif %}
         </div>
       </div>
@@ -68,8 +70,10 @@
             </div>
           </div>
           {% endfor %}
-          {% else %}
+          {% elif record_readable %}
           <p class="text-muted mb-0">No medications found in your records.</p>
+          {% else %}
+          <p class="text-muted mb-0">We could not read your records, so no medications have been listed here.</p>
           {% endif %}
         </div>
       </div>
@@ -78,6 +82,17 @@
       <div class="card mb-4 border-warning">
         <div class="card-header"><i class="fas fa-triangle-exclamation me-2"></i>Allergies</div>
         <div class="card-body">
+          {# Three states, not two. "We looked and found none" and "we could
+             not work out whose record to look at" are different sentences,
+             and only the first may appear above the attestation below (#390). #}
+          {% if not record_readable %}
+          <div class="alert alert-danger mb-3" role="alert">
+            <i class="fas fa-triangle-exclamation me-1"></i>
+            <strong>We could not read your records</strong> &mdash;
+            {{ record_reason }}. Nothing here has been checked against them,
+            and this is not a statement that you have no allergies.
+          </div>
+          {% endif %}
           {% if allergies %}
           <p class="text-muted small">Each allergy below is <strong>from your records</strong>. Confirm or remove each one.</p>
           {% for allergy in allergies %}
@@ -99,7 +114,7 @@
             </div>
           </div>
           {% endfor %}
-          {% else %}
+          {% elif record_readable %}
           <div class="alert alert-warning mb-3" role="alert">
             <i class="fas fa-circle-info me-1"></i>
             No allergies found in your records — add them or affirmatively confirm none below.
@@ -108,13 +123,17 @@
 
           <div class="form-check mt-2 p-3 bg-body-secondary rounded">
             <!-- CRITICAL: never pre-checked. NKA is an explicit attestation,
-                 never inferred from the absence of allergy data. -->
+                 never inferred from the absence of allergy data — nor from an
+                 absence the page could not verify (#390). -->
             <input class="form-check-input" type="checkbox" name="nka" id="nka" value="true">
             <label class="form-check-label fw-bold" for="nka">
               No known allergies (patient confirmed)
             </label>
             <div class="text-muted small">
               Only check this if the patient has affirmatively stated they have no known allergies.
+              {%- if not record_readable %}
+              It is the patient's own statement and confirms nothing about what is on file.
+              {%- endif %}
             </div>
           </div>
         </div>

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -57,6 +57,30 @@ FORM_FILL_BODY = {
                 'body': 'new patient intake form'},
 }
 
+# A transaction Bundle references its own entries by fullUrl, so a patient
+# arrives as `urn:uuid:<id>` rather than `Patient/<id>` (#390).
+URN_ALLERGY = {
+    'resourceType': 'AllergyIntolerance', 'id': 'allergy-urn',
+    'code': {'text': 'Penicillin'},
+    'reaction': [{'manifestation': [{'text': 'Hives'}]}],
+    'patient': {'reference': 'urn:uuid:test-patient-1'},
+}
+# Same shape, but the urn is one no Patient row in the tenant carries — the
+# ingester minted a fresh id for a Bundle entry that had none, so the
+# reference can no longer be tied to anybody.
+ORPHANED_ALLERGY = {
+    'resourceType': 'AllergyIntolerance', 'id': 'allergy-orphan',
+    'code': {'text': 'Penicillin'},
+    'reaction': [{'manifestation': [{'text': 'Hives'}]}],
+    'patient': {'reference': 'urn:uuid:9d2c8f16-not-a-stored-id'},
+}
+
+# Copy the page must (or must not) render. Asserted as literals so a reworded
+# absence claim cannot slip back in silently.
+ABSENCE_LINE = 'No allergies found in your records'
+UNREADABLE_LINE = 'We could not read your records'
+ATTESTATION_CAVEAT = 'confirms nothing about what is on file'
+
 
 def _seed(app, tenant, resources):
     with app.app_context():
@@ -72,9 +96,14 @@ def R6(resource, tenant):
                       resource_id=resource['id'], tenant_id=tenant)
 
 
-def _staged_form_fill(client, tenant_headers, auth_headers):
+def _staged_form_fill(client, tenant_headers, auth_headers, subject_ref=None):
     """propose + commit a form-fill action -> awaiting_confirmation."""
-    r = client.post('/r6/actions/propose', json=FORM_FILL_BODY,
+    body = FORM_FILL_BODY
+    if subject_ref is not None:
+        payload = dict(FORM_FILL_BODY['payload'])
+        payload['subject'] = {'reference': subject_ref}
+        body = dict(FORM_FILL_BODY, payload=payload)
+    r = client.post('/r6/actions/propose', json=body,
                     headers=tenant_headers)
     assert r.status_code == 201, r.get_data(as_text=True)
     action_id = r.get_json()['id']
@@ -136,6 +165,105 @@ def test_get_review_no_allergies_never_prechecks_nka(
     tag = html[html.rfind('<input', 0, input_idx):
                html.find('>', input_idx) + 1]
     assert 'checked' not in tag.lower()
+
+
+# ---------------------------------------------------------------------------
+# "Looked, found none" vs "could not resolve the patient" (#390)
+#
+# The absence line sits directly above the no-known-allergies attestation, so
+# rendering it from a lookup that never resolved a patient walks a skimming
+# patient into attesting to a sentence nothing checked. Both states must stay
+# distinguishable in BOTH directions: swapping the false claim for silence
+# would trade a wrong answer for no answer.
+# ---------------------------------------------------------------------------
+
+def test_get_review_no_patient_row_does_not_claim_no_allergies(
+        client, app, tenant_headers, auth_headers):
+    """A tenant whose source sent clinical resources before demographics."""
+    _seed(app, tenant_headers['X-Tenant-Id'], [MED_A])   # no Patient row
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    assert ABSENCE_LINE not in html
+    assert UNREADABLE_LINE in html
+    # The attestation is still offered — it is the patient's own statement —
+    # but it is not framed as agreeing with anything we read.
+    assert 'name="nka"' in html
+    assert ATTESTATION_CAVEAT in html
+
+
+def test_get_review_urn_uuid_subject_resolves_the_patient(
+        client, app, tenant_headers, auth_headers):
+    """`urn:uuid:` is valid FHIR, so resolve it rather than give up on it."""
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, URN_ALLERGY])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers,
+                                  subject_ref='urn:uuid:test-patient-1')
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    # Resolved both ways: the action's urn subject AND the allergy's urn
+    # patient reference. The allergy renders, so there is no absence claim.
+    assert 'Penicillin' in html
+    assert 'Smith' in html
+    assert ABSENCE_LINE not in html
+    assert UNREADABLE_LINE not in html
+    assert ATTESTATION_CAVEAT not in html
+
+
+def test_get_review_unresolvable_urn_does_not_claim_no_allergies(
+        client, app, tenant_headers, auth_headers):
+    """The half of the urn case that cannot be resolved: allergy records are
+    held, but their reference names no patient we hold. That is an unread
+    record, not an empty one."""
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, ORPHANED_ALLERGY])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    assert ABSENCE_LINE not in html
+    assert UNREADABLE_LINE in html
+    assert ATTESTATION_CAVEAT in html
+
+
+def test_get_review_resolved_empty_record_still_says_none_found(
+        client, app, tenant_headers, auth_headers):
+    """The other direction. A patient we DID resolve, whose record genuinely
+    holds no allergies, still gets the honest absence line — otherwise this
+    fix trades a false claim for no information at all."""
+    _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _get(client, auth_headers, action_id)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    assert ABSENCE_LINE in html
+    assert UNREADABLE_LINE not in html
+    assert ATTESTATION_CAVEAT not in html
+
+
+def test_gather_content_states_are_distinguishable(app, tenant_id):
+    """The two states at the source, not just in the rendered page."""
+    from r6.actions.review import (CONTENT_OK, CONTENT_UNRESOLVED,
+                                   _gather_content)
+    with app.app_context():
+        for resource in (PATIENT, ALLERGY_A):
+            db.session.add(R6(resource, tenant_id))
+        db.session.commit()
+
+        resolved = _gather_content(tenant_id, dict(PATIENT))
+        assert resolved.status == CONTENT_OK
+        assert resolved.reason == ''
+        assert any(r['resourceType'] == 'AllergyIntolerance'
+                   for r in resolved.resources)
+
+        unresolved = _gather_content(tenant_id, None)
+        assert unresolved.status == CONTENT_UNRESOLVED
+        assert unresolved.reason           # names WHY, never a bare empty list
+        assert unresolved.resources == []
 
 
 def test_get_review_requires_step_up(client, app, tenant_headers, auth_headers):


### PR DESCRIPTION
Sprint 2, P0. Closes #390.

## The defect

If the tenant had no `Patient` row, or referenced its patient by `urn:uuid:`, `_gather_content` returned empty and the intake form rendered:

> No allergies found in your records

**immediately above the no-known-allergies attestation checkbox.**

"No known allergies" is a constitutional never-infer here — it may come only from an explicit human attestation, and that checkbox exists to obtain one. **The gate was sound; its context was false.** A patient who skims, sees "no allergies found", and ticks the box has been walked into attesting to a sentence a lookup emptied.

Both triggers are ordinary: a source that sends clinical resources before demographics, and a `urn:uuid:` subject reference (standard inside a transaction Bundle, which is how bundles arrive).

## The fix

`_gather_content` returns `IntakeContent(resources, status, reason)`. **`status` defaults to `unresolved` — ok is earned, not assumed** — and callers reach through `.resources`, so a list cannot be silently read as an answer. Modelled on `_indeterminate()` in `r6/labs/interpret.py`, the fourth use of that pattern this week.

Three states where there were two: rows found; a record we read that holds none; a patient we could not resolve. **Only the second may render an absence line.**

The unresolved case leads with a danger alert — "We could not read your records … this is not a statement that you have no allergies" — from three fixed reason strings.

**The checkbox stays.** A patient can truthfully say "I have no known allergies" whether or not we read their chart, and removing it would make the form unsubmittable. What changes is its framing: the helper text adds *"It is the patient's own statement and confirms nothing about what is on file."* The absence line is suppressed entirely.

Audit `detail` names the unresolved reason — module constants, never record text, so it stays PHI-free. Without it this state is invisible in production.

## `urn:uuid:` is resolved, not merely detected

`_referenced_patient_id` reads both `Patient/<id>` and `urn:uuid:<id>`. A resolved urn is canonicalized onto `Patient/<id>` **on the in-memory copy only** (`to_fhir_json()` returns a fresh dict; the store is untouched), because `r6/sdc/populate.py` matches the relative form alone — without that rewrite the resources gather but never populate.

Where the urn names an id the tenant does not hold, the record is *unanchored*: clinical data we cannot attach to anyone. Reported unread, never as "none found". An absolute URL or another resource type resolves to nothing rather than guessing whose record it is.

## Verification

Six mutations, all killed, **in both directions** — including one that makes the absence line unreachable, guarding against trading a false claim for no information. A resolved, genuinely empty record still says "none found".

Gates: 2486 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean.

## Two P0s found on the relay path, filed separately, NOT fixed here

Both are on this same page and both matter before Aug 18:

- **#395 — the step-up token is rendered into the patient's browser** as a JS literal and served cross-origin from careagents.cloud, contradicting `healthclaw.py`'s documented claim that the browser never sees one. On the relay path it is not even used — the submit route re-injects server-side.
- **#396 — the relayed page loads HealthClaw's nav and CSS against careagents.cloud.** An unstyled page with a nav bar of dead links, shown to a patient mid-approval. The most likely thing to look broken in a live run of this beat.

## Coverage gap, stated plainly

**These template branches are proven on the HealthClaw side only.** The relay's tests fake the page with a one-line HTML string, so nothing asserts the guardrail copy survives the hop to CareAgents — the documented trap where a fake proves a call is made, not accepted. Product named this beat as its biggest Aug 18 risk for exactly this reason.

Also noted, out of scope: `r6/sdc/routes.py` has the same blindness — it cannot distinguish an unresolvable subject from an empty record either. It returns structured `Parameters` rather than patient-facing prose, so it is not this defect, but it is the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)