### PR TITLE
fix: five of seven conformance properties were satisfiable by doing nothing (#213), and two paths asserted a failure they never observed (#220)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -51,6 +51,16 @@ class MailError(RuntimeError):
     """
 
 
+class MailUnconfirmed(MailError):
+    """We asked the provider to send and never learned whether it did.
+
+    The third state (#220). Reporting this as a failure is its own false claim:
+    the mail may already be in the person's inbox, and burning the code to
+    "clean up" would kill a code they are about to type. Subclasses MailError
+    so any handler that only knows about failure still degrades safely.
+    """
+
+
 class AccountService:
     def __init__(self, cfg):
         self.cfg = cfg
@@ -98,7 +108,12 @@ class AccountService:
             code = f"{secrets.randbelow(CODE_MAX):08d}"
             s.add(EmailToken(email=email, code_hash=self._hash(code),
                              purpose=purpose, exp=now() + CODE_TTL))
-        if not mail.send_code(self.cfg, email, code, purpose):
+        # Three outcomes, and each one leaves the just-minted code in a
+        # different place. Compared by identity against the named states, never
+        # truthiness-tested — every state is a truthy string precisely so that
+        # a `if not send_code(...)` cannot be written here again.
+        outcome = mail.send_code(self.cfg, email, code, purpose)
+        if outcome == mail.NOT_SENT:
             # Burn the code we just minted. It was never delivered, and leaving
             # it live would make the resend cooldown above swallow the person's
             # retry — reporting "sent" without sending anything.
@@ -107,6 +122,15 @@ class AccountService:
                     email=email, used=False).update({"used": True})
             raise MailError(
                 "We couldn't send your code just now. Please try again.")
+        if outcome != mail.SENT:
+            # UNCONFIRMED — and anything unrecognised, which is the same state:
+            # we do not know. Keep the code LIVE. Burning it here is what makes
+            # this worse than doing nothing: the mail may already have arrived,
+            # and the person would type a code we had just killed. The resend
+            # cooldown (30s) is the retry path if nothing turns up.
+            raise MailUnconfirmed(
+                "We couldn't confirm your code was sent. Check your inbox — "
+                "if nothing arrives, ask for another code in 30 seconds.")
 
     def verify_email_code(self, email: str, code: str) -> Account:
         email = email.strip().lower()

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -25,13 +25,14 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
 
 from careagents.accounts import (AccountService, AuthError, MailError,
-                                 new_binding_code)
+                                 MailUnconfirmed, new_binding_code)
 from careagents import advisors, connectors
 from careagents import intake_state
 from careagents import labs_timeline as labs_timeline_mod
 from careagents.agent import GENERIC_FAILURE_TEXT
 from careagents.config import Config
-from careagents.healthclaw import HealthClawClient, HealthClawError
+from careagents.healthclaw import (HealthClawClient, HealthClawError,
+                                   HealthClawUnconfirmed)
 from careagents.personas import DEFAULT_PERSONA, PERSONAS
 
 logger = logging.getLogger(__name__)
@@ -200,6 +201,13 @@ def create_app(config: Config | None = None,
             svc.start_email_code(email, purpose)
         except AuthError as exc:
             return jsonify({"error": str(exc)}), 400
+        except MailUnconfirmed as exc:
+            # The third answer (#220). `sent` is null, not false: saying "we
+            # didn't send it" would be as unobserved as saying we did, and the
+            # code is still live, so the person carries on to the code step
+            # rather than being sent back to the start. 202 — accepted, outcome
+            # unknown. Ordered before MailError: MailUnconfirmed subclasses it.
+            return jsonify({"sent": None, "notice": str(exc)}), 202
         except MailError as exc:
             # Never report "sent" when nothing was sent — this is the front
             # door, and a silent failure leaves the person watching an empty
@@ -910,6 +918,24 @@ def create_app(config: Config | None = None,
         if status == 200:
             try:
                 hc.confirm_action(tenant, action_id)
+            except HealthClawUnconfirmed:
+                # The third answer (#220). The engine never replied, so the
+                # action may already be running. "Nothing has been sent — try
+                # again" would be a claim we did not observe, and acting on it
+                # is how a prescription request gets sent twice. `confirmed` is
+                # null: not true, not false, not knowable from here.
+                logger.exception("confirm unanswered after review for %s",
+                                 action_id)
+                body = dict(body) if isinstance(body, dict) else {}
+                body.update({
+                    "confirmed": None,
+                    "message": ("Your review was saved, but we couldn't "
+                                "confirm whether the approval went through. "
+                                "Don't approve again yet — check the request's "
+                                "status first, because approving twice could "
+                                "send it twice."),
+                })
+                return jsonify(body), 502
             except HealthClawError:
                 # The review was recorded but the confirmation didn't land, so
                 # the action is still sitting unexecuted. Swallowing this told

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -35,6 +35,17 @@ class HealthClawError(RuntimeError):
         self.correlation_id = correlation_id
 
 
+class HealthClawUnconfirmed(HealthClawError):
+    """The request went out and the engine never answered.
+
+    Not the same as a refusal (#220). A refusal is an observed response saying
+    no; this is silence, and the engine may have done the thing. Any caller
+    that only knows about HealthClawError still catches it and degrades to
+    "failed" — which is why callers that can act on the difference must catch
+    this FIRST.
+    """
+
+
 class HealthClawClient:
     def __init__(self, base: str, mint_secret: str, timeout: float = 25.0):
         self.base = base.rstrip("/")
@@ -233,22 +244,42 @@ class HealthClawClient:
         return r.json()
 
     def confirm_action(self, tenant: str, action_id: str) -> dict:
-        mint = self.http.post(
-            f"{self.actions}/{action_id}/approval-token",
-            headers={"X-Tenant-Id": tenant,
-                     "X-Internal-Secret": self.mint_secret},
-            timeout=self.timeout)
+        """Confirm a reviewed action. Raises on refusal, HealthClawUnconfirmed
+        on silence.
+
+        Three outcomes, and the caller must be able to tell them apart (#220).
+        The mint is safely retryable, so a transport failure there means the
+        confirm never went out — a refusal. The confirm POST is the one that
+        can execute a clinical action, so losing its answer is NOT evidence
+        that nothing happened.
+        """
+        try:
+            mint = self.http.post(
+                f"{self.actions}/{action_id}/approval-token",
+                headers={"X-Tenant-Id": tenant,
+                         "X-Internal-Secret": self.mint_secret},
+                timeout=self.timeout)
+        except requests.RequestException as exc:
+            # Nothing was confirmed: we never got as far as the confirm call.
+            raise HealthClawError("approval token mint failed", 0) from exc
         token = (mint.json() or {}).get("token") if mint.ok else None
         if not token:
             raise HealthClawError(
                 f"approval token mint failed ({mint.status_code})",
                 mint.status_code)
-        r = self.http.post(f"{self.actions}/{action_id}/confirm",
-                           headers={"X-Tenant-Id": tenant,
-                                    "X-Step-Up-Token": token,
-                                    "X-Agent-Id": "careagents"},
-                           json={"approved_via": "review-page"},
-                           timeout=self.timeout)
+        try:
+            r = self.http.post(f"{self.actions}/{action_id}/confirm",
+                               headers={"X-Tenant-Id": tenant,
+                                        "X-Step-Up-Token": token,
+                                        "X-Agent-Id": "careagents"},
+                               json={"approved_via": "review-page"},
+                               timeout=self.timeout)
+        except requests.RequestException as exc:
+            # A read timeout here means the confirm may already have run. This
+            # used to escape the client entirely (nothing wraps it into
+            # HealthClawError), so the relay's `except HealthClawError` missed
+            # it and the person got a 500 instead of an answer.
+            raise HealthClawUnconfirmed("confirm unanswered", 0) from exc
         if not r.ok:
             raise HealthClawError(f"confirm failed ({r.status_code})",
                                   r.status_code)

--- a/careagents/mail.py
+++ b/careagents/mail.py
@@ -12,12 +12,34 @@ import requests
 
 logger = logging.getLogger("careagents.mail")
 
+# Three outcomes, not two. A provider call can also end without telling us
+# anything — the request went out and the answer never came back — and that is
+# NOT the same as a refusal. Collapsing it into "failed" makes the caller state
+# something it did not observe, which is the whole shape of #220.
+#
+# All three are truthy strings on purpose: `if send_code(...)` cannot be
+# written by accident the way `if not send_code(...)` could, and a stale fake
+# that returns True/None/a code string lands in UNCONFIRMED rather than
+# silently reading as success.
+SENT = "sent"
+NOT_SENT = "not_sent"
+UNCONFIRMED = "unconfirmed"
 
-def send_code(cfg, email: str, code: str, purpose: str) -> bool:
+
+def send_code(cfg, email: str, code: str, purpose: str) -> str:
+    """Send a one-time code. Returns SENT, NOT_SENT, or UNCONFIRMED.
+
+    The rule: a response is the only evidence of an outcome. The provider
+    answering 2xx is a send; the provider answering anything else is a refusal
+    (Resend returns a message id on acceptance, so a non-2xx did not queue);
+    never reaching the provider is a refusal. A request that went out and was
+    never answered — a read timeout — is UNCONFIRMED, because the mail may
+    already be in the person's inbox.
+    """
     verb = "Verify your email" if purpose == "verify" else "Your sign-in code"
     if not cfg.resend_api_key:
         logger.warning("DEV email — %s for %s: %s", verb, email, code)
-        return True
+        return SENT
     html = (
         f"<div style='font-family:system-ui,sans-serif;max-width:420px'>"
         f"<h2 style='color:#22190E'>CareAgents</h2>"
@@ -33,10 +55,17 @@ def send_code(cfg, email: str, code: str, purpose: str) -> bool:
             json={"from": cfg.resend_from, "to": [email],
                   "subject": f"{verb} — CareAgents", "html": html},
             timeout=15)
-    except requests.RequestException as exc:
+    except requests.ConnectionError as exc:
+        # DNS failure, refused connection, TLS failure — the request never
+        # reached Resend, so nothing was sent.
         logger.error("resend send failed: %s", type(exc).__name__)
-        return False
+        return NOT_SENT
+    except requests.RequestException as exc:
+        # Chiefly a read timeout: the POST was written and the answer was
+        # lost. Resend may well have accepted and delivered it.
+        logger.error("resend send unconfirmed: %s", type(exc).__name__)
+        return UNCONFIRMED
     if r.status_code not in (200, 201):
         logger.error("resend send http %s", r.status_code)
-        return False
-    return True
+        return NOT_SENT
+    return SENT

--- a/careagents/static/auth.js
+++ b/careagents/static/auth.js
@@ -61,6 +61,14 @@
     if (!res.ok) return fail(res.d.error || "Couldn't send a code.");
     pendingEmail = email;
     $("code-email").textContent = email;
+    // sent === null is the third answer (#220): the code is live, so this step
+    // is still the right one, but we never saw the mail leave and must not say
+    // we did. Only `true` earns "We sent".
+    const unconfirmed = res.d.sent !== true;
+    $("code-lead").textContent = unconfirmed
+      ? "We couldn't confirm the code reached" : "We sent an 8-digit code to";
+    $("code-note").textContent = unconfirmed ? (res.d.notice || "") : "";
+    $("code-note").hidden = !unconfirmed;
     show("step-code"); $("code").focus();
   });
   $("back-btn").addEventListener("click", () => { clear(); show("step-start"); });

--- a/careagents/templates/auth.html
+++ b/careagents/templates/auth.html
@@ -28,7 +28,9 @@
 
     <!-- Step: code -->
     <div id="step-code" hidden>
-      <p class="setup-sub">We sent an 8-digit code to <b id="code-email"></b>.</p>
+      <p class="setup-sub"><span id="code-lead">We sent an 8-digit code
+          to</span> <b id="code-email"></b>.</p>
+      <p class="auth-fine" id="code-note" hidden></p>
       <label class="field-label" for="code">Code</label>
       <input class="field code-input" id="code" inputmode="numeric"
              maxlength="8" placeholder="••••••••" autocomplete="one-time-code">

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -196,6 +196,12 @@ class ConformanceReport:
             if r.grade is not None:
                 label += f" — {r.effective_grade} ({r.coverage})"
             lines.append(f"  [{'PASS' if r.passed else 'FAIL'}] {label}")
+            # Notes were JSON-only, so the one caveat that limits what a PASS
+            # means — human-in-the-loop grades the gate, not the attestation
+            # behind it (#213/#214) — never reached the scorecard a partner
+            # actually reads.
+            if r.note:
+                lines.append(f"        note: {r.note}")
             for profile_name, profile in r.profiles.items():
                 status = profile.get("status", "unknown")
                 profile_grade = profile.get("grade")
@@ -417,6 +423,35 @@ def _create_synthetic(client, ctx) -> tuple[Optional[str], object]:
     return pid, status
 
 
+def _is_resource(body, resource_type: str, rid: str) -> bool:
+    """The response IS the resource that was asked for."""
+    return (isinstance(body, dict)
+            and body.get("resourceType") == resource_type
+            and body.get("id") == rid)
+
+
+def _bundle_contains(bundle, resource_type: str, rid: str) -> bool:
+    """A searchset actually carries the resource that was asked for."""
+    if not isinstance(bundle, dict) or bundle.get("resourceType") != "Bundle":
+        return False
+    return any(_is_resource((entry or {}).get("resource"), resource_type, rid)
+               for entry in bundle.get("entry") or [])
+
+
+def _tampered(token: str) -> str:
+    """The issued token with one byte changed — i.e. a forged one.
+
+    Missing-header 401 is producible by a route that only checks the header is
+    PRESENT. This is the input that separates "validates the token" from
+    "notices a string", and it needs no knowledge of the token format: whatever
+    the deployment issued, this is not it.
+    """
+    if not token:
+        return "conformance-not-a-real-step-up-token"
+    i = len(token) // 2
+    return token[:i] + ("A" if token[i] != "A" else "B") + token[i + 1:]
+
+
 def probe_phi_redaction(client, ctx) -> ProbeResult:
     r = ProbeResult("phi_redaction", "PHI Redaction")
     pid, status = _create_synthetic(client, ctx)
@@ -429,6 +464,15 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
     blob = text or json.dumps(body or {})
     r.checks += [
         Check("read succeeds", status == 200, f"status {status}"),
+        # Two-sided (#213). The five ABSENCE checks below are all satisfied by
+        # a deployment that returns nothing at all — a redactor that deletes,
+        # a store that lost the row, an endpoint stubbed out. Redaction's
+        # contract is that the record survives it, so the record has to be
+        # here for the absences to mean anything.
+        Check("the redacted record is still returned",
+              _is_resource(body, "Patient", pid),
+              "the read did not return the Patient that was asked for; every "
+              "absence check below passes trivially on an empty response"),
         Check("family name not returned in full", _FAMILY not in blob),
         Check("given name not returned in full", _GIVEN not in blob),
         Check("SSN-class identifier masked", _SSN not in blob),
@@ -446,6 +490,14 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
     sblob = text or json.dumps(body or {})
     r.checks += [
         Check("search succeeds", status == 200, f"status {status}"),
+        # The same trap, and the one the badge was most exposed to: an empty
+        # searchset is a 200 with no PHI in it. Search is what builds an
+        # agent's context, so "search returns nothing" is a live outage that
+        # scored A.
+        Check("the search returns the resource it was asked for",
+              _bundle_contains(body, "Patient", pid),
+              "the searchset did not contain the Patient; an empty Bundle "
+              "passes every redaction check in this block"),
         Check("family name not returned in full (search)", _FAMILY not in sblob),
         Check("given name not returned in full (search)", _GIVEN not in sblob),
         Check("SSN-class identifier masked (search)", _SSN not in sblob),
@@ -539,6 +591,26 @@ def probe_step_up_enforcement(client, ctx) -> ProbeResult:
         _synthetic_patient())
     r.checks.append(Check("write without step-up token is rejected (401)",
                           status == 401, f"status {status}"))
+
+    # Two-sided (#213). A deployment that refuses every write passes the check
+    # above, and so does one whose gate is a `if header missing: 401` with no
+    # validation behind it. The gate has to DISCRIMINATE: the token we were
+    # issued works, a forged one does not.
+    status, _, _ = client.request(
+        "POST", "/Patient", {"X-Tenant-Id": ctx.tenant,
+                             "X-Step-Up-Token": _tampered(ctx.step_up_token),
+                             "Content-Type": "application/fhir+json"},
+        _synthetic_patient())
+    r.checks.append(Check("write with a forged step-up token is rejected (401)",
+                          status == 401,
+                          f"status {status}; a token that is not the one this "
+                          f"deployment issued authorized a write"))
+
+    pid, status = _create_synthetic(client, ctx)
+    r.checks.append(Check("write carrying a valid step-up token is accepted",
+                          bool(pid) and status in (200, 201),
+                          f"status {status}; the gate refuses authorized "
+                          f"writes too, so its 401s prove nothing"))
     return r
 
 
@@ -552,6 +624,24 @@ def probe_human_in_the_loop(client, ctx) -> ProbeResult:
                                   _synthetic_observation())
     r.checks.append(Check("clinical write without human confirmation is blocked (428)",
                           status == 428, f"status {status}"))
+
+    # Two-sided (#213). Blanket-428 on every clinical write passes the check
+    # above while gating nothing, so the confirmed write has to go through.
+    #
+    # What this pair does NOT establish: that a human confirmed anything. The
+    # probe supplies X-Human-Confirmed itself, and that header is a known gap
+    # (#214) — the action rail's separate approval endpoint is the real
+    # mechanism. This grades the gate's behavior, not the attestation behind
+    # it, and the report says so in the note.
+    status, body, _ = client.request("POST", "/Observation", ctx.write_headers(),
+                                     _synthetic_observation())
+    oid = body.get("id") if isinstance(body, dict) else None
+    r.checks.append(Check("confirmed clinical write is accepted",
+                          bool(oid) and status in (200, 201),
+                          f"status {status}; the gate blocks confirmed writes "
+                          f"too, so its 428s prove nothing"))
+    r.note = ("the confirmation header is supplied by the probe: this grades "
+              "the gate, not the human attestation behind it (#214)")
     return r
 
 
@@ -569,6 +659,16 @@ def probe_tenant_isolation(client, ctx) -> ProbeResult:
         "resource is not readable from another tenant",
         status != 200 or returned_id != pid,
         f"status {status}, id={returned_id}"))
+
+    # Two-sided (#213). A deployment that 404s everything isolates perfectly
+    # and serves nobody; isolation means the OWNING tenant still gets it.
+    status, body, _ = client.request(
+        "GET", f"/Patient/{pid}", ctx.read_headers())
+    r.checks.append(Check(
+        "resource IS readable from its own tenant",
+        status == 200 and _is_resource(body, "Patient", pid),
+        f"status {status}; a deployment that returns nothing to anyone passes "
+        f"the isolation check above without isolating anything"))
     return r
 
 
@@ -589,6 +689,15 @@ def probe_medical_disclaimer(client, ctx) -> ProbeResult:
         "_disclaimer" in body or "disclaimer" in blob.lower())
     r.checks.append(Check("clinical read carries a medical disclaimer", has,
                           "no disclaimer on the response"))
+    # Two-sided (#213). The check above is a substring test, so an error page
+    # that happens to say "disclaimer" satisfies it, and so does a response
+    # that is nothing BUT a disclaimer. The disclaimer has to be attached to
+    # the clinical data it disclaims.
+    r.checks.append(Check(
+        "the disclaimer accompanies the clinical record, not an error",
+        status == 200 and _is_resource(body, "Observation", oid),
+        f"status {status}; the disclaimer was not attached to the Observation "
+        f"that was read"))
     r.note = f"Observation/{oid}"
     return r
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -151,7 +151,7 @@ def test_auth_email_reports_failure_instead_of_claiming_it_sent(app, svc,
     # watching an empty inbox with no idea whether to wait or retry.
     import careagents.mail as mailmod
     monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: False)
+                        lambda cfg, e, code, purpose: mailmod.NOT_SENT)
     r = app.test_client().post("/api/auth/email",
                                json={"email": "gene@example.com"})
     assert r.status_code == 502
@@ -164,15 +164,16 @@ def test_a_failed_send_does_not_block_the_retry(app, svc, monkeypatch):
     # without sending anything.
     import careagents.mail as mailmod
     monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: False)
+                        lambda cfg, e, code, purpose: mailmod.NOT_SENT)
     c = app.test_client()
     assert c.post("/api/auth/email",
                   json={"email": "retry@example.com"}).status_code == 502
 
     sent = {}
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: sent.setdefault("c", code)
-                        is not None)
+    monkeypatch.setattr(
+        mailmod, "send_code",
+        lambda cfg, e, code, purpose: (sent.setdefault("c", code)
+                                       and mailmod.SENT))
     r = c.post("/api/auth/email", json={"email": "retry@example.com"})
     assert r.status_code == 200 and sent.get("c"), "retry never sent a code"
 
@@ -206,6 +207,154 @@ def test_review_submit_reports_a_failed_confirmation(cfg, svc, monkeypatch):
     body = r.get_json()
     assert body["confirmed"] is False
     assert "not" in body["message"].lower() or "couldn't" in body["message"]
+
+
+def test_review_submit_does_not_claim_nothing_was_sent_when_it_cannot_tell(
+        cfg, svc, monkeypatch):
+    """The third state (#220): the confirm went out and was never answered.
+
+    Answering "Nothing has been sent — please try approving again" is as
+    unobserved as the old "confirmed". The engine may already be executing the
+    action, and a person who follows that instruction sends it twice.
+    """
+    from careagents.app import create_app
+    from careagents.healthclaw import HealthClawUnconfirmed
+
+    class _Fake(FakeClient):
+        def submit_review(self, tenant, action_id, decisions):
+            return 200, {"ok": True}
+
+        def confirm_action(self, tenant, action_id):
+            raise HealthClawUnconfirmed("confirm unanswered", 0)
+
+    fake = _Fake()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/sample").get_json()
+    agent_id = c.post("/api/agents", json={
+        "name": "A", "persona": "calm",
+        "connection_id": created["id"]}).get_json()["id"]
+
+    monkeypatch.setattr(fake, "action_status",
+                        lambda t, a: {"status": "awaiting_confirmation"})
+    r = c.post(f"/review/{agent_id}/act-1/submit", json={"approved": []})
+    assert r.status_code == 502
+    body = r.get_json()
+    assert body["confirmed"] is None, "unknown is not false"
+    msg = body["message"].lower()
+    assert "nothing has been sent" not in msg
+    assert "couldn't confirm" in msg and "twice" in msg
+
+
+def test_confirm_action_separates_a_refusal_from_an_unanswered_confirm():
+    """The client must not report silence as a refusal.
+
+    A lost answer on /confirm used to escape as a bare requests exception —
+    nothing in this client wraps it — so the relay's `except HealthClawError`
+    never saw it and the person got a 500.
+    """
+    import requests
+    from careagents.healthclaw import (HealthClawClient, HealthClawError,
+                                       HealthClawUnconfirmed)
+
+    class _Minted:
+        ok, status_code = True, 200
+
+        def json(self):
+            return {"token": "tok"}
+
+    def client_with(confirm_result):
+        hc = HealthClawClient("http://engine.invalid", "secret")
+
+        def _post(url, **kw):
+            if url.endswith("/approval-token"):
+                return _Minted()
+            if isinstance(confirm_result, Exception):
+                raise confirm_result
+            return confirm_result
+
+        hc.http.post = _post
+        return hc
+
+    # No answer at all — we cannot tell whether the action ran.
+    with pytest.raises(HealthClawUnconfirmed):
+        client_with(requests.ReadTimeout("read timed out")).confirm_action(
+            "t", "a1")
+
+    # An observed rejection stays an ordinary failure.
+    class _Refused:
+        ok, status_code = False, 409
+
+    err = pytest.raises(HealthClawError,
+                        client_with(_Refused()).confirm_action, "t", "a1")
+    assert not isinstance(err.value, HealthClawUnconfirmed)
+
+    # A transport failure minting the approval token is a refusal, not
+    # silence: the confirm call never went out.
+    hc = HealthClawClient("http://engine.invalid", "secret")
+
+    def _mint_dies(url, **kw):
+        raise requests.ConnectionError("refused")
+
+    hc.http.post = _mint_dies
+    err = pytest.raises(HealthClawError, hc.confirm_action, "t", "a1")
+    assert not isinstance(err.value, HealthClawUnconfirmed)
+
+
+def test_an_unconfirmed_send_keeps_the_code_live_and_says_so(app, svc,
+                                                             monkeypatch):
+    """The third state on the front door (#220).
+
+    A read timeout to Resend is not a refusal: the mail may already be in the
+    inbox. Reporting "we couldn't send it" AND burning the code is worse than
+    doing nothing — the person types a code we just killed.
+    """
+    import careagents.mail as mailmod
+    captured = {}
+    monkeypatch.setattr(
+        mailmod, "send_code",
+        lambda cfg, e, code, purpose: (captured.setdefault("c", code)
+                                       and mailmod.UNCONFIRMED))
+    c = app.test_client()
+    r = c.post("/api/auth/email", json={"email": "unsure@example.com"})
+
+    assert r.status_code == 202
+    body = r.get_json()
+    assert body["sent"] is None, "unknown is neither sent nor not-sent"
+    assert "couldn't confirm" in body["notice"].lower()
+
+    # The code the provider may have delivered still works.
+    r = c.post("/api/auth/verify",
+               json={"email": "unsure@example.com", "code": captured["c"]})
+    assert r.status_code == 200, "an unconfirmed send burned a live code"
+
+
+def test_send_code_calls_a_lost_answer_unconfirmed_not_failed(monkeypatch):
+    """A response is the only evidence of an outcome."""
+    import requests
+    import careagents.mail as mailmod
+
+    class _Cfg:
+        resend_api_key = "key"
+        resend_from = "codes@example.com"
+
+    def sending(raises=None, status=None):
+        def _post(*a, **kw):
+            if raises is not None:
+                raise raises
+            return type("R", (), {"status_code": status})()
+        monkeypatch.setattr(mailmod.requests, "post", _post)
+        return mailmod.send_code(_Cfg(), "x@example.com", "12345678", "verify")
+
+    # Written, never answered — the mail may have gone out.
+    assert sending(raises=requests.ReadTimeout("slow")) == mailmod.UNCONFIRMED
+    # Never delivered to the provider at all.
+    assert sending(raises=requests.ConnectionError("refused")) == mailmod.NOT_SENT
+    # The provider answered and did not accept it.
+    assert sending(status=429) == mailmod.NOT_SENT
+    assert sending(status=200) == mailmod.SENT
 
 
 # --- chat persistence (#222) --------------------------------------------------
@@ -1686,8 +1835,10 @@ def _make_account(svc, monkeypatch, email):
     """
     import careagents.mail as mailmod
     captured = {}
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: captured.setdefault("c", code))
+    monkeypatch.setattr(
+        mailmod, "send_code",
+        lambda cfg, e, code, purpose: (captured.setdefault("c", code)
+                                       and mailmod.SENT))
     svc.start_email_code(email)
     return svc.verify_email_code(email, captured["c"])
 
@@ -1695,13 +1846,15 @@ def _make_account(svc, monkeypatch, email):
 def _sink_code(sink):
     """Stand-in for mail.send_code that records the code and reports success.
 
-    Returning True is load-bearing: a falsy return now means "the send failed"
-    and raises MailError (#220), so a fake that returns None — as bare
-    list.append and dict.__setitem__ do — reads as an outage.
+    Returning mail.SENT is load-bearing: send_code answers with one of three
+    named states (#220), and anything else — True, None, a bare list.append —
+    reads as "we could not tell", which raises MailUnconfirmed.
     """
+    import careagents.mail as mailmod
+
     def _send(cfg, email, code, purpose):
         sink.append(code)
-        return True
+        return mailmod.SENT
     return _send
 
 
@@ -1709,8 +1862,10 @@ def _login(client, svc, monkeypatch, email="gene@example.com"):
     """Log a client in via the real email-code path (code captured from mail)."""
     captured = {}
     import careagents.mail as mailmod
-    monkeypatch.setattr(mailmod, "send_code",
-                        lambda cfg, e, code, purpose: captured.setdefault("c", code))
+    monkeypatch.setattr(
+        mailmod, "send_code",
+        lambda cfg, e, code, purpose: (captured.setdefault("c", code)
+                                       and mailmod.SENT))
     r = client.post("/api/auth/email", json={"email": email})
     assert r.status_code == 200
     r = client.post("/api/auth/verify", json={"email": email, "code": captured["c"]})
@@ -1746,7 +1901,7 @@ def test_fresh_home_gates_agent_modal_and_shows_onboarding(app, svc, monkeypatch
 def test_wrong_email_code_rejected(app, svc, monkeypatch):
     c = app.test_client()
     import careagents.mail as mailmod
-    monkeypatch.setattr(mailmod, "send_code", lambda *a: True)
+    monkeypatch.setattr(mailmod, "send_code", lambda *a: mailmod.SENT)
     c.post("/api/auth/email", json={"email": "x@y.com"})
     r = c.post("/api/auth/verify", json={"email": "x@y.com", "code": "000000"})
     assert r.status_code == 400

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -25,6 +25,22 @@ def test_our_deployment_records_full_conformance(
     assert [r.key for r in report.results if not r.passed] == []
 
 
+def test_the_scorecard_states_what_a_hitl_pass_does_not_prove(
+        client, tenant_id, step_up_token):
+    """The probe supplies X-Human-Confirmed itself (#213).
+
+    A PASS on human-in-the-loop means the gate discriminates, not that a human
+    attested to anything — the action rail's approval endpoint is the real
+    mechanism and the header is a known gap (#214). That limit has to be on
+    the rendered scorecard, not only in the JSON.
+    """
+    report = run_conformance(FlaskProbeClient(client),
+                             _ctx(None, tenant_id, step_up_token))
+    rendered = report.render()
+    assert "the confirmation header is supplied by the probe" in rendered
+    assert "#214" in rendered
+
+
 def test_report_is_json_serializable(client, tenant_id, step_up_token):
     report = run_conformance(FlaskProbeClient(client), _ctx(None, tenant_id, step_up_token))
     d = report.to_dict()
@@ -1019,3 +1035,165 @@ def test_injected_mock_proxy_profile_passes_the_full_error_contract(
     ]
     assert all(hostile_name not in detail for detail in details)
     assert all(hostile_url not in detail for detail in details)
+
+
+# --- #213: a guardrail that is OFF must not be able to score A ---------------
+#
+# Every check in this harness except two was an ABSENCE assertion, and a broken
+# guardrail passes those HARDER — it shrinks the response. The RxNorm lookup
+# returned None for its entire life (#376) while the grade held A. The tests
+# below turn one guardrail off at a time and show the grade follow.
+#
+# Mutations are applied at the HTTP boundary because that is the only surface
+# the harness grades: whatever a deployment does internally, this is what a
+# partner running the harness against it can see.
+
+
+class _MutatedDeployment:
+    """The real app with one response rewritten."""
+
+    def __init__(self, inner, mutate):
+        self._inner = inner
+        self._mutate = mutate
+        self.base = getattr(inner, "base", "")
+
+    def request(self, method, path, headers=None, json_body=None):
+        return self._mutate(
+            method, path, headers,
+            self._inner.request(method, path, headers, json_body))
+
+
+def _failed(report, key):
+    result = next(r for r in report.results if r.key == key)
+    return [c.name for c in result.checks if not c.passed]
+
+
+def test_a_search_that_returns_nothing_no_longer_scores_a(
+        client, tenant_id, step_up_token):
+    """Search stops returning records; every PHI absence check passes harder.
+
+    This is #376's shape exactly — a lookup silently answering with nothing —
+    on the path that builds an agent's context.
+    """
+    empty = {"resourceType": "Bundle", "type": "searchset", "total": 0,
+             "entry": []}
+
+    def mutate(method, path, headers, out):
+        if method == "GET" and path.startswith("/Patient?"):
+            return 200, empty, ""
+        return out
+
+    report = run_conformance(
+        _MutatedDeployment(FlaskProbeClient(client), mutate),
+        _ctx(None, tenant_id, step_up_token))
+
+    assert report.grade != "A", "an empty search path still scored A"
+    assert _failed(report, "phi_redaction") == [
+        "the search returns the resource it was asked for"]
+
+
+def test_step_up_validation_turned_off_no_longer_scores_a(
+        client, tenant_id, step_up_token, monkeypatch):
+    """The guardrail itself, switched off in the app.
+
+    With signature validation stubbed out, any string in X-Step-Up-Token
+    authorizes a write. The missing-header 401 still fires, so the old harness
+    saw nothing wrong.
+    """
+    import r6.routes
+    monkeypatch.setattr(r6.routes, "validate_step_up_token",
+                        lambda *a, **k: (True, ""))
+
+    report = run_conformance(FlaskProbeClient(client),
+                             _ctx(None, tenant_id, step_up_token))
+
+    assert report.grade != "A", "forged tokens were accepted and the grade held"
+    assert _failed(report, "step_up_enforcement") == [
+        "write with a forged step-up token is rejected (401)"]
+
+
+def test_a_deployment_that_refuses_everyone_no_longer_isolates(
+        tenant_id, step_up_token):
+    """Blanket 404 isolates perfectly and serves nobody."""
+    from r6.conformance.probes import probe_tenant_isolation
+
+    class _RefusesEveryRead:
+        base = "scripted-blanket-404"
+
+        def request(self, method, path, headers=None, json_body=None):
+            if method == "POST":
+                return 201, {"resourceType": "Patient", "id": "p1"}, ""
+            return 404, {"resourceType": "OperationOutcome"}, ""
+
+    result = probe_tenant_isolation(_RefusesEveryRead(),
+                                    ProbeContext(tenant_id, step_up_token))
+    assert result.passed is False
+    assert [c.name for c in result.checks if not c.passed] == [
+        "resource IS readable from its own tenant"]
+
+
+def test_a_gate_that_blocks_confirmed_writes_too_is_not_a_gate(
+        tenant_id, step_up_token):
+    """Blanket 428 on every clinical write gates nothing."""
+    from r6.conformance.probes import probe_human_in_the_loop
+
+    class _Blocks:
+        base = "scripted-blanket-428"
+
+        def request(self, method, path, headers=None, json_body=None):
+            return 428, {"resourceType": "OperationOutcome"}, ""
+
+    result = probe_human_in_the_loop(_Blocks(),
+                                     ProbeContext(tenant_id, step_up_token))
+    assert result.passed is False
+    assert [c.name for c in result.checks if not c.passed] == [
+        "confirmed clinical write is accepted"]
+    assert "#214" in result.note, "the report must say what this does not grade"
+
+
+def test_the_word_disclaimer_in_an_error_is_not_a_disclaimer(
+        tenant_id, step_up_token):
+    """The disclaimer has to be attached to the data it disclaims."""
+    from r6.conformance.probes import probe_medical_disclaimer
+
+    class _ErrorsWithTheWord:
+        base = "scripted-disclaimer-in-error"
+
+        def request(self, method, path, headers=None, json_body=None):
+            if method == "POST":
+                return 201, {"resourceType": "Observation", "id": "o1"}, ""
+            return 500, {"resourceType": "OperationOutcome", "issue": [
+                {"severity": "error", "code": "exception",
+                 "details": {"text": "disclaimer service unavailable"}}]}, ""
+
+    result = probe_medical_disclaimer(_ErrorsWithTheWord(),
+                                      ProbeContext(tenant_id, step_up_token))
+    assert result.passed is False
+    assert [c.name for c in result.checks if not c.passed] == [
+        "the disclaimer accompanies the clinical record, not an error"]
+
+
+def test_a_deployment_that_answers_nothing_scores_f(tenant_id, step_up_token):
+    """Refuse or empty everything and the two gate properties still passed.
+
+    Measured against the previous harness this deployment scored 2/7, and the
+    two it passed were step_up_enforcement and human_in_the_loop — the guardrail
+    properties, certified by a deployment that does nothing. Now it passes none.
+    """
+    class _AnswersNothing:
+        base = "scripted-guardrails-off"
+
+        def request(self, method, path, headers=None, json_body=None):
+            if method == "POST" and path.startswith("/Observation"):
+                return 428, {"resourceType": "OperationOutcome"}, ""
+            if method == "POST":
+                return 401, {"resourceType": "OperationOutcome"}, ""
+            if "?" in path:
+                return 200, {"resourceType": "Bundle", "type": "searchset",
+                             "total": 0, "entry": []}, ""
+            return 404, {"resourceType": "OperationOutcome"}, ""
+
+    report = run_conformance(_AnswersNothing(),
+                             _ctx(None, tenant_id, step_up_token))
+    assert report.grade == "F"
+    assert [r.key for r in report.results if r.passed] == []


### PR DESCRIPTION
Sprint 3. Closes #213. Closes #220 (re-scoped — see below).

## #213 — the badge was measuring the wrong thing, and here is the proof

The mutation table is the finding. Run against the **pre-change** harness:

| Mutation | Grade BEFORE | Grade AFTER |
|---|---|---|
| search returns an empty Bundle | **A (7/7)** | B |
| **step-up signature validation stubbed out — forged tokens authorize writes** | **A (7/7)** | B |
| a scripted deployment that 401s / 428s / 404s / empties everything | F (2/7) — and the two it *passed* were `step_up_enforcement` and `human_in_the_loop` | F (0/7) |
| blanket 404 on reads | `tenant_isolation` PASS | FAIL |
| blanket 428 on clinical writes | `human_in_the_loop` PASS | FAIL |
| "disclaimer" inside a 500 body | `medical_disclaimer` PASS | FAIL |

A deployment where **forged step-up tokens authorize clinical writes** scored Grade A. And a deployment that simply refuses everything passed the two properties most central to the product claim, because refusing everything satisfies an assertion that something is absent.

That is #213 stated precisely: the grade is the product claim, and five of seven properties could be earned by a system that does nothing.

Five properties are now two-sided. `audit_trail` and `error_fidelity` were already two-sided and are untouched. **No existing check was weakened.** Our own deployment stays **Grade A (7/7)**.

### One property that cannot be made two-sided, declared rather than papered

Human-in-the-loop's *attestation* half. The probe supplies `X-Human-Confirmed` itself, and that header is the known gap (#214) — the action rail is the real mechanism. So a PASS grades the gate's **discrimination**, not that a human confirmed anything.

`ProbeResult.note` was JSON-only, so note rendering was added to put that caveat on the scorecard a partner actually reads. A limitation a partner cannot see is not a disclosed limitation.

## #220 — stale as written; the inverse defect was live

Both paths the issue names were fixed on 2026-08-01 by `ccf82fe`, confirmed by `git merge-base --is-ancestor` and `git log -S`. **This is the second stale issue this week** (#221 was the first), and both were caught by the rule Sprint 1's retro added.

What was live is the mirror image: both paths asserted a **definite failure they also never observed.**

- `mail.send_code` returned `False` for every `RequestException`, read timeouts included — so `start_email_code` burned the just-minted code. If Resend accepted and the answer was lost, the person receives the mail, types the code, and it is already dead, under a banner saying we could not send it.
- `confirm_action` wrapped no transport failures at all. A `ReadTimeout` escaped as a bare `requests` exception and the patient got a Flask 500. Wrapping it into the existing 502 would have been **worse**: "Nothing has been sent — please try approving again" is an unobserved claim, and following it sends a clinical action **twice**.

Three states, fifth application of the pattern this week: `SENT` / `NOT_SENT` / `UNCONFIRMED`, all truthy strings so `if not send_code(...)` cannot come back and a stale fake returning `True` lands in `UNCONFIRMED` rather than reading as success. `HealthClawUnconfirmed` subclasses `HealthClawError` so every caller that only knows about failure still degrades safely.

The rule, in the docstring: **a response is the only evidence of an outcome.**

## Reported, not suppressed

**Read auth is still ungraded — the largest remaining item in #213.** `READ_AUTH_ENABLED` is required in production but defaults off and is off in the test fixture. Adding a probe would fail `test_our_deployment_records_full_conformance` and drop our CI grade. That makes it a **missing property**, not a one-sided one: the harness needs a way to know whether a deployment *claims* read auth before it can grade it. Design work, and it is the gap a skeptical adopter finds first.

Also still ungraded: the action rail's propose/commit/confirm separation; step-up negatives beyond forged-token (expired, cross-tenant, read-scope-on-write, replayed nonce — all four verified correct by hand); redaction on `$lastn` and `SubscriptionTopic/$list`; rate limiting; mint-gate fail-closed; purge.

And a comment worth not trusting: `healthclaw.py:113-120` claims "every other engine call in this file wraps `requests.RequestException`". It is aspirational, not true — `mint_token`, `seed` and `action_status` still let them escape. Repo-wide, outside this issue, left alone.

Gates: 2492 passed, 12 skipped, 3 xfailed · ruff · mypy · table stakes clean · conformance **A (7/7)**, 35 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)