### PR TITLE
No model call may outlive the run waiting for it (E2)

### DIFF
--- a/careagents/llm.py
+++ b/careagents/llm.py
@@ -68,6 +68,36 @@ MAX_ATTEMPTS = 3
 BACKOFF_BASE_SECONDS = 1.0
 MAX_BACKOFF_SECONDS = 8.0
 
+#: The Anthropic SDK retries 429/5xx itself; this is that count made explicit
+#: so the timeout below can be divided by it.
+_ANTHROPIC_MAX_RETRIES = 2
+
+
+#: Used when a Config predates `run_deadline_seconds`. Never fall through to a
+#: library default: the Anthropic SDK's is 600 seconds, which is five times the
+#: deadline the run is measured against.
+_FALLBACK_DEADLINE_SECONDS = 120.0
+
+#: Leave the run somewhere to land. The deadline is checked BETWEEN calls
+#: (careagents/worker.py) and nothing cancels a call in flight, so a model
+#: budget equal to the deadline guarantees the check happens after it has
+#: already passed.
+_DEADLINE_SHARE = 0.75
+
+
+def _attempt_timeout(cfg, attempts: int) -> float:
+    """Seconds one model call may take, so `attempts` of them still fit.
+
+    The run holds a lease and a hard deadline while this is in flight. A
+    budget larger than the deadline does not make the call succeed; it pins a
+    worker slot to a run that has already been abandoned, which is how one
+    slow provider turns into no capacity at all.
+    """
+    deadline = float(getattr(cfg, "run_deadline_seconds", 0)
+                     or _FALLBACK_DEADLINE_SECONDS)
+    backoff = MAX_BACKOFF_SECONDS * max(0, attempts - 1)
+    return max(5.0, (deadline * _DEADLINE_SHARE - backoff) / attempts)
+
 
 def _retry_delay(attempt: int, retry_after: str | None) -> float:
     """Seconds to wait before attempt N+1. Honours Retry-After when sane."""
@@ -96,15 +126,24 @@ def complete(cfg, system: str, messages: list[dict], tools: list[dict]) -> LLMTu
 def _anthropic_complete(cfg, system, messages, tools) -> LLMTurn:
     import anthropic
 
+    # The SDK defaults to a 600s timeout and 2 internal retries — up to half an
+    # hour of a worker slot for a run abandoned at 120 seconds. Nothing here
+    # cancels an in-flight call, so this budget IS the exposure. Both are set
+    # explicitly; the retries stay, because the SDK is the only thing that can
+    # retry an Anthropic call, but they now fit inside the deadline.
+    _budget = {"timeout": _attempt_timeout(cfg, 1 + _ANTHROPIC_MAX_RETRIES),
+               "max_retries": _ANTHROPIC_MAX_RETRIES}
+
     # An OAuth access token (Claude subscription / OpenClaw) authenticates as a
     # Bearer token with the oauth beta header, instead of an x-api-key. The
     # token is short-lived — refresh it out of band when it expires.
     if getattr(cfg, "anthropic_oauth_token", ""):
         client = anthropic.Anthropic(
             auth_token=cfg.anthropic_oauth_token,
-            default_headers={"anthropic-beta": cfg.anthropic_oauth_beta})
+            default_headers={"anthropic-beta": cfg.anthropic_oauth_beta},
+            **_budget)
     else:
-        client = anthropic.Anthropic(api_key=cfg.anthropic_api_key)
+        client = anthropic.Anthropic(api_key=cfg.anthropic_api_key, **_budget)
     a_tools = [{"name": t["name"], "description": t["description"],
                 "input_schema": t["parameters"]} for t in tools]
     a_messages = _to_anthropic_messages(messages)
@@ -190,7 +229,7 @@ def _openai_complete(cfg, system, messages, tools) -> LLMTurn:
                 # internal reasoning before the visible answer.
                 json={"model": cfg.openai_model, "messages": o_messages,
                       "tools": o_tools, "max_tokens": 4000},
-                timeout=90)
+                timeout=_attempt_timeout(cfg, MAX_ATTEMPTS))
         except requests.RequestException as exc:
             # Previously uncaught: a connection reset or read timeout escaped
             # as a raw requests exception rather than an LLMError, so the

--- a/careagents/worker.py
+++ b/careagents/worker.py
@@ -66,6 +66,12 @@ def _error_class(exc: Exception) -> str:
 _failure_text = agent_failure_text
 
 
+#: Consecutive heartbeat failures before the lease is given up. The interval
+#: is a third of the lease, so two misses still leave a third of it to
+#: recover in; one miss ending the run was the whole of the defect.
+_HEARTBEAT_MAX_MISSES = 3
+
+
 class LeaseHeartbeat:
     """Refresh one run lease independently of blocking provider calls."""
 
@@ -77,6 +83,7 @@ class LeaseHeartbeat:
         self.lease_seconds = lease_seconds
         self.cancel_requested = False
         self.lost = False
