### PR TITLE
Phase 0: PUT body guard, and reap imports stranded by a deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,16 @@ RUN mkdir -p /app/instance
 
 EXPOSE 5000
 
-CMD gunicorn main:app --bind 0.0.0.0:${PORT:-5000} --workers 2 --timeout 300 --keep-alive 5
+# Reap Fasten jobs stranded by the restart that just happened, then serve.
+# Ingest runs in daemon threads inside this process, so every deploy kills
+# whatever was importing; the reaper re-triggers a fresh export for jobs left
+# non-terminal. Its own 5-minute ZOMBIE_MIN_AGE keeps a rolling deploy from
+# double-triggering a job the outgoing container is still running.
+#
+# `;` and not `&&`: recovery is best effort, serving is not. If the reaper
+# exits non-zero — an unreachable database at boot, say — the app must still
+# come up, or a convenience would have become an outage with a restart loop
+# behind it. Not in create_app: tests/test_app_factory.py pins the factory as
+# side-effect-free, and that is worth more than the convenience.
+CMD flask --app main recover-zombies; \
+    gunicorn main:app --bind 0.0.0.0:${PORT:-5000} --workers 2 --timeout 300 --keep-alive 5

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -655,7 +655,11 @@ def update_resource(resource_type, resource_id):
     if too_deep:
         return _operation_outcome('error', 'invalid',
                                   'Request body nesting is too deep'), 400
-    if not body:
+    # isinstance, not truthiness: `[1]`, `42` and `"a string"` are truthy and
+    # lack .get(), so a bare `if not body` let them through to an
+    # AttributeError and a 500. Create got this in #331; update kept the old
+    # shape, and the two guards sat 190 lines apart looking equivalent.
+    if not isinstance(body, dict):
         return _operation_outcome('error', 'invalid', 'Request body must be valid JSON'), 400
 
     # Validate resourceType matches URL

--- a/tests/test_boot_reaper_wiring.py
+++ b/tests/test_boot_reaper_wiring.py
@@ -1,0 +1,122 @@
+"""The zombie reaper runs when a container starts, and never blocks serving.
+
+`r6/fasten/reaper.py` was written to run at boot — its docstring says
+"Called from main.py right after schema_sync", and its 5-minute
+`ZOMBIE_MIN_AGE` exists specifically so "a job started seconds before a
+rolling deploy's second worker boots is not double-triggered". That sentence
+described an intent that no longer matched the code: the only callers were
+`run_legacy_boot_tasks` and the `recover-zombies` CLI command, and
+`railway.toml`'s preDeployCommand runs neither.
+
+The consequence is patient-visible. Fasten NDJSON ingest runs in a daemon
+thread inside the web process (`r6/fasten/routes.py:_launch_ingest`), so
+every deploy kills whatever imports are in flight, and `main` auto-deploys.
+A patient whose records were importing when someone merged got a job wedged
+in a non-terminal state with no automatic recovery — the documented fallback
+being a human hitting the retry endpoint.
+
+It is wired into the container start command rather than into `create_app`,
+because `tests/test_app_factory.py` pins the factory as side-effect-free:
+constructing an app must not touch the database, start a thread, or call an
+external service. That pin is worth more than the convenience, and the CLI
+command already exists for exactly this.
+
+These tests run the Dockerfile's real `CMD` under `/bin/sh` with recording
+stubs on PATH, following `tests/test_careagents_container_roles.py`, so the
+dispatch is observed rather than pattern-matched.
+
+What they do not prove: no image is built and no container is run. They show
+what the start command does, not that Railway runs it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DOCKERFILE = REPO / "Dockerfile"
+
+# /bin/dash is /bin/sh on Debian, so it is both the image's shell and CI's.
+SHELLS = [path for path in ("/bin/sh", "/bin/dash") if os.path.exists(path)]
+
+#: Records its own argv, then exits with $STUB_EXIT (default 0) so a test can
+#: make the reaper fail on demand.
+STUB = """#!/bin/sh
+for arg in "$0" "$@"; do printf '%s\\n' "$arg" >> "$RECORD"; done
+exit ${STUB_EXIT:-0}
+"""
+
+
+def _cmd_script() -> str:
+    """The shell program the image starts."""
+    text = DOCKERFILE.read_text().replace("\\\n", "")
+    match = re.search(r"^CMD (.+)$", text, re.M)
+    assert match, "the Dockerfile no longer has a CMD"
+    script = match.group(1).strip()
+    assert not script.startswith("["), (
+        "CMD became exec form; these tests run it as a shell program")
+    return script
+
+
+@pytest.fixture(scope="module")
+def stubs(tmp_path_factory):
+    path = tmp_path_factory.mktemp("bin")
+    for name in ("gunicorn", "flask"):
+        stub = path / name
+        stub.write_text(STUB)
+        stub.chmod(0o755)
+    return path
+
+
+def _start(stubs, shell="/bin/sh", **env):
+    """Run the real start command; return every argv it launched."""
+    record = stubs / "record"
+    if record.exists():
+        record.unlink()
+    environ = {"PATH": str(stubs), "RECORD": str(record), **env}
+    result = subprocess.run([shell, "-c", _cmd_script()], env=environ,
+                            capture_output=True, text=True)
+    lines = record.read_text().splitlines() if record.exists() else []
+    # $0 is the resolved stub path; the command name is what the assertions
+    # are about, so name the executables and leave their arguments alone.
+    launched = [os.path.basename(line) if line.startswith(str(stubs)) else line
+                for line in lines]
+    return result, launched
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_container_start_reaps_stranded_jobs_before_serving(stubs, shell):
+    """MUTATION: drop the recover-zombies step from CMD -> red.
+
+    Ran it, saw red.
+    """
+    _, launched = _start(stubs, shell=shell)
+    assert "recover-zombies" in launched, (
+        f"the start command never reaps stranded Fasten jobs: {launched}")
+    assert "gunicorn" in launched, launched
+    assert launched.index("recover-zombies") < launched.index("gunicorn"), (
+        "recovery has to run before the app starts taking traffic")
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+def test_a_failing_reaper_never_stops_the_app_from_serving(stubs, shell):
+    """The reaper is best-effort. Serving traffic is not.
+
+    `recover_zombie_jobs` already swallows its own exceptions, but the CLI
+    process can still exit non-zero for reasons it never sees — an
+    unreachable database at boot, a bad entrypoint. If that took gunicorn
+    down with it, a recovery convenience would have become an outage, and
+    the restart policy would retry it three times and give up.
+
+    MUTATION: chain the two commands with `&&` instead -> red, gunicorn
+    never starts. Ran it, saw red.
+    """
+    result, launched = _start(stubs, shell=shell, STUB_EXIT="1")
+    assert "gunicorn" in launched, (
+        f"a failed reaper stopped the app from starting: {launched} "
+        f"(exit {result.returncode})")

--- a/tests/test_non_dict_body_refused.py
+++ b/tests/test_non_dict_body_refused.py
@@ -56,6 +56,36 @@ def test_a_non_object_body_is_refused_not_crashed(client, method, path, body):
         'raise')
 
 
+@pytest.mark.parametrize('body', NON_DICT_BODIES)
+def test_an_update_with_a_non_object_body_is_refused_not_crashed(
+        client, auth_headers, body):
+    """The same defect on PUT, which the rows above could not reach.
+
+    WRITE_PATHS is scoped to "reachable with only a tenant header", so the
+    update path was outside it: PUT runs its step-up gate first and needs a
+    token. The fix for #330/#331 landed on create as
+    `if not isinstance(body, dict)` and on update as `if not body`, so a
+    truthy non-object — `[1]`, `42`, `"a string"` — passed the guard and
+    reached `body.get('resourceType')`.
+
+    Needing a valid step-up token shrinks the blast radius to an authenticated
+    caller. It does not make a 500 the right answer, and an authenticated
+    caller is exactly who finds this by fuzzing a client.
+
+    Note `'null'` and `'[]'` were already refused by the falsy check — the
+    parametrization keeps them so the row proves the guard covers both kinds.
+
+    MUTATION: restore `if not body` at r6/routes.py -> the truthy bodies go
+    red with a 500. Ran it, saw red.
+    """
+    response = client.put(
+        '/r6/fhir/Patient/put-nonobject-1', data=body,
+        headers={**auth_headers, 'Content-Type': 'application/json'})
+    assert response.status_code < 500, (
+        f'PUT answered {response.status_code} for a non-object body {body!r}; '
+        'a malformed body must be refused, not raise')
+
+
 def test_the_human_in_the_loop_hook_tolerates_a_non_dict_body():
     """The hook runs before every handler, so it must not be the crash site.
 


