### PR TITLE
fix(ingest): a dropped resource type has a name now (#377)

### DIFF
--- a/docs/2026-08-05-medicationstatement-support-decision.md
+++ b/docs/2026-08-05-medicationstatement-support-decision.md
@@ -1,0 +1,104 @@
+# MedicationStatement at ingest — what shipped, and what needs a ruling
+
+Issue #377. Written by Dev, for the CTO and Product. The issue asks for two
+things and they are separable. One shipped. One needs a decision this role
+does not hold.
+
+## What shipped
+
+An ingest that discards a resource now names the type it discarded.
+
+`skipped` was one integer covering every type the store does not keep. All
+three ingest paths reported it that way, so "which type did we drop?" had no
+answer in the audit trail or in the log. #377's own precondition — check the
+counters before building anything — could not be met with the counters we
+had.
+
+| Path | Where the answer appears now |
+| --- | --- |
+| `stream_ingest` (Fasten EHI export) | `fasten_import_complete` audit detail, plus the completion log line |
+| `_ingest_bundle` (SHC bridge) | `shc_import_complete` audit detail, the log line, and the returned counts |
+| `$ingest-context` | `skipped_count` and `skipped_types` in the 201 response, plus the audit detail |
+
+`POST /r6/fhir/internal/ingest-bundle` already named the type per entry
+(#227). It is unchanged.
+
+The type name is built from `_NAMEABLE_SKIPPED_TYPES`, a code-owned set in
+`r6/fasten/ingester.py`. `resourceType` is caller-supplied on every line of a
+real export, and audit `detail` is exported into the auditor-facing
+compliance bundle, so the name is constructed rather than repeated. An
+unlisted type counts under `other`. It still counts.
+
+## What did not ship, and why
+
+`MedicationStatement` is still not in `R6Resource.SUPPORTED_TYPES`.
+
+Adding it to the set is one line. Making it reach a patient is not, and
+shipping the one line alone makes the product worse in a specific way: the
+resource would be stored, no read surface would read it, and the skip
+counter that just started naming it would stop. A visible hole becomes an
+invisible one. That is the defect shape in `docs/2026-08-02-retro.md`, moved
+one layer down.
+
+### The half that is clean
+
+- The store keeps canonical JSON. It has no per-type schema.
+- `apply_redaction` walks fields, not types. It needs no profile.
+- `label_codings` is keyed by code. An RxNorm coding on a
+  `MedicationStatement` gets the same label it gets anywhere else.
+- The CapabilityStatement and the direct-upload allowlist both derive from
+  `SUPPORTED_TYPES`.
+- `r6/validator.py` needs a `_validate_medication_statement` for parity with
+  `MedicationRequest`. That is mechanical: status, medication, subject.
+
+### The half that is a modelling decision
+
+FHIR R6 separates the two on purpose. A `MedicationRequest` is an order. A
+`MedicationStatement` is a record of what the person actually takes. A
+patient asking "what am I on?" is asking about statements. A patient asking
+"what did my doctor prescribe?" is asking about requests. Both questions
+reach the same tool today.
+
+Three open questions, in order of how much they cost to get wrong.
+
+**1. Deduplication cannot be done by code alone.** A source that sends a
+request and a statement for the same drug has sent one medication. Two
+statements carrying the same RxNorm code may be a dose change over time, so
+collapsing them loses a real fact. Worst: a statement whose only
+identification is free text has no code to match on, and we cannot read that
+text — redaction strips it, correctly. Dedup by code therefore works on
+exactly the records we can already read and fails silently on the ones we
+cannot. That is the wrong failure direction for a medication list.
+
+**2. The intake form is the highest-stakes surface.** `r6/sdc/` populates the
+medication section from active `MedicationRequest` resources. A patient
+reviews and attests to that list. Changing where it draws from changes what
+a person signs. It needs a clinician's opinion, not a developer's.
+
+**3. The copy is Product's.** Two named groups in a chat answer means new
+patient-facing wording, thirteen days before the webinar, on an issue ranked
+P2 (`docs/2026-08-05-prioritized-backlog.md` row 19).
+
+## Recommendation
+
+**Store both. Keep them apart. Never merge them.**
+
+The double-counting question only exists if the two are flattened into one
+list, and flattening is the thing FHIR says not to do. Presenting them as two
+named groups answers "what am I taking?" honestly and needs no dedup rule.
+
+Sequenced:
+
+1. **Measure first.** Read the new `skipped_types` in
+   `fasten_import_complete` for live tenants. If no connected source sends
+   `MedicationStatement`, this stays a readiness gap and waits. The issue
+   asked for this check and it is now possible.
+2. **If a live feed sends it:** add the type, add the validator case, add it
+   to the `search_records` enum, and read it in `get_health_summary` under
+   its own key. Product owns the two labels the patient sees.
+3. **Leave the intake form on `MedicationRequest`** until a clinician rules
+   otherwise. The review card is the guardrail on that path and its source
+   should not change without one.
+
+Not recommended: a merged medication list, a dedup rule keyed on RxNorm, or
+any path that lets a statement stand in for a request.

--- a/r6/context_builder.py
+++ b/r6/context_builder.py
@@ -5,6 +5,7 @@ Ingests patient-centric Bundles and constructs bounded "context envelopes"
 with retention, redaction, and caching support.
 """
 
+import collections
 import json
 import logging
 import uuid
@@ -55,6 +56,15 @@ class ContextBuilder:
         # Store resources and collect items
         stored_resources = []
         context_items = []
+        # WHICH types we dropped, not just how many we kept. This is the one
+        # synchronous ingest path — the caller is holding the response — and
+        # it reported `resource_count` alone, so a bundle whose medications
+        # arrived as MedicationStatement looked identical to one that had no
+        # medications in it (#377). Imported here rather than at module level
+        # because `r6.fasten` pulls in its blueprint, which imports this
+        # module back.
+        from r6.fasten.ingester import safe_skipped_type
+        skipped_types: collections.Counter = collections.Counter()
 
         try:
             for entry in entries:
@@ -64,6 +74,7 @@ class ContextBuilder:
 
                 resource_type = resource.get('resourceType')
                 if not resource_type or not R6Resource.is_supported_type(resource_type):
+                    skipped_types[safe_skipped_type(resource)] += 1
                     logger.debug(f'Skipping unsupported resource type: {resource_type}')
                     continue
 
@@ -133,6 +144,8 @@ class ContextBuilder:
                 'patient_ref': patient_ref,
                 'encounter_ref': encounter_ref,
                 'resource_count': len(stored_resources),
+                'skipped_count': sum(skipped_types.values()),
+                'skipped_types': dict(skipped_types),
                 'expires_at': envelope.expires_at.isoformat(),
                 'items': context_items
             }

--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -8,10 +8,12 @@ Design:
 - Streams downloads (httpx streaming) to handle 30MB–3GB files without OOM
 - Runs in a daemon thread so the webhook handler returns 200 immediately
 - Commits progress every _PROGRESS_BATCH resources (avoids long DB locks)
-- Skips unsupported resource types gracefully (no crash, logged as skipped)
+- Skips unsupported resource types gracefully (no crash, counted per type
+  in the import summary so a dropped type is nameable — #377)
 - Runs Curatr evaluation post-ingestion for clinical resource types when
   FASTEN_CURATR_SCAN=true is set
 """
+import collections
 import json
 import logging
 import os
@@ -57,6 +59,81 @@ _RESOURCE_ID_PATTERN = re.compile(r'^[A-Za-z0-9\-\.]{1,255}$')
 # carrying an id outside the charset would be dropped, counted as a skip, and
 # reported as a successful import with nothing to page on (#293).
 REFUSED_OUTCOMES = frozenset({'invalid_id', 'forbidden'})
+
+# FHIR resource type names this code is willing to REPEAT.
+#
+# #363 gave a refusal a reason. A `skipped` stayed one integer covering every
+# type the store does not keep, so "which type did we drop?" had no answer in
+# the audit trail or the log. That is the #377 case: an EHR sending the
+# medication list as MedicationStatement looks exactly like an export that
+# carried a few hundred billing rows, and the issue's own precondition —
+# check the counters before building anything — could not be met.
+#
+# `resourceType` is caller-supplied on every line of an NDJSON export, and
+# audit `detail` is exported into the auditor-facing compliance bundle, so
+# the name is CONSTRUCTED from this set rather than filtered out of the feed
+# (docs/agent-task-guide.md §2, same rule as `_safe_unsupported_key`).
+# Anything not listed counts under UNNAMED_SKIPPED_TYPE — still counted,
+# never quoted. A type that later joins R6Resource.SUPPORTED_TYPES simply
+# stops reaching the skip branch, so an entry here going stale is harmless.
+UNNAMED_SKIPPED_TYPE = 'other'
+
+_NAMEABLE_SKIPPED_TYPES = frozenset({
+    # Medication semantics we do not store (#377)
+    'MedicationStatement', 'MedicationAdministration', 'MedicationKnowledge',
+    # Imaging, documents, raw attachments
+    'ImagingStudy', 'ImagingSelection', 'Media', 'Binary', 'Composition',
+    'DocumentManifest',
+    # Financial — usually the bulk of an EHI export by row count
+    'Claim', 'ClaimResponse', 'ExplanationOfBenefit', 'Account', 'Invoice',
+    'ChargeItem', 'PaymentNotice', 'PaymentReconciliation', 'Contract',
+    'EnrollmentRequest', 'EnrollmentResponse', 'InsurancePlan',
+    'CoverageEligibilityRequest', 'CoverageEligibilityResponse',
+    # Workflow, scheduling, orders
+    'Appointment', 'AppointmentResponse', 'Schedule', 'Slot', 'Task',
+    'Communication', 'CommunicationRequest', 'DeviceRequest',
+    'SupplyRequest', 'SupplyDelivery', 'VisionPrescription', 'NutritionOrder',
+    # Clinical types outside the stored set
+    'ClinicalImpression', 'DetectedIssue', 'RiskAssessment', 'AdverseEvent',
+    'BodyStructure', 'EpisodeOfCare', 'EncounterHistory', 'Flag', 'Device',
+    'DeviceUsage', 'DeviceUseStatement', 'Substance', 'MolecularSequence',
+    'GuidanceResponse', 'List', 'Group', 'Basic', 'Linkage',
+    # Directory, terminology, conformance
+    'Person', 'HealthcareService', 'Endpoint', 'Measure', 'MeasureReport',
+    'Library', 'ValueSet', 'CodeSystem', 'ConceptMap', 'NamingSystem',
+    'StructureDefinition', 'SearchParameter', 'OperationDefinition',
+    'CapabilityStatement', 'ImplementationGuide', 'Parameters',
+    'ResearchStudy', 'ResearchSubject', 'VerificationResult',
+})
+
+# How many distinct type names one summary may carry. An export can present
+# arbitrarily many. The summary is a signal, not an inventory, and audit
+# detail is read by humans.
+_SKIPPED_TYPES_IN_SUMMARY = 6
+
+
+def safe_skipped_type(resource: dict) -> str:
+    """The name we are willing to record for a resource we did not store."""
+    name = resource.get('resourceType')
+    if isinstance(name, str) and name in _NAMEABLE_SKIPPED_TYPES:
+        return name
+    return UNNAMED_SKIPPED_TYPE
+
+
+def skipped_type_summary(counts) -> str:
+    """Render `Type:n` pairs, most-skipped first, bounded.
+
+    Empty string when nothing was skipped, so a caller can append it
+    conditionally and a clean import's summary stays unchanged.
+    """
+    if not counts:
+        return ''
+    ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    shown = ordered[:_SKIPPED_TYPES_IN_SUMMARY]
+    rendered = ','.join(f'{name}:{n}' for name, n in shown)
+    if len(ordered) > len(shown):
+        rendered += f',+{len(ordered) - len(shown)}'
+    return rendered
 
 
 def log_refusal(log, where: str, tenant_id: str, resource: dict,
@@ -124,6 +201,7 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
         skipped = 0
         refused = 0
         failed = 0
+        skipped_types: collections.Counter = collections.Counter()
         curatr_eligible_ids: list[tuple[str, str]] = []  # (resource_type, resource_id)
 
         try:
@@ -164,6 +242,7 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
                                             tenant_id, resource, result)
                             else:
                                 skipped += 1
+                                skipped_types[safe_skipped_type(resource)] += 1
                         except json.JSONDecodeError:
                             failed += 1
                         except Exception as exc:
@@ -198,6 +277,11 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
             job.completed_at = datetime.now(timezone.utc)
             db.session.commit()
 
+            # WHICH types were dropped, not just how many. A bare count
+            # cannot tell an export full of billing rows apart from a feed
+            # whose entire medication list is a type we do not keep (#377).
+            types_summary = skipped_type_summary(skipped_types)
+
             record_audit_event(
                 event_type='fasten_import_complete',
                 agent_id='fasten-connect',
@@ -207,12 +291,15 @@ def stream_ingest(app, job_id: int, download_links: list, tenant_id: str) -> Non
                     f'job={job.task_id} '
                     f'ingested={ingested} skipped={skipped} '
                     f'refused={refused} failed={failed}'
+                    + (f' skipped_types={types_summary}'
+                       if types_summary else '')
                 ),
             )
             logger.info(
                 'Fasten job %s complete: ingested=%d skipped=%d '
-                'refused=%d failed=%d',
+                'refused=%d failed=%d skipped_types=%s',
                 job.task_id, ingested, skipped, refused, failed,
+                types_summary or '-',
             )
 
             # Optional: run Curatr quality scan on clinical resources. Best

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -1255,12 +1255,21 @@ def ingest_context():
             ), 401
 
     try:
