### PR TITLE
fix(demo): the guardrail showcase is what broke the guardrail showcase (#415)

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2629,6 +2629,51 @@ def audit_stream():
 
 # --- Agent Demo Loop ---
 
+# The demo loop writes at FIXED ids, one set per tenant. It used to mint a
+# uuid8 suffix per call, so every press of "Run 6-Step Guardrail Demo" — and
+# every e2e run, since dashboard.spec.ts drives that button — left another
+# Patient behind. The demo tenant reached 19, and $care-gaps then correctly
+# refused to guess whose preventive care to evaluate, so two steps of our own
+# 10-minute demo script stopped working (#415). None of the six steps needs a
+# distinct patient per run: they demonstrate create, read, redaction, audit and
+# permission enforcement, all of which a repeated run shows identically. A
+# showcase a viewer can re-run and see the same thing is the point.
+_DEMO_LOOP_PATIENT_ID = 'demo-loop-pt'
+_DEMO_LOOP_OBSERVATION_ID = 'demo-loop-obs'
+_DEMO_LOOP_PERMISSION_ID = 'demo-loop-perm'
+
+
+def _demo_loop_upsert(resource, tenant_id):
+    """Write one demo resource at its fixed id, reviving a tombstone.
+
+    Identity is (tenant_id, resource_type, id) — the composite PK — so a
+    plain insert on the second run collides. Same upsert shape as the Fasten
+    ingester (r6/fasten/ingester.py), including the deliberate absence of an
+    `is_deleted` filter: step 3 soft-deletes every Permission for the tenant,
+    so on run two the Permission written in step 4 is revived from a tombstone
+    this endpoint laid down itself moments earlier.
+    """
+    resource_json = json.dumps(resource, separators=(',', ':'), sort_keys=True)
+    existing = R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type=resource['resourceType'],
+        id=resource['id'],
+    ).first()
+    if existing:
+        existing.update_resource(resource_json)
+        existing.is_deleted = False
+        row = existing
+    else:
+        row = R6Resource(
+            resource_type=resource['resourceType'],
+            resource_json=resource_json,
+            resource_id=resource['id'],
+            tenant_id=tenant_id,
+        )
+        db.session.add(row)
+    db.session.commit()
+    return row
+
+
 @r6_blueprint.route('/demo/agent-loop', methods=['POST'])
 def demo_agent_loop():
     """
@@ -2670,13 +2715,12 @@ def demo_agent_loop():
     if not _internal_mint_authorized(tenant_id):
         return jsonify({'error': 'forbidden'}), 403
 
-    demo_id = str(uuid.uuid4())[:8]
     steps = []
 
     # --- Step 1: Create + Read Patient (redacted) ---
     patient = {
         'resourceType': 'Patient',
-        'id': f'demo-loop-pt-{demo_id}',
+        'id': _DEMO_LOOP_PATIENT_ID,
         'name': [{'family': 'Rivera', 'given': ['Maria', 'Elena']}],
         'gender': 'female',
         'birthDate': '1990-03-15',
@@ -2685,15 +2729,7 @@ def demo_agent_loop():
         'telecom': [{'system': 'phone', 'value': '617-555-0198', 'use': 'mobile'}],
     }
 
-    resource_json = json.dumps(patient, separators=(',', ':'), sort_keys=True)
-    pt_resource = R6Resource(
-        resource_type='Patient',
-        resource_json=resource_json,
-        resource_id=patient['id'],
-        tenant_id=tenant_id,
-    )
-    db.session.add(pt_resource)
-    db.session.commit()
+    _demo_loop_upsert(patient, tenant_id)
     record_audit_event('create', 'Patient', patient['id'],
                        agent_id='demo-agent', tenant_id=tenant_id,
                        detail='Agent demo: created patient for guardrail walkthrough')
@@ -2721,7 +2757,7 @@ def demo_agent_loop():
     # --- Step 2: Agent proposes MedicationRequest ---
     med_request = {
         'resourceType': 'Observation',
-        'id': f'demo-loop-obs-{demo_id}',
+        'id': _DEMO_LOOP_OBSERVATION_ID,
         'status': 'preliminary',
         'code': {
             'coding': [{'system': 'http://loinc.org', 'code': '2339-0', 'display': 'Glucose [Mass/volume] in Blood'}],
@@ -2798,7 +2834,7 @@ def demo_agent_loop():
     # --- Step 4: Create permit rule + re-evaluate → PERMIT ---
     permission = {
         'resourceType': 'Permission',
-        'id': f'demo-loop-perm-{demo_id}',
+        'id': _DEMO_LOOP_PERMISSION_ID,
         'status': 'active',
         'combining': 'permit-overrides',
         'asserter': {'reference': 'Organization/hospital-1'},
@@ -2814,15 +2850,7 @@ def demo_agent_loop():
         }],
     }
 
-    perm_json = json.dumps(permission, separators=(',', ':'), sort_keys=True)
-    perm_resource = R6Resource(
-        resource_type='Permission',
-        resource_json=perm_json,
-        resource_id=permission['id'],
-        tenant_id=tenant_id,
-    )
-    db.session.add(perm_resource)
-    db.session.commit()
+    _demo_loop_upsert(permission, tenant_id)
     record_audit_event('create', 'Permission', permission['id'],
                        agent_id='demo-agent', tenant_id=tenant_id,
                        detail='Agent demo: created permit rule for treatment-purpose writes')
@@ -2894,15 +2922,7 @@ def demo_agent_loop():
     })
 
     # --- Step 6: Commit write with full audit trail ---
-    obs_json = json.dumps(med_request, separators=(',', ':'), sort_keys=True)
-    obs_resource = R6Resource(
-        resource_type='Observation',
-        resource_json=obs_json,
-        resource_id=med_request['id'],
-        tenant_id=tenant_id,
-    )
-    db.session.add(obs_resource)
-    db.session.commit()
+    obs_resource = _demo_loop_upsert(med_request, tenant_id)
     record_audit_event('create', 'Observation', med_request['id'],
                        agent_id='demo-agent', tenant_id=tenant_id,
                        detail='Agent demo: committed Observation after full guardrail sequence')
@@ -2929,7 +2949,10 @@ def demo_agent_loop():
     })
 
     return jsonify({
-        'demo_id': demo_id,
+        # Constant, like the ids it names: a run is no longer distinguishable
+        # from the run before it, which is the fix. Kept in the response
+        # because it is part of the published shape.
+        'demo_id': 'demo-loop',
         'title': 'MCP Guardrail Pattern Sequence',
         'description': 'Complete 6-step walkthrough showing how security patterns protect clinical data when an AI agent accesses FHIR resources via MCP.',
         'guardrails_demonstrated': [

--- a/tests/test_r6_dashboard.py
+++ b/tests/test_r6_dashboard.py
@@ -817,3 +817,53 @@ class TestDemoAgentLoop:
             for name_entry in patient['name']:
                 for given in name_entry.get('given', []):
                     assert given.endswith('.'), f"Given name not redacted: {given}"
+
+    def test_demo_loop_is_idempotent(self, client, tenant_id, tenant_headers):
+        """Two presses of the demo button leave ONE of each resource.
+
+        The loop minted `demo-loop-{pt,obs,perm}-<uuid8>` per call, so every
+        press added a Patient — and the dashboard button plus `dashboard.spec.ts`
+        press it on every CI run. The demo tenant reached 19 Patients, at which
+        point $care-gaps correctly refused to guess whose preventive care to
+        evaluate and two steps of our own demo script stopped working (#415).
+        The guardrail showcase was what broke the guardrail showcase.
+
+        MUTATION: put the uuid8 suffix back on the ids -> red (2, not 1).
+        """
+        for _ in range(2):
+            resp = client.post('/r6/fhir/demo/agent-loop',
+                               content_type='application/json',
+                               headers={'X-Tenant-Id': tenant_id})
+            assert resp.status_code == 200
+
+        # Driven through the real search route, not the ORM: the accumulation
+        # was found by searching Patient on the live tenant.
+        for resource_type in ('Patient', 'Observation', 'Permission'):
+            search = client.get(f'/r6/fhir/{resource_type}',
+                                headers=tenant_headers)
+            assert search.status_code == 200
+            assert search.get_json()['total'] == 1, (
+                f'two demo runs left more than one {resource_type}')
+
+    def test_demo_loop_leaves_care_gaps_answerable(
+            self, client, tenant_id, tenant_headers):
+        """Step 4 of the 10-minute demo script, after two demo-button presses.
+
+        The ambiguity guard (#393) is untouched and must stay that way — it
+        resolves here because the tenant holds one patient again, not because
+        anything now guesses among several.
+        """
+        for _ in range(2):
+            client.post('/r6/fhir/demo/agent-loop',
+                        content_type='application/json',
+                        headers={'X-Tenant-Id': tenant_id})
+
+        resp = client.post('/r6/fhir/Patient/$care-gaps',
+                           headers=tenant_headers, json={})
+        assert resp.status_code == 200
+        params = resp.get_json()['parameter']
+        resolution = json.loads(
+            next(p for p in params
+                 if p['name'] == 'subjectResolution')['valueString'])
+        assert resolution == {'state': 'tenant-default',
+                              'subject': 'Patient/demo-loop-pt'}


### PR DESCRIPTION
Fixes #415 (the step-4 half).

## What was wrong

`POST /demo/agent-loop` minted `demo-loop-{pt,obs,perm}-<uuid8>` on every call.
That endpoint is behind the dashboard's "Run 6-Step Guardrail Demo" button, and
`e2e/tests/dashboard.spec.ts` presses it on every CI run, so every press left
another Patient in the tenant. The demo tenant reached 19 Patients, `$care-gaps`
correctly refused to guess whose preventive care to evaluate, and step 4 of our
own 10-minute demo script stopped working. The guardrail showcase was what broke
the guardrail showcase.

## What changed

The three ids are fixed per tenant (`demo-loop-pt`, `demo-loop-obs`,
`demo-loop-perm`) and the writes upsert, using the same shape as the Fasten
ingester — including the deliberate absence of an `is_deleted` filter. Step 3
soft-deletes every Permission for the tenant, so on run two step 4 revives the
Permission from a tombstone this endpoint laid down moments earlier. That
interaction is covered by the test.

None of the six steps needs a distinct patient per run: they demonstrate create,
read, redaction, audit and permission enforcement, all of which a repeat run
shows identically. The synthetic patient keeps its name, MRN, address and phone
so redaction still has something to strip.

**The ambiguity guard (#393) is untouched.** It resolves again because the tenant
holds one patient, not because anything now guesses among several.

## Proof

Against a live server on `:5099`, driving the real endpoint:

```
BEFORE Patient total: 0
run 1: demo-loop 6 steps ['success','validated','denied','permitted','awaiting_confirmation','committed']
run 2: demo-loop 6 steps ['success','validated','denied','permitted','awaiting_confirmation','committed']
AFTER 2 runs - Patient total: 1   ids: ['demo-loop-pt']
Observation total: 1 ['demo-loop-obs']
Permission total: 1 ['demo-loop-perm']
```

MUTATION: put the uuid8 suffix back on the Patient id →
`test_demo_loop_is_idempotent` fails `2 == 1` and
`test_demo_loop_leaves_care_gaps_answerable` fails `ambiguous-patient !=
tenant-default`. Run, seen red, reverted.

- `uv run python -m pytest tests/ -q` → **2669 passed, 12 skipped, 1 xfailed**
  (the xfail is the pre-existing #304 `/r6/ops/reap` row; 0 xpassed)
- `uv run ruff check .` → **All checks passed!**
- `E2E_PORT=5099 npx playwright test` → **42 passed** (4 files, including
  `dashboard.spec.ts`)
- Conformance stays Grade A (`tests/test_guardrail_conformance.py` green)

## Step 4 is not fully answerable yet, for a second reason

Worth knowing before the recording. With one patient in the tenant, `$care-gaps`
posted with **no subject** — which is what both production callers do, per the
comment in `r6/caregaps/routes.py` — now returns:

```
subjectResolution: {"state": "tenant-default", "subject": "Patient/demo-loop-pt"}
unevaluated: demographics-unavailable
summary: {"due": 0, "up_to_date": 0, "not_applicable": 1, "indeterminate": 6, "total": 7}
```

The refusal changed from `ambiguous-patient` to `demographics-unavailable`. The
evaluator is fed `supplied`, not the resolved `subject`, on purpose: that is the
second half of #389, and the code says it is gated on CTO sign-off and Dr.
Magan's review. Not touched here.

With an explicit subject the operation answers properly:

```
$care-gaps?subject=Patient/demo-loop-pt
summary: {"due": 3, "up_to_date": 0, "not_applicable": 4, "indeterminate": 0, "total": 7}
unevaluated: None
```

So the demo script's step 4 lands only if the caller supplies a subject, or if
the #389 second half is opened. That is a decision, not a bug fix, and it is not
mine to make.

## Cleanup of the existing rows is a separate, owner-run step

This change stops the accumulation. It does not remove the rows already in the
live tenant, and that is deliberately not something this PR does or documents:
a ready-to-paste destructive statement against a production table does not
belong in a public repository.

The cleanup has been handed to the maintainer through a private channel, along
with the count-first query, the reason it has to be a hard delete rather than a
soft one, and the reason it cannot match the new fixed ids. **Nothing has been
run.**

One part of it is worth stating here because it is a code fact, not an
operational one, and it is already visible in the source: `_resolve_subject`
counts Patient rows without filtering `is_deleted`, so tombstones read as
ambiguity. That is worth its own issue independently of this cleanup.

A second accumulator exists and is not this endpoint: `scripts/smoke_medplum.py`
posts a synthetic patient with `birthDate: 1980-01-01`, no gender and no id, so
the server mints one. It is hand-run rather than CI-driven, but it matches the
other rows the issue describes.

Do not merge without a maintainer's review; not deployed.