### PR DESCRIPTION
Two small Phase 0 items from the architecture review. Independent commits,
neither changes a guardrail decision.

### PUT accepted a truthy non-object body

`#330/#331` landed `isinstance(body, dict)` on create and `if not body` on
update — 190 lines apart, looking equivalent, and not. `[1]`, `42`,
`"a string"` are truthy and have no `.get()`, so update reached
`body.get('resourceType')` → `AttributeError` → **500**.

The existing matrix in `tests/test_non_dict_body_refused.py` is scoped to
paths "reachable with only a tenant header", which is exactly why update
escaped it: PUT runs its step-up gate first. Needing a token shrinks the
blast radius to an authenticated caller — it does not make a 500 correct.

### Fasten imports stranded by a deploy were never reaped

`r6/fasten/reaper.py` was written for this. Its docstring says *"Called from
main.py right after schema_sync"* and its 5-minute `ZOMBIE_MIN_AGE` exists so
"a job started seconds before a rolling deploy's second worker boots is not
double-triggered". The code had stopped matching that: the only callers were
`run_legacy_boot_tasks` and the `recover-zombies` CLI, and `railway.toml`
invokes neither.

Ingest runs in daemon threads inside the web process, and `main`
auto-deploys — so every merge that landed mid-import wedged a patient's
records with no automatic recovery.

**Wired into the container start command, not `create_app`.** The review
suggested the factory; `tests/test_app_factory.py:54` pins the factory as
side-effect-free, and that invariant is worth more than the convenience.

`;` not `&&`, with a test for it: recovery is best effort, serving is not. A
reaper exiting non-zero must not take gunicorn down and hand the restart
policy three retries.

### Verification

- `2706 passed`, 12 skipped, 1 xfailed; `ruff` clean
- Every branch mutation-tested: restoring `if not body` reddens the truthy PUT
  rows; `&&` reddens the never-block-serving test; dropping the reaper step
  reddens the other
- `tests/test_boot_reaper_wiring.py` runs the real `CMD` under `/bin/sh` and
  `/bin/dash` with recording stubs, per `test_careagents_container_roles.py`

**Worth knowing:** my first harness compared `argv[0]` to a bare name while
the stub records a resolved path, so it failed against a *correct* Dockerfile
and its `&&` mutation "passed". Both were harness bugs, found and fixed before
either result was trusted — noting it because a green mutation check is only
worth what the harness is worth.

**Not proven here:** no image is built and no container is run, so this shows
what the start command does, not that Railway runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)