### PR TITLE
QA FAIL follow-up: the 401 hole, a false clinical attribution, and a brief nobody could reach

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -1070,7 +1070,7 @@ def create_app(config: Config | None = None,
             # state this branch never observed — the #416 shape, one route
             # over. A patient with a live pending request must not be told it
             # is gone because a proxy timed out.
-            if not HealthClawClient._upstream_answered(status):
+            if not HealthClawClient._answered_about_data(status):
                 logger.warning("review fetch unanswered (%s) for %s",
                                status, action_id)
                 return render_template("chat_error.html",
@@ -1104,7 +1104,7 @@ def create_app(config: Config | None = None,
                 "confirmed": False,
                 "message": _REVIEW_UNSUBMITTED,
             }), 503
-        if status and not HealthClawClient._upstream_answered(status) \
+        if status and not HealthClawClient._answered_about_data(status) \
                 and status != 200:
             # The engine never answered, so we cannot say the review was
             # saved. We CAN say nothing was approved: confirm_action is only

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -123,6 +123,11 @@ class HealthClawClient:
         an edge rejected the request before delivering it. Nothing ran either
         way, so a caller may say so.
 
+        This asks "did it run?", which is the write path's question. A read
+        path asks a different one and must use `_answered_about_data`: a 401
+        settles whether an action executed (it did not) but says nothing about
+        whether a patient has a brief.
+
         Everything else — 5xx, 408, 429 — is a gateway speaking on the
         upstream's behalf, quite possibly after the request was already
         delivered and executed. It is silence with a status code on it. For a
@@ -130,6 +135,24 @@ class HealthClawClient:
         that can execute a clinical action it is the whole of #416.
         """
         return 400 <= status < 500 and status not in (408, 429)
+
+    @staticmethod
+    def _answered_about_data(status: int) -> bool:
+        """Whether `status` is the engine answering about the RESOURCE.
+
+        401 and 403 are the engine answering about our credential. Every read
+        caller turns "answered" into a statement about the patient — an empty
+        conversation, an absent brief, "this form is no longer awaiting
+        review" — so classifying a rejected token as an answer reintroduces
+        the exact collapses #416, #424 and #430 removed, through the one
+        predicate they share. Web and worker drifting onto different
+        credentials is a documented failure mode here, so a stale token is
+        reachable rather than theoretical.
+
+        A 404 stays an answer: the engine looked and there is no such thing.
+        """
+        return (HealthClawClient._upstream_answered(status)
+                and status not in (401, 403))
 
     # --- tenant lifecycle ---------------------------------------------------
 
@@ -477,7 +500,7 @@ class HealthClawClient:
             # though it were the FHIR Basic resource, moving the failure
             # one layer past the boundary that accepted it (#403).
             return self._json_object(r, "appointment brief")
-        if self._upstream_answered(r.status_code):
+        if self._answered_about_data(r.status_code):
             return None
         raise HealthClawError(
             f"appointment brief unavailable ({r.status_code})", r.status_code)
@@ -608,7 +631,7 @@ class HealthClawClient:
                      "X-Step-Up-Token": self.mint_token(tenant)},
             what="chat history")
         if r.status_code != 200:
-            if self._upstream_answered(r.status_code):
+            if self._answered_about_data(r.status_code):
                 return []
             raise HealthClawError(
                 f"chat history unavailable ({r.status_code})", r.status_code)
@@ -616,9 +639,17 @@ class HealthClawClient:
             rows = r.json() or []
         except ValueError as exc:
             raise HealthClawError("chat history was not JSON", 200) from exc
+        # A 200 of the wrong shape is a failed call, not history. Indexing it
+        # raised AttributeError/TypeError out of this module, past the one
+        # boundary whose job is to turn a bad call into a HealthClawError —
+        # and app.py catches only HealthClawError, so each was a 500 on /chat.
+        # #430 hardened the brief against exactly this and left the sibling.
+        if not isinstance(rows, list):
+            raise HealthClawError("chat history returned invalid data", 200)
         out = [{"role": m["role"], "content": m.get("text") or ""}
                for m in reversed(rows)          # endpoint returns newest-first
-               if m.get("role") in ("user", "assistant")]
+               if isinstance(m, dict)
+               and m.get("role") in ("user", "assistant")]
         return out
 
     # --- durable agent runs --------------------------------------------------

--- a/r6/brief/routes.py
+++ b/r6/brief/routes.py
@@ -113,7 +113,12 @@ def register_brief_routes(blueprint, deps):
     operation_outcome = deps["operation_outcome"]
     authenticate_tenant_read = deps["authenticate_tenant_read"]
 
-    @blueprint.get("/fhir/AppointmentBrief")
+    # NOT "/fhir/AppointmentBrief": the blueprint is already mounted at
+    # /r6/fhir, and the extra segment registered the route at
+    # /r6/fhir/fhir/AppointmentBrief while every client asked for
+    # /r6/fhir/AppointmentBrief (#386). The brief page had therefore
+    # never populated for anyone.
+    @blueprint.get("/AppointmentBrief")
     def appointment_brief():
         tenant_id = _tenant()
         if not tenant_id:

--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -111,8 +111,20 @@ def register_caregaps_routes(blueprint, deps):
                          else None)
 
         # `subject`, NOT `supplied` — the Patient the fallback resolved is the
-        # Patient we evaluate. #389 half two, released by Dr. Magan's ruling
-        # on the cadence table.
+        # Patient we evaluate. #389 half two.
+        #
+        # An earlier version of this comment said the change was "released by
+        # Dr. Magan's ruling on the cadence table". No such ruling exists in
+        # docs/, on #389, or on #423, and #389 asked for one in as many words:
+        # "it wants CTO sign-off and Dr. Magan's review, not an engineering
+        # judgement call". What actually released it was the owner's approval
+        # plus #428, which stopped the one rule that was demonstrably unsafe
+        # (colorectal, blind to FIT and Cologuard) from claiming anything.
+        #
+        # That is a narrower thing, and it leaves #389's other named rule
+        # unreviewed: A1c monitoring is patient-visible today and no clinician
+        # has passed on its cadence. Tracked on #389; do not let this comment
+        # be read as clearance.
         patient = _patient_for(subject, tenant_id)
 
         # `check-incomplete` (#417) covered the window in which a resolved

--- a/tests/test_brief_routes.py
+++ b/tests/test_brief_routes.py
@@ -7,10 +7,12 @@ was told they were up to date on colorectal, cervical and breast cancer
 screening by a component that never ran.
 
 NOTE the URL. r6_blueprint is mounted at /r6/fhir and the handler adds a
-second "/fhir", so the route registers at /r6/fhir/fhir/AppointmentBrief
+second "/fhir", so the route registered at /r6/fhir/fhir/AppointmentBrief
 while its only client (careagents/healthclaw.py) requests
-/r6/fhir/AppointmentBrief. That mismatch is a separate defect, untouched
-here; these tests exercise the path the app actually serves.
+/r6/fhir/AppointmentBrief. FIXED (#386) — the URLs now agree, and this
+file asserts the one the client actually requests. Left in the docstring
+because the failure mode is worth remembering: every gate passed, every test
+was green, and the feature had never once run for a patient.
 """
 
 from r6.brief.engine import (
@@ -19,7 +21,7 @@ from r6.brief.engine import (
     CARE_GAPS_UNAVAILABLE,
 )
 
-_URL = "/r6/fhir/fhir/AppointmentBrief"
+_URL = "/r6/fhir/AppointmentBrief"
 _SECTION_PREFIX = "https://healthclaw.io/fhir/StructureDefinition/brief-section-"
 
 
@@ -86,3 +88,31 @@ def test_other_sections_are_unchanged(client, tenant_headers):
 
 def test_brief_requires_a_tenant(client):
     assert client.get(_URL).status_code == 400
+
+
+def test_the_route_serves_the_url_its_client_requests(app):
+    """#386. The defect that made every other test in this file meaningless.
+
+    The route registered at /r6/fhir/fhir/AppointmentBrief; the only client
+    (careagents/healthclaw.py) requested /r6/fhir/AppointmentBrief. Every gate
+    was green and the feature had never once run for a patient, because the
+    tests carried their own URL constant and so agreed with the route rather
+    than with the caller.
+
+    This asserts the two against each other instead: the path the client
+    builds must be a path the app serves. A test-visible URL is not a
+    contract; a shared one is.
+
+    MUTATION: restore "/fhir/AppointmentBrief" on the blueprint -> red.
+    Ran it, saw red.
+    """
+    from careagents.healthclaw import HealthClawClient
+
+    client_url = f"{HealthClawClient('http://x', 's').fhir}/AppointmentBrief"
+    path = client_url[len("http://x"):]
+
+    served = {str(rule) for rule in app.url_map.iter_rules()}
+    assert path in served, (
+        f"the client requests {path}, which the app does not serve. "
+        f"Brief-ish routes registered: "
+        f"{sorted(r for r in served if 'Brief' in r)}")

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -502,13 +502,44 @@ def test_history_loss_is_not_the_same_value_as_an_empty_history(stub_base,
     assert _client(stub_base).recent_messages("t") == [], (
         "an engine that answered with no rows still means no rows")
 
-    for status in (500, 502, 503, 504, 408, 429):
+    # 401/403 included deliberately (QA F1). A rejected or rotated step-up
+    # token is the engine answering about our CREDENTIAL, not about this
+    # patient's conversation — we learn nothing about whether history exists,
+    # so [] would be the same collapse this test was flipped to forbid. The
+    # conversations endpoint answers 401 when the token is stale, which is a
+    # realistic drift between web and worker.
+    for status in (500, 502, 503, 504, 408, 429, 401, 403):
         _set(status=status, body=b'{"error": "down"}')
         with pytest.raises(HealthClawError):
             _client(stub_base).recent_messages("t")
 
     with pytest.raises(HealthClawError):
         _client(DEAD_BASE).recent_messages("t")
+
+
+def test_a_malformed_history_body_does_not_escape_the_boundary(stub_base,
+                                                              reset_mode):
+    """QA F7. #430 hardened the brief against this and left its sibling open.
+
+    `recent_messages` decoded a 200 and then indexed it, so a body that is
+    valid JSON of the wrong type raised AttributeError or TypeError out of the
+    client — past the one boundary whose whole job is to turn a bad call into
+    a HealthClawError. `careagents/app.py` catches HealthClawError and nothing
+    else, so each of these was an unhandled 500 on /chat.
+
+    MUTATION: drop the isinstance/row guards -> red with AttributeError.
+    Ran it, saw red.
+    """
+    for body in (b'{"error": "nope"}', b'42', b'"just-a-string"',
+                 b'[1, 2, 3]', b'[{"role": 7}]'):
+        _set(status=200, body=body)
+        try:
+            got = _client(stub_base).recent_messages("t")
+        except HealthClawError:
+            continue
+        assert isinstance(got, list), f"{body!r} produced {got!r}"
+        for row in got:
+            assert isinstance(row, dict) and "role" in row, repr(row)
 
 
 def test_a_lost_chat_turn_is_reported_to_the_caller(stub_base, reset_mode):
@@ -552,7 +583,7 @@ def test_a_missing_brief_and_an_unreachable_engine_are_both_unavailable(
     assert _client(stub_base).fetch_appointment_brief("t") is None, (
         "the engine answered: there is no brief")
 
-    for status in (500, 502, 503, 504):
+    for status in (500, 502, 503, 504, 401, 403):
         _set(status=status, body=b'{"error": "down"}')
         with pytest.raises(HealthClawError):
             _client(stub_base).fetch_appointment_brief("t")


### PR DESCRIPTION
An adversarial pass over today's seven merges returned **FAIL**. This closes
the four findings I could reproduce; the rest are filed separately.

### F4 — a claim about a real person I could not support

`r6/caregaps/routes.py` said #389 half two was *"released by Dr. Magan's ruling
on the cadence table."* **No such ruling exists** — not in `docs/`, not on
#389, not on #423. And #389 asked for one in as many words:

> it wants CTO sign-off and Dr. Magan's review, **not an engineering judgement
> call**

What actually released it was the owner's approval plus #428 removing the one
demonstrably unsafe rule. The comment now says that — and says what is still
unreviewed: **#389's other named rule is A1c monitoring, patient-visible
today, and no clinician has passed on its cadence.**

Attributing a decision to a named clinician who did not make it is worse than
having no comment at all. This one is mine.

### F1 — 401 was classified as "the engine answered"

`_upstream_answered` treated every 4xx except 408/429 as the engine's own
decision. The conversations endpoint answers **401** on a stale step-up token,
so a rotated credential produced an empty conversation, an absent brief, and
*"this form is no longer awaiting review"* about a live clinical request — the
exact collapses #416, #424 and #430 removed, **reintroduced through the one
predicate all three share.**

The fix is *not* to widen that predicate. On the write path a 401 genuinely
settles that nothing ran, and two existing tests correctly pin it as a refusal
— they caught my first attempt. The callers ask different questions:

| predicate | question | 401 |
|---|---|---|
| `_upstream_answered` | did it run? | answered (nothing ran) |
| `_answered_about_data` | did the engine answer about the **resource**? | **no** |

### F7 — a malformed 200 still escaped `recent_messages`

#430 hardened the brief against exactly this and left its sibling. A 200
carrying `42` or `{"error": …}` raised `AttributeError`/`TypeError` out of the
client, past the boundary that exists to convert those — and `app.py` catches
only `HealthClawError`, so each was an unhandled **500 on /chat**.

### #386 — the brief endpoint has never once served a patient

The route registered at `/r6/fhir/fhir/AppointmentBrief` (the blueprint is
already mounted at `/r6/fhir`) while its only client requested
`/r6/fhir/AppointmentBrief`. Known and filed — worth closing now because it
means **#430's brief work was verified against a path production never
reaches.**

The route drops the doubled segment, and a new test asserts the client's URL
against the app's real `url_map` instead of a constant. **That constant is how
this survived**: the tests agreed with the route rather than with the caller,
so every gate stayed green while the feature had never run.

### Verification

- `2735 passed`, 12 skipped, 1 xfailed; ruff clean; conformance 35
- Mutations, all run: 401 back in the data predicate, dropping the row-shape
  guards, restoring the doubled path segment — each reddens its own test

### Filed, not fixed here

The brief's dead care-gaps section (it requires a `due` key nothing emits),
the missing consumer line for an indeterminate screening, and the
heartbeat/deadline timing findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)