### PR TITLE
HealthClaw 2.0: architecture review, ratchets, and the review-path fix

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -1018,6 +1018,13 @@ def create_app(config: Config | None = None,
     # failure mode here, because nothing was.
     _REVIEW_UNCHECKABLE = ("We couldn't check this form right now. Nothing "
                            "has been approved — please try again in a moment.")
+    #: Distinct from the above: the review was SENT and the engine never
+    #: answered, so whether the decisions were recorded is unknown. What is
+    #: known is that the approval step below was never reached.
+    _REVIEW_UNSUBMITTED = ("We couldn't confirm your review reached your "
+                           "records. Nothing has been approved — please open "
+                           "the form again to check before approving, because "
+                           "approving twice could send it twice.")
 
     @app.get("/review/<agent_id>/<action_id>")
     @login_required
@@ -1030,8 +1037,26 @@ def create_app(config: Config | None = None,
         if not tenant:
             return render_template("chat_error.html",
                                    message="That form isn't yours."), 404
-        status, html = hc.fetch_review_page(tenant, action_id)
+        try:
+            status, html = hc.fetch_review_page(tenant, action_id)
+        except HealthClawError:
+            # A dead socket reached Flask as a 500 before this: no statement
+            # about the form, on the approval gate.
+            logger.exception("review fetch failed for %s", action_id)
+            return render_template("chat_error.html",
+                                   message=_REVIEW_UNCHECKABLE), 503
         if status != 200:
+            # Only the engine's own 4xx is an answer about this form. A 5xx,
+            # 408 or 429 is a gateway speaking for an engine that said
+            # nothing, and "no longer awaiting review" would be a claim about
+            # state this branch never observed — the #416 shape, one route
+            # over. A patient with a live pending request must not be told it
+            # is gone because a proxy timed out.
+            if not HealthClawClient._upstream_answered(status):
+                logger.warning("review fetch unanswered (%s) for %s",
+                               status, action_id)
+                return render_template("chat_error.html",
+                                       message=_REVIEW_UNCHECKABLE), 503
             return render_template(
                 "chat_error.html",
                 message="This form is no longer awaiting review."), 404
@@ -1050,7 +1075,30 @@ def create_app(config: Config | None = None,
         if not tenant:
             return jsonify({"error": "not yours"}), 404
         decisions = request.get_json(silent=True) or dict(request.form)
-        status, body = hc.submit_review(tenant, action_id, decisions)
+        try:
+            status, body = hc.submit_review(tenant, action_id, decisions)
+        except HealthClawError:
+            # The decisions are gone and nobody told the patient. Ownership
+            # was already confirmed, so this is not a permission answer.
+            logger.exception("review submit failed for %s", action_id)
+            return jsonify({
+                "error": "review_unavailable",
+                "confirmed": False,
+                "message": _REVIEW_UNSUBMITTED,
+            }), 503
+        if status and not HealthClawClient._upstream_answered(status) \
+                and status != 200:
+            # The engine never answered, so we cannot say the review was
+            # saved. We CAN say nothing was approved: confirm_action is only
+            # reached on a 200 below, and that is the half that keeps a
+            # second approval from sending the request twice.
+            logger.warning("review submit unanswered (%s) for %s",
+                           status, action_id)
+            return jsonify({
+                "error": "review_unavailable",
+                "confirmed": False,
+                "message": _REVIEW_UNSUBMITTED,
+            }), 503
         if status == 200:
             try:
                 hc.confirm_action(tenant, action_id)

--- a/docs/2026-08-05-graph-and-scaling-review.md
+++ b/docs/2026-08-05-graph-and-scaling-review.md
@@ -1,0 +1,433 @@
+# Codebase graph + scaling review — 2026-08-05
+
+**Question asked:** after a week of 128 commits fixing "a guardrail produced
+nothing and the caller read it as an answer" nine times, does the architecture
+scale, and where are the single points of failure?
+
+**Method:** an AST import-graph of every production Python module (tests,
+migrations, and vendored code excluded), cross-checked by three independent
+review passes over the access kernel, the CareAgents service, and the runtime.
+Numbers below come from the graph or from counted callsites, not from reading
+docs. 172 modules, 325 import edges.
+
+**TL;DR.** The week's 19 merges fixed instances; the graph shows the
+generator. Every guardrail guarantee — tenant check, step-up, audit,
+soft-delete, honest degradation — is implemented as a convention at N call
+sites (audit ×88, tenant header ×55, step-up ×13) instead of a structure at
+one, and the access kernel built to change that has 8 of 11 primitives with
+zero production callers. Five findings dominate: **(1)** the audit write is
+not in the data write's transaction on 88 of 93 sites, so a failed audit
+500s *after* the data committed — and two step-up-gated mutators emit no
+audit at all; **(2)** the patient-facing "nothing read as an answer"
+pattern survives on the review path itself, where an edge 502 tells a
+patient their pending form is gone; **(3)** deploys strand in-flight
+record imports because the reaper is wired to a CLI production never runs;
+**(4)** search silently truncates at 200 with no `next` link — a partial
+answer shaped like a complete one, at the API layer; **(5)** the shipped
+CareAgents config is SQLite with an 8-request-slot ceiling. All four
+import cycles reduce to one ~200-line PR. The plan is 17 items in three
+phases, five of them safe before Aug 18.
+
+---
+
+## 1. The map
+
+```mermaid
+graph LR
+  subgraph HealthClaw["HealthClaw (Flask, PHI)"]
+    n3["main (composition root)"]
+    n1["r6 core<br/>routes.py 3,905 LOC"]
+    n0["r6.actions"]
+    n2["r6.fasten"]
+    n5["r6.smbp"]
+    n6["r6.sdc"]
+    n8["r6.wearables"]
+    n10["r6.command_center"]
+    n9["r6.agent_runs"]
+    n7["r6.ops"]
+    n11["r6.labs"]
+    n14["r6.caregaps"]
+    n13["r6.brief"]
+    n12["r6.shc"]
+    n15["r6.quality"]
+    n4["models (db)"]
+  end
+  n0 -->|11| n1
+  n2 -->|9| n1
+  n3 -->|8| n1
+  n1 -->|8| n4
+  n3 -->|7| n0
+  n5 -->|7| n1
+  n0 -->|6| n4
+  n0 -->|6| n6
+  n7 -->|6| n0
+  n6 -->|5| n1
+  n8 -->|5| n1
+  n2 -->|4| n4
+  n7 -->|4| n1
+  n9 -->|3| n4
+  n10 -->|3| n4
+  n10 -->|3| n1
+  n11 -->|3| n1
+  n12 -->|3| n1
+  n8 -->|3| n4
+  n9 -->|2| n10
+  n13 -->|2| n14
+  n1 -->|2| n2
+  n1 -->|2| n10
+  n14 -->|2| n1
+  n13 -->|2| n1
+  n15 -->|2| n1
+  n1 -->|2| n6
+  style n1 fill:#b91c1c,color:#fff
+  style n4 fill:#b45309,color:#fff
+```
+
+Red is the god module's package; amber is the shared DB layer. Every arrow
+into `r6` core is a blueprint reaching back for a symbol that mostly lives in
+`routes.py`.
+
+### Hotspots, by the numbers
+
+| Module | Fan-in | Fan-out | LOC | Reading |
+|---|---|---|---|---|
+| `models` | 32 | — | — | every module talks to the DB directly |
+| `r6.models` | 23 | — | — | same |
+| `r6.audit` | **21** | — | — | audit is called from 21 modules, not 1 |
+| `r6.stepup` | 13 | — | — | step-up gate called raw from 13 modules |
+| `r6.access` (the kernel) | **5** | 8 | 823 | the designated single gate, barely adopted |
+| `r6.routes` | 5 | **28** | **3,905** | god module; other modules import *from* it |
+| `main` | — | 32 | 417 | composition root — this hub is healthy |
+
+The shape a healthy version of this graph would have: `r6.access` with the
+fan-in that `r6.audit` + `r6.stepup` + `models` have today, and `r6.routes`
+with fan-in 1 (`main`).
+
+---
+
+## 2. Finding: the kernel inversion (highest structural risk)
+
+`r6/access.py` is the declared single tenant-reader / step-up gate / audit
+call / FHIR exit. The graph says the codebase is currently the inverse:
+
+- **8 of the kernel's 11 primitives have zero production callers.**
+  `audit`, `fhir_response`, `outcome_response`, `unredacted_response` are
+  fully tested and never executed. `require_grant` has exactly one caller
+  (`r6/smbp/routes.py:100`).
+- **Adoption is deliberately gated** — `tests/test_access_kernel.py:1022`
+  pins an allowlist of 5 files, and the gate has opened four times. This is
+  good discipline; the risk is not drift, it is *stall*: `r6/access.py` has
+  2 commits while the paths it is meant to replace absorbed ~40 fix commits
+  this week. Every fix that lands in the un-migrated path widens the gap the
+  migration must eventually re-verify.
+- **Slices 0–3 and 9 of the 19-slice spec shipped; 4–8 and 10–14 did not.**
+  The spec itself predicted this cut line for Aug 18 — the plan is on plan.
+  What is *not* on plan is that the week's nine "nothing read as an answer"
+  defects all happened in code the kernel was designed to make impossible.
+- **Two step-up-gated mutators emit no audit events at all**:
+  `r6/command_center` (3 gated writes, 0 audit calls) and `r6/agent_runs`
+  (2 gated writes, 0 audit calls). They are also the two modules the spec
+  deferred for having no write-guard-matrix row. For a PHI system this is
+  the single worst gap in this report: a mutation surface that is
+  authenticated but invisible.
+- 55 raw `X-Tenant-Id` header reads across 14 modules; 10 modules read it
+  with **no validation at all** (`quality:35`, `labs:38`, `caregaps:38`,
+  `brief:31`, `command_center:80,131,263`, `agent_runs:98`, `sdc`,
+  `smbp/scheduler_routes:48`, `actions/routes:60`).
+- `r6/wearables/routes.py` imports four competing access mechanisms in four
+  consecutive lines (23–26); `sync_now` uses the kernel, `sync_status` 30
+  lines above does not. Half-migration in one screenful.
+
+## 3. Finding: all four import cycles are one small PR
+
+The graph shows one SCC through the auth stack — actually four nested cycles
+sharing back-edges, all already deferred (function-local) at runtime:
+
+```mermaid
+graph LR
+  R["r6.routes<br/>3,905 LOC"] --> RL["rate_limit"]
+  RL --> RA["read_auth"]
+  RA --> O["oauth"]
+  R --> HC["health_compliance"]
+  O -.->|"lazy :285<br/>_read_auth_enabled"| R
+  HC -.->|"lazy :124<br/>json_body_within_depth"| R
+  R --> RA
+  R --> O
+  linkStyle 4 stroke:#b91c1c,stroke-width:3px
+  linkStyle 5 stroke:#b91c1c,stroke-width:3px
+```
+
+The two red back-edges exist because three utility symbols live in the god
+module. Breaking every cycle is ~200 lines moved, no behavior change:
+
+1. **Move the env predicates** `read_auth_enabled` / `public_tenants` /
+   `is_public_tenant` from `r6/read_auth.py:26-40` into `r6/runtime_config.py`
+   (they read env vars and nothing else). `oauth.py:285` was importing a
+   re-export alias of the first one out of `routes.py`. Also collapses the
+   duplicate `is_public` in `r6/command_center/access.py:95`.
+2. **Move `json_body_within_depth`** (+ its two pure deps,
+   `routes.py:2070-2121`) into a new `r6/body_guard.py`. Its three importers
+   all import it lazily today, each with an apology comment.
+3. **Move `authenticate_tenant_read`** (`routes.py:250-266`) into
+   `r6/read_auth.py` next to the predicate it wraps — or directly into the
+   kernel as part of slice 10.
+
+After this, nothing imports from `r6/routes.py` except `main.py`, and the
+Workstream-B split of the god module becomes mechanical.
+
+The second SCC (`r6.actions.rails`) is a star, not a chain: the package
+`__init__` imports its own submodules for registration side effects while
+they import shared transport helpers back from it. The refactor plan already
+schedules `_safe_request` for promotion to a repo-wide HTTP seam, which
+breaks this cycle as a side effect — do not do it twice.
+
+## 4. Finding: privilege tiers share a module
+
+`r6/routes.py` carries, behind one blueprint: public FHIR CRUD + search,
+FHIR operations, AuditEvent query/export/SSE, **and** the privileged
+internal surface — `/internal/step-up-token`, `/internal/purge-tenant`,
+`/internal/seed`, `/internal/ingest-bundle` — plus the demo loop and MCP
+app HTML. A change to any of them risks all of them; a reviewer cannot
+tell from the diff header which trust tier is being touched. The split
+(§7, R2) should cut along trust boundaries, not just size.
+
+## 5. Finding: CareAgents failure propagation
+
+The week's fixes hold on 23 of 36 client methods: `_send` wraps transport
+failure, `_upstream_answered` separates "the engine refused" from "the
+gateway timed out," and the mail tri-state is exemplary end to end (a
+truthy-string enum so a fake can't read as success, `NOT_SENT` burns the
+code so the cooldown can't swallow the retry, `sent: null` when delivery
+was unobserved). The worker's claim design is genuinely good: `FOR UPDATE
+SKIP LOCKED` plus the Conversation row as a cross-process mutex, lease
+heartbeats, and mid-tool death parked as `waiting_for_human` rather than
+re-executed.
+
+The same pattern the week spent nine fixes on is still present in four
+places, ranked:
+
+1. **SEV-1, the review path.** `fetch_review_page` returns `(status, text)`
+   unfiltered; `careagents/app.py:1033-1037` maps *any* non-200 —
+   including an edge 502/503/504 — to "This form is no longer awaiting
+   review" with a 404. A patient with a live pending form is told it is
+   gone, by the approval gate itself. `submit_review` one call later is
+   worse: a transport failure raises `HealthClawError` with **no
+   errorhandler registered anywhere in careagents/**, so the patient's
+   approval decisions die as a bare 500 with no "nothing was approved."
+   This is the same defect class as #416/#410, on the same route, fixed on
+   the adjacent lines.
+2. **SEV-2, history.** `recent_messages` returns `[]` for outage and for
+   "new conversation" alike — and it bypasses `_send` entirely. The web
+   tier renders every return visit during an outage as a first visit; the
+   worker builds the agent's context from it, so the agent silently
+   answers with amnesia and tells no one.
+3. **SEV-3, the brief.** `fetch_appointment_brief` returns `None` on
+   everything; the template renders "Not available from your connected
+   records" — a statement about the records, made during an outage. The
+   same page gets it right one section down (screening review requires an
+   explicit `"ok"`, #381). One page, two postures.
+4. **SEV-4, the heartbeat.** One failed lease heartbeat (`worker.py:104`)
+   declares the lease lost, no retry — one 25s blip aborts a turn the
+   model may already have answered.
+
+### Resilience posture, measured
+
+- **No retry, no backoff, no circuit breaker** on any HealthClaw call.
+  One flat 25s timeout for everything.
+- **The Anthropic client has no timeout configured** — SDK default 600s,
+  inside a 120s run deadline and a 60s lease. A hung provider pins a
+  worker slot for ten minutes on a run that died eight minutes earlier.
+  (The OpenAI-compatible path *is* configured: 90s, 3 attempts, honors
+  Retry-After, refuses to sleep past the lease.)
+- **No backpressure signal.** Worker health is presence-only: one live
+  worker with 500 queued runs reads "ready," so every turn is accepted
+  and times out individually. The system can say "up" or "down" but not
+  "busy."
+- **The hard ceiling is 8.** `--workers 2 --threads 4` = 8 request slots;
+  each SSE chat turn holds one up to 150s. Eight simultaneous chatters
+  saturate the web tier including `/healthz` — which then fails readiness
+  and can trigger a restart loop.
+- **SSE poll amplification:** 0.25s poll × 150s = up to 600 HealthClaw
+  calls per browser per turn; the connect page polls at ~1.4 calls/sec
+  sustained (`record_count` alone is 6 sequential searches, 150s worst
+  case in one request). **Zero caching anywhere** in careagents/.
+- **Shipped config is SQLite** for web *and* worker on one file, no WAL,
+  no busy_timeout — the one item on this list that converts load growth
+  into an outage (locked-database 500s) rather than latency. Postgres
+  support exists (`pool_pre_ping`/`pool_recycle`, #384) but
+  `config.py:165` deliberately warns instead of requiring it.
+- **Dead guarantees:** `conversation_locks.py` (85 LOC) is imported only
+  by a test; `MAX_LIVE_CONVERSATIONS` / `CONVERSATION_IDLE_SECONDS` have
+  no reader. Both document bounds nothing implements. The daily-turn cap
+  is read-then-write with no unique constraint, so concurrent turns leak
+  past it.
+
+## 6. Finding: runtime single points of failure
+
+Ranked by blast radius.
+
+### 6.1 The audit write is not in the data write's transaction (89 of 94 sites)
+
+Every FHIR write commits the resource first, then audits
+(`r6/routes.py:531-542` create, `:725-735` update). `record_audit_event`
+(`r6/audit.py:84-113`) opens its own SAVEPOINT and then calls
+`db.session.commit()` — an **ambient commit** that also commits whatever the
+caller had pending. If the audit write fails, nothing catches
+`AuditWriteError`: the caller gets a 500 *with the resource already
+persisted and unaudited*. That is fail-closed on the response and fail-open
+on the data — the inverse of what the class docstring claims.
+
+The correct primitive already exists: `add_audit_event` flushes inside the
+caller's transaction and never commits. Census: `record_audit_event` 89
+sites, `add_audit_event` **5**. The #338 after-flush assertion observes the
+audit row honestly now, but it only runs under `TESTING` /
+`HC_ASSERT_AUDIT_COMMITTED` — production has no tripwire.
+
+For a system whose constitution says "every FHIR resource access emits an
+AuditEvent," this is the top compliance risk in the codebase: the guarantee
+holds only when nothing goes wrong, which is precisely when audit matters
+least.
+
+### 6.2 Deploys strand in-flight imports, and the reaper never runs
+
+Fasten NDJSON ingest and SHC import run as **daemon threads inside the web
+dyno** (`r6/fasten/routes.py:182-191`, `r6/shc/routes.py:238-241`). A
+Railway deploy kills them mid-import. The recovery function exists —
+`recover_zombie_jobs`, `main.py:131` — but its only callers are a CLI
+command and a legacy boot path that `railway.toml` never invokes. Since
+`web` auto-deploys from `main`, **every merge that lands during a patient's
+import strands that import**, and recovery is a human hitting a retry
+endpoint.
+
+### 6.3 `is_deleted` filtering split cleanly along old/new code (#422)
+
+`r6/routes.py` filters `is_deleted` at all 18 query sites. Eleven feature
+modules added since — caregaps, labs, sdc, actions/review, form_fill,
+context_builder, quality, smbp — have **zero** `is_deleted` references
+across 21 query sites. It hasn't detonated because there is no DELETE route
+and only Permission-revoke sets the flag today. It is a loaded gun: the
+demo-tenant cleanup (#422) or any future delete feature fires it, and
+`caregaps` reads soft-deleted Patients straight into the evaluator.
+
+### 6.4 Process-local state and the two-worker multiplier
+
+Postgres is required in production and the rate limiter requires Redis
+(`r6/runtime_config.py:129-133`) — good. But: step-up **replay nonces**,
+the terminology cache, and the conformance report cache are per-process
+dicts; gunicorn runs 2 workers, so any in-memory fallback silently doubles
+limits; and `consume_nonce=False` is the *default* (`r6/stepup.py:190`), so
+step-up replay protection is opt-in per call site.
+
+Four further hardening items — three configuration fail-open conditions
+and one unauthenticated amplification surface — were found in the same
+pass. They are **tracked privately and will be published here once
+fixed**, following the precedent set by this repo's S-1…S-4 findings,
+which were written up publicly only after they were deployed. Nothing in
+that set is exploitable without a deployment mistake, and all four are
+scheduled in Phase 0/1 of the playbook.
+
+### 6.5 Concurrency and conformance residuals (fileable today)
+
+- **PUT accepts a truthy non-dict body** — POST got the #331 fix
+  (`isinstance(body, dict)`, `routes.py:466`); PUT still has `if not body`
+  (`:658`), so `PUT` with `[1]` reaches `.get()` → authenticated 500. The
+  fix didn't carry across.
+- **Optimistic locking is check-then-act.** `If-Match` is compared in
+  Python with no `SELECT FOR UPDATE` and no `WHERE version_id = :expected`
+  — two concurrent PUTs with the same ETag both pass; last writer wins
+  silently. Also `lstrip('W/')` strips a character set, not a prefix.
+- **Search does not paginate.** `_count` clamps at 200, the Bundle carries
+  an accurate `total` and a `self` link, and **no `next` link exists
+  anywhere**. A tenant with 5,000 Observations can see 200 of them. This is
+  the API-level twin of the week's defect pattern: a partial answer shaped
+  like a complete one.
+- **Validation degrades silently** — external validator failure falls back
+  to structural checks with only a server-side log line; the caller can't
+  tell a validated resource from a structurally-plausible one.
+- **MCP manifest carries no `tier` field** — the step-up gate reads the
+  in-process registry (fine for MCP transport), but the exported manifest
+  that the OpenAI/Gemini bridge consumes has no privilege signal beyond
+  hints; the gate cannot be reconstructed from the artifact (#328's goal,
+  half-landed).
+- `r6/schema_sync.py` is dead code with zero production callers,
+  contradicted by its own test suite. Delete it.
+
+## 7. Measured against healthcare/FHIR practice
+
+What the standards expect of a FHIR repository holding PHI, against what
+the graph and the three passes measured. "Held" means verified, not
+assumed.
+
+| Practice | Expectation | Here | Status |
+|---|---|---|---|
+| Audit atomicity (ATNA / AuditEvent) | audit row commits with the operation or the operation fails | 88 sites commit data first, audit second, ambient commit; 5 sites do it right | **Gap — top priority** |
+| Audit completeness | every access and mutation audited | 2 step-up-gated mutators emit zero events (command_center, agent_runs) | **Gap** |
+| Single policy enforcement point | one gate for tenant + scope + audit + exit | kernel built and tested; 8/11 primitives uncalled; 55 raw header reads in 14 modules | **In flight, stalled** |
+| Fail-closed configuration | one production posture | prod closes 4 fail-open dev defaults, except the Vercel branch; MCP auth middleware fail-open minus NODE_ENV | **Partial** |
+| Tenant id validation | validated at every entry | 4 blueprints fixed (slice 9); 10 modules still read the header unvalidated | **Partial** |
+| Search pagination | searchset Bundles with `next` links | accurate `total`, `self` only, hard cap 200, no `next` anywhere | **Gap — silent truncation** |
+| Concurrency (If-Match) | atomic version check | check-then-act in Python, no `WHERE version_id`; last writer wins | **Gap** |
+| Version history | `_history` / vread or documented absence | overwritten in place, honestly declared in CapabilityStatement | Declared, acceptable |
+| Soft-delete consistency | one selector honoring `is_deleted` | old code filters at 18/18 sites, new code at 0/21 | **Gap — latent (#422)** |
+| Durable background work | queue + reaper, not request threads | agent_runs has the good pattern; fasten/SHC ingest are daemon threads with a reaper that never runs | **Gap** |
+| Honest degradation (patient-facing) | outage ≠ negative clinical claim | 9 fixed this week; 4 remain (review page, history, brief, heartbeat) | **In flight** |
+| Backpressure | reject or queue visibly under load | presence-only health; no queue depth; 8-slot ceiling | **Gap** |
+| Replay protection | nonces consumed by default | `consume_nonce=False` default, opt-in per site; in-memory outside Redis | **Partial** |
+| PHI-free failure text | sanitized errors at every boundary | MCP sanitizer is best-in-repo (allowlisted codes, bounded reads, URL-free constants); careagents D5 single-home | **Held** |
+| No PHI in consumer tier | accounts and pointers only | held; session is signed-cookie, replica-safe | **Held** |
+
+The pattern across every "Gap" row: the guarantee exists as a *convention*
+enforced at N call sites rather than a *structure* enforced at one. That is
+the same generator behind the week's nine defects. The retro's phrase was
+"a control that looks like one thing and quietly does two"; the graph's
+version is "a guarantee implemented 88 times is a guarantee broken
+somewhere."
+
+## 8. The plan
+
+Ordered by risk-to-patients over effort, and split at the webinar
+freeze. Nothing in Phase 0 touches clinical logic or interfaces.
+
+### Phase 0 — before Aug 18 (small, contained, each one PR)
+
+| # | Change | Size |
+|---|---|---|
+| 1 | Review path: apply `_upstream_answered` posture to `fetch_review_page` + `submit_review`; register a `HealthClawError` errorhandler in careagents | S |
+| 2 | Carry #331 to PUT: `isinstance(body, dict)` at `routes.py:658` + matrix pin | XS |
+| 3 | Anthropic client: explicit timeout < run deadline; worker heartbeat gets one retry | XS |
+| 4 | `recover_zombie_jobs` into `railway.toml` preDeployCommand | XS |
+| 5 | Brief + history: outage renders as "couldn't check," not "not in your records" / first visit | S |
+
+### Phase 1 — the structural fixes the week's defects were pointing at
+
+| # | Change | Why now |
+|---|---|---|
+| 6 | The cycle-breaking PR: env predicates → `runtime_config`, `json_body_within_depth` → `r6/body_guard`, `authenticate_tenant_read` → `read_auth` (~200 lines, no behavior change) | unblocks every split of routes.py |
+| 7 | Audit atomicity: add audit to command_center + agent_runs first (they have none), then migrate `record_audit_event` → `add_audit_event` per blueprint — this *is* kernel slices 12–13 | the top compliance gap |
+| 8 | Resume kernel slices 4–8 and 10–11 | all nine of the week's defects were in un-migrated code; this is the type-level fix deferred to Aug 19 |
+| 9 | One shared soft-delete-aware selector (the refactor plan already names it); fixes the #422 class wholesale | close it before any delete feature fires it |
+| 10 | Split `routes.py` along trust tiers: internal endpoints out first, then operations | privilege isolation, then size |
+
+### Phase 2 — scale, in the order load will find them
+
+| # | Change |
+|---|---|
+| 11 | CareAgents → Postgres, flip `config.py:165` to `_require`; SSE ceiling (async worker or thread raise) — these two are the outage-shaped limits |
+| 12 | Backpressure: queue depth in `agent_worker_health`; shed at a threshold with an honest "busy, try shortly" |
+| 13 | Search pagination with real `next` links; cap `AuditEvent/$export` |
+| 14 | Atomic If-Match (`UPDATE … WHERE version_id = :expected`) |
+| 15 | Cache the connect-poll reads (`record_count`), add pool_maxsize, per-method timeouts |
+| 16 | Move fasten/SHC ingest onto the agent_runs durable-worker pattern |
+| 17 | Delete the dead guarantees: `schema_sync.py`, `conversation_locks.py`, the unwired constants — code that documents a promise nothing keeps is how the next "looks like one thing, does two" defect starts |
+
+### What held — worth saying plainly
+
+The composition root is clean. The worker claim design (skip-locked +
+conversation mutex + lease + park-don't-replay) is production-grade. The
+mail tri-state is the reference implementation of the week's lesson. The
+MCP failure sanitizer is the best boundary in the repo. Rate limiting is
+Redis-required in production with the XFF and tenant-claim hardening done
+right. The kernel itself is well-built and well-tested — the risk is its
+adoption rate, not its design. And the discipline that produced this
+week's fix quality — pin the defect, fix it, flip the pin in the same PR —
+is the reason this review could measure instead of guess.

--- a/docs/2026-08-05-healthclaw-2.0-playbook.md
+++ b/docs/2026-08-05-healthclaw-2.0-playbook.md
@@ -1,0 +1,222 @@
+# HealthClaw 2.0 — implementation playbook
+
+How the two 2026-08-05 reviews (graph + pattern-first) become shipped code:
+in small chunks, test-first, with dogfood and user-approval gates. This is
+the method document; each slice gets its own task-level plan when it
+starts.
+
+## 0. The premise: 2.0 is a ratchet, not a rewrite
+
+The research did not find a wrong architecture. It found a right
+architecture that nothing *enforces*: four jobs (store, PEP, contract
+ingest, thin heads) that all exist and none of which is the only path.
+A rewrite would throw away the best-engineered code in the repo (the
+newest) to fix the oldest — backwards. So 2.0 is defined not by new code
+but by **eight numbers reaching zero and staying there**:
+
+| Ratchet | Today | 2.0 |
+|---|---|---|
+| `record_audit_event` call sites (post-commit audit) | 88 | 0 |
+| Raw `X-Tenant-Id` reads outside the kernel | 55 | 0 |
+| Step-up call sites not consuming a nonce by default | 13 | 0 |
+| Query sites missing `is_deleted` filtering | 21 | 0 |
+| Modules importing `models`/`r6.models` outside kernel+ingest | 23 | ≤3 |
+| Lazy imports reaching into `r6/routes.py` | 7 | 0 |
+| Patient-visible "nothing read as an answer" sites | 4 known | 0 |
+| Kernel adoption allowlist | 5 files | all blueprints |
+
+**The mechanism is already proven in this repo.** The kernel spec pinned
+an adoption allowlist in a test and opened it one PR at a time. The write-
+guard matrix pinned every write path's behavior. Generalize: every
+workstream below gets a *ratchet test* — a CI assertion of the current
+count that each PR decrements and no PR may increment. The test suite
+becomes the architecture spec. Backsliding becomes a red build, not a
+review comment.
+
+```python
+# tests/test_ratchets.py — the shape (one per ratchet)
+def test_post_commit_audit_sites_only_decrease():
+    assert count_callsites("record_audit_event") <= 88  # ← each PR lowers the pin
+```
+
+Two rules carried over from what worked this month:
+
+1. **One chunk = one PR ≤ ~200 lines of behavior change**, flipping its
+   own characterization pin in the same PR (the §6 rule).
+2. **Strangler order**: build the new path beside the old, move callers
+   behind the ratchet, delete the old path only when its count is zero.
+   Never break the old path while callers remain.
+
+## 1. The six workstreams and their chunks
+
+Chunks within a workstream are sequential; workstreams are parallel
+except where the dependency diagram (§4) says otherwise. Every chunk
+names its ratchet and its test-first artifact.
+
+### A. The kernel becomes the only path (PEP)
+
+| # | Chunk | Ratchet moved | Test-first artifact |
+|---|---|---|---|
+| A1 | Cycle-break PR: env predicates → `runtime_config`, `json_body_within_depth` → `body_guard`, `authenticate_tenant_read` → `read_auth` | lazy-imports 7→0 | import-graph test: "nothing imports from r6.routes but main" |
+| A2 | Kernel slices 4–5 (wearables 403-dialect, actions ×4 step-up sites) | allowlist +2 | existing write-guard matrix rows flip |
+| A3 | Slices 6–8 (routes create/update/share, ingest-context, read_auth scope) | allowlist +1 | matrix rows |
+| A4 | Slice 10: header-only tenant reads (routes.py 33 + 6 copies) | tenant reads 55→~15 | per-blueprint tenant matrix |
+| A5 | Slices 11a–k: multi-source tenant sites, one PR each | tenant reads →0 | same |
+| A6 | `consume_nonce=True` default; exemptions become explicit | nonce sites 13→0 | replay test per exempted site |
+| A7 | Grep-guard lands: `X-Tenant-Id` outside kernel = red build | ratchet → tripwire | the guard is the test |
+| A8 | Split routes.py by trust tier (internal → own blueprint first) | — | route-inventory pin: same routes before/after |
+
+### B. Audit correctness (same-transaction + coverage)
+
+| # | Chunk | Ratchet | Test-first |
+|---|---|---|---|
+| B1 | Audit for `command_center` (3 gated writes, currently 0 events) | coverage gap −1 | audit-assertion (#338 after-flush) turned on for these routes |
+| B2 | Audit for `agent_runs` (2 gated writes) | coverage gap −2 | same |
+| B3–B8 | `record_audit_event` → `add_audit_event`, one blueprint per PR (routes, curatr, labs, caregaps, shc/quality, actions/review) | 88→0 stepwise | audit-atomicity matrix: for each write path, assert audit row in `session.new` before commit |
+| B9 | Delete `record_audit_event` + its ambient commit | primitive count 2→1 | the ratchet at 0 is the precondition |
+| B10 | Enable `HC_ASSERT_AUDIT_COMMITTED` in production once B9 lands | tripwire live | prod_watch check |
+
+### C. Contract ingest (US Core pipeline)
+
+| # | Chunk | Test-first artifact |
+|---|---|---|
+| C1 | Vendor Inferno g(10) fixtures as `tests/fixtures/uscore/` — the free corpus. Golden-file harness: fixture in → canonical form out | the corpus IS the test |
+| C2 | One `to_canonical()` pipeline function: base-R4 hard gate → quarantine table with reason codes | fixtures + hand-broken fixtures |
+| C3 | Soft gate: US Core grade as meta tag (`conformant` / `with-DAR` / `off-profile`) — classify, never reject | graded fixtures |
+| C4 | Move the display/text strip from read-time into the pipeline (read-time strip stays as defense-in-depth) | leak fixture: PHI-in-display must not reach the store |
+| C5 | Route Fasten ingester through `to_canonical()` | fasten NDJSON replay test |
+| C6 | Route `$ingest-context`, HealthEx import, SHC through it; delete per-source shape code | ratchet: "modules that parse raw FHIR" → 1 |
+| C7 | `validator_cli` full-profile validation as a CI job over the corpus (async, not inline — the reference posture) | CI lane |
+
+### D. MCP 2.0 edge (spec-current)
+
+| # | Chunk | Test-first |
+|---|---|---|
+| D1 | Manifest: annotations (`readOnlyHint`/`destructiveHint`/`idempotentHint`) + `tier` — closes #328's other half | manifest test pins property-not-names (extend step-up-gate.test.ts pattern) |
+| D2 | RFC 9728 `/.well-known/oauth-protected-resource` + `aud` validation + `WWW-Authenticate` challenges (keep the token issuer) | transport-errors tests |
+| D3 | `outputSchema` + `structuredContent` on the top 3 read tools, serialized through the schema (allowlist) | schema-conformance test + a display-leak fixture that must fail |
+| D4 | URL-mode elicitation for clinical writes → **closes #214**; the action-rail approval page is the URL target; retire `X-Human-Confirmed` | e2e: write without confirmation → -32042 → confirm on page → retry succeeds |
+| D5 | Migrate `/mcp-apps/*` HTML to `ui://` templates (PHI-free templates, data per render) | template-has-no-PHI grep test |
+
+### E. CareAgents runtime honesty + posture
+
+| # | Chunk | Test-first |
+|---|---|---|
+| E1 | Review path: `_upstream_answered` posture on `fetch_review_page`/`submit_review` + a `HealthClawError` errorhandler (SEV-1) | fake gateway-504 test asserting the page does NOT say "no longer awaiting review" |
+| E2 | `timeouts.py` constants module: LLM < run deadline < lease; heartbeat one-retry | unit tests on the hierarchy invariant |
+| E3 | Brief + history outage states (SEV-2/3): "couldn't check" ≠ "not in your records" | three-state pins per surface |
+| E4 | Postgres required in prod (`_require`), WAL/busy_timeout for dev SQLite | runbook QA test exists — extend |
+| E5 | SSE → poll with server-suggested `Retry-After` + jitter; cache `record_count` | load test: 10 concurrent chatters don't saturate 8 slots |
+| E6 | Backpressure: queue depth in worker health; shed with honest "busy" | fake-queue test |
+
+### F. Subtraction (each its own tiny PR)
+
+F1 `schema_sync.py` · F2 `conversation_locks.py` + dead constants ·
+F3 PUT `isinstance` fix (carries #331) · F4 zombie reaper into
+preDeployCommand · F5 `is_deleted` shared selector (21 sites → one
+`live_resources(tenant_id)` query helper, ratchet to 0) · F6 openclaw
+sunset **after** a hermes-parity dogfood week proves the standards path
+covers it (measure, don't assume).
+
+## 2. The TDD protocol, by chunk type
+
+Three chunk shapes, three test-first disciplines — all already practiced
+in this repo, now stated as the rule:
+
+**Defect chunk** (E1, F3): write the failing test that *is* the defect
+(the gateway-504 test), watch it fail, fix, watch it pass, mutation-check
+(revert the fix in a scratch worktree, confirm the test reddens —
+`PYTHONDONTWRITEBYTECODE=1`). The diff is the defect.
+
+**Migration chunk** (A*, B*): characterization first — pin current
+behavior including the wrong parts (strict-xfail for the wrong parts),
+migrate, flip the pins in the same PR. The write-guard matrix is the
+template; A and B extend it with a tenant matrix and an audit-atomicity
+matrix. Rule from the #409 incident: before pinning a wrongness, check no
+in-flight PR fixes it (issue #414's process rule).
+
+**New-boundary chunk** (C*, D*): contract tests from external truth —
+Inferno fixtures for ingest, the MCP spec's schemas for the edge. Golden
+files, not hand-written expectations, so the test corpus is arguably
+right rather than self-confirming. Hand-break copies of fixtures for the
+rejection paths.
+
+And the standing rule for all three: **the ratchet test is part of the
+chunk.** A chunk that improves the code but doesn't move its number
+didn't happen, architecturally.
+
+## 3. The approval ladder: dogfood before design partner, design partner before done
+
+Four gates per chunk batch (not per PR — per batch that changes behavior
+someone can feel):
+
+```mermaid
+flowchart LR
+  G1["Gate 1 — CI\nsuite + ruff + conformance\nGrade A + ratchets moved"] -->
+  G2["Gate 2 — live shakeout\nscripts/shakeout_live.py +\nprod_watch against seeded stack;\ncross-boundary calls vs REAL\nHealthClaw (fakes prove calls,\nnot acceptance)"] -->
+  G3["Gate 3 — dogfood\nEugene runs the 10-min demo +\ndaily-driver CareAgents on the\nsynthetic tenant; N days quiet"] -->
+  G4["Gate 4 — design partner\nthe design partner's demo script passes;\nthe clinical advisor rules on anything\nclinical-semantic; maintainer\napproves the PR (never self-merge)"]
+```
+
+- **Gate 2 is non-negotiable for anything touching careagents↔engine**,
+  because those tests fake the client (the CLAUDE.md trap: ids don't
+  transfer, rejection is silent).
+- **Gate 3 (dogfooding) has a definition**: the owner uses the real
+  surfaces on synthetic data — the 10-minute demo script start-to-finish
+  plus normal CareAgents use — and the batch sits in that state for a
+  few quiet days before the next batch stacks on it. Demo-script
+  breakage is the canary; it caught #415 once already.
+- **Gate 4 (user approval)**: the design-partner physician is the acceptance tester for
+  patient/clinician-visible behavior — their common-use-case demos are the
+  acceptance suite; formalize each as a recipe-style artifact (Goose
+  pattern: versioned YAML task with declared tools + expected output
+  shape) so "her demos still work" is checkable before she ever sees a
+  regression. the clinical advisor gates clinical semantics (the #423 lesson:
+  reasons about a record no one evaluated). The maintainer-approval rule
+  stays absolute.
+
+Cadence: keep the sprint structure that produced the last three weeks
+(CTO design pass → Dev in worktree → adversarial QA → Product review),
+one workstream-batch per sprint, and a one-line **ratchet report** per
+sprint close: eight numbers, direction, blockers.
+
+## 4. Sequencing
+
+```mermaid
+flowchart TD
+  P0["NOW → Aug 18 (webinar freeze)\nPhase 0: E1 E2 E3 · F3 F4 ·\nratchet tests land at CURRENT values\n(zero behavior change, pure pins)"]
+  P0 --> W1["Aug 19 → early Sept\nA1 cycle-break · A2–A5 kernel ·\nB1–B2 unaudited mutators · F1 F2 F5"]
+  W1 --> W2["Sept\nB3–B10 audit atomicity ·\nA6–A8 nonce default + routes split"]
+  W1 --> W3["Sept, parallel\nD1–D3 MCP manifest/authz/schemas ·\nE4 Postgres · E5 poll"]
+  W2 --> W4["Oct\nC1–C7 contract ingest ·\nD4 URL elicitation (closes #214) ·\nD5 ui:// · E6 backpressure"]
+  W4 --> DONE["2.0 = eight ratchets at zero,\ngates green, F6 sunset decided"]
+```
+
+Why this order and not another:
+
+- **Phase 0 is pins + patient-visible honesty only.** Landing the
+  ratchet tests at *current* values before Aug 18 costs zero risk and
+  means the freeze can't silently regress the numbers.
+- **A before B**: audit migration wants `require_grant`/kernel plumbing
+  in place per blueprint, or you touch every blueprint twice.
+- **B before C**: the ingest pipeline writes resources; write it against
+  the corrected (in-transaction) audit primitive so C never couples to
+  the deprecated one.
+- **D4 (URL elicitation) waits for D2 (authz)** because the elicitation
+  page must be identity-matched to the token's subject — that's the
+  anti-phishing requirement in the spec.
+- **F6 (openclaw sunset) is last** and gated on a measured parity week,
+  not on enthusiasm.
+
+## 5. Definition of done for 2.0
+
+1. All eight ratchets read zero and are tripwires (increments = red CI).
+2. Grade A conformance held on every merge in between (it gates CI
+   already — the constraint is it *stays* the constraint).
+3. The 10-minute demo and the design partner's recipe suite pass on the deployed
+   stack, verified live, not from fakes.
+4. The three tolerated gaps have owners and dates, not vibes: #423
+   (clinical ruling), #413 (curatr token), openclaw sunset decision.
+5. The two review docs and this playbook live in `docs/` — committed,
+   because the repo's rule is that guidance that matters is published,
+   not resident in one person's context window.

--- a/docs/2026-08-05-pattern-first-architecture-review.md
+++ b/docs/2026-08-05-pattern-first-architecture-review.md
@@ -1,0 +1,543 @@
+# Pattern-first architecture review — 2026-08-05
+
+Companion to the same-day graph review (import graph, 172 modules, three
+measured review passes). That document found the defects; this one asks the
+structural question: **is each component the simplest thing that does its
+job, and does the whole match how modern agentic + healthcare platforms are
+built?** External references researched for this review: hermes-agent (Nous
+Research), Block's agentic-app patterns, the current MCP spec direction,
+stateless-tier practice, headless data platforms, US Core/USCDI as an ingest
+contract, and the open-source healthcare connectors (Medplum, Metriport,
+Fasten, Aidbox).
+
+**TL;DR.** First principles reduce the system to four jobs: canonical
+store, policy enforcement point, contract-normalizing ingest, thin heads.
+All four already exist in the codebase; none is yet the *only path*, and
+that gap is where last week's nine defects lived. The external references
+converge on this design from three directions: Block's Buzz makes the
+audit trail the data model with owner attestation ("authorization does
+not erase authorship") — our step-up + human-confirm + AuditEvent thesis
+productized; the MCP spec's URL-mode elicitation is the standardized
+closure of known gap #214, and `outputSchema`-as-allowlist is the
+type-level end of the #282 display-leak family; and the US Core contract
+holds for our scope (all eight consumer data classes stable since USCDI
+v1) with one amendment — the spec's own tolerances mean profile
+validation classifies, never rejects. Component verdicts: the newest
+code is the best-engineered (`agent_runs` is the reference pattern;
+`hermes/` is the integration model at ~0 LOC); the over-engineering
+lives in `curatr` (fix path unreachable), `openclaw` (2,100 LOC doing
+what standards do declaratively), and the kernel's 8 uncalled
+primitives; the under-engineering is one file, `routes.py`. Work is
+consolidation, not invention.
+
+---
+
+## 1. First principles: what this system irreducibly is
+
+Strip away every feature and four jobs remain:
+
+1. **A canonical per-tenant health record store.** Small, boring, correct.
+2. **A policy enforcement point (PEP)** on every access: tenant isolation,
+   scope, step-up, human confirmation, redaction, audit. This is the
+   product. Everything the webinar sells — Grade A, verifiable guardrails —
+   is this box.
+3. **A contract-normalizing ingest boundary**: many source flavors in, one
+   canonical shape out.
+4. **Heads**: MCP server, consumer app, bots — thin delivery surfaces that
+   hold no PHI and re-implement no policy.
+
+Every finding in the companion review is a violation of this decomposition:
+
+- Policy implemented 88 times instead of once → audit gaps, tenant-read
+  variance, step-up drift. Job 2 leaked into every blueprint.
+- Free-text `display` leaks, "could not look it up" confusion, per-source
+  quirks → Job 3 is being done at *read* time (redaction on exit) instead of
+  *write* time (normalize at ingest), so every reader re-solves it.
+- CareAgents holding retry/timeout/error policy per call site → the head is
+  re-deciding things the boundary client should decide once.
+
+The architecture is not wrong. It is **right and unenforced**: the kernel
+exists (job 2), the ingester exists (job 3), the heads mostly hold no PHI
+(job 4). The gap between "exists" and "is the only path" is where all nine
+of last week's defects lived.
+
+## 2. The system today, end to end
+
+```mermaid
+flowchart LR
+  subgraph Sources["Record sources (R4 / US Core-ish)"]
+    FC["Fasten Connect<br/>NDJSON export"]
+    HX["HealthEx"]
+    OW["Open Wearables"]
+    SHC["SMART Health<br/>Cards / Links"]
+    EHR["EHR patient-access<br/>(MEDENT/PPCP, SMART)"]
+  end
+
+  subgraph HC["HealthClaw — Railway web (2 gunicorn workers)"]
+    ING["fasten/ingester<br/>(daemon threads!)"]
+    RT["r6/routes.py 3,905 LOC<br/>CRUD + search + ops +<br/>internal + demo + MCP apps"]
+    BP["14 feature blueprints<br/>labs · caregaps · brief · smbp ·<br/>sdc · wearables · actions · …"]
+    KERNEL["r6/access.py kernel<br/>(8/11 primitives uncalled)"]
+    AUD["r6/audit.py<br/>88 post-commit sites"]
+    RED["redaction + terminology<br/>(applied on exit)"]
+    DB[("Postgres<br/>r6_resources + audit")]
+    PRX["fhir_proxy<br/>(optional upstream mode)"]
+  end
+
+  subgraph Heads["Heads"]
+    MCP["agent-orchestrator (TS)<br/>MCP: stdio + HTTP, token auth"]
+    CA["CareAgents web+worker<br/>(SQLite ship config, SSE poll)"]
+    OC["openclaw Telegram bot"]
+    ADP["adapters bridge<br/>(OpenAI / Gemini)"]
+  end
+
+  subgraph Agents["Agent runtimes"]
+    CL["Claude (desktop/code)"]
+    HM["hermes-agent<br/>(native MCP client)"]
+    GS["Goose / others"]
+  end
+
+  FC --> ING --> DB
+  HX --> RT
+  OW --> BP
+  SHC --> BP
+  EHR -.-> PRX
+  RT --> DB
+  BP --> DB
+  RT -.->|"should route via"| KERNEL
+  BP -.->|"should route via"| KERNEL
+  RT --> AUD --> DB
+  BP --> AUD
+  DB --> RED
+  MCP --> RT
+  CA --> RT
+  OC --> MCP
+  ADP --> RT
+  CL --> MCP
+  HM --> MCP
+  GS --> MCP
+  style KERNEL fill:#b45309,color:#fff
+  style RT fill:#b91c1c,color:#fff
+  style ING fill:#b91c1c,color:#fff
+  style CA fill:#b45309,color:#fff
+```
+
+Red: measured structural problems. Amber: right component, wrong posture.
+The dashed "should route via" edges are the kernel adoption gap; the solid
+edges around it are today's truth.
+
+## 3. Component verdicts
+
+First-principles test applied to each: *what job does it do, is it the
+simplest structure that does that job, and is its complexity spent where
+the risk is?* Verdicts: **over-built** (complexity ahead of need),
+**right-sized**, **under-built** (need ahead of structure), **mis-aimed**
+(right size, wrong place or default).
+
+### The engine (HealthClaw)
+
+| Component | LOC | Job | Verdict | Evidence-based reasoning |
+|---|---|---|---|---|
+| `r6/access.py` kernel | 823 | the PEP | **over-built today, right tomorrow** | 11 primitives, 8 with zero callers, 2 commits vs ~40 landing in code it should replace. The design is good; building all 11 before adopting 3 was inventory. First principles: a PEP earns existence by being *the only path* — until adoption, it is a second implementation of every guarantee, i.e., risk. Fix by adoption, not redesign. |
+| `r6/routes.py` | 3,905 | everything | **under-built** | Eight jobs, four trust tiers, one module. The only component where more structure is unambiguously needed. |
+| `r6/audit.py` | ~200 | audit write | **mis-aimed** | Two primitives; the wrong one (post-commit, ambient-commit) won 88–5. The simple fix is a default, not a framework: `add_audit_event` in the caller's transaction, one deprecation shim. |
+| `r6/stepup.py` | ~250 | write elevation | **mis-aimed** | Sound HMAC design; `consume_nonce=False` default makes replay protection opt-in at 13 call sites. Flip the default, delete the parameter at call sites that don't need an exemption. |
+| `r6/redaction.py` | ~300 | PHI minimization on exit | **right-sized** | Profile-driven, docstring-is-the-spec, boringly effective. Keep exactly as is; it becomes defense-in-depth (not the primary control) once ingest normalizes. |
+| `r6/terminology.py` + resolver | ~400 | code→label, never display | **right-sized** | Static table + opt-in runtime lookup with a per-request budget and deliberate no-DB-cache reasoning. One mismatch (5s timeout vs 0.4s budget). This is what simple-and-effective looks like. |
+| `r6/validator.py` | 752 | structural validation | **mis-aimed** | Right-sized checks, wrong failure mode: external-validator loss silently downgrades to structural. Honest degradation is this repo's own religion — the validator should confess in the OperationOutcome. |
+| `r6/conformance/` | 1,379 probes | verifiable guardrail claims | **right-sized, wrong exposure** | Unusual and strategically valuable (a partner can *prove* the guarantees). But it is an unauthenticated in-process write amplifier with a cache bypass. Lock it; don't shrink it. |
+| `r6/curatr.py` | 1,173 | data-quality engine | **over-built** | Rich evaluation + fix + Provenance pipeline whose apply-fix path is unreachable in production (no `audience='curatr'` token minting, #413). Shipped ahead of its auth story and its user. Freeze feature growth until $curatr-apply-fix has a caller. |
+| `r6/fhir_proxy.py` | 839 | guardrails over an external FHIR store | **strategically under-valued** | This is the headless thesis in embryo: policy layer over *any* store (HAPI, Epic sandbox). If the platform's future is "the guardrail layer, store optional," this component is the future — currently 15 broad excepts and no owner. Decide: elevate or excise. |
+| `r6/agent_runs/` | ~1,400 | durable agent execution | **right-sized — the reference** | Claim via `FOR UPDATE SKIP LOCKED`, conversation-row mutex, leases + heartbeat, park-don't-replay on ambiguous tools, event log. This is the modern durable-execution pattern implemented small. Other components should copy it, not invent. |
+| `r6/fasten/` ingest | ~900 | source→store | **under-built** | Half the durable pattern (jobs table, retry endpoint) with daemon-thread execution and a reaper production never runs. The finished version of this component already exists one package over (`agent_runs`). |
+| `r6/command_center/` | 1,440 | ops dashboard | **under-guarded** | 853-LOC projector is honest (pure functions over durable tables). But 3 step-up-gated writes, 30 tenant filters, 0 audit events. Privilege without evidence. |
+| 8 thin blueprints (labs, caregaps, brief, smbp, sdc, wearables, shc, quality) | ~200–650 ea | features | **right-sized individually, wrong collectively** | Each is small and readable. Collectively they hand-roll tenant+audit+error 8 ways — the convention-vs-structure problem. They are the kernel's adoption backlog, nothing more. |
+
+### The heads
+
+| Component | Job | Verdict | Reasoning |
+|---|---|---|---|
+| `services/agent-orchestrator` (MCP) | agent-facing PEP edge | **right-sized, one gap** | The failure sanitizer (allowlisted codes, bounded reads, URL-free constants) is the best boundary in the repo. Gaps vs current MCP direction: static bearer token (spec has moved to OAuth 2.1 resource-server), manifest carries no tier, and HTTP transport session state should stay stateless. |
+| `careagents/` web | consumer head | **mis-aimed runtime** | Product shape is right (no PHI, pointers, signed cookies). Runtime posture is not: SQLite ship config, 8 request slots held by 150s SSE turns, zero caching, 600s LLM default inside a 120s deadline, dead lock module. The head is thin in data and thick in policy — exactly backwards from the target. |
+| `careagents/worker` | durable turn executor | **right-sized** | Rides `agent_runs` properly. One brittle spot (single heartbeat failure = lost lease). |
+| `openclaw/` bot (991 LOC) + `scripts/bot_commands.py` (1,100) | Telegram gateway | **over-built for its future** | Code-heavy custom integration whose capabilities the hermes path gets via configuration (skills + SOUL.md + native MCP). Two thousand lines maintaining what the standards path does declaratively. Sunset candidate once hermes parity is confirmed. |
+| `hermes/` | agent-runtime integration | **right-sized — the pattern** | Integration by open standards (SKILL.md, MCP, persona file) rather than by code: ~0 LOC of Python, an installer, and config. This is what every future integration should look like. |
+| `adapters/healthclaw_bridge.py` | OpenAI/Gemini function-calling | **watch** | Justified while those ecosystems lack MCP; becomes deletable as MCP adoption spreads. Keep it thin; never let policy in. |
+| `services/shl-server` | SMART Health Links | small, standards-shaped | fine |
+
+### The pattern in the verdicts
+
+Complexity in this codebase correlates with *when* a component was built,
+not with the risk it guards. The newest infrastructure (`agent_runs`,
+kernel, MCP sanitizer, mail tri-state) is the best-engineered; the oldest
+(routes.py, openclaw, curatr's reach) carries the accumulation. That is a
+healthy trajectory — the team's current instincts are right — and it means
+the work is consolidation onto the good patterns, not invention of new ones.
+
+## 4. The contract thesis: R4 + US Core as the ingest boundary
+
+The owner's thesis: incoming FHIR comes in many flavors but will
+ultimately be R4 + US Core / USCDI shaped, so design for the contract and
+skip per-source rules. **Research verdict: the thesis holds, with one
+amendment** — design for the contract's *stated tolerances*, because three
+of them are part of the specification itself.
+
+### What the contract guarantees
+
+- US Core elements come in three tiers: **mandatory** (always present),
+  **must-support** ("populate if you have it; receiver never errors on
+  absence"), and additional-USCDI. The receiver rules are pre-written:
+  a missing must-support element means "not present at the source,"
+  nothing more.
+- **All eight data classes a consumer app cares about — allergies, meds,
+  problems, labs, vitals, immunizations, notes, procedures — have been in
+  USCDI since v1 (2020).** Growth since is additive and at the edges
+  (v2: SDOH/SOGI/encounters; v3: coverage + health-status assessments).
+  The contract for our scope has been stable for six years.
+- Strong vocabulary bindings (LOINC, RxNorm, SNOMED, CVX, UCUM) are the
+  contract's real gift: they make **code-keyed** normalization viable
+  with zero per-source rules — which is precisely the
+  `r6/terminology.py` design, independently validated.
+- A free conformance harness exists: HL7 `validator_cli` with the
+  `hl7.fhir.us.core` package, plus Inferno's g(10) test-kit fixtures as
+  a corpus of "what certified servers must emit."
+
+### The amendment: three tolerances are in the spec
+
+1. **The legacy-data exemption.** ONC explicitly does not require data
+   originating from outside systems to be mapped to USCDI terminologies.
+   A certified endpoint can lawfully serve historical records that are
+   structurally R4 but semantically off-profile. Off-profile data from a
+   certified source is *routine*, not exceptional — so profile
+   validation must classify, never reject.
+2. **Must-support silence.** You cannot distinguish "source has none"
+   from "source didn't map it," and many sources never send
+   DataAbsentReason at all (an ONC carve-out). The three-state
+   discipline this repo learned the hard way is the contract's own
+   posture.
+3. **Free text is unconstrained.** No profile version constrains
+   `display`, `CodeableConcept.text`, or narrative. The repo's
+   non-negotiable (never preserve upstream display; label by code) is
+   the correct defense and nothing in certification replaces it.
+
+Plus: version skew is *within* the contract, not per-source — US Core
+3.1.1 through 8.0.1 are live concurrently, and US Core 8.0.1 enters
+g(10) testing **Aug 13, 2026**, five days before the webinar.
+
+### How the references split, and where we land
+
+Medplum and Aidbox validate at write (base always, profile opt-in via
+`meta.profile`); Metriport canonicalizes at ingest (convert, code-hydrate,
+dedupe, `meta.source` provenance); Fasten Connect — our own upstream —
+passes source R4 through **unmodified**, so the entire conformance burden
+lands on us, the receiver. **Nobody hard-gates ingest on US Core.** The
+aggregators' converged pattern is the thesis: receiver-tolerant,
+code-keyed, one pipeline.
+
+The per-source rules we avoid writing are replaced by exactly three
+generic mechanisms: **a conformance grade** (stored as a meta tag:
+`conformant` / `conformant-with-DAR` / `off-profile`), **a display
+strip**, and **a quarantine** (for base-R4 structural failure only).
+Full-depth profile validation runs async/CI with `validator_cli`, not
+inline — matching all five reference implementations.
+
+### Calibration: the audit-transactionality claim
+
+The companion review calls the post-commit audit write its top compliance
+risk. The research sharpens this honestly: **HIPAA requires durable,
+tamper-resistant, 6-year-retained audit records — not same-transaction
+writes** — and both Medplum and Aidbox use async/outbox delivery, with
+IHE ATNA's architecture being "emit at the access point, deliver durably
+to a separate repository." So the defect is not "we differ from a
+regulation"; it is that the current shape delivers the *worst of both
+postures*: the request fails (strict) while the data commits unaudited
+(lax), plus an ambient commit of unrelated caller state. Same-transaction
+`add_audit_event` remains the right fix at our scale — it is the simplest
+mechanism that guarantees no unaudited PHI access, and the audit table
+then doubles as the outbox (§5) if an external audit repository ever
+materializes. Stricter than the regulation, and cheaper than the
+alternatives. What changes is only the framing: fix it as engineering
+correctness, not as compliance emergency.
+
+## 5. What the agentic-platform references teach
+
+### hermes-agent (Nous Research)
+
+One agent core, many surfaces: a single `AIAgent` loop serves CLI, gateway,
+batch, and API, with 25+ platform adapters normalizing every channel into
+one `MessageEvent`. Tools live in a **self-registering registry with one
+dispatch choke point** — structurally the same bet as `r6/access.py`, made
+by an unrelated team. Skills are `SKILL.md` files (agentskills.io, the
+open standard this repo's `skills/` already ships) with progressive
+disclosure and a learning loop that writes new skills from experience.
+
+Two direct implications for us. First, the `hermes/` integration folder is
+the right model: **~zero code, integration by standards** (SKILL.md + MCP
++ a persona file) — measured against it, `openclaw/` + `bot_commands.py`
+is 2,000 lines maintaining by hand what the standards path gets by
+configuration. Second, Hermes as an MCP client auto-reconnects, treats
+tool descriptions as the entire discovery surface, and may filter tools
+client-side — so **server-side per-call auth is the only auth**, which is
+already this repo's posture; keep it.
+
+Notably: neither Hermes nor Goose is stateless-horizontal. The agent tier
+is deliberately a stateful process with pluggable *execution* isolation.
+The stateless-scale discipline belongs to the consumer web tier, not the
+agent tier — don't import horizontal-scale complexity where the references
+deliberately keep state.
+
+### Block: Buzz + Goose + ACP
+
+Buzz (launched 2026-07-21, Apache-2.0) is the strongest external
+validation of this platform's core thesis. Its substrate: every message,
+patch, and approval is a **cryptographically signed event in one
+append-only log — the audit trail *is* the data model**, not a side
+effect. Agent identity is separated from the harness: the agent holds its
+own keypair, and an **owner-attestation layer** has the human's key sign
+narrowly-scoped authorizations for the agent's key. Their phrase:
+*"authorization does not erase authorship."* That is this repo's
+step-up-token + human-confirmation + per-event AuditEvent design,
+restated by an unrelated team as the foundation of a whole product — and
+it is exactly the agent-trust extension Bo Holland proposed collaborating
+on. The market is converging on the thing the guardrail stack already
+does; the gap is that Buzz makes it *structural* (an event cannot exist
+unsigned) where ours is *conventional* (88 call sites remember to audit).
+
+Goose contributes the **recipe** pattern: a task as a versioned YAML
+artifact — instructions, typed parameters, declared MCP-server
+dependencies, schema-validated output. Block reports recipes carried
+Goose to ~60% internal adoption. Our demo scripts and clinician packets
+are informal recipes; formalizing the 10-minute demo and the design partner's
+common-use-cases as recipe-style artifacts would make them versioned,
+parameterized, and shareable instead of prose.
+
+### Consumer open-source platforms (Cal.com, Supabase, Plausible, Maybe)
+
+The convergent stack: magic-code-first auth with passkeys layered after
+first login (**careagents already implements exactly this**); one
+row-keyed Postgres for multi-tenancy, policy enforced at the data layer;
+background work as a DB queue + workers from the same image with
+idempotent materialization (**agent_runs already implements exactly
+this**); an internal API split from a versioned public API; and hosted +
+self-hosted running **the same image**, diverging by license flag, never
+by fork. CareAgents' deviations from this stack are precisely its
+findings list: SQLite where the pattern says one Postgres, per-process
+limiter state where the pattern says data-layer enforcement.
+
+### The MCP spec's direction (2025-11-25 stable; 2026-07-28 RC)
+
+The spec has moved, and it moved *toward* this repo's architecture in some
+places and *past* it in others:
+
+| Spec direction | Where we stand |
+|---|---|
+| **Stateless core** (2026 RC deletes sessions from the protocol; auth on every request) | already our posture — keep; never add session state to the TS server |
+| **OAuth 2.1 resource server** (RFC 9728 `/.well-known/oauth-protected-resource`, audience-validated tokens; static bearer is below floor for network-exposed servers) | gap: `MCP_AUTH_TOKEN` is a static bearer. Smallest fix: keep the issuer, add the well-known doc + `aud` validation + `WWW-Authenticate` challenges |
+| **Tool annotations as UX, server-side enforcement as truth** ("clients MUST consider annotations untrusted") | our posture already (Flask gates writes) — but annotations + a `tier` field belong in the manifest (#328's missing half) |
+| **Structured tool output** (`outputSchema` + `structuredContent`) | gap, and a big one for PHI: an output schema built from named fields is a **redaction allowlist** — an upstream `display` that isn't in the schema cannot ride along. This is the type-level fix for the #282 defect family, at the protocol layer |
+| **URL-mode elicitation** (SEP-1036: server returns `-32042` + a URL; the user confirms on the server's own authenticated page, identity-matched, invisible to the LLM) | this is the standardized wire form of our action-rail approval endpoint — and the principled *replacement for the `X-Human-Confirmed` header*, i.e., the closure of known gap #214 |
+| **Tasks** (poll-based long operations, server-suggested intervals, auth-context-bound) | protocol twin of the `agent_runs` claim-poll design; adopt when clients support it |
+| **Sampling: deprecated** | we never built on it — nothing to do |
+| **MCP Apps** (`ui://` pre-declared templates, sandboxed render) | our `/mcp-apps/*` HTML surfaces predate the extension; migrating to `ui://` templates separates presentation from PHI (template ships clean, data arrives per-render) |
+
+### Stateless + headless practice, right-sized
+
+The consensus for a platform this size, from the SRE/12-factor literature:
+
+- **Timeout hierarchy as a constants module**: every dependency timeout <
+  handler deadline < LB timeout, in one grep-able file. Our two worst
+  findings (600s LLM default inside a 120s deadline; 150s `record_count`
+  inside a 180s gunicorn worker) are both violations of this one rule.
+- **Retry at one layer only**, 2–3 attempts, jittered, with a ~10% retry
+  budget. Today careagents retries nowhere (one-shot everything) and the
+  LLM path retries at the SDK layer *and* the app layer on the OpenAI
+  path — both wrong in opposite directions.
+- **Circuit breakers: don't.** At this scale the guidance is explicit —
+  timeouts + capped retries + fail-fast readiness deliver the protection;
+  a ten-line consecutive-failure counter per dependency is the whole
+  pattern if one hot third-party dependency (Bland/Twilio, an EHR
+  endpoint) starts hanging. Anything more is over-engineering.
+- **Poll, don't hold.** Short-poll with server-suggested `Retry-After` +
+  jitter is the endorsed small-scale pattern; MCP itself moved there.
+  CareAgents' 0.25s SSE poll ×150s is the anti-pattern twin: a held
+  connection *and* a hot poll.
+- **Postgres for everything at this scale** — sessions, nonces, counters,
+  job claims (`SKIP LOCKED`), outbox. We already require Redis for rate
+  limits (built, keep it), but new state should default to Postgres, not
+  grow the Redis surface.
+- **The headless rule, mechanically enforced**: *no head imports the
+  storage layer* — heads call the kernel/API client only. One CI grep
+  turns the whole headless thesis from a review comment into a build
+  failure. (The graph shows today's violations precisely: `careagents` is
+  clean over HTTP; inside the engine, 23 modules import `r6.models`
+  directly.)
+- **Audit-table-as-outbox**: the same-transaction audit row is not just
+  compliance — it is already the outbox for any future SIEM/export
+  stream. Fix 6.1 of the companion review and the export architecture
+  falls out for free. Never dual-write.
+
+## 6. Target architecture
+
+Three diagrams: the end-to-end target, the ingest contract pipeline, and
+the guarded request path. Nothing here is speculative — every box either
+exists today or is named in the phased plan; the diagrams show where the
+existing pieces *go*, not new inventions.
+
+### 6.1 End to end
+
+```mermaid
+flowchart LR
+  subgraph Sources["Sources (many flavors)"]
+    S1["Fasten / HealthEx /<br/>EHR patient-access APIs"]
+    S2["Wearables / SHC / SHL"]
+  end
+
+  subgraph Ingest["Contract boundary (job 3)"]
+    ACL["per-source ACL<br/>feeds/&lt;source&gt;/translate"]
+    VAL["US Core validator<br/>required + must-support"]
+    NORM["normalize: code-keyed labels,<br/>strip display/text"]
+    Q[("quarantine<br/>+ reason codes")]
+  end
+
+  subgraph Core["HealthClaw engine"]
+    KERNEL["r6/access kernel — THE PEP<br/>tenant · scope · step-up ·<br/>human-confirm · redact · audit"]
+    DB[("Postgres<br/>canonical store +<br/>audit (same txn)")]
+    OUTBOX["audit table = outbox"]
+    JOBS["durable jobs<br/>(agent_runs pattern:<br/>claim · lease · park)"]
+  end
+
+  subgraph Heads["Thin heads (no policy, no PHI)"]
+    MCP["MCP server<br/>OAuth2.1 RS · outputSchema ·<br/>URL elicitation · annotations"]
+    CA["CareAgents<br/>stateless web + worker,<br/>Postgres, poll w/ Retry-After"]
+    STD["standards integrations<br/>hermes · goose · claude<br/>(SKILL.md + MCP, ~0 LOC)"]
+  end
+
+  S1 --> ACL
+  S2 --> ACL
+  ACL --> VAL
+  VAL -->|conforms| NORM --> KERNEL
+  VAL -->|violates| Q
+  KERNEL <--> DB
+  DB --> OUTBOX -.->|"at-least-once relay"| SIEM["export / SIEM<br/>(when needed)"]
+  JOBS <--> DB
+  MCP --> KERNEL
+  CA --> KERNEL
+  STD --> MCP
+  style KERNEL fill:#166534,color:#fff
+  style VAL fill:#166534,color:#fff
+  style Q fill:#b45309,color:#fff
+```
+
+The two green boxes are the same idea at two boundaries: **validate once
+at the edge, then trust the contract inside.** The kernel does it for
+access; the US Core validator does it for data. Everything between them
+stops defending.
+
+### 6.2 The ingest contract pipeline (replaces per-source rules)
+
+```mermaid
+flowchart TD
+  RAW["raw payload<br/>(any source)"] --> T["transport adapter only<br/>(OAuth, webhook, export poll —<br/>once bytes are FHIR JSON, one path)"]
+  T --> G1{"HARD GATE<br/>base-R4 structural"}
+  G1 -->|fails| QU[("quarantine<br/>reason-coded, counted,<br/>source pointer kept")]
+  G1 -->|passes| G2["SOFT GATE: US Core profile<br/>classification, never rejection<br/>grade → meta tag:<br/>conformant · with-DAR · off-profile"]
+  G2 --> C2["strip display / CodeableConcept.text<br/>(PHI vector — unconditionally)"]
+  C2 --> C3["normalize codings by system|code,<br/>re-label from terminology;<br/>emit DataAbsentReason for<br/>required-but-absent"]
+  C3 --> C4{"codes resolve?"}
+  C4 -->|yes| STORE[("canonical store<br/>+ meta.source provenance,<br/>references rewired to local ids")]
+  C4 -->|no| UNC["store as 'recorded, not<br/>coded at source' (#348)"]
+  UNC --> STORE
+  style QU fill:#b45309,color:#fff
+  style C2 fill:#166534,color:#fff
+  style G2 fill:#1d4ed8,color:#fff
+```
+
+Two rules the references converged on and this diagram encodes: **the
+hard gate is base-R4 only** (a certified endpoint can lawfully serve
+off-profile legacy data, so US Core violations are a *grade*, not a
+rejection — quarantining them would silently drop real records, a
+patient-safety bug), and **read-side code assumes only the mandatory
+floor**, treating every must-support element as optional.
+
+Note what this pipeline is: the week's defect fixes (#282 display echo,
+#348 source-uncoded, #377 skipped-type naming, #379 free-text blame)
+**arranged as one pipeline instead of scattered as patches**. The
+contract doesn't add new rules — it gives the existing rules one home
+and one order, so the next source doesn't re-litigate them.
+
+### 6.3 The guarded request path (every head, every read/write)
+
+```mermaid
+sequenceDiagram
+  participant A as Agent (via MCP / CareAgents)
+  participant H as Head (thin)
+  participant K as Kernel (PEP)
+  participant DB as Postgres
+  participant U as Patient (browser)
+
+  A->>H: tool call / API request
+  H->>K: request + token (no policy in head)
+  K->>K: tenant_from_request (validated)
+  K->>K: require_grant (scope, step-up, nonce consumed)
+  alt clinical write
+    K-->>H: -32042 elicitation URL
+    H-->>A: needs human confirmation
+    A->>U: link to approval page
+    U->>K: confirm on server's own page (identity-matched)
+  end
+  K->>DB: BEGIN · data write · audit row · COMMIT (one txn)
+  K->>K: redact + label on exit (defense-in-depth)
+  K-->>H: fhir_response (three-state, never nothing-as-answer)
+  H-->>A: structuredContent (outputSchema = allowlist)
+```
+
+Every annotation on this sequence is a shipped decision or a filed issue:
+the validated tenant read is kernel slice 9 (done for 4 blueprints), the
+consumed nonce is the `consume_nonce` default flip, the one-transaction
+write+audit is companion-review finding 6.1, URL elicitation closes #214,
+and `outputSchema`-as-allowlist is the protocol-level end of the #282
+family.
+
+## 7. Over-engineering audit: delete, freeze, don't-build
+
+First-principles rule applied: complexity is justified only by a caller
+that exists or a risk that is live.
+
+**Delete now** (code documenting promises nothing keeps):
+
+- `r6/schema_sync.py` — zero production callers; contradicted by its own
+  test suite.
+- `careagents/conversation_locks.py` (85 LOC) — imported only by a test;
+  serialization lives in the engine's claim now.
+- `careagents/app.py:67-68` dead constants (`MAX_LIVE_CONVERSATIONS`,
+  `CONVERSATION_IDLE_SECONDS`) — bounds nothing implements.
+- The demo-loop route's residue and `scripts/export_healthex_legacy.py`
+  (1,081 LOC, superseded) — after confirming no caller.
+
+**Freeze** (stop investing until a precondition is met):
+
+- `r6/curatr.py` feature growth — until `$curatr-apply-fix` has a
+  production caller (#413's token design). An evaluation engine whose fix
+  path is unreachable is a demo, not a feature.
+- `openclaw/` + `scripts/bot_commands.py` (~2,100 LOC) — until the hermes
+  path is confirmed at parity; then sunset. Integration by standards
+  (SKILL.md + MCP) made code-per-channel obsolete this year.
+- Kernel primitive expansion — no 12th primitive until the existing 8
+  unused ones have callers. Adoption, not construction.
+- New R6-ballot resource support — the market contract is R4 + US Core
+  (§4); R6 features are differentiation only where a guardrail needs
+  them (Permission is one; most are not).
+
+**Don't build** (temptations the references explicitly warn against):
+
+- A message bus / Kafka / CDC — the outbox pattern on Postgres with the
+  existing claim-poll worker covers every current propagation need.
+- Circuit-breaker or service-mesh libraries — the ten-line counter.
+- WebSockets for chat/progress — polling with `Retry-After` is endorsed
+  at this scale and matches MCP's own direction.
+- Per-tenant databases or sharding — one row-keyed Postgres is what
+  Cal.com-scale platforms run; RLS is available if defense-in-depth is
+  wanted below the kernel.
+- A second "unified" agent framework — Hermes/Goose/Claude connect via
+  MCP already; the platform's job is to be the best MCP citizen, not to
+  own the agent loop.

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3596,6 +3596,127 @@ def test_a_review_we_could_not_check_is_never_reported_as_not_yours(
     assert posted.get_json().get("confirmed") is not True
 
 
+def test_a_gateway_504_never_says_the_form_is_no_longer_awaiting_review(
+        cfg, svc, monkeypatch):
+    """The #416 posture, applied to the review page itself.
+
+    `_agent_owns_action` learned this three lines earlier (#410): an outage
+    is not an answer about ownership. The very next branch had not. Any
+    non-200 from the review fetch — including a 502/503/504 the gateway
+    wrote on the engine's behalf, having learned nothing about the form —
+    was rendered as "This form is no longer awaiting review." with a 404.
+
+    That is a claim about state, made by a branch that observed no state, on
+    the human-approval gate this product exists to guarantee. A patient with
+    a live pending prescription request is told it is gone.
+
+    A 4xx from the engine is still an answer and must still read as gone
+    (pinned below). 5xx/408/429 must not.
+
+    MUTATION: restore the flat `if status != 200` -> red on the 504 case.
+    Ran it, saw red.
+    """
+    from careagents.app import create_app
+
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    fake.fetch_review_page = lambda tenant, action_id: (504, "gateway timeout")
+    page = c.get(f"/review/{agent}/act-1")
+    body = page.get_data(as_text=True)
+    assert page.status_code == 503, "a gateway timeout is not a verdict"
+    assert "no longer awaiting review" not in body
+    assert "Nothing has been approved" in body
+
+    # The engine's own answer still means what it says.
+    fake.fetch_review_page = lambda tenant, action_id: (404, "gone")
+    gone = c.get(f"/review/{agent}/act-1")
+    assert gone.status_code == 404
+    assert "no longer awaiting review" in gone.get_data(as_text=True)
+
+
+def test_a_dead_socket_on_the_review_path_is_not_a_bare_500(
+        cfg, svc, monkeypatch):
+    """`fetch_review_page` and `submit_review` raise; nothing caught them.
+
+    careagents registers no errorhandler for HealthClawError (there is not
+    one in the whole package), so a transport failure on either verb reached
+    Flask as a 500. On the submit verb that is worse than ugly: the patient's
+    approval decisions are gone with no statement about what happened to
+    them, after ownership was already confirmed.
+
+    MUTATION: drop the try/except around either call -> red with a 500.
+    Ran it, saw red.
+    """
+    from careagents.app import create_app
+
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    fake.fetch_review_page = _unreachable
+    page = c.get(f"/review/{agent}/act-1")
+    assert page.status_code == 503, "a dead socket is not a 500 here"
+    assert "Nothing has been approved" in page.get_data(as_text=True)
+
+    fake.submit_review = _unreachable
+    posted = c.post(f"/review/{agent}/act-1/submit",
+                    json={"med-0": "yes", "nka": "true"})
+    assert posted.status_code == 503
+    assert posted.get_json().get("confirmed") is not True
+    assert "Nothing has been approved" in posted.get_json()["message"]
+
+
+def test_a_gateway_504_on_review_submit_does_not_claim_the_review_was_saved(
+        cfg, svc, monkeypatch):
+    """The engine never answered, so neither may we.
+
+    A 5xx here was passed straight through as the response status with the
+    engine's body, which tells the patient nothing about whether their
+    decisions were recorded. What we DO know is that `confirm_action` is
+    only reached on a 200, so nothing was approved — that half is sayable,
+    and it is the half that stops a second approval sending twice.
+
+    MUTATION: return `jsonify(body), status` unconditionally -> red.
+    Ran it, saw red.
+    """
+    from careagents.app import create_app
+
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    fake.submit_review = lambda t, a, d: (502, {"error": "bad gateway"})
+    posted = c.post(f"/review/{agent}/act-1/submit",
+                    json={"med-0": "yes", "nka": "true"})
+    assert posted.status_code == 503
+    payload = posted.get_json()
+    assert payload.get("confirmed") is not True
+    assert "Nothing has been approved" in payload["message"]
+
+    # A 422 is the engine's own answer — attestation missing — and must
+    # still reach the patient as the engine's answer, unchanged.
+    fake.submit_review = FakeClient.submit_review.__get__(fake, FakeClient)
+    refused = c.post(f"/review/{agent}/act-1/submit", json={"med-0": "yes"})
+    assert refused.status_code == 422
+
+
 def test_an_unreachable_engine_is_never_reported_as_an_unknown_run(
         cfg, svc, monkeypatch):
     """"Unknown run" and "unknown form" are claims about what exists (#410).

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -1,0 +1,284 @@
+"""Architecture ratchets — the counts that define HealthClaw 2.0.
+
+Every guardrail guarantee in this codebase is currently a *convention*
+repeated at N call sites rather than a *structure* enforced at one: audit is
+called from 88 places, the tenant header is read raw in dozens, step-up is
+validated directly at 23. That is the generator behind the week of
+"a guardrail produced nothing and the caller read it as an answer" defects
+(`docs/2026-08-02-retro.md`), and driving those counts to zero is what
+`docs/2026-08-05-healthclaw-2.0-playbook.md` means by 2.0.
+
+A ratchet is a pin on a count that may only go DOWN. Each migration PR
+lowers its pin in the same commit that lowers the count — the §6 rule from
+`docs/agent-task-guide.md` applied to architecture instead of behavior. A PR
+that adds a new call site goes red, which is the point: the old path stops
+being a thing you can quietly reach for.
+
+These tests assert nothing about behavior. They are the architecture spec,
+made executable so that backsliding is a red build rather than a review
+comment somebody has to notice.
+
+WHEN YOU MIGRATE: lower the number, keep the comment honest about what is
+left. Never raise a pin to make a build pass — that is the one edit that
+turns this file into decoration.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_PRODUCTION_DIRS = ('r6', 'careagents', 'adapters', 'api', 'services',
+                    'scripts', 'openclaw', 'hermes', 'migrations')
+_PRODUCTION_ROOT_FILES = ('main.py', 'app.py', 'models.py')
+
+#: A scan that walks nothing passes every ratchet forever — the false green
+#: that is this repo's own defect shape pointed at its own test suite. Every
+#: counter asserts this floor, so a broken path list fails loudly instead of
+#: reporting perfect compliance. 172 production modules exist today.
+_SCAN_FLOOR = 100
+
+
+def _production_python_files():
+    for name in _PRODUCTION_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            yield path
+    for folder in _PRODUCTION_DIRS:
+        base = REPO_ROOT / folder
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob('*.py')):
+            if '__pycache__' in path.parts:
+                continue
+            yield path
+
+
+def _rel(path):
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _scan(collect, *, skip=()):
+    """Walk production modules, collecting `collect(tree, path) -> [str]`.
+
+    Returns (sites, scanned). Counting is AST-based on purpose: grep counts
+    the word in a docstring that *describes* the old primitive and reports a
+    migration as incomplete when it is done, or counts a commented-out line
+    and hides one that is not.
+    """
+    sites, scanned = [], 0
+    for path in _production_python_files():
+        rel = _rel(path)
+        if rel in skip:
+            continue
+        scanned += 1
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        sites.extend(collect(tree, path))
+    assert scanned > _SCAN_FLOOR, (
+        f'the ratchet scan only walked {scanned} files — the path list is '
+        f'broken, and every count below is meaningless until it is fixed')
+    return sites, scanned
+
+
+def _called_name(node):
+    """The bare name of a call target: f(), obj.f(), a.b.f() -> 'f'."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _calls_to(name):
+    def collect(tree, path):
+        found = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _called_name(node) == name:
+                found.append(f'{_rel(path)}:{node.lineno}')
+        return found
+    return collect
+
+
+def _report(sites, pin, what):
+    """A failure message that names the sites, so the fix is obvious."""
+    listing = '\n  '.join(sites[:40])
+    more = '' if len(sites) <= 40 else f'\n  ... and {len(sites) - 40} more'
+    return (f'{what}\n'
+            f'  pinned at {pin}, found {len(sites)}\n  {listing}{more}')
+
+
+# ---------------------------------------------------------------------------
+# A — the kernel becomes the only path
+# ---------------------------------------------------------------------------
+
+#: Direct step-up validation. `r6/access.require_grant` is the replacement:
+#: it raises rather than returning a (bool, str) tuple that a truthiness test
+#: silently misreads as authorized (#307). r6/access.py itself is excluded —
+#: it is the one module that is *supposed* to call this.
+#: Playbook chunks A2, A3, A6.
+_STEP_UP_CALLSITES = 20
+
+
+def test_direct_step_up_validation_only_decreases():
+    """MUTATION: add a validate_step_up_token() call anywhere -> red."""
+    sites, _ = _scan(_calls_to('validate_step_up_token'),
+                     skip=('r6/access.py',))
+    assert len(sites) <= _STEP_UP_CALLSITES, _report(
+        sites, _STEP_UP_CALLSITES,
+        'Direct step-up validation should route through r6.access.require_grant.')
+
+
+#: Modules that reach into r6/routes.py for a symbol. Every one of these is a
+#: utility that leaked out of a 3,905-line module because there was nowhere
+#: else to put it, and each import is written lazily to dodge the four
+#: import cycles through the auth stack. Playbook chunk A1 moves the three
+#: symbols out and takes this to 1 (main.py, for the blueprint itself).
+_ROUTES_IMPORTERS = 8
+
+
+def test_imports_out_of_the_god_module_only_decrease():
+    """MUTATION: add `from r6.routes import x` anywhere -> red."""
+    def collect(tree, path):
+        found = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == 'r6.routes':
+                found.append(f'{_rel(path)}:{node.lineno}')
+        return found
+    sites, _ = _scan(collect)
+    assert len(sites) <= _ROUTES_IMPORTERS, _report(
+        sites, _ROUTES_IMPORTERS,
+        'Nothing but main.py should import from r6/routes.py.')
+
+
+# ---------------------------------------------------------------------------
+# B — audit correctness
+# ---------------------------------------------------------------------------
+
+#: `record_audit_event` commits the audit row in its own SAVEPOINT *after*
+#: the caller has already committed the data, and its db.session.commit()
+#: also commits whatever else the caller had pending. A failed audit
+#: therefore 500s the request with the resource already persisted and
+#: unaudited: fail-closed on the response, fail-open on the data.
+#:
+#: `add_audit_event` flushes inside the caller's transaction and never
+#: commits — same transaction, genuinely fail-closed. Playbook B3-B9 moves
+#: these one blueprint per PR; B9 deletes the old primitive when this is 0.
+_POST_COMMIT_AUDIT_CALLSITES = 88
+
+
+def test_post_commit_audit_callsites_only_decrease():
+    """MUTATION: add a record_audit_event() call anywhere -> red."""
+    sites, _ = _scan(_calls_to('record_audit_event'), skip=('r6/audit.py',))
+    assert len(sites) <= _POST_COMMIT_AUDIT_CALLSITES, _report(
+        sites, _POST_COMMIT_AUDIT_CALLSITES,
+        'New audit calls must use add_audit_event (same transaction).')
+
+
+#: The two step-up-gated mutators that emit no audit events at all. They
+#: perform authenticated writes with no trail — the worst shape in the
+#: codebase for a system whose constitution says every FHIR resource access
+#: emits an AuditEvent. Playbook B1, B2. This ratchet counts blueprints
+#: that mutate without auditing; it goes to 0 and then becomes a tripwire.
+_UNAUDITED_MUTATOR_PACKAGES = {'r6/command_center', 'r6/agent_runs'}
+
+
+def test_no_new_package_mutates_without_auditing():
+    """MUTATION: delete the audit import from a gated blueprint -> red.
+
+    A package qualifies as a mutator if it validates step-up (it guards a
+    write). If it does that and never calls either audit primitive, the
+    write is authenticated and invisible.
+    """
+    gates, audits = {}, {}
+    scanned = 0
+    for path in _production_python_files():
+        rel = _rel(path)
+        if not rel.startswith('r6/') or rel == 'r6/access.py':
+            continue
+        package = '/'.join(rel.split('/')[:2]) if '/' in rel[3:] else 'r6'
+        scanned += 1
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _called_name(node)
+            if name == 'validate_step_up_token' or name == 'require_grant':
+                gates.setdefault(package, []).append(f'{rel}:{node.lineno}')
+            elif name in ('record_audit_event', 'add_audit_event', 'audit'):
+                audits.setdefault(package, []).append(f'{rel}:{node.lineno}')
+    assert scanned > 40, f'the mutator scan only walked {scanned} r6 files'
+    silent = {pkg for pkg in gates if pkg not in audits}
+    assert silent <= _UNAUDITED_MUTATOR_PACKAGES, _report(
+        sorted(silent - _UNAUDITED_MUTATOR_PACKAGES),
+        len(_UNAUDITED_MUTATOR_PACKAGES),
+        'A package that gates writes with step-up must audit them.')
+
+
+# ---------------------------------------------------------------------------
+# C — soft-delete consistency (#422)
+# ---------------------------------------------------------------------------
+
+#: Files that query R6Resource without ever mentioning is_deleted. r6/routes.py
+#: filters at all 18 of its query sites; the feature modules added since filter
+#: at none of theirs. Nothing has detonated because no DELETE route exists and
+#: only Permission-revoke sets the flag — it is a loaded gun, not a fire.
+#: Playbook F5 introduces one shared live-resource selector and takes this to 0.
+_FILES_QUERYING_WITHOUT_SOFT_DELETE = 12
+
+#: r6/purge.py hard-deletes a tenant's rows. It must NOT filter is_deleted —
+#: a purge that skipped soft-deleted rows would leave exactly the records the
+#: caller asked to destroy. Exempt on purpose, so nobody "fixes" it.
+_SOFT_DELETE_EXEMPT = ('r6/purge.py',)
+
+
+def test_soft_delete_blind_query_files_only_decrease():
+    """MUTATION: strip is_deleted from a query in r6/routes.py -> red."""
+    def collect(tree, path):
+        source = path.read_text(encoding='utf-8')
+        if 'R6Resource' not in source or 'query' not in source:
+            return []
+        queries = [n for n in ast.walk(tree)
+                   if isinstance(n, ast.Attribute) and n.attr == 'query']
+        if not queries:
+            return []
+        if 'is_deleted' in source:
+            return []
+        return [f'{_rel(path)}:{queries[0].lineno}']
+    sites, _ = _scan(collect, skip=_SOFT_DELETE_EXEMPT)
+    assert len(sites) <= _FILES_QUERYING_WITHOUT_SOFT_DELETE, _report(
+        sites, _FILES_QUERYING_WITHOUT_SOFT_DELETE,
+        'A resource query that ignores is_deleted reads deleted rows.')
+
+
+# ---------------------------------------------------------------------------
+# The ratchets themselves
+# ---------------------------------------------------------------------------
+
+def test_every_ratchet_names_its_playbook_chunk():
+    """A pin without a migration plan is a number nobody will ever lower."""
+    source = pathlib.Path(__file__).read_text(encoding='utf-8')
+    assert 'docs/2026-08-05-healthclaw-2.0-playbook.md' in source
+    for pin in ('_STEP_UP_CALLSITES', '_ROUTES_IMPORTERS',
+                '_POST_COMMIT_AUDIT_CALLSITES',
+                '_FILES_QUERYING_WITHOUT_SOFT_DELETE'):
+        assert f'{pin} = ' in source, f'{pin} lost its pin'
+
+
+@pytest.mark.parametrize('pin,value', [
+    ('step-up callsites', _STEP_UP_CALLSITES),
+    ('routes.py importers', _ROUTES_IMPORTERS),
+    ('post-commit audit callsites', _POST_COMMIT_AUDIT_CALLSITES),
+    ('soft-delete-blind files', _FILES_QUERYING_WITHOUT_SOFT_DELETE),
+])
+def test_no_ratchet_is_already_at_zero(pin, value):
+    """When one reaches 0, delete its ratchet and add the grep guard instead.
+
+    A ratchet pinned at 0 is doing a tripwire's job with a counter's
+    machinery. The playbook's chunk A7 is exactly this transition for the
+    tenant-header read: ratchet until 0, then forbid outright.
+    """
+    assert value > 0, (
+        f'{pin} is at 0 — replace the ratchet with a hard guard (playbook A7)')


### PR DESCRIPTION
Three commits from a full-codebase review. They are independent — the docs
and the ratchets change no behavior; the third is a patient-safety fix.

## 1. `docs:` the review (no behavior change)

An AST import graph of all 172 production modules, three measured review
passes (kernel adoption, CareAgents resilience, runtime), and external
pattern research (MCP spec direction, agentic-app references, US Core as an
ingest contract, the open-source connectors).

The finding behind the findings: **every guardrail guarantee is a convention
repeated at N call sites rather than a structure enforced at one** — audit
×88, tenant header ×55, step-up ×20 — and the access kernel built to change
that has 8 of 11 primitives with zero production callers. That is the
generator behind the nine "a guardrail produced nothing and the caller read
it as an answer" defects fixed last week.

Four hardening items found in the same pass are **tracked privately until
fixed**, per the precedent set by S-1…S-4 in the 2026-08-02 audit (this repo
is public; those were published after they shipped). The doc says so and
points at nothing exploitable.

## 2. `test:` the ratchets (no behavior change)

Four counts pinned at today's measured values. A migration PR lowers its pin
in the same commit that lowers the count; a PR that adds a call site to a
deprecated path goes red.

| ratchet | pinned |
|---|---|
| post-commit audit callsites | 88 |
| direct step-up validation | 20 |
| imports out of `r6/routes.py` | 8 |
| soft-delete-blind query files | 12 |

AST-based, not grep — grep counts the word in a docstring describing the old
primitive and calls a finished migration incomplete. My first step-up pin
was 23 from a grep; the AST says 20.

Two guards worth review: every counter asserts a **scan floor**, because a
scan that walks nothing passes every ratchet forever (this repo's own defect
shape pointed at its own test suite); and `r6/purge.py` is **exempt** from
the soft-delete ratchet on purpose — it hard-deletes, and filtering
`is_deleted` there would leave exactly the rows the caller asked to destroy.

## 3. `fix:` the review path (SEV-1, patient-facing)

A gateway 502/503/504 on the review page rendered as **"This form is no
longer awaiting review."** with a 404 — a claim about state from a branch
that observed no state, on the human-approval gate. `_agent_owns_action`
learned this in #410; the very next branch had not.

Also: both review verbs could raise `HealthClawError` out of an unguarded
call and reach Flask as a bare 500 — on submit, the patient's approval
decisions vanished with no statement, after ownership was confirmed.

The engine's own 4xx still reads as "gone". Everything else now says "we
couldn't check — nothing has been approved". On submit we don't claim the
review was saved (we don't know) but we do say nothing was approved (we do
know — `confirm_action` is only reached on a 200), which is the half that
stops a second approval sending twice.

**Deliberately not here:** a package-wide `HealthClawError` errorhandler.
careagents has none, and adding one changes the failure shape of ~30 unpinned
call sites at once — the control-that-does-two-things shape. It needs its own
PR with a pin per surface.

## Verification

- `2709 passed`, 12 skipped, 1 xfailed (baseline before these commits: 2696)
- `uv run ruff check .` — all checks passed
- Every new branch mutation-tested; each mutation reddens its own test and
  only that test. Ran them, saw red.
- Conformance untouched (no guardrail behavior changed).

Not verified: nothing here has run against a live HealthClaw. The careagents
tests fake the client, so they prove the call is made, not accepted — the
review path deserves a live pair before it ships, per the repo's own trap
list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)