### PR TITLE
Break the auth-stack import cycles (A1)

### DIFF
--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -41,6 +41,7 @@ from r6.rate_limit import rate_limit_middleware
 from r6.read_auth import authorize_tenant_read
 from r6.stepup import generate_step_up_token, validate_step_up_token
 from r6.telegram_push import notify_tenant
+from r6.body_guard import json_body_within_depth
 
 logger = logging.getLogger(__name__)
 
@@ -305,7 +306,6 @@ def propose_action():
     # tenant. There is no auth gate to move above it; bounding the depth is
     # the fix (#312). Lazy import, like authenticate_tenant_read below, to
     # keep the r6.routes <-> r6.actions import graph acyclic.
-    from r6.routes import json_body_within_depth
     body, too_deep = json_body_within_depth()
     if too_deep:
         return _error(400, 'request body nesting is too deep')

--- a/r6/body_guard.py
+++ b/r6/body_guard.py
@@ -1,0 +1,68 @@
+"""Request-body limits shared by every write path.
+
+Moved out of `r6/routes.py` whole. It lived there because that is where the
+first caller was, and three other modules then imported it back out — each
+with a function-local import and a comment explaining that a module-level one
+would deadlock. Those lazy imports were two of the back-edges holding
+`r6.routes` inside an import cycle with the auth stack, which is what kept the
+module from being split.
+
+Nothing here touches the database, a blueprint, or another `r6` module: it
+reads `flask.request` and returns a tuple. That is the whole reason it can
+live at the bottom of the graph.
+"""
+
+from __future__ import annotations
+
+from flask import request
+
+#: FHIR resources do not nest anywhere near this deep in practice. Headroom,
+#: not a tight bound.
+INGEST_MAX_JSON_DEPTH = 32
+
+
+def json_depth_within(obj, limit, _depth=0):
+    """Bounded depth check, not a recursion-limit workaround.
+
+    Refuses at `limit` (32) regardless of Python's actual recursion ceiling
+    (typically ~1000), so a hostile payload is rejected long before it can
+    exhaust the stack — this walker itself never recurses past limit+1
+    levels.
+    """
+    if _depth > limit:
+        return False
+    if isinstance(obj, dict):
+        return all(json_depth_within(v, limit, _depth + 1)
+                   for v in obj.values())
+    if isinstance(obj, list):
+        return all(json_depth_within(v, limit, _depth + 1) for v in obj)
+    return True
+
+
+def json_body_within_depth(limit=INGEST_MAX_JSON_DEPTH):
+    """Parse this request's JSON body, refusing one nested too deep to be safe.
+
+    The write paths' shared entry point to the guard #267 put on
+    /internal/ingest-bundle. `request.get_json(silent=True)` suppresses decode
+    errors but NOT `RecursionError`, which json.loads raises on a ~1000-deep
+    payload — so every handler that parsed before its auth gate turned a few
+    kilobytes of `[[[[...` into a 500 with no credential presented (#312).
+
+    Returns `(body, too_deep)`. `body` is whatever `get_json(silent=True)`
+    returned (None on any decode failure) and `too_deep` is True when the
+    payload must be refused outright. The caller formats its own error, so no
+    handler's wire format changes: the FHIR routes answer an
+    OperationOutcome, actions answer `{"error": ...}`, smbp answers its own
+    OperationOutcome, all with the 400 they already use for a bad body.
+
+    Two layers, as on ingest-bundle: catching RecursionError handles the
+    payload that cannot be parsed, and json_depth_within handles the one that
+    parses but is still absurd enough to hurt a downstream consumer.
+    """
+    try:
+        body = request.get_json(silent=True)
+    except RecursionError:
+        return None, True
+    if not json_depth_within(body, limit):
+        return None, True
+    return body, False

--- a/r6/health_compliance.py
+++ b/r6/health_compliance.py
@@ -13,6 +13,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from flask import request, jsonify
+from r6.body_guard import json_body_within_depth
 
 logger = logging.getLogger(__name__)
 
