### PR TITLE
fix(caregaps): a reason that blames the record, and a partial list sold as whole (#417)

### DIFF
--- a/careagents/agent.py
+++ b/careagents/agent.py
@@ -357,7 +357,19 @@ def _execute_tool(hc: HealthClawClient, tenant: str, name: str,
         gaps = hc.care_gaps(tenant)
         consumer = gaps.get("consumer") or {}
         out = {"consumer_summary": consumer}
-        if consumer.get("unevaluated"):
+        if consumer.get("unevaluated") and consumer.get("lines"):
+            # Some rules were decided and some were not (#417). The
+            # could-not-run note below would suppress the real due screenings
+            # in `lines`; no note at all would sell four screenings as the
+            # whole answer. Neither, so the partial case says it is partial.
+            out["note"] = (
+                "This preventive-care answer is PARTIAL: "
+                f"{consumer.get('unevaluated_count')} screening(s) could not "
+                f"be checked — reason: {consumer['unevaluated']}. Report the "
+                "lines you were given AND say, using unevaluated_note, which "
+                "screenings were not checked and why. Do not describe an "
+                "unchecked screening as up to date or as not due.")
+        elif consumer.get("unevaluated"):
             # The check produced no lines because it could not run, not
             # because nothing is outstanding. Those two arrive here looking
             # identical, and the second was being read out to people as the

--- a/r6/caregaps/evaluate.py
+++ b/r6/caregaps/evaluate.py
@@ -11,7 +11,13 @@ Honesty posture (matches the lab interpreter):
   abnormal results, pregnancy) legitimately changes cadence — noted in output.
 - "Due" means no satisfying record was found in the CONNECTED data. It is NOT a
   claim the screening wasn't done elsewhere — the consumer wording says so.
-- Missing age/sex → `indeterminate`, never a false "due".
+- Missing age/sex → `indeterminate`, never a false "due". Each such result also
+  carries `indeterminate_reason` naming WHICH demographic was missing, because
+  the consumer summary quotes it back to the person and a reason covering both
+  is a false claim about the one that was on file (#417). It says what THIS
+  CALL was given, not what the record holds: a caller that passes no patient
+  gets `birth-date-unknown` on every rule, and report.py is careful not to
+  read that as a statement about the person's data.
 """
 
 from __future__ import annotations
@@ -233,6 +239,7 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
         # Age gate — unknown age on an age-gated rule is indeterminate, never a false due
         if age is None:
             results.append({**base, "applicable": None, "status": "indeterminate",
+                            "indeterminate_reason": "birth-date-unknown",
                             "note": "date of birth unknown — cannot determine eligibility"})
             continue
         if not (applies["min_age"] <= age <= applies["max_age"]):
@@ -241,6 +248,7 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
             continue
         if applies["sex"] and not gender:
             results.append({**base, "applicable": None, "status": "indeterminate",
+                            "indeterminate_reason": "sex-unknown",
                             "note": "sex not recorded — cannot determine eligibility"})
             continue
 

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -12,10 +12,15 @@ _CONSUMER_NOTE = (
     "records may be incomplete, so confirm anything here with your "
     "clinician.")
 
-# Why the consumer list came back empty, in the person's own words. One entry
-# per reason; the reason itself travels as `unevaluated` so a caller can
-# branch on it without matching prose.
-_UNEVALUATED_NOTES = {
+# Why part or all of the consumer list is missing, in the person's own words.
+# The reason itself travels as `unevaluated` so a caller can branch on it
+# without matching prose.
+#
+# CALLER reasons — the caller knows the rules never got a record to read, and
+# the engine cannot see that. Nothing here describes the person's data,
+# because nothing of their data was looked at. Fixed prose: there is no
+# finding to report.
+_NOT_EVALUATED_NOTES = {
     "no-patient": (
         "There is no patient record connected here yet, so this check had "
         "nothing to read. Nothing was examined, and that is not a finding "
@@ -24,11 +29,31 @@ _UNEVALUATED_NOTES = {
         "More than one patient record is connected here, so this check could "
         "not tell whose preventive care to look at. Nothing was examined, "
         "and that is not a finding that you have no screenings outstanding."),
-    "demographics-unavailable": (
-        "Your date of birth and sex were not available to this check, so it "
-        "could not work out which screenings apply to you. That is not a "
-        "finding that you have no screenings outstanding."),
+    "check-incomplete": (
+        "This check could not be completed for your record right now, so "
+        "nothing here was decided either way. That is a limit on the check "
+        "and not something found in your record, and it is not a finding "
+        "that you have no screenings outstanding."),
 }
+
+# ENGINE reasons — the rules did read a record and could not decide. Only
+# valid on that path, and the clause names ONLY what was missing from it. One
+# `demographics-unavailable` covering every case told a person whose birthDate
+# was on file that it was not; a sharper reason on a record we never opened is
+# the same false statement with better aim (#417).
+_DEMOGRAPHIC_REASONS = {
+    frozenset({"birth-date-unknown"}): (
+        "birth-date-unavailable",
+        "your date of birth was not available to this check"),
+    frozenset({"sex-unknown"}): (
+        "sex-unavailable",
+        "your sex was not recorded in the records this check can read"),
+}
+# Both missing, or a cause the engine did not record. Claims more than either
+# of the above, so it is the fallback and never the common path.
+_UNKNOWN_DEMOGRAPHICS = (
+    "demographics-unavailable",
+    "your date of birth and sex were not available to this check")
 
 
 def build_caregaps_summary(results):
@@ -57,27 +82,60 @@ def _consumer_line(r):
     return None
 
 
-def _unevaluated_reason(results, unresolved):
-    """Why there are no consumer lines, or None when the emptiness is a finding.
+def _name_all(titles):
+    if len(titles) == 1:
+        return titles[0]
+    return f"{', '.join(titles[:-1])} and {titles[-1]}"
+
+
+def _demographics_marker(undecided, titles):
+    """Reason + prose for rules that DID read a record and could not decide."""
+    causes = frozenset(
+        r.get("indeterminate_reason") for r in undecided) - {None}
+    reason, cause = _DEMOGRAPHIC_REASONS.get(causes, _UNKNOWN_DEMOGRAPHICS)
+    n = len(undecided)
+    noun, pronoun = ("screening", "it is") if n == 1 else ("screenings", "they are")
+    named = f": {_name_all(titles)}" if titles else ""
+    return reason, (
+        f"{n} {noun} could not be checked because {cause}{named}. That is not "
+        f"a finding that {pronoun} up to date.")
+
+
+def _unevaluated_marker(results, not_evaluated):
+    """What was not evaluated and why, or None when the answer is whole.
 
     An empty list is ambiguous by construction: "we looked and nothing is
     outstanding" and "we never got far enough to look" render identically,
     and the second was reaching patients as the first (#389, after #379 and
-    #381). So the reason travels with the emptiness. Same posture as
-    r6/labs/interpret.py `_indeterminate` — say what could not be decided
-    rather than emitting a clean result.
+    #381). Same posture as r6/labs/interpret.py `_indeterminate` — say what
+    could not be decided rather than emitting a clean result.
+
+    A caller reason OUTRANKS the rules' own causes, and that ordering is the
+    whole point. When no record reached the engine, every rule reports the
+    date of birth as unknown — an artefact of the call, not a fact about the
+    person. Quoting it back produced "Your date of birth and sex were not
+    available to this check" for records holding both (#417). While we are not
+    looking at someone's demographics, no reason we give about their
+    demographics can be true, however precisely aimed.
     """
-    if unresolved:
-        return unresolved
-    if any(r.get("status") == "indeterminate" for r in results):
-        return "demographics-unavailable"
-    return None
+    undecided = [r for r in results if r.get("status") == "indeterminate"]
+    if not not_evaluated and not undecided:
+        return None
+    titles = [r["title"] for r in undecided if r.get("title")]
+    if not_evaluated:
+        reason, note = not_evaluated, _NOT_EVALUATED_NOTES[not_evaluated]
+    else:
+        reason, note = _demographics_marker(undecided, titles)
+    return {"unevaluated": reason, "unevaluated_count": len(undecided),
+            "unevaluated_titles": titles, "unevaluated_note": note}
 
 
-def build_consumer_summary(results, unresolved=None):
-    """`unresolved` is the subject-resolution failure, if any — the caller
-    knows about it and the engine cannot see it, since an unidentifiable
-    patient produces exactly the same rule results as a healthy one."""
+def build_consumer_summary(results, not_evaluated=None):
+    """`not_evaluated` is the caller's reason the rules never got a record to
+    read — no patient, an ambiguous one, or a resolved one the route did not
+    hand over. The caller knows all three and the engine can see none of them,
+    since an unidentifiable patient produces exactly the rule results a
+    healthy one does."""
     lines = []
     for r in results:
         if r.get("status") in ("due", "up_to_date"):
@@ -86,8 +144,7 @@ def build_consumer_summary(results, unresolved=None):
                 lines.append(line)
     out = {"lines": lines, "note": _CONSUMER_NOTE}
     if not lines:
-        reason = _unevaluated_reason(results, unresolved)
-        if reason:
-            out["unevaluated"] = reason
-            out["unevaluated_note"] = _UNEVALUATED_NOTES[reason]
+        marker = _unevaluated_marker(results, not_evaluated)
+        if marker:
+            out.update(marker)
     return out

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -110,6 +110,13 @@ def _unevaluated_marker(results, not_evaluated):
     #381). Same posture as r6/labs/interpret.py `_indeterminate` — say what
     could not be decided rather than emitting a clean result.
 
+    A PARTIAL list is that same defect one size down, and the marker used to
+    be attached only when `lines` came back entirely empty. A Patient with a
+    birthDate and no gender — routine in real feeds — showed four screenings
+    with the two sex-gated ones dropped in silence (#417). All-or-nothing is
+    the wrong granularity for a completeness marker, so it rides on any
+    undecided rule and says how many and which.
+
     A caller reason OUTRANKS the rules' own causes, and that ordering is the
     whole point. When no record reached the engine, every rule reports the
     date of birth as unknown — an artefact of the call, not a fact about the
@@ -143,8 +150,7 @@ def build_consumer_summary(results, not_evaluated=None):
             if line:
                 lines.append(line)
     out = {"lines": lines, "note": _CONSUMER_NOTE}
-    if not lines:
-        marker = _unevaluated_marker(results, not_evaluated)
-        if marker:
-            out.update(marker)
+    marker = _unevaluated_marker(results, not_evaluated)
+    if marker:
+        out.update(marker)
     return out

--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -107,7 +107,8 @@ def register_caregaps_routes(blueprint, deps):
 
         supplied = _subject_from_request()
         subject, state = _resolve_subject(supplied, tenant_id)
-        unresolved = state if state in ("no-patient", "ambiguous-patient") else None
+        not_evaluated = (state if state in ("no-patient", "ambiguous-patient")
+                         else None)
 
         # `supplied`, NOT `subject`. Feeding the evaluator the Patient the
         # fallback just resolved makes every age-gated rule resolve, which
@@ -118,6 +119,16 @@ def register_caregaps_routes(blueprint, deps):
         # `indeterminate`, and the consumer summary says why it is empty
         # instead of reading as "nothing due".
         patient = _patient_for(supplied, tenant_id)
+
+        # No Patient reached the evaluator, so every rule comes back
+        # indeterminate for a reason that has nothing to do with this person's
+        # record — the engine reports the date of birth as unknown because it
+        # was never given one. Passed through, that became "Your date of birth
+        # and sex were not available to this check" for a record holding both
+        # (#417). While we are not looking at someone's demographics, the only
+        # honest reason is our own limitation.
+        if not_evaluated is None and patient is None:
+            not_evaluated = "check-incomplete"
 
         # No subject means nothing to compare against, so we do not pretend to
         # have read anything.
@@ -132,7 +143,7 @@ def register_caregaps_routes(blueprint, deps):
             as_of=as_of)
 
         summary = build_caregaps_summary(results)
-        consumer = build_consumer_summary(results, unresolved=unresolved)
+        consumer = build_consumer_summary(results, not_evaluated=not_evaluated)
 
         record_audit_event(
             "read", resource_type="Patient", resource_id=None,

--- a/templates/mcp_apps/care_gaps.html
+++ b/templates/mcp_apps/care_gaps.html
@@ -126,9 +126,15 @@
           (r.status || '').replace(/_/g, ' '))}</span></div>
         ${r.note ? `<div class="note">${esc(r.note)}</div>` : ''}
       </div>`).join('');
-    const lines = (consumer.lines || []).map(l => `<li>${esc(l)}</li>`).join('');
+    // A line is {rule_id, title, message}, not a string. Interpolating the
+    // object renders "[object Object]" — latent only because this box has
+    // never had a populated list to draw (#417).
+    const lines = (consumer.lines || [])
+      .map(l => `<li>${esc(l.message || l)}</li>`).join('');
     const consumerBox = lines ? `
       <div class="consumer"><h3>In plain terms</h3><ul>${lines}</ul>
+        ${consumer.unevaluated_note
+          ? `<div class="note">${esc(consumer.unevaluated_note)}</div>` : ''}
         ${consumer.note ? `<div class="note">${esc(consumer.note)}</div>` : ''}
       </div>` : '';
     contentEl.innerHTML = stats + consumerBox +

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -4280,6 +4280,35 @@ def test_care_gaps_that_could_not_run_forbids_reporting_no_screenings(
     assert "Do NOT tell the person they have no screenings due" in out["note"]
 
 
+def test_care_gaps_partial_result_reports_its_lines_and_says_what_is_missing(
+        cfg, svc):
+    """Some rules decided and some not (#417).
+
+    The could-not-run note tells the model to name no screening from the
+    result. Reused here it would suppress four real due screenings; dropped
+    here it would sell four lines as the whole answer. Neither, so the partial
+    case gets its own instruction.
+
+    MUTATION: fall through to the could-not-run note -> red.
+    """
+    import json as _json
+
+    from careagents.agent import _execute_tool
+
+    class _HC:
+        def care_gaps(self, _tenant):
+            return {"summary": {}, "consumer": {
+                "lines": [{"rule_id": "bp-screening", "message": "due"}],
+                "unevaluated": "sex-unavailable", "unevaluated_count": 2,
+                "unevaluated_note": "2 screenings could not be checked"}}
+
+    out = _json.loads(_execute_tool(_HC(), "t", "get_care_gaps", {}, []))
+    assert "PARTIAL" in out["note"]
+    assert "2" in out["note"]
+    assert "Do NOT tell the person they have no screenings due" not in out["note"]
+    assert "do not name or infer any screening" not in out["note"]
+
+
 def test_care_gaps_with_real_findings_carries_no_could_not_run_note(cfg, svc):
     """The note is earned, not boilerplate — a check that ran says nothing
     about having failed."""

--- a/tests/test_caregaps_evaluate.py
+++ b/tests/test_caregaps_evaluate.py
@@ -68,6 +68,29 @@ def test_unknown_age_is_indeterminate_not_a_false_alarm():
     assert res["mammography"]["status"] == "indeterminate"
 
 
+def test_indeterminate_results_name_which_demographic_was_missing():
+    """report.py turns this into the words the patient reads, and it must not
+    have to guess: one reason covering both demographics is how a person whose
+    birthDate was on file got told it was not (#417).
+
+    An indeterminate result with no cause recorded falls back to claiming BOTH
+    are missing, so the cause is load-bearing rather than decorative.
+    """
+    no_dob = {r["rule_id"]: r for r in evaluate_care_gaps(
+        {"resourceType": "Patient", "gender": "female"}, as_of="2026-07-01")}
+    assert no_dob["mammography"]["indeterminate_reason"] == "birth-date-unknown"
+
+    no_sex = {r["rule_id"]: r for r in evaluate_care_gaps(
+        {"resourceType": "Patient", "birthDate": "1968-05-01"}, as_of="2026-07-01")}
+    assert no_sex["mammography"]["indeterminate_reason"] == "sex-unknown"
+    assert no_sex["bp-screening"]["status"] != "indeterminate"
+
+    for res in (no_dob, no_sex):
+        for r in res.values():
+            if r["status"] == "indeterminate":
+                assert r.get("indeterminate_reason"), r["rule_id"]
+
+
 def test_colorectal_satisfied_by_recent_procedure():
     proc = {"resourceType": "Procedure", "status": "completed",
             "code": {"coding": [{"system": "http://www.ama-assn.org/go/cpt",

--- a/tests/test_caregaps_report.py
+++ b/tests/test_caregaps_report.py
@@ -7,10 +7,19 @@ _BANNED = re.compile(r"diagnos|prescrib|treatment", re.IGNORECASE)
 
 def _result(rule_id="bp-screening", title="Blood pressure check", cadence="yearly",
            source="uspstf", last_done=None, note="", applicable=True,
-           status="due"):
-    return {"rule_id": rule_id, "title": title, "cadence": cadence, "source": source,
-            "last_done": last_done, "note": note, "applicable": applicable,
-            "status": status}
+           status="due", indeterminate_reason=None):
+    out = {"rule_id": rule_id, "title": title, "cadence": cadence, "source": source,
+           "last_done": last_done, "note": note, "applicable": applicable,
+           "status": status}
+    if indeterminate_reason:
+        out["indeterminate_reason"] = indeterminate_reason
+    return out
+
+
+def _undecided(rule_id, title, why):
+    """An indeterminate rule as the engine emits it — carrying the cause."""
+    return _result(rule_id=rule_id, title=title, status="indeterminate",
+                   applicable=None, indeterminate_reason=why)
 
 
 def test_summary_counts_by_status():
@@ -91,7 +100,7 @@ def test_consumer_summary_note_text():
 def test_unresolved_subject_travels_with_the_empty_list():
     """An unresolvable subject is carried, not swallowed. The caller cannot
     otherwise tell it apart from a clean sheet."""
-    consumer = build_consumer_summary([], unresolved="no-patient")
+    consumer = build_consumer_summary([], not_evaluated="no-patient")
     assert consumer["lines"] == []
     assert consumer["unevaluated"] == "no-patient"
     assert "not a finding" in consumer["unevaluated_note"]
@@ -119,6 +128,58 @@ def test_no_lines_and_no_indeterminate_rules_claims_no_reason():
 
 
 def test_unevaluated_notes_have_no_banned_words():
-    for reason in ("no-patient", "ambiguous-patient", "demographics-unavailable"):
-        consumer = build_consumer_summary([], unresolved=reason)
+    for reason in ("no-patient", "ambiguous-patient", "check-incomplete"):
+        consumer = build_consumer_summary([], not_evaluated=reason)
         assert not _BANNED.search(consumer["unevaluated_note"])
+    for why in ("birth-date-unknown", "sex-unknown"):
+        consumer = build_consumer_summary(
+            [_undecided("mammography", "Breast cancer screening (mammogram)", why)])
+        assert not _BANNED.search(consumer["unevaluated_note"])
+
+
+# ─────────────────────────────────────────────
+# A reason may only claim what was actually read (#417)
+# ─────────────────────────────────────────────
+
+def test_the_reason_names_only_the_demographic_that_was_actually_missing():
+    """Reachable when a caller supplies a subject whose Patient really is
+    missing a field — the one path where we read the record and can say what
+    was not in it.
+
+    One `demographics-unavailable` covering every case told a person whose
+    birthDate was on file that it was not.
+    """
+    sex_only = build_consumer_summary(
+        [_undecided("mammography", "Breast cancer screening (mammogram)",
+                    "sex-unknown")])
+    assert sex_only["unevaluated"] == "sex-unavailable"
+    assert "date of birth" not in sex_only["unevaluated_note"]
+
+    dob_only = build_consumer_summary(
+        [_undecided("bp-screening", "Blood pressure check", "birth-date-unknown")])
+    assert dob_only["unevaluated"] == "birth-date-unavailable"
+    assert "sex" not in dob_only["unevaluated_note"]
+
+
+def test_a_caller_reason_outranks_anything_the_rules_seem_to_say():
+    """When the caller knows no Patient reached the evaluator, the rules'
+    own causes are an artefact of that and must not be quoted back.
+
+    Every rule below claims the date of birth was unknown. It was not — the
+    caller simply never handed it over.
+    """
+    consumer = build_consumer_summary(
+        [_undecided("bp-screening", "Blood pressure check", "birth-date-unknown"),
+         _undecided("flu-immunization", "Influenza (flu) vaccine",
+                    "birth-date-unknown")],
+        not_evaluated="check-incomplete")
+    assert consumer["unevaluated"] == "check-incomplete"
+    assert "date of birth" not in consumer["unevaluated_note"]
+
+
+def test_one_undecided_rule_reads_as_one():
+    consumer = build_consumer_summary(
+        [_undecided("mammography", "Breast cancer screening (mammogram)",
+                    "sex-unknown")])
+    assert "1 screening could not be checked" in consumer["unevaluated_note"]
+    assert "screenings" not in consumer["unevaluated_note"]

--- a/tests/test_caregaps_report.py
+++ b/tests/test_caregaps_report.py
@@ -177,6 +177,37 @@ def test_a_caller_reason_outranks_anything_the_rules_seem_to_say():
     assert "date of birth" not in consumer["unevaluated_note"]
 
 
+def test_a_partial_list_carries_the_marker_alongside_its_lines():
+    """Screenings decided and screenings not decided is not "the screenings".
+
+    The marker was attached only when `lines` came back entirely empty, so a
+    Patient with a birthDate and no gender had the two sex-gated rules dropped
+    with no hint they existed. All-or-nothing is the wrong granularity for a
+    completeness marker.
+
+    MUTATION: guard the marker with `if not lines:` again -> red.
+    """
+    consumer = build_consumer_summary([
+        _result(status="due"),
+        _result(rule_id="flu-immunization", title="Influenza (flu) vaccine",
+                status="due"),
+        _undecided("cervical-screening", "Cervical cancer screening (Pap)",
+                   "sex-unknown"),
+        _undecided("mammography", "Breast cancer screening (mammogram)",
+                   "sex-unknown"),
+    ])
+    assert len(consumer["lines"]) == 2
+    assert consumer["unevaluated"] == "sex-unavailable"
+    assert consumer["unevaluated_count"] == 2
+    assert consumer["unevaluated_titles"] == [
+        "Cervical cancer screening (Pap)",
+        "Breast cancer screening (mammogram)"]
+    # Counted and named — a partial answer has to say how much of it is missing.
+    assert "2 screenings" in consumer["unevaluated_note"]
+    for title in consumer["unevaluated_titles"]:
+        assert title in consumer["unevaluated_note"]
+
+
 def test_one_undecided_rule_reads_as_one():
     consumer = build_consumer_summary(
         [_undecided("mammography", "Breast cancer screening (mammogram)",

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -1,5 +1,6 @@
 # tests/test_caregaps_routes.py
 import json
+from datetime import date
 
 from r6.models import R6Resource, db
 
@@ -15,12 +16,25 @@ def _store(app, resource, tenant_id):
 
 
 def _seed_patient(app, tenant_id, pid="p1", gender="female", birth="1968-05-01"):
-    _store(app, {"resourceType": "Patient", "id": pid, "gender": gender,
-                 "birthDate": birth}, tenant_id)
+    # gender=None omits the element rather than coding it null — the shape a
+    # real feed sends when sex was never captured.
+    patient = {"resourceType": "Patient", "id": pid, "birthDate": birth}
+    if gender:
+        patient["gender"] = gender
+    _store(app, patient, tenant_id)
     _store(app, {"resourceType": "Observation", "id": f"o-{pid}", "status": "final",
                  "code": {"coding": [{"system": "http://loinc.org", "code": "8480-6"}]},
                  "subject": {"reference": f"Patient/{pid}"},
                  "effectiveDateTime": "2026-03-01"}, tenant_id)
+
+
+def _birth_date_for_age(years):
+    """A birthDate that is `years` old whichever day the suite runs.
+
+    `as_of` is date.today() inside the route, so a hardcoded year would walk
+    a patient across the age bands and change which rules apply.
+    """
+    return f"{date.today().year - years}-01-01"
 
 
 def _resp_param(body, name):
@@ -198,6 +212,43 @@ def test_the_fallback_path_claims_nothing_about_the_persons_record(
     assert "no screenings outstanding" in note
 
 
+def test_a_partial_screening_list_says_how_much_of_it_is_missing(
+        client, app, tenant_id, tenant_headers):
+    """A Patient with a birthDate and no gender — routine in real feeds.
+
+    Four screenings are decided and the two sex-gated ones are not. The marker
+    was attached only when the consumer list was ENTIRELY empty, so four lines
+    shipped as the whole answer and cervical and mammography disappeared
+    without a word (#417).
+
+    Driven with an explicit subject, which is the only shape that reads the
+    Patient today — the fallback path is held behind the clinical gate, and
+    a reason about this record would be false there (see the fallback test
+    above). The defect and its fix are in the consumer summary either way.
+
+    MUTATION: restore `if not lines:` in build_consumer_summary -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-nosex", gender=None,
+                  birth=_birth_date_for_age(50))
+
+    r = client.get("/r6/fhir/Patient/$care-gaps?subject=Patient/p-nosex",
+                   headers=tenant_headers)
+    assert r.status_code == 200
+    consumer = json.loads(
+        _resp_param(r.get_json(), "consumerSummary")["valueString"])
+    assert len(consumer["lines"]) == 4
+    assert consumer["unevaluated"] == "sex-unavailable"
+    assert consumer["unevaluated_count"] == 2
+    assert consumer["unevaluated_titles"] == [
+        "Cervical cancer screening (Pap)",
+        "Breast cancer screening (mammogram)"]
+    # Both named to the person, and the reason claims only what was actually
+    # missing from the record we did read — the birthDate was on file.
+    for title in consumer["unevaluated_titles"]:
+        assert title in consumer["unevaluated_note"]
+    assert "date of birth" not in consumer["unevaluated_note"]
+
+
 # ─────────────────────────────────────────────
 # MCP App page (embedded HTML surface)
 # ─────────────────────────────────────────────
@@ -225,6 +276,25 @@ class TestCareGapsMcpApp:
         import re
         fetches = re.findall(r"fetch\('([^']+)'", body)
         assert fetches == ['/r6/fhir/Patient/$care-gaps']
+
+    def test_plain_terms_list_renders_the_message_not_the_object(self, client):
+        """`consumer.lines` are objects — {rule_id, title, message}.
+
+        The page interpolated the object itself, which renders as
+        "[object Object]". Latent only because this box has never had a
+        populated list to draw; it would surface the moment one worked.
+        String-level assertion — these pages have no JS harness in the Python
+        suite.
+        """
+        body = client.get('/r6/fhir/mcp-apps/care-gaps/').get_data(as_text=True)
+        assert 'esc(l.message' in body
+        assert 'esc(l)' not in body
+
+    def test_plain_terms_list_shows_what_was_not_checked(self, client):
+        """Whatever this box does draw, it must not draw a partial list as a
+        whole one (#417)."""
+        body = client.get('/r6/fhir/mcp-apps/care-gaps/').get_data(as_text=True)
+        assert 'unevaluated_note' in body
 
     def test_no_tenant_renders_empty_shell(self, client):
         resp = client.get('/r6/fhir/mcp-apps/care-gaps/')

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -162,6 +162,43 @@ def test_care_gaps_with_a_supplied_subject_reports_that_state(
 
 
 # ─────────────────────────────────────────────
+# What we say when we did not look (#417)
+# ─────────────────────────────────────────────
+
+def test_the_fallback_path_claims_nothing_about_the_persons_record(
+        client, app, tenant_id, tenant_headers):
+    """The production call shape, against a record holding birthDate AND gender.
+
+    The resolved Patient is deliberately held back from the evaluator
+    (#389 half two, behind the clinical gate), so every rule is indeterminate
+    for a reason that has nothing to do with this person's data. We told them
+    "Your date of birth and sex were not available to this check" anyway.
+
+    While we are not looking at someone's demographics, no reason we give
+    about their demographics can be true — including a more precise one. The
+    reason has to describe our limitation, not their record.
+
+    MUTATION: drop the `check-incomplete` branch in the route -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-onfile", gender="female",
+                  birth="1985-04-02")
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    body = r.get_json()
+    resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
+    assert resolution == {"state": "tenant-default", "subject": "Patient/p-onfile"}
+
+    consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
+    assert consumer["unevaluated"] == "check-incomplete"
+    note = consumer["unevaluated_note"]
+    for claim in ("date of birth", "were not available", "not recorded"):
+        assert claim not in note, note
+    assert "no screenings outstanding" in note
+
+
+# ─────────────────────────────────────────────
 # MCP App page (embedded HTML surface)
 # ─────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes the un-gated half of #417, per the filer's re-scoping comment. Two
commits, one per fix group, each with its mutation run.

**The clinical gate at `r6/caregaps/routes.py:113-120` stays shut.** Nothing
here changes which screenings a person is told they are due for. The held half
is #421, stacked on this branch.

## 1. Stop explaining our own gap with the patient's record

Production callers pass no `subject`. The fallback resolves the tenant's own
Patient, the route deliberately does not hand it to the evaluator, and every
rule therefore comes back `indeterminate` reporting the date of birth as
unknown — because the engine was never given one.

That artefact went straight to the person: *"Your date of birth and sex were
not available to this check"*, about a record carrying both. Not the absence of
a statement about their data, a false one — and it sends someone to re-enter
demographics already on file.

The fallback path now reports our limitation and claims nothing about their
record:

> This check could not be completed for your record right now, so nothing here
> was decided either way. That is a limit on the check and not something found
> in your record, and it is not a finding that you have no screenings
> outstanding.

**Sharpening the claim would have been worse than leaving it vague.** My first
draft of this PR did exactly that — it derived `birth-date-unavailable` from
the engine's per-rule causes and shipped it on the fallback path, which is the
same false statement with better aim. The precise reasons survive in the code
because they are genuinely reachable where a Patient really was read and really
was missing a field, which today means an explicitly supplied subject. A caller
reason outranks the engine's causes precisely because those causes are an
artefact of the call on the fallback path.

`unresolved=` becomes `not_evaluated=`: it now carries a resolved-but-unread
subject as well as the two resolution failures, and a parameter named
"unresolved" holding a resolved one is the control-that-quietly-does-two-things
shape `docs/2026-08-02-retro.md` is about.

## 2. A partial list has to say it is partial

`if not lines:` attached the marker only when the consumer list was *entirely*
empty. A Patient with a `birthDate` and no `gender` got four screenings shown,
two silently dropped, no marker — and the two are cervical and mammography.

The marker now rides on any undecided rule and carries `unevaluated_count` and
`unevaluated_titles`:

> 2 screenings could not be checked because your sex was not recorded in the
> records this check can read: Cervical cancer screening (Pap) and Breast
> cancer screening (mammogram). That is not a finding that they are up to date.

The route test drives an explicit subject rather than the production
no-subject shape, because the fallback path is gated and answers
`check-incomplete` there by design. An explicit subject is the only shape that
reads the Patient today. The production shape of this test is in #421, where it
can be true.

## Two downstream consumers, deliberately in scope

Without these, the marker fix ships a new false statement on the surfaces it
newly reaches.

- **`careagents/agent.py:360`** told the model *"do not name or infer any
  screening from this result"* whenever the marker was set. On a partial answer
  that suppresses four real due screenings. The partial case gets its own
  instruction: report the lines **and** say what was not checked.
- **`templates/mcp_apps/care_gaps.html:129`** interpolated line *objects* into
  the "In plain terms" list — `[object Object]`. Latent only because that box
  has never had a populated list to draw; it would surface the moment anything
  worked. It also renders the marker now. Assertions are string-level — these
  pages have no JS harness in the Python suite.

## Mutations

| Mutation | Result |
| --- | --- |
| drop the `check-incomplete` branch in the route | `test_the_fallback_path_claims_nothing_about_the_persons_record` FAILED — `- check-incomplete / + birth-date-unavailable`, i.e. the sharpened reason landing on a record we never opened. Reverted, 41 passed. |
| restore `if not lines:` in `build_consumer_summary` | 2 failed, 240 passed — `test_a_partial_list_carries_the_marker_alongside_its_lines` and `test_a_partial_screening_list_says_how_much_of_it_is_missing`, and **only** those two, at both layers. Reverted, 242 passed. |

The CareAgents partial test does not redden under the second mutation, by
design — it feeds `_execute_tool` a fake consumer dict, so it pins the agent
layer independently of `report.py`.

## Gates

```
2677 passed, 12 skipped, 1 xfailed, 2 warnings in 119.09s
uv run ruff check .  ->  All checks passed!
tests/test_guardrail_conformance.py  ->  35 passed   (grade == "A")
```

## Deliberately not touched

- **#389 half two.** Held in #421 behind the clinical gate.
- **#381**, the brief's own care-gaps path. It resolves no subject of its own
  and inherits nothing from this.
- **Not verified against a running HealthClaw.** CareAgents tests fake the
  client, so the two halves are tested either side of a fake boundary — the
  documented repo trap. Worth one live check before this reaches the webinar
  path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
