### PR TITLE
A screening we cannot fully check is not one you are due for (#425)

### DIFF
--- a/r6/caregaps/evaluate.py
+++ b/r6/caregaps/evaluate.py
@@ -72,6 +72,14 @@ CARE_GAP_RULES = [
         "cadence_months": 120,  # colonoscopy interval (conservative upper bound)
         "satisfied_by": {"resource": "Procedure",
                          "codes": {"45378", "45380", "45385", "44388", "45330"}},
+        # USPSTF accepts stool-based screening on its own schedule — FIT
+        # annually, FIT-DNA every 1-3 years — and those arrive as lab
+        # Observations, not Procedures. This rule reads neither, so an absent
+        # colonoscopy is not evidence of an absent screening (#425). Until
+        # the modalities are modelled, say what we did not read instead of
+        # calling the patient due. Removing this line does not add coverage;
+        # it only stops the disclosure.
+        "unread_evidence": "stool-based tests (FIT or Cologuard)",
         "source": "uspstf",
         "related_ecqm": "CMS130",
     },
@@ -260,6 +268,18 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
             results.append({**base, "applicable": True, "status": "up_to_date",
                             "last_done": last.isoformat(),
                             "note": f"recommended {cadence}"})
+        elif rule.get("unread_evidence"):
+            # We did not find the evidence this rule reads, and this rule is
+            # known not to read everything that satisfies it. "Due" would be a
+            # claim about the patient built out of a gap in our own model
+            # (#425), so name the gap. The prompt to act survives, because a
+            # patient who has genuinely never been screened still needs it.
+            results.append({**base, "applicable": True, "status": "indeterminate",
+                            "indeterminate_reason": "evidence-not-read",
+                            "unread_evidence": rule["unread_evidence"],
+                            "note": (f"we do not yet read {rule['unread_evidence']}, "
+                                     "so we cannot tell whether this is up to "
+                                     "date — worth raising with your clinician")})
         else:
             results.append({**base, "applicable": True, "status": "due",
                             "note": ("no record found in your connected data — "

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -101,6 +101,28 @@ def _demographics_marker(undecided, titles):
         f"a finding that {pronoun} up to date.")
 
 
+#: A rule that could not decide because WE do not read all the evidence that
+#: satisfies it — not because the record was missing anything (#425). Kept
+#: apart from the demographic causes on purpose: "your sex was not recorded"
+#: is a statement about the person, and applying it to a screening that failed
+#: for our own reason is the #417 defect with a different subject.
+_COVERAGE_CAUSE = "evidence-not-read"
+
+
+def _coverage_marker(undecided, titles):
+    """Reason + prose for rules this check knowingly cannot fully read."""
+    evidence = sorted({r["unread_evidence"] for r in undecided
+                       if r.get("unread_evidence")})
+    n = len(undecided)
+    noun, pronoun = ("screening", "it is") if n == 1 else ("screenings", "they are")
+    named = f": {_name_all(titles)}" if titles else ""
+    what = _name_all(evidence) if evidence else "every test that can satisfy them"
+    return _COVERAGE_CAUSE, (
+        f"{n} {noun} could not be checked because this check does not yet read "
+        f"{what}{named}. That is a limit on the check and not a finding that "
+        f"{pronoun} up to date.")
+
+
 def _unevaluated_marker(results, not_evaluated):
     """What was not evaluated and why, or None when the answer is whole.
 
@@ -132,7 +154,25 @@ def _unevaluated_marker(results, not_evaluated):
     if not_evaluated:
         reason, note = not_evaluated, _NOT_EVALUATED_NOTES[not_evaluated]
     else:
-        reason, note = _demographics_marker(undecided, titles)
+        # Two kinds of undecided, and they must not borrow each other's
+        # reason. The record failed to say something, or this check failed to
+        # read something. Reporting a coverage gap as "your sex was not
+        # recorded" would be false about the person; reporting a demographic
+        # gap as a coverage limit would excuse us from a real one.
+        coverage = [r for r in undecided
+                    if r.get("indeterminate_reason") == _COVERAGE_CAUSE]
+        record = [r for r in undecided if r not in coverage]
+        if coverage and record:
+            _, record_note = _demographics_marker(
+                record, [r["title"] for r in record if r.get("title")])
+            _, coverage_note = _coverage_marker(
+                coverage, [r["title"] for r in coverage if r.get("title")])
+            reason = "partly-unchecked"
+            note = f"{record_note} {coverage_note}"
+        elif coverage:
+            reason, note = _coverage_marker(coverage, titles)
+        else:
+            reason, note = _demographics_marker(record, titles)
     return {"unevaluated": reason, "unevaluated_count": len(undecided),
             "unevaluated_titles": titles, "unevaluated_note": note}
 

--- a/tests/test_caregaps_evaluate.py
+++ b/tests/test_caregaps_evaluate.py
@@ -101,6 +101,57 @@ def test_colorectal_satisfied_by_recent_procedure():
     assert res["colorectal-screening"]["status"] == "up_to_date"
 
 
+def test_colorectal_with_no_procedure_does_not_claim_the_patient_is_due():
+    """#425 — the rule cannot see two of the accepted tests.
+
+    Colorectal screening is satisfied here only by CPT colonoscopy and
+    sigmoidoscopy codes, which are Procedures. FIT (annual) and FIT-DNA /
+    Cologuard (1-3 yearly) are equally acceptable under USPSTF and arrive as
+    lab Observations, so this rule never looks at them.
+
+    "Due" therefore asserted something we had not checked: a patient
+    screening exactly as advised with annual FIT matched nothing and was told
+    they were overdue. The generic due note ("no record found in your
+    connected data") is not enough, because it implies we read the data that
+    would have satisfied the rule. We did not read it at all.
+
+    Indeterminate is the honest status while a whole class of qualifying
+    evidence is invisible, and the note still tells the patient to raise it —
+    so nothing prompting them to act is lost. The status change is the point:
+    a red "DUE" badge with fine print underneath is still a claim.
+
+    MUTATION: drop `unread_evidence` from the colorectal rule -> red,
+    status back to "due". Ran it, saw red.
+    """
+    res = {r["rule_id"]: r for r in evaluate_care_gaps(
+        _patient(birth="1968-05-01"), as_of="2026-07-01")}
+    gap = res["colorectal-screening"]
+
+    assert gap["status"] == "indeterminate", (
+        "claimed a screening gap without reading two of the accepted tests")
+    assert gap["applicable"] is True, "the patient is still in the age range"
+    assert gap["indeterminate_reason"] == "evidence-not-read"
+    note = gap["note"].lower()
+    assert "stool" in note, "the note must name what we could not see"
+    assert "clinician" in note, "the patient must still be told to raise it"
+
+
+def test_a_rule_with_no_blind_spot_still_reports_a_real_gap():
+    """The disclosure must not become a blanket refusal to answer.
+
+    Mammography reads the evidence that satisfies it, so an absent record
+    means absent, and "due" is the honest answer. If this ever goes
+    indeterminate too, the guard above has been over-applied and the report
+    has stopped being useful.
+
+    MUTATION: return indeterminate for every unsatisfied rule -> red.
+    """
+    res = {r["rule_id"]: r for r in evaluate_care_gaps(
+        _patient(birth="1968-05-01", gender="female"), as_of="2026-07-01")}
+    assert res["mammography"]["status"] == "due"
+    assert res["bp-screening"]["status"] == "due"
+
+
 def test_year_only_birthdate_still_yields_age():
     # FHIR partial dates are legal — and HealthClaw's own redaction truncates
     # birthDate to the year. A ~60yo must not come back all-indeterminate.

--- a/tests/test_caregaps_report.py
+++ b/tests/test_caregaps_report.py
@@ -214,3 +214,81 @@ def test_one_undecided_rule_reads_as_one():
                     "sex-unknown")])
     assert "1 screening could not be checked" in consumer["unevaluated_note"]
     assert "screenings" not in consumer["unevaluated_note"]
+
+
+# ─────────────────────────────────────────────
+# #425 — a coverage gap is not a gap in the record
+# ─────────────────────────────────────────────
+
+def _unread(rule_id, title, evidence):
+    """An indeterminate rule the check knowingly cannot fully read."""
+    out = _undecided(rule_id, title, "evidence-not-read")
+    out["unread_evidence"] = evidence
+    return out
+
+
+def test_a_coverage_gap_never_borrows_a_reason_about_the_person():
+    """The reason has to name whose limitation it is.
+
+    Colorectal screening is undecided because this check reads only
+    colonoscopy and sigmoidoscopy procedures, never the stool-based tests that
+    also satisfy it. Saying "your sex was not recorded" about that screening
+    would be false about the patient; saying "we do not read everything" about
+    a genuinely missing sex would excuse a real gap in the record. Both
+    directions are #417 with the subject swapped.
+
+    MUTATION: fold the coverage rules back into _demographics_marker -> red,
+    the reason becomes demographics-unavailable and the note claims the
+    person's record was short. Ran it, saw red.
+    """
+    results = [
+        _result(status="due"),
+        _undecided("cervical-screening", "Cervical cancer screening (Pap)",
+                   "sex-unknown"),
+        _unread("colorectal-screening", "Colorectal cancer screening",
+                "stool-based tests (FIT or Cologuard)"),
+    ]
+    out = build_consumer_summary(results)
+
+    assert out["unevaluated"] == "partly-unchecked"
+    assert out["unevaluated_count"] == 2
+    note = out["unevaluated_note"]
+    # Each screening sits with its own cause.
+    assert "sex was not recorded" in note
+    assert "Cervical cancer screening (Pap)" in note
+    assert "does not yet read stool-based tests (FIT or Cologuard)" in note
+    assert "Colorectal cancer screening" in note
+    # And neither cause is offered as a finding about the patient's care.
+    assert "not a finding" in note
+
+
+def test_a_coverage_gap_alone_reads_as_our_limit_not_the_record_s():
+    """MUTATION: return the demographics fallback when no record cause exists
+    -> red with demographics-unavailable. Ran it, saw red."""
+    out = build_consumer_summary([
+        _result(status="due"),
+        _unread("colorectal-screening", "Colorectal cancer screening",
+                "stool-based tests (FIT or Cologuard)"),
+    ])
+    assert out["unevaluated"] == "evidence-not-read"
+    assert out["unevaluated_count"] == 1
+    note = out["unevaluated_note"]
+    assert "limit on the check" in note
+    assert "not a finding that it is up to date" in note
+    assert "your" not in note.lower().split("up to date")[0].replace(
+        "your clinician", ""), "a coverage limit must not describe the patient"
+
+
+def test_demographic_causes_alone_are_unchanged_by_the_split():
+    """The existing shape must survive. MUTATION: route record causes through
+    _coverage_marker -> red."""
+    out = build_consumer_summary([
+        _result(status="due"),
+        _undecided("cervical-screening", "Cervical cancer screening (Pap)",
+                   "sex-unknown"),
+        _undecided("mammography", "Breast cancer screening (mammogram)",
+                   "sex-unknown"),
+    ])
+    assert out["unevaluated"] == "sex-unavailable"
+    assert out["unevaluated_count"] == 2
+    assert "sex was not recorded" in out["unevaluated_note"]

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -236,17 +236,31 @@ def test_a_partial_screening_list_says_how_much_of_it_is_missing(
     assert r.status_code == 200
     consumer = json.loads(
         _resp_param(r.get_json(), "consumerSummary")["valueString"])
-    assert len(consumer["lines"]) == 4
-    assert consumer["unevaluated"] == "sex-unavailable"
-    assert consumer["unevaluated_count"] == 2
+    # PIN MOVED with #425, in the PR that moved it. Colorectal screening used
+    # to be decided here and reported "due"; it is now undecided, because this
+    # check reads only colonoscopy and sigmoidoscopy procedures and a patient
+    # on annual FIT would have matched nothing. So the decided list drops from
+    # four to three and a third screening joins the undecided set — for a
+    # different reason than the other two.
+    assert len(consumer["lines"]) == 3
+    assert consumer["unevaluated_count"] == 3
     assert consumer["unevaluated_titles"] == [
+        "Colorectal cancer screening",
         "Cervical cancer screening (Pap)",
         "Breast cancer screening (mammogram)"]
-    # Both named to the person, and the reason claims only what was actually
-    # missing from the record we did read — the birthDate was on file.
+
+    # The two causes stay apart. "Your sex was not recorded" is true of the
+    # sex-gated pair and false of colorectal, which failed for our reason and
+    # not the record's — borrowing one reason for both is #417 with a
+    # different subject.
+    assert consumer["unevaluated"] == "partly-unchecked"
+    note = consumer["unevaluated_note"]
     for title in consumer["unevaluated_titles"]:
-        assert title in consumer["unevaluated_note"]
-    assert "date of birth" not in consumer["unevaluated_note"]
+        assert title in note
+    assert "sex was not recorded" in note
+    assert "does not yet read" in note and "stool-based" in note
+    # Still nothing about a birthDate that was on file.
+    assert "date of birth" not in note
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #425. This is the interim fix I flagged when filing it, and it is the
one thing standing between #423 and a demo that answers *honestly*.

### The defect

Colorectal screening was satisfied only by CPT colonoscopy/sigmoidoscopy
codes — `Procedure` resources. USPSTF equally accepts stool-based screening
on its own schedule (FIT annually, FIT-DNA every 1–3 years), and those arrive
as **lab `Observation`s**. The rule never looked at them.

A patient screening exactly as advised with annual FIT matched nothing and
was told they were **due**. That is a claim about their care built out of a
gap in our model — the house defect shape, pointed at clinical content.

The existing due note ("no record found in your connected data") does not
cover it: that sentence implies we read the data that would have satisfied
the rule.

### The fix

A rule may declare `unread_evidence`. When it finds nothing *and* is known
not to read everything that satisfies it, the result is `indeterminate` and
the note names what we did not read. **The prompt to act survives** — a
patient never screened still needs to raise it — but the status stops
asserting. A red DUE badge with fine print under it is still a claim.

Declared on the rule, not branched on the rule id: the next rule with a blind
spot should have to *say so* rather than be remembered.

### The two reasons stay apart

This creates a second kind of undecided, and they must not borrow each other's
reason. *"Your sex was not recorded"* is about the person and is false of
colorectal. *"We don't read everything"* would excuse a genuinely missing sex.
Both are #417 with the subject swapped.

| undecided because | reason |
|---|---|
| the record was short | `sex-unavailable` / `birth-date-unavailable` (unchanged) |
| we don't read it | `evidence-not-read` |
| both | `partly-unchecked`, each cause naming its own screenings |

### Pin moved in the same PR

`test_a_partial_screening_list_says_how_much_of_it_is_missing` pinned 4
decided / 2 undecided. Colorectal moves across, so it is now 3 and 3 with
mixed causes. Updated here with the reason written down, per §6.

### What this does NOT do

It does not add FIT/FIT-DNA coverage. Which LOINC codes count, at what
intervals, is a clinical decision with a code-list question inside it — and a
plausible-looking wrong code in a screening rule passes review and is wrong in
production. #425 stays open for that.

### Verification

- `2724 passed`, 12 skipped, 1 xfailed; ruff clean; **conformance 35 passed (Grade A)**
- Mutations, both run: folding coverage back into `_demographics_marker`
  reddens the separation tests; dropping `unread_evidence` returns the status
  to `due`

**Not verified against a running HealthClaw** — and this one is worth a live
check with #423, since together they are what make the demo's screening button
produce a real answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)