+        self._misses = 0
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=self._loop, name=f"lease-{run_id[:8]}", daemon=True)
@@ -94,17 +101,40 @@ class LeaseHeartbeat:
         if self.lost:
             raise HealthClawError("worker lease was lost", 409)
 
+    def _beat_once(self) -> None:
+        """One heartbeat. Gives the lease up only after repeated failures.
+
+        A single failure used to end the run. The interval is a third of the
+        lease, so one blip shorter than the remaining two thirds costs
+        nothing — while abandoning the turn cost the patient an answer the
+        model may already have produced, reported as "something went wrong on
+        our side". Recovery then waited out the full lease inside a shorter
+        deadline, so the run usually died rather than being retried.
+
+        Consecutive failures still lose it: if the engine is genuinely gone,
+        holding a slot for a lease nobody is honouring helps no one.
+        """
+        try:
+            result = self.hc.heartbeat_agent_run(
+                self.run_id, self.worker_id, self.lease_seconds)
+        except HealthClawError as exc:
+            self._misses += 1
+            logger.warning("heartbeat %d/%d failed for run %s: %s",
+                           self._misses, _HEARTBEAT_MAX_MISSES,
+                           self.run_id, exc)
+            if self._misses >= _HEARTBEAT_MAX_MISSES:
+                logger.error("lease lost for run %s after %d misses",
+                             self.run_id, self._misses)
+                self.lost = True
+            return
+        self._misses = 0
+        self.cancel_requested = bool(result.get("cancel_requested"))
+
     def _loop(self) -> None:
         interval = max(2.0, self.lease_seconds / 3)
         while not self._stop.wait(interval):
-            try:
-                result = self.hc.heartbeat_agent_run(
-                    self.run_id, self.worker_id, self.lease_seconds)
-                self.cancel_requested = bool(result.get("cancel_requested"))
-            except HealthClawError as exc:
-                logger.error("heartbeat failed for run %s: %s",
-                             self.run_id, exc)
-                self.lost = True
+            self._beat_once()
+            if self.lost:
                 return
 
 

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -259,3 +259,150 @@ def test_the_failure_text_has_exactly_one_home():
     assert owners == ["agent.py"], (
         f"patient-facing failure text is defined in {owners}; only agent.py "
         "may own it — import GENERIC_FAILURE_TEXT instead")
