### PR TITLE
docs: one connector URL on the page, and the wrong one is no longer copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ curl "https://app.healthclaw.io/r6/fhir/\$conformance?format=text"
 Point any MCP client at the **public demo server** — URL `https://mcp-demo-production-ee2c.up.railway.app/mcp`,
 no key required — then ask: *"Search my health records for lab results and explain them in plain
 language."* The demo server is unauthenticated but hard-pinned to a synthetic demo tenant, so it can
-only ever serve fake data. The **production endpoint** (`https://mcp-server-production-5112.up.railway.app/mcp`)
-requires a deployment-scoped `Authorization: Bearer <token>` — real records stay behind auth, always.
+only ever serve fake data. A separate **production endpoint** (`mcp-server-production-5112`) requires a
+deployment-scoped `Authorization: Bearer <token>` — real records stay behind auth, always. Hosted
+connectors cannot attach that header, so the demo URL above is the one to paste.
 One-command installs:
 `gemini extensions install https://github.com/aks129/HealthClawGuardrails` ·
 `claude plugin marketplace add aks129/HealthClawGuardrails` ·

--- a/docs/quickstarts/README.md
+++ b/docs/quickstarts/README.md
@@ -4,23 +4,29 @@ HealthClaw Guardrails is a remote MCP server. Any agent that speaks MCP can
 connect to it and work with health records behind enforced guardrails (PHI
 redaction, audit trail, human-in-the-loop, disclaimers).
 
-**Connector URL (public demo server):**
+## The connector URL
+
+There is exactly one URL to paste. This is it:
 
 ```text
 https://mcp-demo-production-ee2c.up.railway.app/mcp
 ```
 
-No API key needed: this server is hard-pinned to the `desktop-demo` tenant — a
-synthetic demo patient panel with realistic conditions, labs, immunizations,
-and medications. **Nothing in it is real patient data, which makes it safe to
-demo on camera.**
+No API key. No Client ID. If your agent asks for either one, you have the wrong
+URL: see [Troubleshooting](claude.md#troubleshooting).
 
-Real records live on a separate production endpoint
-(`https://mcp-server-production-5112.up.railway.app/mcp`) that requires a
-deployment-scoped `Authorization: Bearer <token>` and returns 401 without one.
-Don't paste that URL into a hosted connector — it cannot attach the header, and
-the sign-in step will fail. See
-[mcp-generic.md](mcp-generic.md#tenancy-and-auth).
+The server is hard-pinned to the `desktop-demo` tenant, a synthetic patient
+panel with conditions, labs, immunizations, and medications. **None of it is
+real patient data, so it is safe to record.**
+
+### There is a second server, and you do not want it
+
+Real records live on a separate production endpoint, `mcp-server-production-5112`.
+It requires a deployment-scoped bearer token and answers 401 without one. Hosted
+connectors cannot attach that header, so pasting it produces a sign-in loop that
+cannot succeed. The full URL is deliberately not printed here, because the only
+reason to copy it from this page would be by mistake. See
+[mcp-generic.md](mcp-generic.md#tenancy-and-auth) for the tenancy model.
 
 ## Pick your agent
 


### PR DESCRIPTION
Our beta tester (a physician recording the launch demo) read the quickstart, saw two URLs, and had to ask which was current. That is the **second** time this page has cost her time. The first was a stale URL that pointed her at the token-locked server, where the 401 made Claude hunt for OAuth endpoints that do not exist.

The URLs were already correct. The page still printed the production endpoint as a complete, copy-pasteable string one paragraph below the demo one, under a heading that did not say "do not use this."

## Changes

- **`docs/quickstarts/README.md`** — the demo URL gets its own section, headed "There is exactly one URL to paste." The production endpoint is named (`mcp-server-production-5112`) but its full URL is no longer printed, with a line saying why. Adds the symptom to look for: an agent asking for an API key or a Client ID means the wrong URL.
- **`README.md`** — same treatment, plus the reason hosted connectors cannot use it.
- **`mcp-generic.md`** — unchanged. It keeps both names in its tenancy comparison table, which is the one place a reader is deliberately comparing the two.

## Verification

69 doc-drift tests pass. No test pinned the printed production URL, so nothing needed flipping. `uv run ruff check .` clean.

The demo URL was confirmed live against the running server while reviewing her demo plan: `initialize` returns `healthclaw-guardrails 1.9.0`, and the tenant is the synthetic `desktop-demo` panel.