### PR TITLE
fix(careagents): a 504 on confirm is not a refusal (#416)

### DIFF
--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -43,6 +43,10 @@ class HealthClawUnconfirmed(HealthClawError):
     that only knows about HealthClawError still catches it and degrades to
     "failed" — which is why callers that can act on the difference must catch
     this FIRST.
+
+    Silence is not only an absent response. A gateway 502/503/504 is a
+    response, and a 200 carrying an interstitial is a response, but neither is
+    the ENGINE's answer (#416).
     """
 
 
@@ -110,6 +114,22 @@ class HealthClawClient:
             raise HealthClawError(f"{what} returned invalid data",
                                   r.status_code)
         return body
+
+    @staticmethod
+    def _upstream_answered(status: int) -> bool:
+        """Whether `status` is the ENGINE's own decision about the request.
+
+        A 4xx other than 408/429 is an answer: either the engine declined, or
+        an edge rejected the request before delivering it. Nothing ran either
+        way, so a caller may say so.
+
+        Everything else — 5xx, 408, 429 — is a gateway speaking on the
+        upstream's behalf, quite possibly after the request was already
+        delivered and executed. It is silence with a status code on it. For a
+        call with no side effect that distinction does not matter; for one
+        that can execute a clinical action it is the whole of #416.
+        """
+        return 400 <= status < 500 and status not in (408, 429)
 
     # --- tenant lifecycle ---------------------------------------------------
 
@@ -306,6 +326,11 @@ class HealthClawClient:
         confirm never went out — a refusal. The confirm POST is the one that
         can execute a clinical action, so losing its answer is NOT evidence
         that nothing happened.
+
+        "Losing the answer" is wider than a dropped socket, which is the gap
+        #416 closed: a gateway status (5xx, 408, 429) and a 200 whose body
+        will not decode are both responses that say nothing about what the
+        engine did. Only `_upstream_answered` is a refusal.
         """
         # Nothing was confirmed if this fails: we never reached the confirm.
         mint = self._send(
@@ -330,9 +355,24 @@ class HealthClawClient:
                        json={"approved_via": "review-page"},
                        what="confirm", error=HealthClawUnconfirmed)
         if not r.ok:
+            if not self._upstream_answered(r.status_code):
+                # An edge 502/503/504 IS a response, so `_send` handed it
+                # back — but it is not the engine's, and the confirm may
+                # already have run. Filing it as a refusal is what told a
+                # patient "nothing has been sent, please try approving again"
+                # for an action the engine had executed (#416).
+                raise HealthClawUnconfirmed(
+                    f"confirm unanswered ({r.status_code})", r.status_code)
             raise HealthClawError(f"confirm failed ({r.status_code})",
                                   r.status_code)
-        return self._json_object(r, "confirm")
+        try:
+            return self._json_object(r, "confirm")
+        except HealthClawError as exc:
+            # Same rule on the success side: something answered 200, and a
+            # body we cannot read says nothing about whether the engine
+            # executed. Only a decodable answer is a confirmation.
+            raise HealthClawUnconfirmed("confirm returned invalid data",
+                                        r.status_code) from exc
 
     # --- review-page relay (credential-injecting proxy) ----------------------
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -233,6 +233,12 @@ def test_review_submit_does_not_claim_nothing_was_sent_when_it_cannot_tell(
     Answering "Nothing has been sent — please try approving again" is as
     unobserved as the old "confirmed". The engine may already be executing the
     action, and a person who follows that instruction sends it twice.
+
+    This fake raises HealthClawUnconfirmed itself, so it proves the ROUTE
+    handles it and can never prove the client produces it — which is half of
+    why #416 survived a suite that looked like it covered this. The other half
+    is in tests/test_healthclaw_transport.py, where the real client meets a
+    real 504 over a real socket.
     """
     from careagents.app import create_app
     from careagents.healthclaw import HealthClawUnconfirmed
@@ -300,7 +306,11 @@ def test_confirm_action_separates_a_refusal_from_an_unanswered_confirm():
         client_with(requests.ReadTimeout("read timed out")).confirm_action(
             "t", "a1")
 
-    # An observed rejection stays an ordinary failure.
+    # An observed rejection stays an ordinary failure. 409 is a status the
+    # ENGINE answers with, so this assertion is true — and it says nothing
+    # about the statuses a gateway produces on the engine's behalf. A 504 took
+    # this same branch all through #416. Which statuses mean what is
+    # classified in tests/test_healthclaw_transport.py, against a real socket.
     class _Refused:
         ok, status_code = False, 409
 

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -39,7 +39,8 @@ import time
 import pytest
 import requests
 
-from careagents.healthclaw import HealthClawClient, HealthClawError
+from careagents.healthclaw import (HealthClawClient, HealthClawError,
+                                   HealthClawUnconfirmed)
 
 # The discard port: nothing listens, so connect() fails immediately.
 DEAD_BASE = "http://127.0.0.1:9"
@@ -56,22 +57,35 @@ class _Mode:
         self.body = b'{"ok": 1}'
         self.ctype = "application/json"
         self.delay = 0.0
+        # `confirm_action` mints an approval token before it confirms. With
+        # this set the mint is answered normally whatever the rest of the mode
+        # says, so the mode describes the confirm POST itself — otherwise
+        # every confirm case below would fail in the mint and never reach the
+        # call it names.
+        self.mint_ok = False
 
 
 MODE = _Mode()
+
+MINTED = b'{"token": "approval-token"}'
 
 
 class _Handler(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def _serve(self):
+        if MODE.mint_ok and self.path.endswith("/approval-token"):
+            return self._write(200, MINTED, "application/json")
         if MODE.delay:
             time.sleep(MODE.delay)
-        self.send_response(MODE.status)
-        self.send_header("Content-Type", MODE.ctype)
-        self.send_header("Content-Length", str(len(MODE.body)))
+        self._write(MODE.status, MODE.body, MODE.ctype)
+
+    def _write(self, status, body, ctype):
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
         self.end_headers()
-        self.wfile.write(MODE.body)
+        self.wfile.write(body)
 
     do_GET = do_POST = _serve
 
@@ -120,8 +134,10 @@ def _client(base):
     return c
 
 
-def _set(status=200, body=b'{"ok": 1}', ctype="application/json", delay=0.0):
+def _set(status=200, body=b'{"ok": 1}', ctype="application/json", delay=0.0,
+         mint_ok=False):
     MODE.status, MODE.body, MODE.ctype, MODE.delay = status, body, ctype, delay
+    MODE.mint_ok = mint_ok
 
 
 # --------------------------------------------------------------------------
@@ -357,6 +373,106 @@ def test_worker_health_type_checks_its_200_body(stub_base, reset_mode):
     _set(status=200, body=b'"just-a-string"')
     with pytest.raises(HealthClawError):
         _client(stub_base).agent_worker_health()
+
+
+# --------------------------------------------------------------------------
+# A confirm that was never answered — with a status code on it
+# --------------------------------------------------------------------------
+# `confirm_action` is the one call on this seam that can EXECUTE a clinical
+# action, so what it raises decides what a patient is told after they approve.
+# #220 typed the case where no response arrives at all. #416 is the case a
+# gateway answers instead: an edge 502/503/504 IS a response, so `_send`
+# returns it and `if not r.ok` filed it as a refusal — "Nothing has been sent,
+# please try approving again", for an action the engine had already run. QA
+# drove that against a live engine and watched the action move
+# awaiting_confirmation -> failed while the patient was told to approve again.
+#
+# So the question is never "was it 2xx". It is what the status says about the
+# UPSTREAM: only an engine that answered and declined is a refusal.
+
+GATEWAY_BODY = b"<html><body>gateway</body></html>"
+
+
+def test_a_confirmed_action_returns_the_engines_answer(stub_base, reset_mode):
+    """Positive control. Without it every case below could be passing because
+    the confirm never reaches the stub at all."""
+    _set(status=200, body=b'{"status": "confirmed"}', mint_ok=True)
+    assert _client(stub_base).confirm_action("t", "a1") == {
+        "status": "confirmed"}
+
+
+@pytest.mark.parametrize("status", (408, 429, 500, 502, 503, 504))
+def test_a_confirm_a_gateway_answered_is_not_a_refusal(status, stub_base,
+                                                       reset_mode):
+    """A 504 is the production shape of "we do not know", not of "no".
+
+    The edge answers on the upstream's behalf after the request was already
+    delivered, so the confirm may have executed. Reporting it as a refusal
+    tells the patient nothing was sent and invites a second approval, which on
+    the human-approval path is an instruction to double-execute.
+
+    MUTATION: raise `HealthClawError` for 5xx in `confirm_action` -> red here
+    for 500/502/503/504. Ran it with PYTHONDONTWRITEBYTECODE=1, saw red.
+    """
+    _set(status=status, body=GATEWAY_BODY, ctype="text/html", mint_ok=True)
+    with pytest.raises(HealthClawUnconfirmed):
+        _client(stub_base).confirm_action("t", "a1")
+
+
+@pytest.mark.parametrize("status", (400, 401, 403, 404, 409, 410, 422))
+def test_a_confirm_the_engine_declined_stays_a_refusal(status, stub_base,
+                                                       reset_mode):
+    """The other half, and the half that made the old bug invisible: a 4xx is
+    an answer. Either the engine declined or an edge rejected the request
+    before delivering it — nothing ran either way, so "nothing has been sent,
+    try approving again" is true and must keep being said.
+    """
+    _set(status=status, body=b'{"error": "not awaiting confirmation"}',
+         mint_ok=True)
+    err = pytest.raises(HealthClawError,
+                        _client(stub_base).confirm_action, "t", "a1")
+    assert not isinstance(err.value, HealthClawUnconfirmed)
+
+
+def test_a_confirm_answered_200_but_unreadable_is_not_a_refusal(stub_base,
+                                                                reset_mode):
+    """The narrower sibling. A 200 carrying a proxy's HTML interstitial is not
+    a decline either, and `_json_object` raising plain `HealthClawError`
+    produced the same "Nothing has been sent" message.
+
+    MUTATION: decode with a bare `self._json_object(r, "confirm")` -> red.
+    Ran it with PYTHONDONTWRITEBYTECODE=1, saw red.
+    """
+    _set(status=200, body=NON_JSON_BODY, ctype="text/html", mint_ok=True)
+    with pytest.raises(HealthClawUnconfirmed):
+        _client(stub_base).confirm_action("t", "a1")
+
+
+def test_a_confirm_answered_by_nobody_stays_unconfirmed(stub_base,
+                                                        reset_mode):
+    """#220's own case, kept green here rather than only in the route test.
+
+    The POST is on the wire and the read times out. This is the path
+    `_send(error=HealthClawUnconfirmed)` already covers; regressing it
+    reintroduces the defect the rest of this section generalizes.
+    """
+    _set(delay=SLOW_ENOUGH_TO_TIME_OUT, mint_ok=True)
+    with pytest.raises(HealthClawUnconfirmed):
+        _client(stub_base).confirm_action("t", "a1")
+
+
+def test_a_lost_approval_mint_is_a_refusal_and_not_silence(stub_base,
+                                                           reset_mode):
+    """The mint runs BEFORE the confirm and has no side effect on the action
+    (`issue_action_approval_token` reads it and signs a token), so losing its
+    answer means the confirm never went out. Nothing executed, "try approving
+    again" is the correct instruction, and the classification must not flatten
+    that in the other direction to make the 504 case pass.
+    """
+    _set(status=504, body=GATEWAY_BODY, ctype="text/html")
+    err = pytest.raises(HealthClawError,
+                        _client(stub_base).confirm_action, "t", "a1")
+    assert not isinstance(err.value, HealthClawUnconfirmed)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #416.

## The defect

`careagents/healthclaw.py:332` treated every non-2xx confirm response as a
refusal. `_send(error=HealthClawUnconfirmed)` covers the case where **no
response arrives**; a gateway 502/503/504 *is* a response, so `_send` returned
it and `if not r.ok` filed it as an engine decision. QA drove it against a live
engine with a fault proxy: the action moved `awaiting_confirmation -> failed`,
the confirm had executed, and the patient got *"Nothing has been sent — please
try approving again."* On the human-approval path, for a clinical action, that
is an instruction to double-execute — the harm #220 exists to prevent, through
a door #220 did not close.

## The fix

Classify by what the status says about the **upstream**, not by whether it is
2xx. `HealthClawClient._upstream_answered` is true only for a 4xx other than
408/429 — either the engine declined, or an edge rejected the request before
delivering it, and nothing ran either way.

| Response | Type |
|---|---|
| 2xx, parseable | return |
| 2xx, unparseable | `HealthClawUnconfirmed` |
| 4xx except 408/429 | `HealthClawError` |
| 408, 429, 5xx | `HealthClawUnconfirmed` |
| no response | `HealthClawUnconfirmed` (unchanged) |

**Scope check.** `confirm_action` is the only method that needed it.
`r6/actions/routes.py:439` names confirm "the ONLY place an action executes";
commit is `SUBMIT-FOR-CONFIRMATION` and `issue_action_approval_token` reads the
action and signs a token. Losing either answer leaves nothing executed, so both
stay `HealthClawError` — pinned by
`test_a_lost_approval_mint_is_a_refusal_and_not_silence`, so the classification
cannot be widened in the other direction to make the 504 case pass.

## The tests

The suite looked like it covered this and did not, which is the more
transferable finding:

- `tests/test_careagents.py` used `status_code = 409` as its "observed
  rejection". True, and it generalizes silently to statuses that are not
  answers — a 504 took that branch all through this bug.
- the route test's fake **raises `HealthClawUnconfirmed` itself**, so it proves
  the route handles the exception and can never prove the client produces it.

New cases drive the **real client** against the real socket stub in
`tests/test_healthclaw_transport.py` — 408/429/500/502/503/504 and a
200-with-HTML produce `HealthClawUnconfirmed`; 400/401/403/404/409/410/422 stay
`HealthClawError`; the timeout case stays green so the #220 path cannot regress;
a positive control proves the confirm reaches the stub at all. The stub answers
the approval-token mint separately, or every case would fail in the mint and
never reach the call it names. Both older tests keep their shape and gained a
note saying what they do not prove.

## MUTATION

Each run with `PYTHONDONTWRITEBYTECODE=1` and confirmed red:

- `_upstream_answered` returns `status >= 400 and status not in (408, 429)`
  (5xx back to `HealthClawError`) ->
  `test_a_confirm_a_gateway_answered_is_not_a_refusal[500/502/503/504]`,
  4 failed with `HealthClawError: confirm failed (504)`
- decode with a bare `self._json_object(r, "confirm")` ->
  `test_a_confirm_answered_200_but_unreadable_is_not_a_refusal`

## Definition of done

- [x] `uv run python -m pytest tests/ -q` — **2684 passed, 12 skipped, 1 xfailed**
- [x] `uv run ruff check .` — clean
- [x] Conformance **Grade A** (`tests/test_guardrail_conformance.py`, 35 passed)
- [x] Negative tests included (the 4xx rows, and the mint row)
- [x] No caller/backend text reflected — the raised messages carry the status
      code only
- [x] No Node changes
- [x] Signed off

Not deployed. Not merged.
