### PR TITLE
test: a HealthClaw outage reaches the patient as 'you have no records' (#294), and the scorecard can find its tenant (#378)

### DIFF
--- a/scripts/shakeout_live.py
+++ b/scripts/shakeout_live.py
@@ -2,6 +2,8 @@
 """Live-data shakeout scorecard — is the agent actually using the record?
 
     railway ssh --service HealthClawGuardrails \
+        "python scripts/shakeout_live.py --list-tenants"
+    railway ssh --service HealthClawGuardrails \
         "python scripts/shakeout_live.py --tenant <tenant-id>"
 
 or locally against any database:
@@ -12,7 +14,8 @@ Exit codes, matching scripts/prod_watch.py:
 
     0  every automatable row passes
     1  a row regressed
-    2  cannot evaluate (no database, empty tenant)
+    2  cannot evaluate (no database, or no behavioural row was scored —
+       an empty tenant, or the wrong one)
 
 Why this exists
 ---------------
@@ -38,6 +41,20 @@ enforced by the kernel and pinned by isolation tests; the residual check is
 reading an answer). Those are the owner's five minutes in the UI, with the
 exact questions listed in the plan doc. A scorecard that quietly checked
 less than it appears to would be worse than a narrow, stated one.
+
+Finding the tenant (#378)
+-------------------------
+`--list-tenants` exists because the first live run scored two tenants that
+reported every behavioural row as SKIP, which reads as "the deploy is
+unexercised" — while the agent was running on a third tenant found only by
+hand-querying `AgentRun`. A SKIP is supposed to mean "nothing has exercised
+this yet"; pointed at the wrong tenant it means "you are looking in the wrong
+place", and the scorecard could not tell those two apart. Distinguishing
+states honestly is the whole product, so a state it cannot name is a defect.
+
+The discovery listing carries tenant ids, counts and timestamps and nothing
+else — the same class of data the audit trail already holds, PHI-free by
+construction rather than by filtering.
 """
 from __future__ import annotations
 
@@ -75,6 +92,104 @@ def _one(cur, sql: str, params: tuple):
     cur.execute(sql, params)
     row = cur.fetchone()
     return row
+
+
+# --- tenant discovery (#378) ------------------------------------------------
+#
+# Three sources, because a tenant can be interesting for three different
+# reasons and any one of them alone would hide the tenant this script was
+# pointed at by hand: agent runs (someone asked something), stored resources
+# (records landed), audit events (anything touched the record at all).
+#
+# Every column here is an id, a count or a timestamp. No resource content, no
+# audit `detail`, no free text of any kind reaches this query — the listing is
+# PHI-free by construction, not by redaction.
+
+DISCOVER_TENANTS_SQL = """
+    SELECT tenant_id,
+           sum(runs) AS runs,
+           sum(resources) AS resources,
+           sum(audits) AS audits,
+           max(last_seen) AS last_seen
+    FROM (
+        SELECT tenant_id, count(*) AS runs, 0 AS resources, 0 AS audits,
+               max(created_at) AS last_seen
+          FROM agent_runs GROUP BY tenant_id
+        UNION ALL
+        SELECT tenant_id, 0, count(*), 0, max(last_updated)
+          FROM r6_resources
+         WHERE coalesce(is_deleted, FALSE) = FALSE
+         GROUP BY tenant_id
+        UNION ALL
+        SELECT tenant_id, 0, 0, count(*), max(recorded)
+          FROM audit_events
+         WHERE tenant_id IS NOT NULL
+         GROUP BY tenant_id
+    ) activity
+    GROUP BY tenant_id
+    ORDER BY max(last_seen) DESC
+"""
+
+
+def discover_tenants(cur) -> list[tuple]:
+    """(tenant, runs, resources, audits, last_seen), newest activity first."""
+    cur.execute(DISCOVER_TENANTS_SQL, ())
+    return [(r[0], int(r[1] or 0), int(r[2] or 0), int(r[3] or 0), r[4])
+            for r in cur.fetchall()]
+
+
+def tenant_record_count(cur, tenant: str) -> int:
+    """How many live resources this tenant holds. Separates "nobody has asked
+    yet" from "there is nothing here to ask about"."""
+    row = _one(cur, """
+        SELECT count(*) FROM r6_resources
+        WHERE tenant_id = %s AND coalesce(is_deleted, FALSE) = FALSE
+    """, (tenant,))
+    return int(row[0] or 0) if row else 0
+
+
+def format_tenant_table(rows: list[tuple]) -> str:
+    """Fixed-width listing. Counts, never content."""
+    if not rows:
+        return ("no tenant has any agent run, stored resource or audit event "
+                "on this database")
+    head = (f"  {'tenant':<32}{'runs':>7}{'records':>10}{'audits':>9}"
+            f"   last activity")
+    out = [head]
+    for tenant, runs, resources, audits, last_seen in rows:
+        seen = str(last_seen or "")[:19] or "-"
+        out.append(f"  {str(tenant)[:32]:<32}{runs:>7}{resources:>10}"
+                   f"{audits:>9}   {seen}")
+    return "\n".join(out)
+
+
+def recent_activity_hint(rows: list[tuple], limit: int = 5) -> str:
+    """One line naming where the activity actually is.
+
+    A fruitless run has to end by pointing somewhere. Without this the reader
+    is left choosing between "the deploy is unexercised" and "wrong tenant" —
+    the two states #378 was filed about.
+    """
+    if not rows:
+        return ("tenants with recent activity: none — this database has no "
+                "agent runs, stored resources or audit events at all")
+    names = ", ".join(str(r[0]) for r in rows[:limit])
+    more = f" (+{len(rows) - limit} more)" if len(rows) > limit else ""
+    return f"tenants with recent activity: {names}{more}"
+
+
+EMPTY_TENANT_SKIP = ("this tenant holds no records — asking the agent will "
+                     "not move this row; the records are somewhere else")
+
+
+def explain_skip(detail: str, record_count: int) -> str:
+    """Re-word a SKIP on a tenant that holds nothing.
+
+    "ask the agent something first" is the right next step on a stocked
+    tenant and the wrong one on an empty tenant, where no amount of asking
+    changes the row. Different problems, different fixes.
+    """
+    return EMPTY_TENANT_SKIP if record_count == 0 else detail
 
 
 def check_s1_labs_interpreted(cur, tenant: str) -> tuple[str, str]:
@@ -184,6 +299,20 @@ CHECKS = [
     ("ingest not stranded", check_ingest_not_stranded),
 ]
 
+# The rows that can only go green because the agent DID something. `ingest not
+# stranded` is not one of them: it returns PASS on a tenant with nothing in it
+# at all, because "no stranded jobs" is trivially true of no jobs.
+#
+# That distinction is load-bearing for #378. The report was "every behavioural
+# row was SKIP", and counting the vacuous PASS as an evaluated row would make
+# a run on the wrong tenant exit 0 with "all evaluable rows pass (1 checked)" —
+# i.e. the scorecard would report success for a run that measured nothing about
+# the agent, and the "look over here instead" hint would be unreachable code.
+BEHAVIOURAL_CHECKS = frozenset({
+    "check_s1_labs_interpreted", "check_s3_medication_reads",
+    "check_s5_run_health", "check_s8_tool_rounds",
+})
+
 MANUAL_ROWS = """\
 Owner's five minutes in the UI (this script cannot read prose):
   S1  "What do my labs say?"          -> cites actual values, incl. cholesterol
@@ -197,9 +326,14 @@ Owner's five minutes in the UI (this script cannot read prose):
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--tenant", required=True,
+    ap.add_argument("--tenant",
                     help="tenant id to score (an opaque id, never PHI)")
+    ap.add_argument("--list-tenants", action="store_true",
+                    help="list tenants with any activity, newest first, "
+                         "then exit (ids and counts only)")
     args = ap.parse_args()
+    if not args.list_tenants and not args.tenant:
+        ap.error("--tenant is required (or --list-tenants to find one)")
 
     uri = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
     if not uri:
@@ -208,35 +342,73 @@ def main() -> int:
         return 2
     host = urllib.parse.urlsplit(
         uri.replace("postgresql+psycopg2://", "postgresql://", 1)).hostname
-    print(f"{D}scoring tenant {args.tenant} against {host}{X}\n")
 
     conn = _connect(uri)
     cur = conn.cursor()
 
-    failed = evaluated = 0
+    if args.list_tenants:
+        rows = discover_tenants(cur)
+        cur.close()
+        conn.close()
+        print(f"{D}tenants on {host} — ids, counts and timestamps only{X}\n")
+        print(format_tenant_table(rows))
+        print()
+        if not rows:
+            print(f"{Y}{recent_activity_hint(rows)}{X}")
+            return 2
+        print(f"{D}score one with: --tenant <id>{X}")
+        return 0
+
+    print(f"{D}scoring tenant {args.tenant} against {host}{X}\n")
+
+    # Counted up front: it is what tells a SKIP meaning "nobody has asked yet"
+    # apart from a SKIP meaning "there is nothing here to ask about".
+    try:
+        records = tenant_record_count(cur, args.tenant)
+    except Exception:  # noqa: BLE001 — never let discovery break the card
+        records = -1
+
+    failed = evaluated = behavioural = 0
     for name, check in CHECKS:
         try:
             verdict, detail = check(cur, args.tenant)
         except Exception as exc:  # noqa: BLE001 — report, don't crash the card
             verdict, detail = "FAIL", f"check crashed: {type(exc).__name__}"
+        if verdict == "SKIP" and records >= 0:
+            detail = explain_skip(detail, records)
         color = {"PASS": G, "FAIL": R, "SKIP": Y}[verdict]
         print(f"  {color}{verdict:4}{X}  {name}: {detail}")
         if verdict != "SKIP":
             evaluated += 1
+            if check.__name__ in BEHAVIOURAL_CHECKS:
+                behavioural += 1
         if verdict == "FAIL":
             failed += 1
+
+    hint = ""
+    if behavioural == 0:
+        # Say where the activity IS. Leaving the reader to guess between
+        # "unexercised deploy" and "wrong tenant" is the #378 defect.
+        try:
+            hint = recent_activity_hint(discover_tenants(cur))
+        except Exception:  # noqa: BLE001
+            hint = "tenants with recent activity: could not query"
 
     cur.close()
     conn.close()
 
     print()
     print(MANUAL_ROWS)
-    if evaluated == 0:
-        print(f"{Y}nothing was evaluable — is this the right tenant?{X}")
-        return 2
     if failed:
         print(f"{R}{failed} row(s) regressed{X}")
         return 1
+    if behavioural == 0:
+        held = records if records >= 0 else "?"
+        print(f"{Y}no behavioural row was evaluable on tenant {args.tenant} "
+              f"({held} stored record(s)) — this run measured nothing about "
+              f"the agent{X}")
+        print(f"{Y}{hint}{X}")
+        return 2
     print(f"{G}all evaluable rows pass ({evaluated} checked){X}")
     return 0
 

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -1,0 +1,572 @@
+"""#294 — what a CareAgents caller sees when the HealthClaw transport fails.
+
+`careagents/healthclaw.py` is the ONLY data path out of CareAgents, so its
+failure wrapping is the seam every call crosses. The repo's standing trap is
+that CareAgents tests fake this client: they prove a call is MADE, never that
+it is ACCEPTED, and never what comes back when the wire itself fails.
+
+So nothing here is faked below the client. A real `requests.Session` talks to
+a real socket:
+
+  * connection refused — a closed port
+  * timeout            — a server that sleeps past the client deadline
+  * non-JSON body      — the HTML error page a proxy or edge serves
+  * 5xx                — the engine up but failing
+  * 200, wrong shape   — a JSON body that is not the object the caller expects
+
+The property under test is one line: **a caller must be able to tell "this
+failed" from "there is nothing there."** A method that answers a dead socket
+with `0`, `False`, `[]` or `None` has erased that difference, and every
+consumer downstream then reports emptiness to a patient as fact.
+
+That is not a hypothetical here. Six defects in one week had this exact shape
+(docs/2026-08-02-retro.md), and two of the paths below still do — they are
+`xfail(strict=True)` against #294 with the live consequence spelled out, so
+the day someone fixes them the pin turns red and gets updated rather than
+quietly staying wrong.
+"""
+
+from __future__ import annotations
+
+import http.server
+import socketserver
+import threading
+import time
+
+import pytest
+import requests
+
+from careagents.healthclaw import HealthClawClient, HealthClawError
+
+# The discard port: nothing listens, so connect() fails immediately.
+DEAD_BASE = "http://127.0.0.1:9"
+
+CLIENT_TIMEOUT = 0.4
+SLOW_ENOUGH_TO_TIME_OUT = 2.0
+
+
+class _Mode:
+    """What the stub engine should do to the next request."""
+
+    def __init__(self):
+        self.status = 200
+        self.body = b'{"ok": 1}'
+        self.ctype = "application/json"
+        self.delay = 0.0
+
+
+MODE = _Mode()
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _serve(self):
+        if MODE.delay:
+            time.sleep(MODE.delay)
+        self.send_response(MODE.status)
+        self.send_header("Content-Type", MODE.ctype)
+        self.send_header("Content-Length", str(len(MODE.body)))
+        self.end_headers()
+        self.wfile.write(MODE.body)
+
+    do_GET = do_POST = _serve
+
+    def log_message(self, *_args):
+        pass
+
+
+class _Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        # The timeout cases hang up mid-response on purpose, so the handler
+        # thread reliably sees ConnectionResetError. Printing a traceback for
+        # the thing the test asked for buries the real output.
+        pass
+
+
+@pytest.fixture(scope="module")
+def stub_base():
+    """A real HTTP server on a real port, whose behaviour each test sets."""
+    srv = _Server(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.fixture
+def reset_mode():
+    yield
+    MODE.__init__()
+
+
+def _client(base):
+    """A client with its step-up token pre-cached.
+
+    Without this every call would fail inside `mint_token` first, and the
+    method under test would never run its own response handling — the tests
+    would all pass while proving nothing about the method named in them.
+    """
+    c = HealthClawClient(base, "mint-secret", timeout=CLIENT_TIMEOUT)
+    c._tokens["t"] = ("cached-step-up-token", time.time())
+    return c
+
+
+def _set(status=200, body=b'{"ok": 1}', ctype="application/json", delay=0.0):
+    MODE.status, MODE.body, MODE.ctype, MODE.delay = status, body, ctype, delay
+
+
+# --------------------------------------------------------------------------
+# The headline: a failure that reads as an empty record set
+# --------------------------------------------------------------------------
+# `record_count` and `tenant_has_records` are the two calls behind the patient's
+# connect-and-refresh screen. Both collapse an engine failure into a number or
+# a boolean that means "nothing here", and careagents/app.py believes them.
+
+
+def test_record_count_zero_must_not_be_how_an_outage_is_reported(
+        stub_base, reset_mode):
+    """A 503 from the engine must not read as "you have no records".
+
+    `record_count` sums six `_summary=count` searches and swallows
+    `HealthClawError` per type (careagents/healthclaw.py:311-324), so a total
+    outage returns 0 — the same value as a genuinely empty tenant.
+
+    Live consequence: careagents/app.py:526 baselines a refresh on this
+    number and app.py:554 reports growth against it. During an engine
+    incident the patient is told, as fact, that their record count is zero.
+
+    MUTATION (once fixed): make the `except HealthClawError: continue` arm
+    swallow again -> red.
+    """
+    _set(status=503, body=b'{"error": "down"}')
+    with pytest.raises(HealthClawError):
+        _client(stub_base).record_count("t")
+
+
+def test_poll_must_not_report_pending_when_the_engine_is_failing(
+        stub_base, reset_mode):
+    """`tenant_has_records` returns False on a 503, and the poll endpoint
+    (careagents/app.py:544) turns False into `{"status": "pending"}`.
+
+    Live consequence: during an engine incident the connect screen says "still
+    fetching your records" forever. The patient waits on a spinner for a
+    condition that will never be re-evaluated, and nothing anywhere says the
+    record store is down. This is the connect journey, on a phone.
+    """
+    _set(status=503, body=b'{"error": "down"}')
+    with pytest.raises(HealthClawError):
+        _client(stub_base).tenant_has_records("t")
+
+
+test_record_count_zero_must_not_be_how_an_outage_is_reported = pytest.mark.xfail(
+    strict=True,
+    reason="#294: record_count() catches HealthClawError per resource type and "
+           "returns 0, so 'the engine is down' and 'this tenant has no "
+           "records' are the same answer to the caller.",
+)(test_record_count_zero_must_not_be_how_an_outage_is_reported)
+
+test_poll_must_not_report_pending_when_the_engine_is_failing = pytest.mark.xfail(
+    strict=True,
+    reason="#294: tenant_has_records() catches HealthClawError and returns "
+           "False, which careagents/app.py:544 renders as 'pending' — an "
+           "outage is indistinguishable from records not having landed yet.",
+)(test_poll_must_not_report_pending_when_the_engine_is_failing)
+
+
+# --------------------------------------------------------------------------
+# Transport failure must be typed, on every method
+# --------------------------------------------------------------------------
+# `HealthClawError` is the type CareAgents catches. Anything else escaping this
+# module reaches Flask as an unhandled 500, which breaks the JSON error
+# contract the UI depends on — the defect #267 fixed for ingest_bundle alone.
+
+def _call(client, name):
+    return {
+        "search": lambda: client.search("t", "Patient", {"_summary": "count"}),
+        "read": lambda: client.read("t", "Patient", "p1"),
+        "interpret_labs": lambda: client.interpret_labs("t"),
+        "care_gaps": lambda: client.care_gaps("t"),
+        "record_count": lambda: client.record_count("t"),
+        "tenant_has_records": lambda: client.tenant_has_records("t"),
+        "purge_tenant": lambda: client.purge_tenant("t"),
+        "action_status": lambda: client.action_status("t", "a1"),
+        "start_form_action": lambda: client.start_form_action("t"),
+        "confirm_action": lambda: client.confirm_action("t", "a1"),
+        "fetch_review_page": lambda: client.fetch_review_page("t", "a1"),
+        "submit_review": lambda: client.submit_review("t", "a1", {}),
+        "seed": lambda: client.seed("t"),
+        "mint_token": lambda: client.mint_token("fresh-tenant"),
+        "bind_telegram": lambda: client.bind_telegram("t", 1),
+        "conformance_badge": lambda: client.conformance_badge(),
+        "ingest_bundle": lambda: client.ingest_bundle(
+            "t", {"resourceType": "Bundle"}),
+        "create_agent_run": lambda: client.create_agent_run("t", "m1"),
+        "get_agent_run": lambda: client.get_agent_run("t", "r1"),
+        "agent_run_events": lambda: client.agent_run_events("t", "r1"),
+        "claim_agent_run": lambda: client.claim_agent_run("w1"),
+        "agent_worker_health": lambda: client.agent_worker_health(),
+        "finalize_agent_run": lambda: client.finalize_agent_run(
+            "r1", "w1", "text", "cp1"),
+    }[name]()
+
+
+# Wrapped today: ingest_bundle (fixed by #267) and the durable-run family.
+WRAPS_TRANSPORT_FAILURE = [
+    "ingest_bundle", "create_agent_run", "get_agent_run", "agent_run_events",
+    "claim_agent_run", "agent_worker_health", "finalize_agent_run",
+]
+
+# Unwrapped: `requests` exceptions escape as themselves. #267 fixed one method
+# rather than the seam, so the reads the patient's chat depends on are all here.
+LEAKS_TRANSPORT_FAILURE = [
+    "search", "read", "interpret_labs", "care_gaps", "record_count",
+    "tenant_has_records", "purge_tenant", "action_status", "start_form_action",
+    "confirm_action", "fetch_review_page", "submit_review", "seed",
+    "mint_token", "bind_telegram", "conformance_badge",
+]
+
+_LEAK_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason="#294: the method does not wrap requests.RequestException, so a "
+           "connection refusal or timeout escapes careagents/healthclaw.py as "
+           "a raw requests exception and reaches Flask as an unhandled 500.",
+)
+
+
+def _leaky(names):
+    return [pytest.param(n, marks=[_LEAK_XFAIL]) for n in names]
+
+
+@pytest.mark.parametrize(
+    "method",
+    WRAPS_TRANSPORT_FAILURE + _leaky(LEAKS_TRANSPORT_FAILURE))
+def test_connection_refused_is_a_typed_failure(method):
+    """Nothing is listening. Every method must say so in the one type
+    CareAgents catches."""
+    with pytest.raises(HealthClawError):
+        _call(_client(DEAD_BASE), method)
+
+
+@pytest.mark.parametrize(
+    "method",
+    WRAPS_TRANSPORT_FAILURE + _leaky(LEAKS_TRANSPORT_FAILURE))
+def test_a_timeout_is_a_typed_failure(method, stub_base, reset_mode):
+    """The engine accepted the connection and then stopped answering — the
+    shape a saturated worker pool actually produces."""
+    _set(delay=SLOW_ENOUGH_TO_TIME_OUT)
+    with pytest.raises(HealthClawError):
+        _call(_client(stub_base), method)
+
+
+def test_a_raw_requests_exception_really_does_escape_the_unwrapped_reads():
+    """Pins the CURRENT defect, so the xfails above cannot be dismissed as a
+    harness artefact.
+
+    `search` is the call behind every question the patient asks. On a refused
+    connection it raises `requests.ConnectionError`, which is not
+    `HealthClawError` and which no CareAgents caller catches.
+
+    DELETE THIS TEST when #294 is fixed. It asserts the defect, so it goes red
+    on the fix — which is the point: the fix cannot land while a test still
+    claims the old behaviour is correct.
+    """
+    with pytest.raises(requests.RequestException) as exc:
+        _client(DEAD_BASE).search("t", "Patient", {})
+    assert not isinstance(exc.value, HealthClawError)
+
+
+# --------------------------------------------------------------------------
+# A 200 whose body is not JSON
+# --------------------------------------------------------------------------
+# What a proxy, an edge cache or an auth interstitial returns. `requests`
+# raises `JSONDecodeError`, which subclasses BOTH ValueError and
+# RequestException — so wrapping RequestException covers this case too.
+
+NON_JSON_BODY = b"<html><body>502 Bad Gateway</body></html>"
+
+
+_DECODE_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason="#294: r.json() on the success path is unguarded, so an "
+           "unparseable 200 escapes as a raw requests.JSONDecodeError. On the "
+           "durable-run methods the decode sits OUTSIDE the try that wraps "
+           "requests.RequestException — wrapping the call but not the decode "
+           "leaves exactly half the seam covered.",
+)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [pytest.param(n, marks=[_DECODE_XFAIL]) for n in
+     ("search", "read", "interpret_labs", "care_gaps", "seed", "purge_tenant",
+      "action_status", "mint_token", "conformance_badge", "create_agent_run",
+      "get_agent_run", "agent_run_events", "claim_agent_run",
+      "finalize_agent_run")])
+def test_an_html_body_on_a_200_is_a_typed_failure(method, stub_base,
+                                                  reset_mode):
+    _set(status=200, body=NON_JSON_BODY, ctype="text/html")
+    with pytest.raises(HealthClawError):
+        _call(_client(stub_base), method)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#294: ingest_bundle() maps an unparseable 200 body to `body = "
+           "None` and then returns `{}`, so a proxy interstitial is reported "
+           "to the upload tile as a successful ingest of nothing.",
+)
+def test_an_unparseable_ingest_response_is_not_a_successful_empty_ingest(
+        stub_base, reset_mode):
+    """`{}` here means `ingested = 0`, which careagents/app.py:433 treats as
+    "empty file, not an error" and reports to the patient as a completed
+    upload. The records were never written."""
+    _set(status=200, body=NON_JSON_BODY, ctype="text/html")
+    with pytest.raises(HealthClawError):
+        _client(stub_base).ingest_bundle("t", {"resourceType": "Bundle"})
+
+
+def test_worker_health_already_rejects_a_body_it_cannot_parse(stub_base,
+                                                              reset_mode):
+    """The one method that gets this right, kept green as the reference.
+
+    `agent_worker_health` parses, type-checks and raises. Every finding in
+    this file is "apply what this method already does to the rest of the
+    seam", not "invent a policy".
+    """
+    _set(status=200, body=NON_JSON_BODY, ctype="text/html")
+    with pytest.raises(HealthClawError):
+        _client(stub_base).agent_worker_health()
+
+
+# --------------------------------------------------------------------------
+# A 200 whose body is JSON but the wrong shape
+# --------------------------------------------------------------------------
+# Valid JSON, wrong type. The client asks it for `.get(...)`, or hands it
+# straight back to the agent as if it were a Bundle.
+
+WRONG_SHAPE = [
+    pytest.param(b'"just-a-string"', id="json-string"),
+    pytest.param(b"[1, 2, 3]", id="json-array"),
+    pytest.param(b"null", id="json-null"),
+]
+
+
+@pytest.mark.parametrize("body", WRONG_SHAPE)
+@pytest.mark.xfail(
+    strict=True,
+    reason="#294: search() returns r.json() unchecked, so a non-object 200 is "
+           "handed to the agent as if it were a FHIR Bundle. The failure "
+           "surfaces later as an AttributeError in caller code, far from the "
+           "boundary that accepted it.",
+)
+def test_a_wrongly_shaped_search_body_is_rejected_at_the_boundary(
+        body, stub_base, reset_mode):
+    _set(status=200, body=body)
+    with pytest.raises(HealthClawError):
+        _client(stub_base).search("t", "Patient", {})
+
+
+@pytest.mark.parametrize("body", WRONG_SHAPE)
+@pytest.mark.xfail(
+    strict=True,
+    reason="#294: record_count() calls .get('total') on whatever the 200 "
+           "body decoded to, so a non-object body raises AttributeError — "
+           "which is not a RequestException, so even wrapping the transport "
+           "would not catch it.",
+)
+def test_a_wrongly_shaped_count_body_is_a_typed_failure(body, stub_base,
+                                                        reset_mode):
+    _set(status=200, body=body)
+    with pytest.raises(HealthClawError):
+        _client(stub_base).record_count("t")
+
+
+def test_worker_health_type_checks_its_200_body(stub_base, reset_mode):
+    """Kept green: the reference implementation of the missing check."""
+    _set(status=200, body=b'"just-a-string"')
+    with pytest.raises(HealthClawError):
+        _client(stub_base).agent_worker_health()
+
+
+# --------------------------------------------------------------------------
+# Failure vs emptiness, for the paths that deliberately degrade
+# --------------------------------------------------------------------------
+# Some methods are documented as best-effort and must not raise. That is a
+# legitimate choice — but the caller still has to be able to tell the two
+# states apart, and today it cannot.
+
+
+def test_history_loss_is_not_the_same_value_as_an_empty_history(stub_base,
+                                                                reset_mode):
+    """`recent_messages` returns [] both for "this is a new conversation" and
+    for "HealthClaw is unreachable", so the agent silently answers with no
+    history instead of saying it lost the thread.
+
+    Not raised as a blocking defect: it logs, and answering without history
+    beats failing the turn. Pinned so the collapse is a decision on the
+    record rather than an accident.
+    """
+    _set(status=503, body=b'{"error": "down"}')
+    outage = _client(stub_base).recent_messages("t")
+
+    _set(status=200, body=b"[]")
+    empty = _client(stub_base).recent_messages("t")
+
+    assert outage == empty == [], (
+        "pinned as today's behaviour — if this changed, the collapse was "
+        "fixed and this test should assert the new distinction instead")
+
+
+def test_a_lost_chat_turn_is_reported_to_the_caller(stub_base, reset_mode):
+    """`log_message` returning False is honest: losing a transcript must not
+    break the conversation, and the caller is told."""
+    _set(status=503, body=b'{"error": "down"}')
+    assert _client(stub_base).log_message("t", "user", "hi") is False
+    assert _client(DEAD_BASE).log_message("t", "user", "hi") is False
+
+
+def test_an_unclaimable_inbound_message_is_never_reported_as_claimed(
+        stub_base, reset_mode):
+    """The idempotency contract: (True, id) created, (False, id) replay,
+    (None, None) storage unavailable. A transport failure must land in the
+    third case — reporting a replay would drop the patient's message."""
+    for status, body in ((503, b'{"error": "down"}'),
+                         (200, b"<html>502</html>")):
+        _set(status=status, body=body, ctype="text/html")
+        assert _client(stub_base).claim_inbound_message(
+            "t", "hi", "a", "c", "web", "r1") == (None, None)
+    assert _client(DEAD_BASE).claim_inbound_message(
+        "t", "hi", "a", "c", "web", "r1") == (None, None)
+
+
+def test_a_missing_brief_and_an_unreachable_engine_are_both_unavailable(
+        stub_base, reset_mode):
+    """`fetch_appointment_brief` is documented as None-on-any-failure and the
+    callers render "brief unavailable", which is true of both states. Pinned
+    because the docstring's promise — never raise to the UI — is the part
+    that must not regress."""
+    _set(status=404, body=b'{"error": "no brief"}')
+    assert _client(stub_base).fetch_appointment_brief("t") is None
+
+    _set(status=503, body=b'{"error": "down"}')
+    assert _client(stub_base).fetch_appointment_brief("t") is None
+
+    assert _client(DEAD_BASE).fetch_appointment_brief("t") is None
+
+    _set(delay=SLOW_ENOUGH_TO_TIME_OUT)
+    assert _client(stub_base).fetch_appointment_brief("t") is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#294: fetch_appointment_brief() returns r.json() on any 200 "
+           "without checking it decoded to an object, so a wrongly-shaped "
+           "body is handed to the brief renderer as though it were the FHIR "
+           "Basic resource. Its own docstring promises 'the FHIR Basic "
+           "resource dict, or None'.",
+)
+def test_the_brief_returns_a_resource_or_none_and_never_a_bare_string(
+        stub_base, reset_mode):
+    """The contract is dict-or-None. Anything else moves the failure into
+    whatever renders the brief, one layer away from the boundary that
+    accepted it."""
+    _set(status=200, body=b'"just-a-string"')
+    got = _client(stub_base).fetch_appointment_brief("t")
+    assert got is None or isinstance(got, dict), repr(got)
+
+
+# --------------------------------------------------------------------------
+# Against a REAL running HealthClaw
+# --------------------------------------------------------------------------
+# The stub above proves what happens when the wire breaks. It cannot prove the
+# client's requests are shaped the way the engine accepts — a fake accepts wire
+# formats production rejects, which is this repo's documented trap. So: the
+# real engine, served over a real socket, on a real port.
+
+
+@pytest.fixture
+def live_engine(tmp_path, monkeypatch):
+    """A real HealthClaw serving real HTTP on a real port."""
+    from werkzeug.serving import make_server
+
+    # READ_AUTH_ENABLED is what production sets; without it every tenant read
+    # is allowed for local convenience, and a test that did not set it would
+    # be checking the permissive path while claiming to check the gate.
+    monkeypatch.setenv("READ_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PUBLIC_TENANTS", "ca-transport")
+    db_path = tmp_path / "engine.db"
+    from main import create_app
+    from models import db
+
+    app = create_app({"TESTING": True,
+                      "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+                      "LEGACY_BOOT_ON_CREATE": False})
+    with app.app_context():
+        db.create_all()
+
+    srv = make_server("127.0.0.1", 0, app, threaded=True)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_port}", app
+    finally:
+        srv.shutdown()
+
+
+def test_a_real_engine_answers_the_clients_own_search_over_real_http(
+        live_engine):
+    """Positive control. Without this the failure tests could all be passing
+    because the client cannot talk to HealthClaw at all."""
+    base, _app = live_engine
+    client = HealthClawClient(base, "mint-secret", timeout=10.0)
+    client._tokens["ca-transport"] = ("unused-public-tenant", time.time())
+
+    bundle = client.search("ca-transport", "Patient", {"_summary": "count"})
+    assert isinstance(bundle, dict)
+    assert bundle.get("resourceType") == "Bundle"
+    assert int(bundle.get("total") or 0) == 0
+
+
+def test_a_real_engines_rejection_reaches_the_caller_as_a_typed_failure(
+        live_engine):
+    """A refusal the ENGINE decides on — not one the harness simulated.
+
+    An unknown tenant with no credential is refused by the real read-auth
+    gate, and the caller must see HealthClawError carrying the status, not a
+    bare empty Bundle that would read as "this person has no records".
+    """
+    base, _app = live_engine
+    client = HealthClawClient(base, "wrong-secret", timeout=10.0)
+    client._tokens["not-a-tenant"] = ("forged", time.time())
+
+    with pytest.raises(HealthClawError) as exc:
+        client.search("not-a-tenant", "Patient", {"_summary": "count"})
+    assert exc.value.status >= 400
+    assert exc.value.status != 0, "a refusal is not a transport failure"
+
+
+def test_the_real_engine_is_what_makes_the_dead_socket_meaningful(live_engine):
+    """Same client, same call, one difference: the engine is gone.
+
+    The contrast is the whole of #294. Against a live engine the call returns
+    a Bundle; against a closed port it must raise rather than return anything
+    that could be mistaken for one. Deliberately indifferent to WHICH
+    exception, so this stays a positive control after the wrapping is fixed —
+    the type is pinned by the xfail matrix above, not here.
+    """
+    base, _app = live_engine
+    live = HealthClawClient(base, "mint-secret", timeout=10.0)
+    live._tokens["ca-transport"] = ("unused-public-tenant", time.time())
+    assert live.search(
+        "ca-transport", "Patient", {"_summary": "count"})["resourceType"] == (
+            "Bundle")
+
+    dead = HealthClawClient(DEAD_BASE, "mint-secret", timeout=CLIENT_TIMEOUT)
+    dead._tokens["ca-transport"] = ("unused-public-tenant", time.time())
+    with pytest.raises((requests.RequestException, HealthClawError)):
+        dead.search("ca-transport", "Patient", {"_summary": "count"})

--- a/tests/test_shakeout_live.py
+++ b/tests/test_shakeout_live.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 
+import pytest
+
 _spec = importlib.util.spec_from_file_location(
     "shakeout_live",
     pathlib.Path(__file__).resolve().parent.parent / "scripts" / "shakeout_live.py")
@@ -139,6 +141,57 @@ def _sqlite_params(sql: str) -> str:
     return sql.replace("%%", "\x00").replace("%s", "?").replace("\x00", "%")
 
 
+EXECUTED: list[str] = []
+
+
+class _RealCur:
+    """Adapts psycopg2-style SQL onto the real test database session.
+
+    Module-level rather than nested, because every query this script grows
+    has to come through here — the one thing unit stubs structurally cannot
+    check is whether the statement is executable at all.
+    """
+
+    def __init__(self):
+        self._rows = []
+
+    def execute(self, sql, params=None):
+        import sqlite3
+
+        EXECUTED.append(sql)
+        bind = db.engine
+        is_sqlite = bind.dialect.name == "sqlite"
+        statement = _sqlite_params(sql) if is_sqlite else sql
+        if is_sqlite:
+            # now() / make_interval are Postgres-only; the point of this
+            # test on SQLite is name resolution, so neutralise the clause
+            # while leaving every identifier intact.
+            statement = statement.replace(
+                "created_at > now() - make_interval(hours => ?)",
+                "created_at IS NOT NULL AND ? IS NOT NULL")
+        raw = bind.raw_connection()
+        try:
+            cur = raw.cursor()
+            cur.execute(statement, tuple(params or ()))
+            self._rows = cur.fetchall()
+            cur.close()
+        except sqlite3.OperationalError as exc:
+            raise AssertionError(
+                f"shakeout query does not match the schema: {exc}\n{sql}"
+            ) from exc
+        finally:
+            raw.close()
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
 def test_every_check_query_actually_executes(app):
     """MUTATION: rename any queried column (e.g. `recorded` -> `recorded_at`)
     -> red. This is the defect that reached production.
@@ -147,55 +200,420 @@ def test_every_check_query_actually_executes(app):
     column or table that does not exist raises here instead of at 3am against
     the live record.
     """
-    import sqlite3
-
-    executed = []
-
-    class _RealCur:
-        """Adapts psycopg2-style SQL onto the test database session."""
-
-        def __init__(self):
-            self._rows = []
-
-        def execute(self, sql, params=None):
-            executed.append(sql)
-            bind = db.engine
-            is_sqlite = bind.dialect.name == "sqlite"
-            statement = _sqlite_params(sql) if is_sqlite else sql
-            if is_sqlite:
-                # now() / make_interval are Postgres-only; the point of this
-                # test on SQLite is name resolution, so neutralise the clause
-                # while leaving every identifier intact.
-                statement = statement.replace(
-                    "created_at > now() - make_interval(hours => ?)",
-                    "created_at IS NOT NULL AND ? IS NOT NULL")
-            raw = bind.raw_connection()
-            try:
-                cur = raw.cursor()
-                cur.execute(statement, tuple(params or ()))
-                self._rows = cur.fetchall()
-                cur.close()
-            except sqlite3.OperationalError as exc:
-                raise AssertionError(
-                    f"shakeout query does not match the schema: {exc}\n{sql}"
-                ) from exc
-            finally:
-                raw.close()
-
-        def fetchone(self):
-            return self._rows[0] if self._rows else None
-
-        def fetchall(self):
-            return self._rows
-
+    EXECUTED.clear()
     with app.app_context():
         for name, check in shakeout.CHECKS:
             verdict, detail = check(_RealCur(), "some-tenant")
             assert verdict in ("PASS", "FAIL", "SKIP"), (name, verdict)
 
-    assert len(executed) >= len(shakeout.CHECKS), (
+    assert len(EXECUTED) >= len(shakeout.CHECKS), (
         "a check returned without running its query — it cannot have "
         "measured anything")
+
+
+# ---------------------------------------------------------------------------
+# #378 — tenant discovery
+# ---------------------------------------------------------------------------
+# The scorecard could not name one of its own states. Scored against a tenant
+# the agent does not run on, every behavioural row returned SKIP — identical
+# output to "the deploy is unexercised", which is what it was read as. Three
+# attempts went by before the real tenant was found by hand-querying
+# AgentRun. These pin the two states apart.
+
+
+def test_discovery_sql_actually_executes(app):
+    """MUTATION: rename any column in DISCOVER_TENANTS_SQL (say
+    `last_updated` -> `updated_at`) -> red.
+
+    Same reason as the check queries above: this script's one shipped defect
+    was a query that every stubbed test accepted and no database would run.
+    A discovery query that crashes is worse than no discovery query, because
+    it crashes exactly when someone is lost.
+    """
+    EXECUTED.clear()
+    with app.app_context():
+        rows = shakeout.discover_tenants(_RealCur())
+        assert rows == [], "a fresh database has no tenant activity"
+        assert shakeout.tenant_record_count(_RealCur(), "nobody") == 0
+    assert len(EXECUTED) == 2, EXECUTED
+
+
+def _seed_activity(tenant, *, resources=0, audits=0, runs=0, when=None):
+    """Insert real rows through the real models, FKs and all."""
+    import uuid
+    from datetime import datetime, timedelta, timezone
+
+    from r6.models import AuditEventRecord, R6Resource
+    from r6.agent_runs.models import AgentRun
+    from r6.command_center.models import Conversation, ConversationMessage
+
+    stamp = when or datetime.now(timezone.utc)
+    for i in range(resources):
+        row = R6Resource(resource_type="Observation", resource_json="{}",
+                         resource_id=f"obs-{i}", tenant_id=tenant)
+        row.last_updated = stamp
+        db.session.add(row)
+    for i in range(audits):
+        db.session.add(AuditEventRecord(
+            id=str(uuid.uuid4()), event_type="read", tenant_id=tenant,
+            resource_type="Observation", detail="read; n=1", recorded=stamp))
+    if runs:
+        conv = Conversation(id=f"conv-{tenant}", tenant_id=tenant)
+        db.session.add(conv)
+        db.session.flush()
+        for i in range(runs):
+            msg = ConversationMessage(
+                id=f"msg-{tenant}-{i}", tenant_id=tenant,
+                conversation_id=conv.id, role="user", text="hi")
+            db.session.add(msg)
+            db.session.flush()
+            db.session.add(AgentRun(
+                id=f"run-{tenant}-{i}", tenant_id=tenant,
+                conversation_id=conv.id, message_id=msg.id,
+                deadline_at=stamp + timedelta(minutes=2), created_at=stamp))
+    db.session.commit()
+
+
+def test_discover_tenants_finds_all_three_kinds_of_activity(app):
+    """MUTATION: drop any one of the three UNION branches -> red.
+
+    #378 in one test. The tenant that mattered had agent runs; the two that
+    were scored had records and audit events. A listing built on any single
+    source hides exactly the tenant someone is hunting for.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("t-runs-only", runs=3, when=now)
+        _seed_activity("t-records-only", resources=7,
+                       when=now - timedelta(hours=2))
+        _seed_activity("t-audits-only", audits=5,
+                       when=now - timedelta(hours=4))
+        rows = shakeout.discover_tenants(_RealCur())
+
+    by_tenant = {r[0]: r for r in rows}
+    assert set(by_tenant) == {"t-runs-only", "t-records-only", "t-audits-only"}
+    assert by_tenant["t-runs-only"][1] == 3       # runs
+    assert by_tenant["t-records-only"][2] == 7    # resources
+    assert by_tenant["t-audits-only"][3] == 5     # audits
+
+
+def test_discover_tenants_orders_newest_activity_first(app):
+    """MUTATION: drop the ORDER BY, or flip it to ASC -> red.
+
+    "Newest first" is the whole ergonomic point: the tenant someone is
+    looking for is the one that was just used.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("t-old", resources=1, when=now - timedelta(days=9))
+        _seed_activity("t-newest", resources=1, when=now)
+        _seed_activity("t-middle", resources=1, when=now - timedelta(days=3))
+        rows = shakeout.discover_tenants(_RealCur())
+
+    assert [r[0] for r in rows] == ["t-newest", "t-middle", "t-old"]
+
+
+def test_counts_merge_across_sources_for_one_tenant(app):
+    """MUTATION: change the outer GROUP BY to also group by a per-branch
+    column -> red (the tenant splits into three rows).
+
+    One tenant is one row, with all three counts on it — otherwise the
+    listing is longer than the tenant list and reads as more tenants than
+    exist.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("t-all", runs=2, resources=4, audits=6, when=now)
+        rows = shakeout.discover_tenants(_RealCur())
+
+    assert len(rows) == 1
+    tenant, runs, resources, audits, _last = rows[0]
+    assert (tenant, runs, resources, audits) == ("t-all", 2, 4, 6)
+
+
+def test_deleted_resources_are_not_counted_as_records(app):
+    """MUTATION: drop the is_deleted filter -> red.
+
+    A purged tenant reporting records is the discovery version of the bug
+    this whole card exists to catch: a number that says data is there when
+    it is not.
+    """
+    from datetime import datetime, timezone
+
+    from r6.models import R6Resource
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("t-purged", resources=2, when=now)
+        for row in R6Resource.query.filter_by(tenant_id="t-purged").all():
+            row.is_deleted = True
+        db.session.commit()
+        assert shakeout.tenant_record_count(_RealCur(), "t-purged") == 0
+        rows = shakeout.discover_tenants(_RealCur())
+
+    assert [r[0] for r in rows] == [], (
+        "a tenant whose only rows are soft-deleted holds no records")
+
+
+def test_tenant_record_count_is_scoped_to_the_tenant(app):
+    """MUTATION: drop `tenant_id = %s` from tenant_record_count -> red.
+
+    An unscoped count would report every tenant's records as this one's,
+    which would silently turn the empty-tenant SKIP wording back off.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("t-has", resources=5, when=now)
+        _seed_activity("t-empty", audits=1, when=now)
+        assert shakeout.tenant_record_count(_RealCur(), "t-has") == 5
+        assert shakeout.tenant_record_count(_RealCur(), "t-empty") == 0
+
+
+def test_the_listing_reads_no_record_content(app):
+    """MUTATION: add `detail` or `resource_json` to the SELECT -> red.
+
+    PHI-free BY CONSTRUCTION, not by filtering afterwards. `audit_events`
+    and `r6_resources` both hold free text that real feeds put patient names
+    into (docs/constitution.md; the `display` rule in CLAUDE.md). The
+    discovery query must never name those columns at all — a listing that
+    reads them and then drops them is one refactor away from printing them.
+    """
+    sql = shakeout.DISCOVER_TENANTS_SQL.lower()
+    for content_column in ("resource_json", "detail", "text", "payload",
+                           "metadata_json", "outcome_detail_code",
+                           "resource_id", "agent_id", "sha256"):
+        assert content_column not in sql, (
+            f"discovery SQL touches {content_column!r} — the listing carries "
+            "ids, counts and timestamps only")
+
+    # And prove it on real rows: nothing from a seeded record's content can
+    # appear in the rendered table.
+    from datetime import datetime, timezone
+    with app.app_context():
+        _seed_activity("t-content", resources=1, audits=1,
+                       when=datetime.now(timezone.utc))
+        table = shakeout.format_tenant_table(
+            shakeout.discover_tenants(_RealCur()))
+    assert "Observation" not in table and "read; n=1" not in table
+
+
+def test_the_table_shows_counts_and_a_timestamp_per_tenant():
+    """MUTATION: drop a count column from format_tenant_table -> red.
+
+    "with counts and the most recent timestamp" is the requirement; a bare
+    list of ids would not have told anyone which tenant to score.
+    """
+    rows = [("ca-3f9a21bd7e", 142, 1284, 3908, "2026-08-04 21:14:07"),
+            ("desktop-demo", 0, 698, 1205, "2026-08-04 18:02:55")]
+    table = shakeout.format_tenant_table(rows)
+    assert "ca-3f9a21bd7e" in table and "desktop-demo" in table
+    for number in ("142", "1284", "3908", "698", "1205"):
+        assert number in table
+    assert "2026-08-04 21:14:07" in table
+    assert table.index("ca-3f9a21bd7e") < table.index("desktop-demo")
+
+
+def test_an_empty_database_says_so_rather_than_printing_a_bare_header():
+    empty = shakeout.format_tenant_table([])
+    assert "no tenant" in empty
+
+
+def test_a_fruitless_run_names_where_the_activity_is():
+    """MUTATION: return "" from recent_activity_hint -> red.
+
+    The #378 report: two tenants scored all-SKIP and the output left the
+    reader to guess between "unexercised deploy" and "wrong tenant". The run
+    has to end by pointing somewhere.
+    """
+    rows = [("ca-3f9a21bd7e", 142, 1284, 3908, "2026-08-04 21:14:07"),
+            ("desktop-demo", 0, 698, 1205, "2026-08-04 18:02:55")]
+    hint = shakeout.recent_activity_hint(rows)
+    assert hint.startswith("tenants with recent activity:")
+    assert "ca-3f9a21bd7e" in hint and "desktop-demo" in hint
+
+
+def test_the_hint_truncates_instead_of_printing_every_tenant():
+    """A hint that scrolls off the terminal is not a hint."""
+    rows = [(f"t-{i}", 1, 1, 1, "2026-08-04") for i in range(9)]
+    hint = shakeout.recent_activity_hint(rows, limit=3)
+    assert "t-0" in hint and "t-8" not in hint and "+6 more" in hint
+
+
+def test_the_hint_is_honest_when_the_database_itself_is_empty():
+    """No tenants anywhere is a different answer from "look over there",
+    and saying "look over there" would restart the hunt that #378 is about."""
+    hint = shakeout.recent_activity_hint([])
+    assert "none" in hint
+
+
+def test_a_skip_on_an_empty_tenant_says_it_holds_no_records():
+    """MUTATION: make explain_skip return `detail` unconditionally -> red.
+
+    Two different problems with two different fixes. On a stocked tenant a
+    SKIP means "ask the agent something". On a tenant holding nothing,
+    asking changes nothing — the records are elsewhere, which is precisely
+    the #378 situation.
+    """
+    original = "no $interpret call recorded yet — ask 'what do my labs say?' first"
+    empty = shakeout.explain_skip(original, 0)
+    assert "holds no records" in empty
+    assert "ask" not in empty.split("—")[0]
+    assert shakeout.explain_skip(original, 186) == original
+
+
+def test_the_empty_tenant_wording_does_not_send_the_reader_back_to_the_agent():
+    """The wrong next step is worse than no next step: it burns another
+    round trip before anyone questions the tenant id."""
+    assert "holds no records" in shakeout.EMPTY_TENANT_SKIP
+    assert "ask the agent" not in shakeout.EMPTY_TENANT_SKIP
+
+
+def test_a_vacuous_pass_is_not_counted_as_evidence_about_the_agent():
+    """MUTATION: add `check_ingest_not_stranded` to BEHAVIOURAL_CHECKS -> red.
+
+    `ingest not stranded` returns PASS on a tenant containing nothing at all,
+    because "no stranded jobs" is trivially true of no jobs. Counting it as a
+    scored row is what made the first draft of this fix dead code: every run,
+    on every wrong tenant, had one PASS and so never looked fruitless.
+    """
+    wired = {fn.__name__ for _name, fn in shakeout.CHECKS}
+    assert shakeout.BEHAVIOURAL_CHECKS < wired, (
+        "behavioural rows must be a strict subset — at least one row passes "
+        "without the agent having done anything")
+    assert "check_ingest_not_stranded" not in shakeout.BEHAVIOURAL_CHECKS
+
+    # And the row really does pass on an empty tenant, which is the premise.
+    assert shakeout.check_ingest_not_stranded(_Cur(one=(0,)), "t")[0] == "PASS"
+
+
+def _run_main(app, monkeypatch, capsys, *argv):
+    """Drive main() end to end against the real test database."""
+    import sys
+
+    class _Conn:
+        def cursor(self):
+            return _RealCur()
+
+        def close(self):
+            pass
+
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "postgresql://x/y")
+    monkeypatch.setattr(shakeout, "_connect", lambda uri: _Conn())
+    monkeypatch.setattr(sys, "argv", ["shakeout_live.py", *argv])
+    with app.app_context():
+        code = shakeout.main()
+    return code, capsys.readouterr().out
+
+
+def test_scoring_the_wrong_tenant_exits_2_and_names_the_right_one(
+        app, monkeypatch, capsys):
+    """MUTATION: count every non-SKIP row instead of behavioural ones -> red.
+
+    #378 end to end. `desktop-demo` holds 698 records and has never been
+    asked anything; the agent runs on `ca-live`. Before this, the run
+    reported "all evaluable rows pass (1 checked)" and exited 0 — success,
+    for a run that measured nothing about the agent, on the wrong tenant.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("desktop-demo", resources=698,
+                       when=now - timedelta(hours=3))
+        _seed_activity("ca-live", runs=4, resources=186, when=now)
+
+    code, out = _run_main(app, monkeypatch, capsys, "--tenant", "desktop-demo")
+
+    assert code == 2, out
+    assert "no behavioural row was evaluable" in out
+    assert "tenants with recent activity:" in out
+    assert "ca-live" in out, "the run must name where the activity actually is"
+
+
+def test_scoring_the_tenant_the_agent_runs_on_does_not_print_the_hint(
+        app, monkeypatch, capsys):
+    """The pointer is for lost readers. On a tenant that scored something it
+    would be noise, and noise is how a card stops being read."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("ca-live", runs=4, resources=186, when=now)
+
+    code, out = _run_main(app, monkeypatch, capsys, "--tenant", "ca-live")
+
+    assert "S5 run health honest" in out
+    assert "tenants with recent activity:" not in out
+    assert code == 0, out
+
+
+def test_list_tenants_prints_the_table_and_exits_0(app, monkeypatch, capsys):
+    """The whole point of #378, driven through main()."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    with app.app_context():
+        _seed_activity("desktop-demo", resources=698,
+                       when=now - timedelta(hours=3))
+        _seed_activity("ca-live", runs=4, resources=186, audits=40, when=now)
+
+    code, out = _run_main(app, monkeypatch, capsys, "--list-tenants")
+
+    assert code == 0, out
+    assert "ca-live" in out and "desktop-demo" in out
+    assert "698" in out and "186" in out and "40" in out
+    assert out.index("ca-live") < out.index("desktop-demo"), "newest first"
+    assert "--tenant" in out, "the listing must say what to do with a tenant id"
+
+
+def test_list_tenants_on_an_empty_database_exits_2(app, monkeypatch, capsys):
+    """Nothing anywhere is "cannot evaluate", not "all clear"."""
+    code, out = _run_main(app, monkeypatch, capsys, "--list-tenants")
+    assert code == 2
+    assert "no tenant" in out
+
+
+def test_list_tenants_runs_without_a_tenant_and_scoring_still_needs_one():
+    """MUTATION: restore `required=True` on --tenant -> red.
+
+    Discovery that requires the answer it exists to find is not discovery.
+    The reverse must stay true too: scoring without a tenant is an error,
+    not a silent scan of everything.
+    """
+    import contextlib
+    import io
+    import subprocess
+    import sys
+
+    parser_probe = subprocess.run(
+        [sys.executable, "scripts/shakeout_live.py", "--list-tenants"],
+        capture_output=True, text=True,
+        cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+        env={"PATH": "/usr/bin:/bin"})
+    # No database configured -> exit 2 with the URI message, NOT an argparse
+    # usage error about a missing --tenant.
+    assert parser_probe.returncode == 2, parser_probe.stderr
+    assert "SQLALCHEMY_DATABASE_URI" in parser_probe.stdout
+    assert "--tenant" not in parser_probe.stderr
+
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err), pytest.raises(SystemExit) as exc:
+        _argv = sys.argv
+        sys.argv = ["shakeout_live.py"]
+        try:
+            shakeout.main()
+        finally:
+            sys.argv = _argv
+    assert exc.value.code == 2
+    assert "--tenant is required" in err.getvalue()
 
 
 def test_run_health_is_windowed_not_all_time():


### PR DESCRIPTION
Sprint 3. Closes #378. Characterizes #294 — **no production code changed**; the defects are pinned as `xfail(strict=True)` with the live patient consequence in each reason.

## #294 — the sixth instance of this week's pattern, on the connect screen

Two functions collapse failure into emptiness, and both sit on the journey a **new patient** sees on their phone:

- `healthclaw.py:311` `record_count()` swallows `HealthClawError` per resource type and returns **0**. `app.py:526` baselines a refresh on that number and `app.py:554` reports growth against it. **During an engine incident the patient is told, as fact, that their record count is zero.**
- `healthclaw.py:297` `tenant_has_records()` returns **False** on any `HealthClawError`, which `app.py:544` renders as `{"status": "pending"}`. **During an incident the connect screen says "still fetching your records" forever**, and nothing anywhere says the store is down.

Three more on the same seam:

- **16 of 23 methods do not wrap `requests.RequestException`** — a refused connection escapes raw and hits Flask as an unhandled 500. #267 fixed `ingest_bundle` rather than the seam, so `search`, `read`, `interpret_labs` and `care_gaps` are all still exposed.
- Success-path `r.json()` is unguarded everywhere, including durable-run methods that *do* wrap the request. In `ingest_bundle` an unparseable 200 becomes `{}` and **reports a successful ingest of nothing**.
- A wrongly-shaped 200 is returned as data — `search()` hands a JSON string to the agent as a Bundle.

`agent_worker_health()` already does this correctly. Every finding is "apply that to the rest of the seam."

## #378 — the scorecard can find its own tenant

```
tenant                             runs   records   audits   last activity
ca-3f9a21bd7e                        12       186       41   2026-08-04 23:48:16
desktop-demo                          0       698       12   2026-08-04 20:53:16
gigi-bce09504                         0         0        2   2026-08-02 23:53:16
```

PHI-free **by construction** — the query never names a content column, so there is nothing to redact afterwards. A fruitless run now ends with "tenants with recent activity: …", and a SKIP on a record-less tenant says "this tenant holds no records" rather than sending you back to the agent.

The SQL is tested on SQLite **and real Postgres 16**, which is where the `UNION ALL` bigint/integer unification and `coalesce(is_deleted, FALSE)` against a real boolean get checked. SQLite catches neither.

### It found a bug in its own first draft

The draft counted `ingest not stranded` as an evaluated row. That check **passes on an empty tenant**, so every wrong-tenant run had one PASS, exited 0 with "all evaluable rows pass (1 checked)", and the new hint was unreachable code. Only driving the real CLI surfaced it. `BEHAVIOURAL_CHECKS` now separates rows that need the agent to have done something, and exit 2 means what the docstring always claimed.

That is the same defect this whole sprint is about, reproduced inside the tool built to detect it.

## Two mutation lessons worth keeping

- One mutation reported "STILL GREEN" and it was a **stale `__pycache__` artifact**, not a weak test. Bytecode is keyed on (mtime, size), and back-to-back rewrites inside one second can hand pytest a stale `.pyc`. **Any mutation harness in this repo needs `PYTHONDONTWRITEBYTECODE=1`** — worth adopting, since mutation checks are now the standard here.
- A first attempted fix for `fetch_appointment_brief` (widening its `except`) did **not** flip its test, because the method never raises — it returns the wrong shape. The test refused a wrong fix, which is the property you actually want.

13/13 mutations red for #378; all five fix-groups flip their strict xfails for #294.

## Gates

2525 passed, 12 skipped, **59 xfailed** (baseline 2481/12/3 — the new xfails are the #294 characterizations). ruff clean, table stakes clean, conformance Grade A intact, **no `r6/` or `careagents/` production file touched** (verified by diff).

## Not covered

- CI's real-Postgres lane for the whole suite — three test modules were run against embedded Postgres (219 passed), not all 2525.
- `--list-tenants` against the **live Railway database**; validated on seeded local Postgres only.
- No browser pass. "Spinner forever" is traced from code, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)