@@ -120,8 +121,6 @@ def enforce_human_in_loop():
     # in before_request, ahead of every handler's auth gate, with nothing but
     # a tenant header presented. A depth guard inside create/update alone
     # would never be reached, because the RecursionError escapes from here.
-    # Lazy import: r6.routes imports this module at load time.
-    from r6.routes import json_body_within_depth
     body, too_deep = json_body_within_depth()
     if too_deep:
         return jsonify({

--- a/r6/oauth.py
+++ b/r6/oauth.py
@@ -23,6 +23,7 @@ import uuid
 from functools import wraps
 from flask import request, jsonify
 from r6.runtime_config import resolve_app_env
+from r6.runtime_config import read_auth_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -282,8 +283,7 @@ def register_oauth_routes(blueprint):
         # real per-user consent (out of scope for this reference OAuth server).
         requested_tenant = request.headers.get('X-Tenant-Id', 'default')
         from r6.command_center.access import is_public
-        from r6.routes import _read_auth_enabled
-        if _read_auth_enabled() and not is_public(requested_tenant):
+        if read_auth_enabled() and not is_public(requested_tenant):
             return jsonify({
                 'error': 'access_denied',
                 'error_description': 'Auto-approve authorization is limited to '

--- a/r6/read_auth.py
+++ b/r6/read_auth.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-import os
 import re
 
 from flask import request, session
 
+# Env-only predicates live in runtime_config, at the bottom of the import
+# graph. They were here, and r6.oauth reached through r6.routes' re-export of
+# one of them to get at it — a cycle built to fetch three lines that read an
+# environment variable. Re-exported so this module's own importers are
+# unchanged.
+from r6.runtime_config import is_public_tenant, read_auth_enabled
 from r6.oauth import validate_bearer_token
 from r6.stepup import validate_step_up_token
 
@@ -21,23 +26,6 @@ _OAUTH_READ_SCOPES = frozenset({
     "user/*.read",
     "system/*.read",
 })
-
-
-def read_auth_enabled() -> bool:
-    """Return whether tenant read authentication is explicitly enabled."""
-    return os.environ.get("READ_AUTH_ENABLED", "").strip().lower() in _TRUE_VALUES
-
-
-def public_tenants() -> frozenset[str]:
-    """Return the explicit allowlist of synthetic public tenants."""
-    raw = os.environ.get("PUBLIC_TENANTS", "").strip()
-    if not raw:
-        return frozenset()
-    return frozenset(item.strip() for item in raw.split(",") if item.strip())
-
-
-def is_public_tenant(tenant_id: str) -> bool:
-    return tenant_id in public_tenants()
 
 
 def read_auth_required(tenant_id: str) -> bool:

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -46,6 +46,9 @@ from r6.read_auth import (
 )
 from r6.runtime_config import resolve_app_env
 from r6.version import __version__
+from r6.body_guard import (INGEST_MAX_JSON_DEPTH as _INGEST_MAX_JSON_DEPTH,
+                           json_body_within_depth,
+                           json_depth_within as _json_depth_within)
 from r6.rate_limit import rate_limit_middleware
 from r6.health_compliance import (
     add_disclaimer, enforce_human_in_loop, deidentify_resource,
@@ -2071,59 +2074,9 @@ _INGEST_BUNDLE_ALLOWED_TYPES = frozenset(
     set(R6Resource.SUPPORTED_TYPES) - _INGEST_BUNDLE_FORBIDDEN_TYPES)
 
 
-_INGEST_MAX_JSON_DEPTH = 32
-
-
-def _json_depth_within(obj, limit, _depth=0):
-    """Bounded depth check, not a recursion-limit workaround.
-
-    Refuses at `limit` (32) regardless of Python's actual recursion ceiling
-    (typically ~1000), so a hostile payload is rejected long before it can
-    exhaust the stack — this walker itself never recurses past limit+1
-    levels. FHIR resources do not nest anywhere close to 32 levels deep in
-    practice; this is headroom, not a tight bound.
-    """
-    if _depth > limit:
-        return False
-    if isinstance(obj, dict):
-        return all(_json_depth_within(v, limit, _depth + 1)
-                  for v in obj.values())
-    if isinstance(obj, list):
-        return all(_json_depth_within(v, limit, _depth + 1) for v in obj)
-    return True
-
-
-def json_body_within_depth(limit=_INGEST_MAX_JSON_DEPTH):
-    """Parse this request's JSON body, refusing one nested too deep to be safe.
-
-    The write paths' shared entry point to the guard #267 put on
-    /internal/ingest-bundle. `request.get_json(silent=True)` suppresses decode
-    errors but NOT `RecursionError`, which json.loads raises on a ~1000-deep
-    payload — so every handler that parsed before its auth gate turned a few
-    kilobytes of `[[[[...` into a 500 with no credential presented (#312).
-
-    Returns `(body, too_deep)`. `body` is whatever `get_json(silent=True)`
-    returned (None on any decode failure) and `too_deep` is True when the
-    payload must be refused outright. The caller formats its own error, so no
-    handler's wire format changes: the FHIR routes answer an
-    OperationOutcome, actions answer `{"error": ...}`, smbp answers its own
-    OperationOutcome, all with the 400 they already use for a bad body.
-
-    Two layers, as on ingest-bundle: catching RecursionError handles the
-    payload that cannot be parsed, and _json_depth_within handles the one that
-    parses but is still absurd enough to hurt a downstream consumer.
-
-    Imported lazily by r6/actions and r6/smbp (`from r6.routes import
-    json_body_within_depth`), matching how those modules already borrow
-    authenticate_tenant_read, so the import graph stays acyclic.
-    """
-    try:
-        body = request.get_json(silent=True)
-    except RecursionError:
-        return None, True
-    if not _json_depth_within(body, limit):
-        return None, True
-    return body, False
+# Moved to r6/body_guard.py: three modules imported these back out of
+# here, lazily, to dodge the import cycle that reaching into this
+# module created. Re-exported for the callers already inside it.
 
 
 @r6_blueprint.route('/internal/step-up-token', methods=['POST'])

--- a/r6/runtime_config.py
+++ b/r6/runtime_config.py
@@ -20,6 +20,23 @@ _INSECURE_STEP_UP_SECRETS = frozenset({
 _MIN_SECRET_LENGTH = 32
 
 
+def read_auth_enabled() -> bool:
+    """Whether tenant read authentication is explicitly enabled."""
+    return os.environ.get("READ_AUTH_ENABLED", "").strip().lower() in TRUE_VALUES
+
+
+def public_tenants() -> frozenset[str]:
+    """The explicit allowlist of synthetic public tenants."""
+    raw = os.environ.get("PUBLIC_TENANTS", "").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(item.strip() for item in raw.split(",") if item.strip())
+
+
+def is_public_tenant(tenant_id: str) -> bool:
+    return tenant_id in public_tenants()
+
+
 def resolve_app_env(environ: Mapping[str, str] | None = None) -> str:
     """Resolve one canonical environment while preserving ``FLASK_ENV``.
 

--- a/r6/smbp/routes.py
+++ b/r6/smbp/routes.py
@@ -19,6 +19,7 @@ from r6.smbp.models import SMBPSession
 from r6.smbp.monitoring import build_bp_observation
 from r6.smbp.triage import classify
 from r6.smbp.report import build_report, render_html, render_pdf
+from r6.body_guard import json_body_within_depth
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,6 @@ def enroll():
     # row), so this parse is reachable with no credential. No gate to move
     # above it; the depth bound is the fix (#312). Lazy import to keep the
     # r6.routes <-> r6.smbp import graph acyclic, as the report handler does.
-    from r6.routes import json_body_within_depth
     body, too_deep = json_body_within_depth()
     if too_deep:
         return jsonify(_oo("error", "invalid",

--- a/tests/test_import_acyclicity.py
+++ b/tests/test_import_acyclicity.py
@@ -1,0 +1,124 @@
+"""The auth stack imports in one direction.
+
+`r6.routes` sat in a strongly-connected component with `rate_limit`,
+`read_auth`, `oauth` and `health_compliance` — four nested cycles sharing two
+back-edges, both of which reached back into the 3,900-line module for a
+utility that had nowhere else to live:
+
+    oauth.py             -> routes._read_auth_enabled
+    health_compliance.py -> routes.json_body_within_depth
+
+Both were written as function-local imports to keep the process from
+deadlocking at load time, each with a comment apologising for it. That worked,
+and it hid the coupling from every tool that reads imports — including the
+reader deciding whether `routes.py` can be split.
+
+The cycles were never a runtime bug. They were a structural one: nothing
+could move out of `r6/routes.py` while two other modules reached into it, so
+the split kept not happening.
+
+This test walks the real import graph with `ast` and fails on any cycle
+inside the auth stack, counting deferred (function-local) imports the same as
+module-level ones. A cycle you cannot see is the kind that comes back.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: The modules that formed the SCC, plus the two the fix introduces or
+#: extends. Scoped rather than repo-wide on purpose: `r6.actions.rails` has a
+#: second, benign star-shaped SCC (a package importing its own submodules for
+#: their registration side effect), and the plan retires that one by promoting
+#: its shared transport helper, not by breaking it here.
+_AUTH_STACK = frozenset({
+    "r6.routes", "r6.rate_limit", "r6.read_auth", "r6.oauth",
+    "r6.health_compliance", "r6.runtime_config", "r6.body_guard",
+    "r6.stepup",
+})
+
+
+def _module_name(path: pathlib.Path) -> str:
+    rel = path.relative_to(REPO_ROOT)
+    parts = list(rel.parts)
+    parts[-1] = parts[-1][:-3]
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _edges() -> dict[str, set[str]]:
+    """Every in-stack import edge, deferred ones included."""
+    out: dict[str, set[str]] = {name: set() for name in _AUTH_STACK}
+    for name in _AUTH_STACK:
+        path = REPO_ROOT / (name.replace(".", "/") + ".py")
+        if not path.exists():
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            targets: list[str] = []
+            if isinstance(node, ast.Import):
+                targets = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                targets = [module] + [f"{module}.{a.name}" for a in node.names]
+            for target in targets:
+                for candidate in _AUTH_STACK:
+                    if target == candidate or target.startswith(candidate + "."):
+                        if candidate != name:
+                            out[name].add(candidate)
+    return out
+
+
+def _cycles(edges: dict[str, set[str]]) -> list[list[str]]:
+    """Every simple cycle, as paths, via depth-first search."""
+    found: list[list[str]] = []
+    seen: set[tuple[str, ...]] = set()
+
+    def walk(node: str, path: list[str]) -> None:
+        for nxt in sorted(edges.get(node, ())):
+            if nxt in path:
+                cycle = path[path.index(nxt):] + [nxt]
+                key = tuple(sorted(set(cycle)))
+                if key not in seen:
+                    seen.add(key)
+                    found.append(cycle)
+                continue
+            walk(nxt, path + [nxt])
+
+    for start in sorted(edges):
+        walk(start, [start])
+    return found
+
+
+def test_the_auth_stack_has_no_import_cycles():
+    """MUTATION: restore `from r6.routes import _read_auth_enabled` in
+    r6/oauth.py, or the lazy json_body_within_depth import in
+    r6/health_compliance.py -> red, naming the cycle. Ran both, saw red.
+    """
+    edges = _edges()
+    # A graph with no edges would pass forever.
+    assert sum(len(v) for v in edges.values()) > 5, (
+        f"the import scan found almost no edges ({edges}) — it is broken, and "
+        "a green result here means nothing")
+
+    cycles = _cycles(edges)
+    assert not cycles, "import cycles in the auth stack:\n" + "\n".join(
+        " -> ".join(c) for c in cycles)
+
+
+def test_nothing_in_the_auth_stack_imports_the_god_module():
+    """`r6.routes` may depend on the stack; the stack may not depend on it.
+
+    That direction is what lets routes.py be split. The moment a utility
+    inside it acquires an importer, the split acquires a blocker — which is
+    exactly how the two back-edges arrived.
+    """
+    edges = _edges()
+    importers = sorted(name for name, targets in edges.items()
+                       if "r6.routes" in targets)
+    assert importers == [], (
+        f"{importers} import from r6/routes.py; move the symbol out instead")

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -132,11 +132,21 @@ def test_direct_step_up_validation_only_decreases():
 
 
 #: Modules that reach into r6/routes.py for a symbol. Every one of these is a
-#: utility that leaked out of a 3,905-line module because there was nowhere
-#: else to put it, and each import is written lazily to dodge the four
-#: import cycles through the auth stack. Playbook chunk A1 moves the three
-#: symbols out and takes this to 1 (main.py, for the blueprint itself).
-_ROUTES_IMPORTERS = 8
+#: utility that leaked out of a 3,900-line module because there was nowhere
+#: else to put it.
+#:
+#: A1 moved the two that formed import cycles — the env predicates now live in
+#: r6/runtime_config, the body guard in r6/body_guard — and
+#: tests/test_import_acyclicity.py holds that line directly. What is left is
+#: main.py importing the blueprint, which is the point, and three imports of
+#: `authenticate_tenant_read`.
+#:
+#: That one is deliberately still here. It needs an OperationOutcome builder,
+#: which is `r6.access.outcome_response` — so moving it is kernel slice work
+#: (A2-A5) rather than a cut-and-paste, and doing it here would either
+#: duplicate the builder or adopt the kernel outside its own slice. Ratchet
+#: reaches 1, not 0.
+_ROUTES_IMPORTERS = 4
 
 
 def test_imports_out_of_the_god_module_only_decrease():


### PR DESCRIPTION
First Phase 1 chunk. **No behaviour change** — two symbol moves and their
importers.

### The problem

`r6.routes` sat in an SCC with `rate_limit`, `read_auth`, `oauth` and
`health_compliance`: four nested cycles sharing two back-edges, both reaching
into a 3,900-line module for a utility with nowhere else to live.

```
oauth.py:285             -> routes._read_auth_enabled
health_compliance.py:124 -> routes.json_body_within_depth
```

Both were function-local imports, each with a comment explaining that a
module-level one would deadlock. That worked — and it hid the coupling from
every tool that reads imports, including the reader deciding whether
`routes.py` can be split.

**The cycles were never a runtime bug.** They were the reason nothing could
move out of that file, so the split kept not happening.

### The moves

| symbol | from | to | why there |
|---|---|---|---|
| `read_auth_enabled`, `public_tenants`, `is_public_tenant` | `r6/read_auth` | `r6/runtime_config` | reads env vars and nothing else; `runtime_config` imports nothing from `r6` |
| `json_body_within_depth` + 2 pure helpers | `r6/routes` | **new** `r6/body_guard` | touches `flask.request` and nothing else |

`r6.oauth` was reaching *through* `r6.routes`' re-export of one of these — a
cycle built to fetch three lines that read an environment variable.
`r6.read_auth` re-exports what it uses, so its own importers are untouched.

### The test

`tests/test_import_acyclicity.py` walks the real graph with `ast` and fails on
any cycle in the auth stack, **counting deferred imports the same as
module-level ones** — a cycle you cannot see is the kind that comes back. It
also holds the direction: `routes.py` may depend on the stack; the stack may
not depend on it.

### Ratchet: 8 → 4

What remains is `main.py` importing the blueprint (the point) and three
imports of `authenticate_tenant_read`.

**That one stays deliberately.** It needs an OperationOutcome builder — which
is `r6.access.outcome_response` — so moving it is kernel-slice work (A2–A5),
not a cut-and-paste. Doing it here would either duplicate the builder or adopt
the kernel outside its own slice. The ratchet's target is 1, not 0, and says so.

### Verification

- `2735 passed`, 12 skipped, 1 xfailed; ruff clean; **conformance 35**;
  write-guard matrix green
- Mutations, both run: restoring either back-edge reddens the acyclicity test
  and names the cycle

Also noted, not fixed here: `r6/command_center/access.py` carries its own
duplicate `_public_tenants()`. It belongs with the kernel's tenant slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)