+        from r6.fasten.ingester import skipped_type_summary
+
         result = context_builder.ingest_bundle(body, tenant_id=tenant_id)
+        # The types are code-owned names, never the feed's own string — see
+        # `safe_skipped_type`. A discard the audit trail cannot name is the
+        # #377 silence with a 201 on it.
+        types_summary = skipped_type_summary(result['skipped_types'])
         record_audit_event('create', 'Bundle', None,
                            agent_id=request.headers.get('X-Agent-Id'),
                            context_id=result['context_id'],
                            tenant_id=tenant_id,
-                           detail=f'ingested {result["resource_count"]} resources')
+                           detail=(f'ingested {result["resource_count"]} resources'
+                                   + (f'; skipped {result["skipped_count"]}: '
+                                      f'{types_summary}'
+                                      if types_summary else '')))
         return jsonify(result), 201
     except ValueError as e:
         return _operation_outcome('error', 'invalid', str(e)), 400

--- a/r6/shc/routes.py
+++ b/r6/shc/routes.py
@@ -34,6 +34,7 @@ Environment variables:
   SHC_BASE_URL          Where SmartHealthConnect is deployed (for Telegram links)
 """
 
+import collections
 import hmac
 import logging
 import os
@@ -258,6 +259,7 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str,
 
     with app.app_context():
         ingested = skipped = refused = failed = 0
+        skipped_types: collections.Counter = collections.Counter()
         curatr_eligible_ids: list[tuple[str, str]] = []
 
         for resource in entries:
@@ -274,6 +276,7 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str,
                                          tenant_id, resource, result)
                 else:
                     skipped += 1
+                    skipped_types[ingester.safe_skipped_type(resource)] += 1
             except Exception as exc:
                 failed += 1
                 # CRITICAL: roll back the failed flush so the session isn't
@@ -293,8 +296,12 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str,
                 logger.warning('SHC ingest error (job=%s): %s',
                                job_id, type(exc).__name__)
 
+        # `dict(...)` so a caller reading the counts cannot mutate the
+        # Counter, and so the returned shape is plain JSON-able data.
         counts = {'ingested': ingested, 'skipped': skipped,
-                  'refused': refused, 'failed': failed}
+                  'refused': refused, 'failed': failed,
+                  'skipped_types': dict(skipped_types)}
+        types_summary = ingester.skipped_type_summary(skipped_types)
         record_audit_event(
             event_type='shc_import_complete',
             agent_id=f'shc-{source}',
@@ -304,12 +311,14 @@ def _ingest_bundle(app, entries: list, tenant_id: str, source: str,
                 f'job={job_id} source={source} '
                 f'ingested={ingested} skipped={skipped} '
                 f'refused={refused} failed={failed}'
+                + (f' skipped_types={types_summary}' if types_summary else '')
             ),
         )
         logger.info(
             'SHC job %s complete: source=%s ingested=%d skipped=%d '
-            'refused=%d failed=%d',
+            'refused=%d failed=%d skipped_types=%s',
             job_id, source, ingested, skipped, refused, failed,
+            types_summary or '-',
         )
 
         curatr_issues = 0

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -347,3 +347,202 @@ def test_the_fasten_path_refuses_the_same_way_the_shc_path_does(app, caplog):
     assert "Jane Doe" not in joined and "MRN" not in joined, (
         "the refused id reached the log — it is refused precisely because "
         "it looks like this")
+
+
+# ---------------------------------------------------------------------------
+# #377: the other half of #293. A refusal is now named. A SKIP is not.
+# `skipped` is one integer covering every type this store does not keep, so
+# "which type did we drop?" has no answer anywhere — not in the audit trail,
+# not in the log. #377's own precondition is "check the ingest counters
+# before building anything", and the counters cannot be checked: an EHR that
+# sends the medication list as MedicationStatement is indistinguishable from
+# one whose export carried a few hundred ExplanationOfBenefit rows.
+#
+# The type name is the one caller-supplied field these tests care about, so
+# it goes through an allowlist that CONSTRUCTS (docs/agent-task-guide.md §2)
+# rather than being repeated verbatim — a real NDJSON line can put a name
+# there as readily as it can put one in an id.
+# ---------------------------------------------------------------------------
+def _ndjson_stream(lines):
+    """The httpx.stream context manager `stream_ingest` consumes."""
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            return iter(lines)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    return _Resp()
+
+
+def _run_fasten_ingest(app, task_id, resources, caplog):
+    """Drive the REAL Fasten path over an NDJSON export of `resources`.
+
+    A unit test over `_ingest_one` proves an outcome code. It cannot prove
+    the import summary carries it, which is the whole defect. Returns
+    (job, summary_audit_detail).
+    """
+    import json as _json
+    import logging
+    from unittest.mock import patch
+
+    from models import db
+    import r6.fasten.ingester as ingester_mod
+    from r6.fasten.models import FastenJob
+
+    lines = [_json.dumps(r) for r in resources]
+    seen: dict = {}
+
+    def capture(**kw):
+        if kw.get("event_type") == "fasten_import_complete":
+            seen.update(kw)
+
+    original = ingester_mod.record_audit_event
+    ingester_mod.record_audit_event = capture
+    try:
+        with app.app_context():
+            job = FastenJob(task_id=task_id, org_connection_id="c1",
+                            tenant_id="test-tenant", status="pending")
+            db.session.add(job)
+            db.session.commit()
+            job_id = job.id
+
+            with patch("r6.fasten.ingester.httpx.stream",
+                       return_value=_ndjson_stream(lines)), \
+                    caplog.at_level(logging.INFO):
+                ingester_mod.stream_ingest(
+                    app, job_id,
+                    ["https://download.example.invalid/e.ndjson"],
+                    "test-tenant")
+
+            db.session.expire_all()
+            return db.session.get(FastenJob, job_id), seen.get("detail", "")
+    finally:
+        ingester_mod.record_audit_event = original
+
+
+def test_a_skipped_medication_statement_is_named_in_the_import_summary(
+        app, caplog):
+    """#377. An EHR that records "what the patient is actually taking" as
+    MedicationStatement — many do, because a statement of current use is not
+    a prescription — has every one of those resources dropped at ingest.
+
+    The drop itself is a policy question. The SILENCE is not: the patient
+    asks their agent what they are taking and gets a confident answer over a
+    hole, and nobody operating the system can tell that the hole is there.
+    One integer cannot distinguish a feed sending medications we discard
+    from an export carrying a few hundred billing rows we never wanted.
+    """
+    job, detail = _run_fasten_ingest(app, "skip-named-job", [
+        {"resourceType": "Observation", "id": "skipnamed-ok-1",
+         "status": "final", "code": {"coding": [{"code": "x"}]}},
+        {"resourceType": "MedicationStatement", "id": "skipnamed-ms-1",
+         "status": "recorded"},
+        {"resourceType": "ExplanationOfBenefit", "id": "skipnamed-eob-1"},
+        {"resourceType": "ExplanationOfBenefit", "id": "skipnamed-eob-2"},
+    ], caplog)
+
+    assert job.ingested_resources == 1
+    assert job.skipped_resources == 3
+
+    assert "MedicationStatement:1" in detail, (
+        "the import summary counted three skips and named none of them — "
+        "#377's own precondition ('check the ingest counters') cannot be "
+        f"answered from {detail!r}")
+    assert "ExplanationOfBenefit:2" in detail, (
+        "a per-type count is what separates 'this feed sends medications we "
+        "drop' from 'this export was mostly billing'")
+    assert "MedicationStatement" in caplog.text, (
+        "an operator reading the job's completion log still cannot see it")
+
+
+def test_the_skipped_type_summary_cannot_carry_a_name_from_the_feed(
+        app, caplog):
+    """The allowlist half. `resourceType` is caller-supplied on every line of
+    a real export, so naming it back into audit detail is the reflection rule
+    (docs/agent-task-guide.md §2) with a different field — audit `detail` is
+    exported into the auditor-facing compliance bundle.
+
+    Unknown types still have to COUNT, or this trades one silence for
+    another.
+    """
+    job, detail = _run_fasten_ingest(app, "skip-unnamed-job", [
+        {"resourceType": "Jane Doe 1980-01-01 MRN 12345", "id": "un-1"},
+        {"resourceType": "MedicationStatement", "id": "un-ms-1"},
+    ], caplog)
+
+    assert job.skipped_resources == 2, "an unnameable type still gets counted"
+    assert "other:1" in detail, (
+        "the unknown type vanished from the summary instead of being "
+        "counted under a code-owned name")
+    for leak in ("Jane Doe", "MRN", "1980-01-01"):
+        assert leak not in detail, (
+            f"{leak!r} reached the audit detail — the type name was repeated "
+            "verbatim rather than constructed from the allowlist")
+        assert leak not in caplog.text, f"{leak!r} reached the log"
+
+
+def test_the_shc_path_names_skipped_types_the_same_way(app, tenant_id):
+    """Both ingest paths, one vocabulary — the #306 lesson. The SHC path is
+    the one that historically went years without a fix the Fasten path got.
+    """
+    from r6.shc import routes as shc
+
+    seen: dict = {}
+
+    def capture(**kw):
+        seen.update(kw)
+
+    import r6.shc.routes as shcmod
+    original = shcmod.record_audit_event
+    shcmod.record_audit_event = capture
+    try:
+        counts = shc._ingest_bundle(
+            app,
+            [{"resourceType": "Observation", "id": "shc-skipnamed-1",
+              "status": "final", "code": {"coding": [{"code": "x"}]}},
+             {"resourceType": "MedicationStatement", "id": "shc-ms-1"}],
+            tenant_id, "flexpa", "job377")
+    finally:
+        shcmod.record_audit_event = original
+
+    assert counts["ingested"] == 1 and counts["skipped"] == 1
+    assert counts["skipped_types"] == {"MedicationStatement": 1}, (
+        "the returned counts are the assertable surface (#293); a per-type "
+        "breakdown no test can read is the next version of the same defect")
+    assert "MedicationStatement:1" in seen.get("detail", "")
+
+
+def test_ingest_context_tells_its_caller_what_it_dropped(client, tenant_headers):
+    """The third ingest path, and the only SYNCHRONOUS one — the caller is
+    holding the response. It answered `resource_count: 1` for a two-entry
+    bundle and said nothing about the other entry, which is the same silence
+    with a 201 on it.
+    """
+    import json as _json
+
+    resp = client.post(
+        '/r6/fhir/Bundle/$ingest-context',
+        data=_json.dumps({
+            'resourceType': 'Bundle', 'type': 'collection',
+            'entry': [
+                {'resource': {'resourceType': 'Patient', 'id': 'ctx-pt-377'}},
+                {'resource': {'resourceType': 'MedicationStatement',
+                              'id': 'ctx-ms-377'}},
+            ],
+        }),
+        content_type='application/json', headers=tenant_headers)
+
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body['resource_count'] == 1
+    assert body['skipped_count'] == 1, (
+        "one of two entries was discarded and the response reported only "
+        "what it kept")
+    assert body['skipped_types'] == {'MedicationStatement': 1}

--- a/tests/test_r6_dashboard.py
+++ b/tests/test_r6_dashboard.py
@@ -380,7 +380,12 @@ class TestBundleEdgeCases:
         assert resp.status_code == 400
 
     def test_bundle_with_unsupported_resources_skips_them(self, client, tenant_headers):
-        """Unsupported resource types in a Bundle should be silently skipped."""
+        """Unsupported resource types in a Bundle are skipped, not stored.
+
+        The skip is reported rather than silent — see
+        tests/test_ingest_resilience.py::test_ingest_context_tells_its_caller_what_it_dropped
+        for the `skipped_count` / `skipped_types` half (#377).
+        """
         bundle = {
             'resourceType': 'Bundle', 'type': 'collection',
             'entry': [


### PR DESCRIPTION
Closes part of #377.

## The defect

`R6Resource.is_supported_type("MedicationStatement")` is `False`, so an EHR
that records "what the patient is actually taking" that way has those
resources dropped at ingest. The patient asks their agent what they are on
and gets a confident answer over a hole.

#363 gave a **refusal** a reason. A **skip** stayed one integer covering
every type the store does not keep. So "which type did we drop?" had no
answer in the audit trail or the log — including for the check #377 itself
asks for before any code gets written ("check the ingest counters ... if no
live feed uses it, this is a readiness gap").

## What this PR does

Every ingest path that discards a resource now names the type.

| Path | Where the answer appears |
| --- | --- |
| `stream_ingest` (Fasten EHI export) | `fasten_import_complete` audit detail + completion log line |
| `_ingest_bundle` (SHC bridge) | `shc_import_complete` audit detail, log line, and the returned counts |
| `$ingest-context` | `skipped_count` / `skipped_types` on the 201, plus audit detail |

`POST /r6/fhir/internal/ingest-bundle` already named the type per entry
(#227) and is unchanged.

Example audit detail:

```
job=<task> ingested=1 skipped=3 refused=0 failed=0 skipped_types=ExplanationOfBenefit:2,MedicationStatement:1
```

**The name is constructed, not repeated.** `resourceType` is caller-supplied
on every line of an NDJSON export, and audit `detail` is exported into the
auditor-facing compliance bundle. `safe_skipped_type` builds the name from
`_NAMEABLE_SKIPPED_TYPES`, a code-owned set — the reflection rule
(`docs/agent-task-guide.md` §2), same shape as `_safe_unsupported_key`. An
unlisted type counts under `other`. It still counts.

## What this PR does NOT do, deliberately

`MedicationStatement` is still not in `SUPPORTED_TYPES`.

Adding it is one line, and the line alone makes things worse: the resource
would be stored where no read surface reads it, and the counter that just
started naming it would go quiet. A visible hole becomes an invisible one —
the `docs/2026-08-02-retro.md` defect shape, one layer down.

The store half is clean (type-agnostic JSON, field-based redaction,
code-keyed labels). The read half is not:

- **Dedup cannot be done by code alone.** A request plus a statement for the
  same drug is one medication. Two statements with the same RxNorm code may
  be a dose change. A statement identified only by free text has no code to
  match on and we cannot read that text — redaction strips it, correctly. So
  dedup by code works on the records we can already read and fails silently
  on the ones we cannot.
- **The intake form is the high-stakes surface.** `r6/sdc/` populates
  medications from active `MedicationRequest`. A patient signs that list.
- **The copy is Product's**, 13 days out, on a P2 row.

Recommendation, written up in
`docs/2026-08-05-medicationstatement-support-decision.md`: **store both, keep
them apart, never merge.** Measure with the new counters first — if no live
feed sends `MedicationStatement`, this stays a readiness gap.

## Proof

Tests drive the **real** path: an NDJSON export carrying a
`MedicationStatement` goes through `stream_ingest`, not a fake ingester.

**Mutation** (`PYTHONDONTWRITEBYTECODE=1`, red observed, restored):

1. `safe_skipped_type` returns `UNNAMED_SKIPPED_TYPE` unconditionally →
   **3 failed**. Nothing is ever named.
2. `safe_skipped_type` returns the feed's `resourceType` verbatim →
   **1 failed**, with `skipped_types=Jane Doe 1980-01-01 MRN 12345:1` in the
   audit detail. That is the leak the allowlist exists to stop.
3. Drop the ` skipped_types=` clause from the Fasten summary → **2 failed**.
   The count survives, the answer does not.

## Definition of done

- [x] `uv run python -m pytest tests/ -q` → **2485 passed, 12 skipped, 3 xfailed** (baseline on `main`: 2481 passed)
- [x] `uv run ruff check .` → **All checks passed!**
- [x] Conformance **Grade A** — `tests/test_guardrail_conformance.py` 28 passed
- [x] Write-guard matrix: 173 passed, 6 skipped, 3 xfailed — **0 failed, 0 xpassed**
- [x] Negative test present: the type name from the feed never reaches audit detail or log
- [x] No caller/backend text reflected into errors, warnings, or audit detail
- [x] No new query added
- [x] Signed off (`git commit -s`)

Node untouched. Synthetic test data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
