### PR TITLE
fix: worker idle backoff (#341) and the access log that ate retention (#375)

### DIFF
--- a/careagents/config.py
+++ b/careagents/config.py
@@ -108,6 +108,8 @@ class Config:
         self.run_lease_seconds = int(e.get("CARE_RUN_LEASE_SECONDS", "60"))
         self.run_worker_concurrency = int(e.get("CARE_RUN_WORKERS", "4"))
         self.run_poll_seconds = float(e.get("CARE_RUN_POLL_SECONDS", "0.5"))
+        self.run_poll_max_seconds = float(e.get(
+            "CARE_RUN_POLL_MAX_SECONDS", "6.0"))
         self.run_worker_stale_seconds = int(e.get(
             "CARE_RUN_WORKER_STALE_SECONDS", "30"))
         self.run_sse_poll_seconds = float(e.get(
@@ -122,6 +124,14 @@ class Config:
             raise ConfigError("CARE_RUN_WORKERS must be 1-32")
         if not 0.05 <= self.run_poll_seconds <= 30:
             raise ConfigError("CARE_RUN_POLL_SECONDS must be 0.05-30")
+        if not 0.05 <= self.run_poll_max_seconds <= 30:
+            raise ConfigError("CARE_RUN_POLL_MAX_SECONDS must be 0.05-30")
+        # The cap can never sit below the floor, so setting it to the floor
+        # pins the idle interval flat — the rollback path, by variable change
+        # and no redeploy. Without the clamp a smaller cap would invert the
+        # doubling instead of disabling it.
+        self.run_poll_max_seconds = max(
+            self.run_poll_seconds, self.run_poll_max_seconds)
         if not 5 <= self.run_worker_stale_seconds <= 300:
             raise ConfigError(
                 "CARE_RUN_WORKER_STALE_SECONDS must be 5-300")

--- a/careagents/worker.py
+++ b/careagents/worker.py
@@ -411,12 +411,47 @@ class RunWorker:
             raise RunDeadlineExceeded("run deadline exceeded")
 
 
+class _IdleBackoff:
+    """Per-slot idle poll interval for one worker pool.
+
+    A slot doubles its own interval while the queue hands it nothing, up to
+    the cap; a claim by any slot returns every slot to the floor. Slots are
+    threads in one process, so that reset is a shared list under a lock, not
+    coordination between processes.
+
+    The cap is bounded by latency, not by safety. Presence is committed by
+    the claim itself, so an idle slot's interval is also how stale its
+    presence row gets, and the cap has to stay well inside
+    CARE_RUN_WORKER_STALE_SECONDS.
+    """
+
+    def __init__(self, slots: int, floor: float, cap: float) -> None:
+        self._floor = floor
+        self._cap = cap
+        self._lock = threading.Lock()
+        self._intervals = [floor] * slots
+
+    def on_claim(self) -> None:
+        """Note that a slot took work: every slot returns to the floor."""
+        with self._lock:
+            self._intervals = [self._floor] * len(self._intervals)
+
+    def on_empty(self, slot: int) -> float:
+        """Return this slot's wait, then double it for the next empty poll."""
+        with self._lock:
+            interval = self._intervals[slot]
+            self._intervals[slot] = min(interval * 2, self._cap)
+            return interval
+
+
 def run_worker_pool(cfg: Config, stop: threading.Event | None = None) -> None:
     """Run a fixed-size pool; each slot owns its HTTP session and lease id."""
     stop = stop or threading.Event()
     accounts = AccountService(cfg)
     host = socket.gethostname().split(".")[0]
     base_id = f"careagents-{host}-{os.getpid()}"
+    backoff = _IdleBackoff(cfg.run_worker_concurrency, cfg.run_poll_seconds,
+                           cfg.run_poll_max_seconds)
 
     def loop(slot: int) -> None:
         hc = HealthClawClient(cfg.healthclaw_base, cfg.mint_secret)
@@ -427,8 +462,12 @@ def run_worker_pool(cfg: Config, stop: threading.Event | None = None) -> None:
             except HealthClawError as exc:
                 logger.error("run claim failed: %s", exc)
                 worked = False
-            if not worked:
-                stop.wait(cfg.run_poll_seconds)
+            if worked:
+                backoff.on_claim()
+            else:
+                # Stays stop.wait, never time.sleep: a capped sleep would be
+                # added to every SIGTERM drain and every deploy.
+                stop.wait(backoff.on_empty(slot))
 
     threads = [threading.Thread(target=loop, args=(slot,), daemon=False,
                                 name=f"careagents-worker-{slot}")

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -56,7 +56,8 @@ The worker pool is bounded by `CARE_RUN_WORKERS` (default 4). Important knobs:
 | `CARE_RUN_WORKERS` | 4 | Concurrent worker slots per process |
 | `CARE_RUN_DEADLINE_SECONDS` | 120 | End-to-end run deadline |
 | `CARE_RUN_LEASE_SECONDS` | 60 | Claim lease, heartbeated every third |
-| `CARE_RUN_POLL_SECONDS` | 0.5 | Empty-queue polling delay |
+| `CARE_RUN_POLL_SECONDS` | 0.5 | Empty-queue polling delay, and the floor idle backoff returns to |
+| `CARE_RUN_POLL_MAX_SECONDS` | 6.0 | Idle backoff cap; doubles from the floor, any claim resets every slot. Set to the floor to pin the interval flat — the rollback, no redeploy |
 | `CARE_RUN_WORKER_STALE_SECONDS` | 30 | Maximum age of successful queue access |
 | `CARE_RUN_SSE_TIMEOUT_SECONDS` | 150 | One browser projection window |
 

--- a/main.py
+++ b/main.py
@@ -308,7 +308,18 @@ def _register_request_hooks(flask_app: Flask) -> None:
         duration_ms = round(
             (time.time() - getattr(g, "request_start", time.time())) * 1000, 1
         )
-        request_logger.info(
+        # This is a debug access log, not an audit trail — AuditEvent is that,
+        # and it is durable and PHI-free. Logged at INFO for every request it
+        # made retention a line budget: the idle run-claim poll alone was
+        # ~100% of the engine's volume and evicted the reaper warnings and
+        # ingest errors an operator needs. Successes go to DEBUG; anything
+        # that did not succeed stays at INFO, correlation id and all.
+        level = (
+            logging.DEBUG if 200 <= response.status_code < 300
+            else logging.INFO
+        )
+        request_logger.log(
+            level,
             json.dumps(
                 {
                     "request_id": getattr(g, "request_id", "-"),

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -66,6 +66,22 @@ def test_production_on_postgres_does_not_warn(caplog):
     assert not any("SQLite" in r.message for r in caplog.records)
 
 
+def test_idle_poll_cap_defaults_to_six_and_never_sits_below_the_floor():
+    base = {"CARE_RP_ID": "localhost", "CARE_ORIGIN": "http://localhost",
+            "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m"}
+    assert Config(env=base).run_poll_max_seconds == 6.0
+
+    # The rollback contract: the cap set to the floor pins the interval flat,
+    # and a cap below the floor clamps up rather than inverting the doubling.
+    for value, expected in (("0.5", 0.5), ("0.1", 0.5)):
+        cfg = Config(env={**base, "CARE_RUN_POLL_MAX_SECONDS": value})
+        assert cfg.run_poll_max_seconds == cfg.run_poll_seconds == expected
+
+    for bad in ("0.04", "31"):
+        with pytest.raises(ConfigError):
+            Config(env={**base, "CARE_RUN_POLL_MAX_SECONDS": bad})
+
+
 # --- build provenance (#258) --------------------------------------------------
 # Both deployments were once found serving code months older than main while
 # every production check was green. The marker is what makes that visible — so
@@ -704,6 +720,193 @@ def test_worker_pool_creates_only_the_configured_number_of_slots(
         "careagents-worker-0", "careagents-worker-1",
         "careagents-worker-2"]
     assert all(thread.started and thread.joined for thread in threads)
+
+
+# --- idle poll backoff (#341) -------------------------------------------------
+
+class _RecordingStop:
+    """Stop event that records each wait and advances a simulated clock.
+
+    The clock is what makes presence freshness assertable: a slot commits
+    presence by calling claim, so the interval it waits between claims *is*
+    the age its presence row reaches.
+    """
+
+    def __init__(self):
+        self.waits: list[float] = []
+        self.claims: list[float] = []
+        self.clock = 0.0
+        self._set = False
+
+    def is_set(self) -> bool:
+        return self._set
+
+    def set(self) -> None:
+        self._set = True
+
+    def wait(self, timeout=None) -> bool:
+        self.waits.append(timeout)
+        self.clock += timeout or 0.0
+        return self._set
+
+
+def _drive_pool(cfg, monkeypatch, outcomes):
+    """Run one worker slot against a scripted sequence of claim outcomes.
+
+    `outcomes` is one bool per poll: True means the slot claimed a run. The
+    pool runs synchronously on fake threads and stops once the script is
+    exhausted. Driving the real `run_worker_pool` rather than the backoff
+    object alone is deliberate — it pins that the backoff is wired to the
+    empty branch and the reset to the claimed one.
+    """
+    from careagents import worker as worker_mod
+
+    cfg.run_worker_concurrency = 1
+    stop = _RecordingStop()
+    pending = list(outcomes)
+
+    class _ScriptedWorker:
+        def __init__(self, *_args):
+            pass
+
+        def run_once(self):
+            stop.claims.append(stop.clock)
+            worked = pending.pop(0)
+            if not pending:
+                stop.set()
+            return worked
+
+    class _Thread:
+        def __init__(self, target, args, daemon, name):
+            self.target, self.args = target, args
+
+        def start(self):
+            self.target(*self.args)
+
+        def join(self):
+            pass
+
+    monkeypatch.setattr(worker_mod.threading, "Thread", _Thread)
+    monkeypatch.setattr(worker_mod, "AccountService", lambda _cfg: object())
+    monkeypatch.setattr(worker_mod, "HealthClawClient",
+                        lambda *_args: object())
+    monkeypatch.setattr(worker_mod, "RunWorker", _ScriptedWorker)
+    worker_mod.run_worker_pool(cfg, stop)
+    return stop
+
+
+def test_idle_poll_doubles_to_the_cap_and_stays_there(cfg, monkeypatch):
+    cfg.run_poll_seconds = 0.5
+    cfg.run_poll_max_seconds = 6.0
+
+    stop = _drive_pool(cfg, monkeypatch, [False] * 7)
+
+    assert stop.waits == [0.5, 1.0, 2.0, 4.0, 6.0, 6.0, 6.0]
+
+
+def test_a_claim_returns_the_claiming_slot_to_the_floor(cfg, monkeypatch):
+    cfg.run_poll_seconds = 0.5
+    cfg.run_poll_max_seconds = 6.0
+
+    # Ramp to the cap, claim one run, then go idle again. The cap must only
+    # ever bite on the first message after silence.
+    stop = _drive_pool(cfg, monkeypatch, [False] * 5 + [True] + [False] * 3)
+
+    assert stop.waits == [0.5, 1.0, 2.0, 4.0, 6.0, 0.5, 1.0, 2.0]
+
+
+def test_a_claim_in_one_slot_returns_the_other_slots_to_the_floor():
+    from careagents.worker import _IdleBackoff
+
+    backoff = _IdleBackoff(slots=2, floor=0.5, cap=6.0)
+    # Slot 1 ramps to the cap while slot 0 is busy.
+    assert [backoff.on_empty(1) for _ in range(5)] == [0.5, 1.0, 2.0, 4.0, 6.0]
+
+    # Slot 0 claims a run. Slot 1 claimed nothing, but a live conversation
+    # means work is arriving, so it must poll at the floor too.
+    backoff.on_claim()
+
+    assert backoff.on_empty(1) == 0.5
+
+
+def test_poll_cap_equal_to_poll_floor_reproduces_todays_flat_interval(
+        cfg, monkeypatch):
+    # The rollback path: CARE_RUN_POLL_MAX_SECONDS=0.5 restores today's
+    # behaviour with a variable change and no redeploy.
+    cfg.run_poll_seconds = 0.5
+    cfg.run_poll_max_seconds = 0.5
+
+    stop = _drive_pool(cfg, monkeypatch, [False] * 6)
+
+    assert stop.waits == [0.5] * 6
+
+
+def test_idle_backoff_keeps_worker_presence_inside_the_readiness_window(
+        cfg, monkeypatch):
+    """The cap must never open a presence gap the readiness check fails on.
+
+    `claim_next` commits presence on every claim including the empty ones,
+    so an idle slot's poll interval is exactly how stale its presence row
+    gets. Web readiness fails closed at CARE_RUN_WORKER_STALE_SECONDS, so a
+    cap at or above that threshold would take /healthz to 503 on an idle
+    queue — the outage the fail-closed design exists to make visible.
+    """
+    cfg.run_poll_seconds = 0.5
+    cfg.run_poll_max_seconds = 6.0
+
+    # Long enough to ramp to the cap and then sit at it across several
+    # readiness windows, not merely long enough to touch it once.
+    stop = _drive_pool(cfg, monkeypatch, [False] * 40)
+
+    gaps = [later - earlier
+            for earlier, later in zip(stop.claims, stop.claims[1:])]
+    assert stop.claims[-1] > 3 * cfg.run_worker_stale_seconds, (
+        "ramp too short to say anything about a 30s readiness window")
+    assert max(gaps) == pytest.approx(cfg.run_poll_max_seconds)
+    assert max(gaps) < cfg.run_worker_stale_seconds
+
+
+def test_idle_backoff_sleep_stays_interruptible_so_shutdown_drains(
+        cfg, monkeypatch):
+    """The wait must stay `stop.wait`, never `time.sleep`.
+
+    A `time.sleep(cap)` adds the full cap to every SIGTERM drain and every
+    deploy. Floor and cap are pinned to 30s so the difference is
+    unmistakable: milliseconds against `stop.wait`, half a minute against
+    `time.sleep`.
+    """
+    import threading
+    from careagents import worker as worker_mod
+
+    cfg.run_worker_concurrency = 1
+    cfg.run_poll_seconds = 30.0
+    cfg.run_poll_max_seconds = 30.0
+    polled = threading.Event()
+
+    class _IdleWorker:
+        def __init__(self, *_args):
+            pass
+
+        def run_once(self):
+            polled.set()
+            return False
+
+    monkeypatch.setattr(worker_mod, "AccountService", lambda _cfg: object())
+    monkeypatch.setattr(worker_mod, "HealthClawClient",
+                        lambda *_args: object())
+    monkeypatch.setattr(worker_mod, "RunWorker", _IdleWorker)
+
+    stop = threading.Event()
+    pool = threading.Thread(target=worker_mod.run_worker_pool,
+                            args=(cfg, stop), daemon=True)
+    started = time.monotonic()
+    pool.start()
+    assert polled.wait(10), "worker slot never polled"
+    stop.set()
+    pool.join(timeout=10)
+
+    assert not pool.is_alive(), "pool did not drain: the sleep is not a wait"
+    assert time.monotonic() - started < 10
 
 
 def test_queued_run_history_stops_at_its_claimed_message(

--- a/tests/test_request_access_log.py
+++ b/tests/test_request_access_log.py
@@ -1,0 +1,121 @@
+"""Request access-log level discrimination (#375).
+
+`log_request` looks like an audit trail and is a debug access log. The real
+audit trail is AuditEvent, which is durable and PHI-free. Logging every
+request at INFO made retention a line budget rather than a time budget: the
+idle run-claim poll alone was ~100% of the engine's log volume, which evicted
+the lines an operator actually needs (the Fasten reaper's zombie-job warnings,
+ingest and webhook errors) inside minutes.
+
+So: successes go to DEBUG, anything that did not succeed stays at INFO, and
+request_id correlation survives both.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def probe_client(app):
+    """Client with routes pinned to the statuses under test.
+
+    204 is not an arbitrary success — it is exactly what the run-claim poll
+    returns 620k times a day.
+    """
+
+    @app.route("/__probe/claim")
+    def _probe_claim():
+        return "", 204
+
+    @app.route("/__probe/ok")
+    def _probe_ok():
+        return "fine", 200
+
+    @app.route("/__probe/boom")
+    def _probe_boom():
+        return "", 500
+
+    @app.route("/__probe/moved")
+    def _probe_moved():
+        return "", 302, {"Location": "/__probe/ok"}
+
+    return app.test_client()
+
+
+def _lines(caplog):
+    """Access-log records as {path: record}."""
+    import json
+
+    found = {}
+    for record in caplog.records:
+        if record.name != "request":
+            continue
+        entry = json.loads(record.getMessage())
+        found[entry["path"]] = (record.levelno, entry)
+    return found
+
+
+def test_successful_requests_log_at_debug_and_failures_at_info(
+        probe_client, caplog):
+    with caplog.at_level(logging.DEBUG, logger="request"):
+        probe_client.get("/__probe/claim")
+        probe_client.get("/__probe/ok")
+        probe_client.get("/__probe/boom")
+        probe_client.get("/__probe/no-such-route")
+
+    lines = _lines(caplog)
+
+    assert lines["/__probe/claim"][0] == logging.DEBUG
+    assert lines["/__probe/ok"][0] == logging.DEBUG
+    assert lines["/__probe/boom"][0] == logging.INFO
+    assert lines["/__probe/no-such-route"][0] == logging.INFO
+
+
+def test_default_level_drops_the_success_lines_and_keeps_the_failures(
+        probe_client, caplog):
+    """The volume claim, measured the way production sees it.
+
+    Production runs the root logger at INFO, so this is the level at which
+    the ~11x/620k-line reduction is actually realised. A change that only
+    reworded the line would fail here.
+    """
+    with caplog.at_level(logging.INFO, logger="request"):
+        for _ in range(10):
+            probe_client.get("/__probe/claim")
+        probe_client.get("/__probe/boom")
+
+    paths = [record.getMessage() for record in caplog.records
+             if record.name == "request"]
+
+    assert len(paths) == 1
+    assert "/__probe/boom" in paths[0]
+
+
+def test_request_id_correlation_survives_at_both_levels(
+        probe_client, caplog):
+    with caplog.at_level(logging.DEBUG, logger="request"):
+        ok = probe_client.get("/__probe/claim",
+                              headers={"X-Request-Id": "corr-ok"})
+        bad = probe_client.get("/__probe/boom",
+                               headers={"X-Request-Id": "corr-bad"})
+
+    assert ok.headers["X-Request-Id"] == "corr-ok"
+    assert bad.headers["X-Request-Id"] == "corr-bad"
+
+    lines = _lines(caplog)
+    assert lines["/__probe/claim"][1]["request_id"] == "corr-ok"
+    assert lines["/__probe/boom"][1]["request_id"] == "corr-bad"
+
+
+def test_redirects_stay_visible_at_info(probe_client, caplog):
+    # Only 2xx is "it worked". A 302 is a routing surprise worth seeing, and
+    # the loop that a misconfigured redirect causes is invisible at DEBUG.
+    with caplog.at_level(logging.DEBUG, logger="request"):
+        moved = probe_client.get("/__probe/moved")
+
+    assert moved.status_code == 302
+    lines = _lines(caplog)
+    assert lines["/__probe/moved"][0] == logging.INFO


### PR DESCRIPTION
Sprint 3. Closes #341. Closes #375. Implements the design approved in #373 — **not a redesign**. Nothing under `r6/` is touched, which the design named as its own conformance check.

## The falsification ran first, and it passed

The design's §1.4 says to verify prod knobs are at defaults before trusting the cap arithmetic. `timeout` does not exist on this machine, so the same 60-second capture was done in Python rather than skipped:

| | measured | design expected |
|---|---:|---:|
| claim rate | **7.25 req/s** | 7.2 req/s |
| extrapolated / 60s | **435** | ~430 |
| claim lines / total | **500 / 500 (100%)** | ~100% |
| statuses | all `204` | all `204` |

So the §4 arithmetic stands. Worth noting *why* 100% of lines are claims: a successful poll logs nothing, which is the same measurement trap that made my original "24 of 43 lines are 502s" figure meaningless.

## #341 — idle backoff

`CARE_RUN_POLL_MAX_SECONDS`, default 6.0, validated `0.05 ≤ v ≤ 30`, then clamped `max(poll, max)`. Interval over empty claims: `0.5, 1, 2, 4, 6, 6, …`; **any claim by any slot resets every slot to the floor.** Projected 0.66 req/s — an 11× cut.

The clamp is what makes rollback exact: `CARE_RUN_POLL_MAX_SECONDS=0.5` gives a flat 0.5s, and a value *below* the floor clamps up rather than inverting the doubling. Both pinned.

### Presence freshness is proven, not assumed

This was the design's main risk — web readiness fails closed at `CARE_RUN_WORKER_STALE_SECONDS = 30`.

The test drives the real `run_worker_pool` against a simulated clock, over a **40-poll, 217-second ramp** — more than three full readiness windows, not just long enough to touch the cap once. It asserts the largest gap between presence commits equals the 6.0s cap and stays under the stale threshold. It fails loudly if the ramp is ever shortened to the point of being meaningless, and it fails if anyone raises the cap toward the threshold.

A second test pins floor and cap at 30s and asserts the pool drains promptly on `stop.set()` — milliseconds against `stop.wait`, half a minute against `time.sleep`. That is the trap the design called out.

## #375 — the access log

`main.py` logged every non-`/static` request at INFO with no level discrimination — a 204 and a 500 identically. Now DEBUG for success, INFO retained for non-2xx, `request_id` correlation preserved.

## Mutations — four, all killed

| Mutant | Result |
|---|---|
| cap removed (uncapped doubling) | 4 red, including presence freshness |
| `on_claim` made a no-op | 2 red |
| every line forced to DEBUG | 3 red — failures lose their signal |
| every line forced to INFO (today) | 2 red — success lines return |

## Post-merge verification — I did NOT deploy

The engine auto-deploys on merge, so **#375 ships immediately**. CareAgents is manual and gated; deploy **both** services from the *same* stage per the runbook.

Three gates after that: claim lines ≤ before/10; previously-evicted lines (`zombie job|fasten|ingest|webhook|reaper`) now non-zero — *that is the actual point of #341*, not the volume number; and sixty consecutive `/healthz` 200s with the queue idle.

Rollback needs no redeploy:
```bash
railway variables --set CARE_RUN_POLL_MAX_SECONDS=0.5 --service careagents-worker
```

## One correction to the agent's report

It noted the design's Defect B (a 502 after `claim_next` commits strands a run) and said no issue existed. **One does — #374**, filed earlier tonight, with the SQL to count it. Nothing to open.

## Deliberately not touched

- The **20s heartbeat margin** when all four slots are busy leaves 10s of headroom against the 30s threshold. That tightness exists today and is not introduced here — but it is now *thinner than the idle path's* 24s, which is worth knowing.
- A claim does not interrupt a slot already inside `stop.wait(6)`; it resets that slot's interval from its next cycle. Interrupting would need a second event per slot and complicate the SIGTERM path, and §4's latency math already assumes phase-drifted slots.

Gates: 2492 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)