+
+
+# --- the call must not outlive the run waiting for it ----------------------
+#
+# A run holds a lease (60s) and a hard deadline (120s). The deadline is only
+# checked BETWEEN calls (careagents/worker.py), and nothing cancels a call in
+# flight, so any budget larger than the deadline is a worker slot pinned to a
+# run that is already dead.
+
+class _DeadlineCfg(_Cfg):
+    run_deadline_seconds = 120
+
+
+def test_the_openai_budget_fits_inside_the_run_deadline(monkeypatch, slept):
+    """MUTATION: drop the per-attempt timeout back to a flat 90 -> red.
+
+    3 attempts x 90s = 270s against a 120s deadline: the run is abandoned at
+    120 and the slot stays busy for another two and a half minutes. Ran it,
+    saw red.
+    """
+    seen: list[float] = []
+
+    def post(*_args, **kwargs):
+        seen.append(kwargs["timeout"])
+        return _Resp(200)
+
+    monkeypatch.setattr(llm.requests, "post", post)
+    llm.complete(_DeadlineCfg(), "sys", [{"role": "user", "content": "hi"}], [])
+
+    assert seen, "no call was made"
+    budget = seen[0] * llm.MAX_ATTEMPTS + llm.MAX_BACKOFF_SECONDS * (
+        llm.MAX_ATTEMPTS - 1)
+    assert budget <= _DeadlineCfg.run_deadline_seconds, (
+        f"worst-case model budget {budget}s exceeds the "
+        f"{_DeadlineCfg.run_deadline_seconds}s run deadline")
+
+
+def test_a_config_without_a_deadline_still_gets_a_bounded_timeout(
+        monkeypatch, slept):
+    """Config objects in the wild may predate the field; never fall back to
+    the library default, which is unbounded in practice.
+
+    MUTATION: return None when the attribute is missing -> red.
+    """
+    seen: list[float] = []
+
+    def post(*_args, **kwargs):
+        seen.append(kwargs["timeout"])
+        return _Resp(200)
+
+    monkeypatch.setattr(llm.requests, "post", post)
+    llm.complete(_Cfg(), "sys", [{"role": "user", "content": "hi"}], [])
+    assert seen and 0 < seen[0] <= 90
+
+
+def test_the_anthropic_client_is_given_an_explicit_budget(monkeypatch):
+    """The SDK default is 600s with 2 internal retries — 30 minutes of a
+    worker slot for a run that is abandoned at 120 seconds. Nothing here
+    cancels an in-flight call, so the budget IS the exposure.
+
+    MUTATION: construct Anthropic() without timeout/max_retries -> red.
+    Ran it, saw red.
+    """
+    captured: dict = {}
+
+    class _Messages:
+        def create(self, **_kw):
+            raise AssertionError("not reached")
+
+    class _Client:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.messages = _Messages()
+
+    fake_sdk = types.SimpleNamespace(
+        Anthropic=_Client, APIError=Exception,
+        NOT_GIVEN=None)
+    monkeypatch.setitem(__import__("sys").modules, "anthropic", fake_sdk)
+
+    class _ACfg:
+        provider = "anthropic"
+        anthropic_api_key = "k"
+        anthropic_model = "m"
+        anthropic_oauth_token = ""
+        run_deadline_seconds = 120
+
+    with pytest.raises(Exception):
+        llm.complete(_ACfg(), "sys", [{"role": "user", "content": "hi"}], [])
+
+    assert "timeout" in captured, "the client was built without a timeout"
+    assert "max_retries" in captured, "retries were left to the SDK default"
+    budget = captured["timeout"] * (1 + captured["max_retries"])
+    assert budget <= 120, f"worst-case Anthropic budget {budget}s exceeds 120s"
+
+
+# --- one heartbeat blip is not a lost lease -------------------------------
+
+class _FlakyHC:
+    """Fails the first N heartbeats, then succeeds."""
+
+    def __init__(self, failures):
+        self.failures = failures
+        self.calls = 0
+
+    def heartbeat_agent_run(self, *_args, **_kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise worker.HealthClawError("heartbeat failed", 0)
+        return {"cancel_requested": False}
+
+
+def _beat(hc, times=1):
+    """Drive LeaseHeartbeat._loop's body without the thread or the sleep."""
+    hb = worker.LeaseHeartbeat(hc, "run-1", "w-1", lease_seconds=60)
+    for _ in range(times):
+        if hb.lost:
+            break
+        hb._beat_once()
+    return hb
+
+
+def test_a_single_failed_heartbeat_does_not_abandon_the_run():
+    """One 25s blip on a 20s interval aborted a turn the model may already
+    have answered, and the patient read "something went wrong on our side".
+
+    Recovery cost up to a full 60s lease expiry inside a 120s deadline, so the
+    run usually died rather than being retried.
+
+    MUTATION: set self.lost on the first failure -> red. Ran it, saw red.
+    """
+    hc = _FlakyHC(failures=1)
+    hb = _beat(hc, times=2)
+    assert hb.lost is False, "one failure ended the run"
+    assert hc.calls == 2, "the heartbeat did not try again"
+
+
+def test_consecutive_failures_still_lose_the_lease():
+    """The tolerance must not become "never give up".
+
+    If the engine is genuinely gone the run has to stop, or the worker keeps
+    a slot busy for a lease nobody is honouring.
+
+    MUTATION: never set self.lost -> red.
+    """
+    hc = _FlakyHC(failures=99)
+    hb = _beat(hc, times=4)
+    assert hb.lost is True, "the lease was never given up"


### PR DESCRIPTION
Phase 0 item E2 from `docs/2026-08-05-healthclaw-2.0-playbook.md`. Four
numbers that did not fit inside each other.

### The timeout hierarchy was inverted

The rule is *dependency timeout < handler deadline < LB timeout*. Both model
paths broke it:

| path | worst case | run deadline |
|---|---|---|
| Anthropic | **600s × 3 attempts** (SDK defaults, both implicit) | 120s |
| OpenAI-compatible | 90s × 3 + backoff ≈ **286s** | 120s |

The deadline is only checked *between* calls, and nothing cancels a call in
flight — so the budget **is** the exposure. One slow provider pins a worker
slot long after the run it belongs to was abandoned, on a tier with 8 request
slots total.

`_attempt_timeout(cfg, attempts)` now divides three quarters of the run
deadline across the attempts a path actually makes, less the backoff it will
sleep. A config predating `run_deadline_seconds` falls back to 120s rather
than a library default — that default is the defect.

The Anthropic retries stay (the SDK is the only thing that can retry that
call) but are now declared, so the timeout can be divided by them.

### A single failed heartbeat ended the run

The interval is a third of the lease, so one blip shorter than the remaining
two thirds costs nothing. It set `lost` anyway and abandoned a turn **the
model may already have answered** — the patient read "something went wrong on
our side". Recovery then waited out the full 60s lease inside a 120s
deadline, so the run usually died rather than being retried.

Three consecutive misses now lose it; any success resets the count. Genuine
absence still ends the run: holding a slot for a lease nobody honours helps
no one.

### Verification

- `2731 passed`, 12 skipped, 1 xfailed; ruff clean
- Five mutations, each reddening its own test and only its own: dropping the
  Anthropic budget, restoring the flat 90s timeout, returning an unbounded
  fallback, losing the lease on the first miss, and never losing it

**Not verified against a live provider or a running HealthClaw** — the
heartbeat test drives the loop body directly rather than through the thread,
so it proves the miss policy, not the timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)