### PR TITLE
Evaluate the Patient the fallback resolved (#389 half two)

### DIFF
--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -110,23 +110,18 @@ def register_caregaps_routes(blueprint, deps):
         not_evaluated = (state if state in ("no-patient", "ambiguous-patient")
                          else None)
 
-        # `supplied`, NOT `subject`. Feeding the evaluator the Patient the
-        # fallback just resolved makes every age-gated rule resolve, which
-        # changes WHICH screenings a person is told they are due for. That is
-        # clinical output and it is the second half of #389, gated on CTO
-        # sign-off and Dr. Magan's review — deliberately not this change.
-        # Until then age stays unknown on the fallback path, those rules stay
-        # `indeterminate`, and the consumer summary says why it is empty
-        # instead of reading as "nothing due".
-        patient = _patient_for(supplied, tenant_id)
+        # `subject`, NOT `supplied` — the Patient the fallback resolved is the
+        # Patient we evaluate. #389 half two, released by Dr. Magan's ruling
+        # on the cadence table.
+        patient = _patient_for(subject, tenant_id)
 
-        # No Patient reached the evaluator, so every rule comes back
-        # indeterminate for a reason that has nothing to do with this person's
-        # record — the engine reports the date of birth as unknown because it
-        # was never given one. Passed through, that became "Your date of birth
-        # and sex were not available to this check" for a record holding both
-        # (#417). While we are not looking at someone's demographics, the only
-        # honest reason is our own limitation.
+        # `check-incomplete` (#417) covered the window in which a resolved
+        # Patient was held back from the evaluator: every rule reported the
+        # date of birth as unknown because the engine was never given one, and
+        # no reason about this person's demographics could be true. The
+        # evaluator now sees the record, so the engine's own causes ARE about
+        # the record and say what is missing from it. A subject naming a row
+        # we do not hold still reads nothing, and still says so.
         if not_evaluated is None and patient is None:
             not_evaluated = "check-incomplete"
 

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -179,23 +179,41 @@ def test_care_gaps_with_a_supplied_subject_reports_that_state(
 # What we say when we did not look (#417)
 # ─────────────────────────────────────────────
 
-def test_the_fallback_path_claims_nothing_about_the_persons_record(
-        client, app, tenant_id, tenant_headers):
-    """The production call shape, against a record holding birthDate AND gender.
+def test_a_subject_we_hold_no_record_for_claims_nothing_about_that_record(
+        client, tenant_headers):
+    """A supplied subject naming a row we do not hold reads nothing, so it
+    cannot say what that record was missing.
 
-    The resolved Patient is deliberately held back from the evaluator
-    (#389 half two, behind the clinical gate), so every rule is indeterminate
-    for a reason that has nothing to do with this person's data. We told them
-    "Your date of birth and sex were not available to this check" anyway.
-
-    While we are not looking at someone's demographics, no reason we give
-    about their demographics can be true — including a more precise one. The
-    reason has to describe our limitation, not their record.
+    `check-incomplete` (#417) covers it. It used to answer
+    "Your date of birth and sex were not available to this check", which
+    describes a record this deployment has never seen.
 
     MUTATION: drop the `check-incomplete` branch in the route -> red.
     """
+    r = client.get("/r6/fhir/Patient/$care-gaps?subject=Patient/nope",
+                   headers=tenant_headers)
+    assert r.status_code == 200
+    consumer = json.loads(
+        _resp_param(r.get_json(), "consumerSummary")["valueString"])
+    assert consumer["unevaluated"] == "check-incomplete"
+    for claim in ("date of birth", "were not available", "not recorded"):
+        assert claim not in consumer["unevaluated_note"]
+
+
+def test_the_fallback_path_evaluates_the_patient_it_resolved(
+        client, app, tenant_id, tenant_headers):
+    """The production call shape, against a record holding birthDate AND gender.
+
+    The fallback resolved the Patient and reported it in `subjectResolution`,
+    then handed the evaluator `supplied` — None. Age and sex unknown, all
+    seven rules indeterminate, and the person got a reason instead of an
+    answer. #389 half two; released by the clinical ruling on the cadence
+    table, not by engineering.
+
+    MUTATION: pass `supplied` to _patient_for again -> red.
+    """
     _seed_patient(app, tenant_id, pid="p-onfile", gender="female",
-                  birth="1985-04-02")
+                  birth=_birth_date_for_age(50))
 
     r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
                     json={})
@@ -204,12 +222,43 @@ def test_the_fallback_path_claims_nothing_about_the_persons_record(
     resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
     assert resolution == {"state": "tenant-default", "subject": "Patient/p-onfile"}
 
+    # A 50yo woman: only the A1c rule is gated out (no diabetes Condition).
+    summary = json.loads(_resp_param(body, "summary")["valueString"])
+    assert summary["indeterminate"] == 0
+    assert summary["due"] + summary["up_to_date"] == 6
+
     consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
-    assert consumer["unevaluated"] == "check-incomplete"
-    note = consumer["unevaluated_note"]
-    for claim in ("date of birth", "were not available", "not recorded"):
-        assert claim not in note, note
-    assert "no screenings outstanding" in note
+    assert len(consumer["lines"]) == 6
+    assert "unevaluated" not in consumer
+    assert "were not available" not in r.get_data(as_text=True)
+
+
+def test_the_fallback_path_now_carries_a_reason_that_is_true(
+        client, app, tenant_id, tenant_headers):
+    """The production shape of #417's partial list, reachable only once the
+    evaluator sees the record.
+
+    On the held path this same call answered `check-incomplete`, because a
+    reason about demographics we never read could not be true. Now we read
+    them, so `sex-unavailable` describes the record and names the two
+    screenings it could not decide.
+
+    MUTATION: pass `supplied` to _patient_for again -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-nosex", gender=None,
+                  birth=_birth_date_for_age(50))
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    consumer = json.loads(
+        _resp_param(r.get_json(), "consumerSummary")["valueString"])
+    assert len(consumer["lines"]) == 4
+    assert consumer["unevaluated"] == "sex-unavailable"
+    assert consumer["unevaluated_count"] == 2
+    assert consumer["unevaluated_titles"] == [
+        "Cervical cancer screening (Pap)",
+        "Breast cancer screening (mammogram)"]
+    assert "date of birth" not in consumer["unevaluated_note"]
 
 
 def test_a_partial_screening_list_says_how_much_of_it_is_missing(

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -222,15 +222,29 @@ def test_the_fallback_path_evaluates_the_patient_it_resolved(
     resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
     assert resolution == {"state": "tenant-default", "subject": "Patient/p-onfile"}
 
-    # A 50yo woman: only the A1c rule is gated out (no diabetes Condition).
+    # A 50yo woman: the A1c rule is gated out (no diabetes Condition), and
+    # colorectal is undecided because this check does not read stool-based
+    # tests (#425) — five decide.
+    #
+    # PIN MOVED with #425, in the PR that moved it. The property this test
+    # exists for is unchanged and is asserted below: the rules read the
+    # record. What moved is that one rule now declines for a reason of OURS.
     summary = json.loads(_resp_param(body, "summary")["valueString"])
-    assert summary["indeterminate"] == 0
-    assert summary["due"] + summary["up_to_date"] == 6
+    assert summary["indeterminate"] == 1
+    assert summary["due"] + summary["up_to_date"] == 5
 
     consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
-    assert len(consumer["lines"]) == 6
-    assert "unevaluated" not in consumer
+    assert len(consumer["lines"]) == 5
+
+    # The point of #389 half two, stated directly: nothing is undecided for
+    # want of demographics, because the evaluator was handed the record. The
+    # one undecided screening names our coverage, never the person.
+    assert consumer["unevaluated"] == "evidence-not-read"
+    assert consumer["unevaluated_titles"] == ["Colorectal cancer screening"]
+    assert "limit on the check" in consumer["unevaluated_note"]
     assert "were not available" not in r.get_data(as_text=True)
+    for demographic in ("date of birth", "sex was not recorded"):
+        assert demographic not in consumer["unevaluated_note"]
 
 
 def test_the_fallback_path_now_carries_a_reason_that_is_true(
@@ -240,8 +254,14 @@ def test_the_fallback_path_now_carries_a_reason_that_is_true(
 
     On the held path this same call answered `check-incomplete`, because a
     reason about demographics we never read could not be true. Now we read
-    them, so `sex-unavailable` describes the record and names the two
-    screenings it could not decide.
+    them, so the sex-gated pair is explained by the record's own gap and
+    named.
+
+    PIN MOVED with #425, in the PR that moved it: colorectal joins the
+    undecided set for a reason of ours, so the marker carries both causes and
+    keeps them apart. That is the same property this test was written for —
+    a reason that is true of what it covers — now proven across two causes
+    instead of one.
 
     MUTATION: pass `supplied` to _patient_for again -> red.
     """
@@ -252,13 +272,22 @@ def test_the_fallback_path_now_carries_a_reason_that_is_true(
                     json={})
     consumer = json.loads(
         _resp_param(r.get_json(), "consumerSummary")["valueString"])
-    assert len(consumer["lines"]) == 4
-    assert consumer["unevaluated"] == "sex-unavailable"
-    assert consumer["unevaluated_count"] == 2
+    assert len(consumer["lines"]) == 3
+    assert consumer["unevaluated"] == "partly-unchecked"
+    assert consumer["unevaluated_count"] == 3
     assert consumer["unevaluated_titles"] == [
+        "Colorectal cancer screening",
         "Cervical cancer screening (Pap)",
         "Breast cancer screening (mammogram)"]
-    assert "date of birth" not in consumer["unevaluated_note"]
+
+    note = consumer["unevaluated_note"]
+    # The record's gap explains the two it explains, and ours explains ours.
+    assert "sex was not recorded" in note
+    assert "Cervical cancer screening (Pap)" in note
+    assert "does not yet read" in note and "stool-based" in note
+    assert "Colorectal cancer screening" in note
+    # The birthDate was on file, and no reason may say otherwise.
+    assert "date of birth" not in note
 
 
 def test_a_partial_screening_list_says_how_much_of_it_is_missing(


### PR DESCRIPTION
**Unblocked.** The clinical gate that held this is cleared, and the specific
defect that made it unsafe — a FIT-current patient reading as overdue — is
fixed in #425/#428, which is now in `main` ahead of this.

Rebased onto `main`; the two stacked #417 commits were already squash-merged
as #420 and were dropped as duplicates. What remains is one change.

## What it does

Production callers pass no `subject`. The tenant-default fallback resolved
the tenant's own Patient and reported it in `subjectResolution` — then handed
the evaluator `supplied`, which is `None`. Age and sex unknown, every rule
indeterminate, and "Any screenings I'm due for?" — one of four buttons on the
chat's first screen — returned a reason instead of an answer.

```diff
-        patient = _patient_for(supplied, tenant_id)
+        patient = _patient_for(subject, tenant_id)
```

## Why the order mattered

Landing this before #428 would have shipped a false clinical claim: this PR
is precisely what lets the cadence table's output reach a patient, and that
table told anyone screening with annual FIT that they were overdue. #428 made
that rule decline honestly first. The two are only safe in this order.

## Pins moved

Both fallback tests were written when colorectal still decided. They move
here, with the reason recorded:

- `..._evaluates_the_patient_it_resolved` — five rules decide, one is
  undecided. The property is now asserted directly rather than by counting:
  **nothing is undecided for want of demographics**, because the evaluator
  was handed the record. The one undecided screening names our coverage,
  never the person.
- `..._carries_a_reason_that_is_true` — the marker carries both causes and
  keeps them apart, which is the same property proven across two causes.

## Verification

- `2726 passed`, 12 skipped, 1 xfailed; ruff clean; **conformance 35 (Grade A)**
- Gate mutation re-run after the rebase: `_patient_for(supplied, …)` reddens
  both fallback tests

**Not verified against a running HealthClaw.** This is the change that makes
the screening button produce a real answer, so it is the one most worth a live
pair before the demo path depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)