### PR TITLE
An outage is not an empty chart and not an empty conversation (E3)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -691,11 +691,20 @@ def create_app(config: Config | None = None,
         conversation_id = hc.conversation_id(agent_id)
         # Show the conversation they actually had. Rendering only the canned
         # greeting made every return visit look like a first visit.
-        past = hc.recent_messages(
-            ctx["tenant"], limit=30,
-            conversation_id=conversation_id,
-            agent_id=agent_id,
-        )
+        try:
+            past = hc.recent_messages(
+                ctx["tenant"], limit=30,
+                conversation_id=conversation_id,
+                agent_id=agent_id,
+            )
+            history_lost = False
+        except HealthClawError:
+            # An outage used to render as an empty conversation, so a
+            # returning patient was greeted as though they had never been
+            # here. Say we could not load it rather than showing a blank
+            # slate that looks like a fact about them.
+            logger.exception("chat history unavailable for agent %s", agent_id)
+            past, history_lost = [], True
         conn = ctx.get("connection") or {}
         pending = conn.get("status") == "pending"
         totals = None
@@ -739,6 +748,7 @@ def create_app(config: Config | None = None,
                                agent_id=agent_id,
                                conversation_id=conversation_id,
                                past=past,
+                               history_lost=history_lost,
                                intake=intake,
                                summary_counts=intake.counts)
 
@@ -750,10 +760,18 @@ def create_app(config: Config | None = None,
         ctx = svc.get_agent_context(acct.id, agent_id)
         if not ctx:
             return redirect(url_for("home"))
-        raw = hc.fetch_appointment_brief(ctx["tenant"])
+        try:
+            raw = hc.fetch_appointment_brief(ctx["tenant"])
+            unavailable = False
+        except HealthClawError:
+            # "Not available from your connected records" is a statement about
+            # the records. We did not read them, so we cannot make it.
+            logger.exception("brief unavailable for agent %s", agent_id)
+            raw, unavailable = None, True
         sections = _parse_brief_sections(raw) if raw else {}
         return render_template("brief.html", me=ctx["agent"],
                                agent_id=agent_id, sections=sections,
+                               brief_unavailable=unavailable,
                                care_gaps_ok=(_parse_care_gaps_status(raw)
                                              == _CARE_GAPS_OK))
 

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -455,25 +455,32 @@ class HealthClawClient:
         return total
 
     def fetch_appointment_brief(self, tenant: str) -> dict | None:
-        """Fetch the pre-appointment brief for this tenant.
+        """The brief, or None when the engine answered and there is none.
 
-        Returns the FHIR Basic resource dict, or None on any failure.
-        Callers treat None as "brief unavailable" — never raise to the UI.
+        Raises HealthClawError when we could not find out. The two were the
+        same value before, and the template renders None as "Not available
+        from your connected records" — a statement about the patient's
+        records, made during an outage that read none of them. The same page
+        already gets this right one section down, where the screening review
+        requires an explicit "ok" before it claims anything (#381).
+
+        A malformed 200 raises too: it means we did not learn whether a brief
+        exists, which is the same fact as an unreachable engine.
         """
-        try:
-            r = self._send(
-                "GET", f"{self.fhir}/AppointmentBrief",
-                headers=self._headers(tenant),
-                what="appointment brief")
-            if r.status_code == 200:
-                # dict-or-None is what the brief renderer is written against.
-                # A wrongly-shaped 200 used to be handed straight through as
-                # though it were the FHIR Basic resource, moving the failure
-                # one layer past the boundary that accepted it (#403).
-                return self._json_object(r, "appointment brief")
-        except (requests.RequestException, HealthClawError, ValueError):
-            pass
-        return None
+        r = self._send(
+            "GET", f"{self.fhir}/AppointmentBrief",
+            headers=self._headers(tenant),
+            what="appointment brief")
+        if r.status_code == 200:
+            # dict-or-None is what the brief renderer is written against.
+            # A wrongly-shaped 200 used to be handed straight through as
+            # though it were the FHIR Basic resource, moving the failure
+            # one layer past the boundary that accepted it (#403).
+            return self._json_object(r, "appointment brief")
+        if self._upstream_answered(r.status_code):
+            return None
+        raise HealthClawError(
+            f"appointment brief unavailable ({r.status_code})", r.status_code)
 
     def purge_tenant(self, tenant: str) -> dict:
         """Delete this tenant's records in HealthClaw. Raises on failure.
@@ -582,23 +589,33 @@ class HealthClawClient:
                         conversation_id: str | None = None,
                         agent_id: str | None = None,
                         through_message_id: str | None = None) -> list[dict]:
-        """Oldest-first [{role, text}] for rehydrating a conversation."""
-        try:
-            r = self.http.get(
-                f"{self.base}/command-center/api/conversations",
-                params={"limit": limit, "full": "1", "tenant": tenant,
-                        "conversation_id": conversation_id,
-                        "agent_id": agent_id,
-                        "through_message_id": through_message_id},
-                headers={"X-Tenant-Id": tenant,
-                         "X-Step-Up-Token": self.mint_token(tenant)},
-                timeout=self.timeout)
-            if r.status_code != 200:
+        """Oldest-first [{role, text}] for rehydrating a conversation.
+
+        An empty list means the engine answered and there is nothing to
+        replay. Losing the thread raises instead, because the two were the
+        same value and the collapse was invisible in both directions: the web
+        tier rendered every return visit during an outage as a first visit,
+        and the worker built the agent's context from it, so the model
+        answered with amnesia and said nothing about it.
+        """
+        r = self._send(
+            "GET", f"{self.base}/command-center/api/conversations",
+            params={"limit": limit, "full": "1", "tenant": tenant,
+                    "conversation_id": conversation_id,
+                    "agent_id": agent_id,
+                    "through_message_id": through_message_id},
+            headers={"X-Tenant-Id": tenant,
+                     "X-Step-Up-Token": self.mint_token(tenant)},
+            what="chat history")
+        if r.status_code != 200:
+            if self._upstream_answered(r.status_code):
                 return []
+            raise HealthClawError(
+                f"chat history unavailable ({r.status_code})", r.status_code)
+        try:
             rows = r.json() or []
-        except (requests.RequestException, HealthClawError, ValueError):
-            logger.warning("could not load chat history for %s", tenant)
-            return []
+        except ValueError as exc:
+            raise HealthClawError("chat history was not JSON", 200) from exc
         out = [{"role": m["role"], "content": m.get("text") or ""}
                for m in reversed(rows)          # endpoint returns newest-first
                if m.get("role") in ("user", "assistant")]

--- a/careagents/templates/brief.html
+++ b/careagents/templates/brief.html
@@ -29,7 +29,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="brief-empty">Not available from your connected records.</p>
+    {% if brief_unavailable %}<p class="brief-empty">We could not reach your records just now, so this section was not checked.</p>{% else %}<p class="brief-empty">Not available from your connected records.</p>{% endif %}
     {% endif %}
   </div>
 
@@ -48,7 +48,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="brief-empty">Not available from your connected records.</p>
+    {% if brief_unavailable %}<p class="brief-empty">We could not reach your records just now, so this section was not checked.</p>{% else %}<p class="brief-empty">Not available from your connected records.</p>{% endif %}
     {% endif %}
   </div>
 
@@ -67,7 +67,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="brief-empty">Not available from your connected records.</p>
+    {% if brief_unavailable %}<p class="brief-empty">We could not reach your records just now, so this section was not checked.</p>{% else %}<p class="brief-empty">Not available from your connected records.</p>{% endif %}
     {% endif %}
   </div>
 
@@ -110,7 +110,7 @@
       {% endfor %}
     </div>
     {% else %}
-    <p class="brief-empty">Not available from your connected records.</p>
+    {% if brief_unavailable %}<p class="brief-empty">We could not reach your records just now, so this section was not checked.</p>{% else %}<p class="brief-empty">Not available from your connected records.</p>{% endif %}
     {% endif %}
   </div>
 

--- a/careagents/templates/chat.html
+++ b/careagents/templates/chat.html
@@ -37,6 +37,13 @@
       {% endif %}
     </div>
     {% endif %}
+    {% if history_lost %}
+    {# An outage rendered as an empty conversation, so a returning patient was
+       greeted as a stranger. Say what happened instead of showing a blank
+       slate that looks like a fact about them. #}
+    <div class="chat-resumed">We could not load your earlier messages just now.
+      Nothing has been lost — try refreshing in a moment.</div>
+    {% endif %}
     {% if past %}
     {# Returning: replay what was actually said rather than greeting them as a
        stranger. The starters are for someone who hasn't asked anything yet. #}

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2565,6 +2565,61 @@ def test_brief_renders_unavailable_when_fetch_fails(app, svc, monkeypatch):
     assert b"Not available from your connected records" in resp.data
 
 
+def test_an_unreachable_engine_does_not_blame_the_patient_s_records(
+        app, svc, monkeypatch):
+    """"Not available from your connected records" is a claim about the
+    records. During an outage we read none of them, so we cannot make it.
+
+    The same page already gets this right one section down: the screening
+    review says "unavailable" unless the brief carries an explicit "ok"
+    (#381). This is that posture applied to the other four sections.
+
+    MUTATION: swallow HealthClawError in the brief route and render None ->
+    red, the page blames the records again. Ran it, saw red.
+    """
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn_id = c.post("/api/connections/sample").get_json()["id"]
+    agent_id = c.post("/api/agents", json={"name": "Ada", "persona": "direct",
+                                           "connection_id": conn_id}
+                      ).get_json()["id"]
+
+    def _down(self, tenant):
+        raise HealthClawError("appointment brief unavailable (503)", 503)
+
+    monkeypatch.setattr(FakeClient, "fetch_appointment_brief", _down)
+    resp = c.get(f"/brief?agent={agent_id}")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "could not reach your records" in body
+    assert "Not available from your connected records" not in body
+
+
+def test_a_returning_patient_is_not_greeted_as_a_stranger_during_an_outage(
+        app, svc, monkeypatch):
+    """An outage collapsed into an empty conversation, so every return visit
+    rendered as a first visit — a blank slate that reads as a fact about the
+    person rather than about the connection.
+
+    MUTATION: swallow HealthClawError and render past=[] silently -> red.
+    Ran it, saw red.
+    """
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn_id = c.post("/api/connections/sample").get_json()["id"]
+    agent_id = c.post("/api/agents", json={"name": "Ada", "persona": "direct",
+                                           "connection_id": conn_id}
+                      ).get_json()["id"]
+
+    def _down(self, *a, **k):
+        raise HealthClawError("chat history unavailable (503)", 503)
+
+    monkeypatch.setattr(FakeClient, "recent_messages", _down)
+    resp = c.get(f"/chat?agent={agent_id}")
+    assert resp.status_code == 200
+    assert "could not load your earlier messages" in resp.get_data(as_text=True)
+
+
 def test_brief_unknown_agent_redirects(app, svc, monkeypatch):
     c = app.test_client()
     _login(c, svc, monkeypatch)

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -485,23 +485,30 @@ def test_a_lost_approval_mint_is_a_refusal_and_not_silence(stub_base,
 
 def test_history_loss_is_not_the_same_value_as_an_empty_history(stub_base,
                                                                 reset_mode):
-    """`recent_messages` returns [] both for "this is a new conversation" and
-    for "HealthClaw is unreachable", so the agent silently answers with no
-    history instead of saying it lost the thread.
+    """PIN FLIPPED (E3). This test used to assert the collapse and invited
+    exactly this change: "if this changed, the collapse was fixed and this
+    test should assert the new distinction instead".
 
-    Not raised as a blocking defect: it logs, and answering without history
-    beats failing the turn. Pinned so the collapse is a decision on the
-    record rather than an accident.
+    [] meant both "this is a new conversation" and "HealthClaw is
+    unreachable". The earlier note reasoned that answering without history
+    beats failing the turn — true for the web tier, and wrong for the worker,
+    which builds the agent's context from this and so answered with amnesia
+    while saying nothing about it. The web tier had its own version: every
+    return visit during an outage rendered as a first visit.
+
+    MUTATION: return [] for the 503 again -> red. Ran it, saw red.
     """
-    _set(status=503, body=b'{"error": "down"}')
-    outage = _client(stub_base).recent_messages("t")
-
     _set(status=200, body=b"[]")
-    empty = _client(stub_base).recent_messages("t")
+    assert _client(stub_base).recent_messages("t") == [], (
+        "an engine that answered with no rows still means no rows")
 
-    assert outage == empty == [], (
-        "pinned as today's behaviour — if this changed, the collapse was "
-        "fixed and this test should assert the new distinction instead")
+    for status in (500, 502, 503, 504, 408, 429):
+        _set(status=status, body=b'{"error": "down"}')
+        with pytest.raises(HealthClawError):
+            _client(stub_base).recent_messages("t")
+
+    with pytest.raises(HealthClawError):
+        _client(DEAD_BASE).recent_messages("t")
 
 
 def test_a_lost_chat_turn_is_reported_to_the_caller(stub_base, reset_mode):
@@ -528,20 +535,34 @@ def test_an_unclaimable_inbound_message_is_never_reported_as_claimed(
 
 def test_a_missing_brief_and_an_unreachable_engine_are_both_unavailable(
         stub_base, reset_mode):
-    """`fetch_appointment_brief` is documented as None-on-any-failure and the
-    callers render "brief unavailable", which is true of both states. Pinned
-    because the docstring's promise — never raise to the UI — is the part
-    that must not regress."""
+    """PIN FLIPPED (E3). They are not both "unavailable" to the reader.
+
+    The template renders None as "Not available from your connected records"
+    — a statement about the patient's records, made during an outage that
+    read none of them. The same page already gets this right one section
+    down, where the screening review requires an explicit "ok" (#381).
+
+    404 is the engine answering that there is no brief, and still returns
+    None. Everything else raises, and the route renders "we could not reach
+    your records" instead.
+
+    MUTATION: return None for the 503 again -> red. Ran it, saw red.
+    """
     _set(status=404, body=b'{"error": "no brief"}')
-    assert _client(stub_base).fetch_appointment_brief("t") is None
+    assert _client(stub_base).fetch_appointment_brief("t") is None, (
+        "the engine answered: there is no brief")
 
-    _set(status=503, body=b'{"error": "down"}')
-    assert _client(stub_base).fetch_appointment_brief("t") is None
+    for status in (500, 502, 503, 504):
+        _set(status=status, body=b'{"error": "down"}')
+        with pytest.raises(HealthClawError):
+            _client(stub_base).fetch_appointment_brief("t")
 
-    assert _client(DEAD_BASE).fetch_appointment_brief("t") is None
+    with pytest.raises(HealthClawError):
+        _client(DEAD_BASE).fetch_appointment_brief("t")
 
     _set(delay=SLOW_ENOUGH_TO_TIME_OUT)
-    assert _client(stub_base).fetch_appointment_brief("t") is None
+    with pytest.raises(HealthClawError):
+        _client(stub_base).fetch_appointment_brief("t")
 
 
 def test_the_brief_returns_a_resource_or_none_and_never_a_bare_string(
@@ -557,11 +578,21 @@ def test_the_brief_returns_a_resource_or_none_and_never_a_bare_string(
     which is why the type check and not the wrapping is what turns this
     green.
 
+    PIN NARROWED (E3): the contract is now dict, or None when the engine said
+    there is no brief, or a raise. A malformed 200 raises rather than
+    returning None, because it means we did not learn whether a brief exists
+    — the same fact as an unreachable engine, and the caller now has somewhere
+    to put that. What the test is for is unchanged: a wrong shape must never
+    reach the renderer.
+
     MUTATION: return `r.json()` here instead of `self._json_object(...)` ->
     red, with `'just-a-string'` returned. Ran it, saw red.
     """
     _set(status=200, body=b'"just-a-string"')
-    got = _client(stub_base).fetch_appointment_brief("t")
+    try:
+        got = _client(stub_base).fetch_appointment_brief("t")
+    except HealthClawError:
+        got = None
     assert got is None or isinstance(got, dict), repr(got)
 
 


### PR DESCRIPTION
Final Phase 0 item. Two collapses that were **pinned as deliberate** — and
whose pins invited this exact change:

> *"pinned as today's behaviour — if this changed, the collapse was fixed and
> this test should assert the new distinction instead"*

### The brief blamed the records

`fetch_appointment_brief` returned `None` on everything, and the template
renders `None` as **"Not available from your connected records."** That is a
statement about the patient's records, made during an outage that read none
of them.

The same page already gets this right one section down: the screening review
says "unavailable" unless the brief carries an explicit `"ok"` (#381). One
page, two postures.

Now: **404 still returns None** (the engine answered — there is no brief). A
gateway 5xx, a dead socket, and a malformed 200 raise, because all three mean
we did not learn whether a brief exists. The page says *"we could not reach
your records just now, so this section was not checked."*

### The history greeted returning patients as strangers

`recent_messages` returned `[]` for *"new conversation"* and *"HealthClaw is
unreachable"* alike. The original note reasoned that answering without history
beats failing the turn — true for the web tier, **wrong for the worker**,
which builds the agent's context from this call and therefore answered with
amnesia while saying nothing about it.

An engine that answers with no rows still means no rows. Losing the thread now
raises; the chat page says so; the worker's existing boundary records an honest
failure instead of inventing a blank slate.

### Pins moved (3, all in this commit)

| pin | why |
|---|---|
| `..._history_loss_is_not_the_same_value_as_an_empty_history` | flipped — it asked to be |
| `..._a_missing_brief_and_an_unreachable_engine_are_both_unavailable` | flipped — same |
| `..._brief_returns_a_resource_or_none_and_never_a_bare_string` | narrowed: a malformed 200 now raises rather than returning None. What the test is *for* is unchanged — a wrong shape must never reach the renderer |

### Verification

- `2733 passed`, 12 skipped, 1 xfailed; ruff clean
- Four mutations, each reddening its own test and only its own: returning
  `None` for a gateway 503, returning `[]` on an outage, and hiding either
  failure in its route

**Not verified against a running HealthClaw** — these tests fake the client,
so they prove the branch, not the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)