### PR TITLE
docs: 2026-08-06 retro, the 2.0 release plan, and the 08-06 incident

### DIFF
--- a/docs/2026-08-06-retro-and-2.0-release-plan.md
+++ b/docs/2026-08-06-retro-and-2.0-release-plan.md
@@ -1,0 +1,280 @@
+# Retro + HealthClaw 2.0 release plan — 2026-08-06
+
+Covers the eight PRs from 2026-08-05/06 (#424, #426, #428, #423, #429, #430,
+#431, #434 — all merged), re-measured against the import graph rather than
+recalled. Companion to the 2026-08-05 graph review, pattern-first review, and
+playbook.
+
+It also covers a production incident on the night of 08-06 that this document's
+own author caused. That is written up in §4 rather than a separate postmortem,
+because its generator is the same one the rest of the retro is about.
+
+**Reading note:** I took "PRA" as the shipped PRs and the architecture. If it
+meant something else, this is the wrong document and I would rather be told
+than guess twice.
+
+---
+
+## 1. The one number that matters
+
+```
+main, before today   172 modules   325 edges   2 cycles
+main, after 6 merges 172 modules   325 edges   2 cycles
+```
+
+**Six merges moved the structure not at all.** That is not a failure — every
+one of them was a behaviour fix, and behaviour was what was wrong. But it is
+the retro's central fact, and it is the shape of the whole problem: you can
+ship all day against a codebase whose guarantees are conventions, and the
+conventions stay exactly as re-breakable as they were that morning.
+
+The seventh PR is the first structural one:
+
+```
++#431 (A1)           173 modules   328 edges   1 cycle
+```
+
+| measure | main today | with A1 |
+|---|---|---|
+| import cycles | 2 | **1** (the benign `actions.rails` star) |
+| modules importing `r6.routes` | 5 | **3** |
+| ↳ which ones | main, actions, smbp, **health_compliance, oauth** | main, actions, smbp |
+| `r6.routes` fan-out | 28 | 29 |
+
+That last row is the right direction and worth stating: `routes.py` gained a
+dependency (`body_guard`) while shedding two dependents. A module that depends
+downward can be split; a module that is depended upon cannot.
+
+## 2. What shipped, and what each one actually stops
+
+| PR | The claim it stops being able to make |
+|---|---|
+| #424 | "This form is no longer awaiting review" — said on a gateway 504, on the approval gate, to a patient whose form was live |
+| #426 | An authenticated `PUT` with `[1]` → 500 · imports stranded by a deploy, reaper wired to a CLI production never runs |
+| #428 | "You are due for colorectal screening" — to a patient screening exactly as advised with annual FIT |
+| #423 | The screening button could not answer at all |
+| #429 | A 600-second model timeout inside a 120-second deadline · one heartbeat blip killing a run |
+| #430 | "Not available from your connected records" during an outage that read none of them · a returning patient greeted as a stranger |
+| #431 | (structure) the auth-stack cycles that kept `routes.py` unsplittable |
+
+Six of seven are the same defect species the 2026-08-02 retro named: **a
+control produced nothing, and the caller read it as an answer.** That count is
+now 15 instances across 15 subsystems in nine days.
+
+## 3. What went right, and why
+
+**The ratchets earned their keep on day one.** `_ROUTES_IMPORTERS` went 8 → 4
+in the same PR that lowered it, and the acyclicity test caught its own
+mutations. The mechanism the playbook proposed on paper survived contact.
+
+**Ordering was a real decision, not a formality.** #428 had to land before
+#423. #423 is what lets the cadence table reach a patient, and that table told
+FIT-current patients they were overdue. Merged the other way, the demo would
+have shipped a false clinical claim to everyone watching. Nothing in CI would
+have caught it — both PRs were green in either order.
+
+**Three findings came from reading the code rather than the plan:**
+
+1. The clinician packet asked the advisor to rule on A1c gating that had been
+   implemented since **July 5**. The packet claimed to be "generated from the
+   running code"; for that row it was not. Caught before sending.
+2. The review's own recommendation to call the reaper from `create_app` would
+   have broken `test_app_factory.py`, which deliberately pins the factory as
+   side-effect-free. The review was wrong; the test was right.
+3. My first mutation harness compared `argv[0]` to a bare name while the stub
+   recorded a resolved path — so it failed against a *correct* Dockerfile and
+   its mutation "passed". A green mutation check is worth exactly what the
+   harness is worth.
+
+## 4. What went wrong, honestly
+
+**I wrote a false statement into a document going to a physician.** Not a
+close call — the code had said otherwise for a month. The packet's header
+("generated from the running code, not retyped") is what made it credible and
+what made it wrong. Whatever generated that row did not read `evaluate.py`.
+The fix landed, but the lesson is that a provenance claim in a document is
+itself a claim that needs checking.
+
+**Seven characterization pins moved in one day.** Each was justified and each
+carries its reason, but seven is a lot, and two of them moved because *another
+PR the same day* changed what they pinned (#428 → #423's fallback tests).
+That is the #414 process gap — two PRs in flight, one pinning what the other
+fixes — recurring, in a smaller form, with no rule yet covering it.
+
+**A stale-state near miss.** Rebasing #423 replayed two commits already
+squash-merged as #420. Skipping was right, but "skip" and "drop the fix" look
+identical in a terminal, and only reading the diff distinguished them.
+
+**One unexplained flake.** A `prod_watch` test failed once in a full run and
+never again. I could not explain it and did not pretend to. Filed as #433.
+
+### The incident: I took production down cleaning up hosting
+
+Late on 08-06, asked to remove Vercel projects idle for over two months, I
+deleted four. One of them, `healthclaw-app-proxy`, was the edge that fronted
+`app.healthclaw.io`. Its Vercel domain list showed only its own `.vercel.app`
+URL, so the pre-delete check cleared it.
+
+The check is not what failed. Hours earlier, in this same session, I had
+written that no Vercel project appeared to claim `app.healthclaw.io` "yet
+Vercel was serving it 200 at 03:35 today — I cannot fully explain that." I
+put that contradiction in front of the maintainer, who correctly chose to
+investigate before cutting DNS, and then I deleted the project anyway without
+resolving it.
+
+Restoring it made things worse. I attached the hostname to the Vercel
+`healthclaw` project, having compared that project's configuration against the
+Railway service and concluded Railway was the unsafe one. The comparison was
+against the wrong baseline: `healthclaw` on Vercel carries
+`DISABLE_COMMAND_CENTER`, and the CareAgents worker claims runs *through* the
+command center, so that deployment was never what served the worker. Railway
+had been production all along. The hostname came back up pointing at a
+read-only demo deployment that rate-limited every request.
+
+Three findings fell out of the recovery, and they are worth more than the
+outage cost:
+
+1. **The rate limiter is a self-inflicted denial of service on Vercel.**
+   `r6/rate_limit.py::_client_ip` takes the RIGHTMOST `X-Forwarded-For` hop,
+   documented as correct "behind a single trusted proxy (Railway/Vercel
+   edge)." On Vercel the rightmost hop is Vercel's own internal address, so
+   every untenanted request in the world collapses into one bucket at 120
+   requests per minute. The same code is correct on Railway and wrong on
+   Vercel, and nothing in it can tell which platform it is running on.
+2. **`$conformance` awards Grade A on an empty response** (see §8).
+3. **The CareAgents worker was generating ~1.7M requests/month while idle** —
+   four poller threads at a six-second cap, each poll a billed edge request
+   against a Hobby-tier ceiling. That is what triggered the fair-use block
+   that started the whole night. Throttled to one slot at twenty seconds,
+   a 13x cut, pending the structural fix: presence is committed BY the claim
+   (`careagents/worker.py`), so the idle interval cannot back off past
+   `CARE_RUN_WORKER_STALE_SECONDS` until presence is decoupled from claiming.
+
+**The generator is the same one this retro is about.** A control produced
+nothing — a domain list that did not list the domain — and I read it as an
+answer. Twice I recorded an uncertainty and then acted as though I had
+resolved it. The lesson is not "check domains before deleting projects." It is
+that an unexplained contradiction is a stop condition, not a footnote.
+
+## 5. Where 2.0 actually stands
+
+Eight ratchets, measured now:
+
+| ratchet | 2026-08-05 | now | 2.0 |
+|---|---|---|---|
+| post-commit audit callsites | 88 | **88** | 0 |
+| direct step-up validation | 20 | **20** | 0 |
+| imports out of `routes.py` | 8 | **4** (A1 merged) | 1 |
+| soft-delete-blind files | 12 | **12** | 0 |
+| raw tenant-header reads | 55 | **55** | 0 |
+| step-up sites without nonce | 13 | **13** | 0 |
+| known "nothing as an answer" sites | 4 | **0** | 0 |
+| kernel adoption allowlist | 5 files | **5** | all |
+
+One ratchet moved. One went to zero. Six have not started. **That is an honest
+picture of a first day, not a shortfall** — the playbook put the structural
+work after the webinar freeze deliberately, and Phase 0 was never going to
+move those numbers.
+
+## 6. Release plan
+
+### 2.0-alpha — "the kernel is the only path" (Sept)
+
+Ships when: audit ratchet 88 → 0, step-up 20 → 0, tenant reads 55 → 0,
+adoption allowlist covers every blueprint.
+
+Order, and why:
+
+1. **A2–A5** kernel slices 4–8, one blueprint per PR. Picks up
+   `authenticate_tenant_read` properly (it needs `access.outcome_response`,
+   which is why A1 left it).
+2. **B1–B2 first inside B**: `command_center` and `agent_runs` perform
+   step-up-gated writes and emit **zero** audit events. Authenticated and
+   invisible is the worst shape in the codebase; it should not wait behind 88
+   migrations.
+3. **B3–B9** `record_audit_event` → `add_audit_event`, one blueprint per PR,
+   then delete the old primitive when the ratchet reads 0.
+4. **A6** flip `consume_nonce` to default-on; exemptions become explicit.
+5. **F5** one soft-delete-aware selector, before any delete feature exists to
+   fire the 12 blind sites.
+
+### 2.0-beta — "the contract is the boundary" (Oct)
+
+Ships when: one `to_canonical()` ingest path, Inferno g(10) fixtures as the
+regression corpus, MCP edge current with the spec.
+
+- **C1–C7** contract ingest: base-R4 hard gate, US Core grade as a meta tag
+  (classify, never reject), display-strip at write rather than read.
+- **D1–D4** MCP: manifest tier + annotations, RFC 9728 resource metadata,
+  `outputSchema` as a redaction allowlist, and **URL-mode elicitation, which
+  closes #214** — the forgeable `X-Human-Confirmed` header.
+- **E4–E6** CareAgents → Postgres required, SSE ceiling, backpressure.
+
+### 2.0 — "the guarantees are structures" (Nov)
+
+Ships when all eight ratchets read zero and each has become a tripwire rather
+than a counter. Plus: `routes.py` split along trust tiers, and the four
+private hardening items closed and published.
+
+### Gates that do not move
+
+Grade A on every merge. Never self-merge. Live verification for anything
+crossing the CareAgents↔engine boundary, because those tests fake the client.
+The design partner's demos are the acceptance suite.
+
+## 7. The three things I would fix about how we work
+
+1. **A rule for concurrent pins.** #414 is filed and unclosed, and it bit
+   again today in a smaller form. Cheapest version: a PR that moves a pin
+   another open PR touches must say so in its body, and the second one rebases
+   rather than merging.
+2. **Provenance claims need a check.** "Generated from the running code" is a
+   claim. If a document says it, something should verify it — for the clinician
+   packet specifically, generate it from `evaluate.py` at build time instead of
+   by hand.
+3. **File the flake.** An unexplained red that never recurs is exactly the
+   shape of the defect this repo keeps finding: something produced nothing and
+   nobody read it as anything. (Done: #433.)
+4. **An unexplained contradiction is a stop condition.** Written up in §4. The
+   cheap version: if a sentence in your own notes contains "I cannot explain,"
+   nothing downstream of it may be destructive until it is explained.
+
+---
+
+## 8. The finding that outranks the rest
+
+`$conformance` returned `{"grade": "A", "passed": true}` on a run containing
+this check:
+
+```json
+{"name": "the redacted record is still returned",
+ "detail": "the read did not return the Patient that was asked for;
+            every absence check below passes trivially on an empty response",
+ "passed": true}
+```
+
+The synthetic Patient was created, the read back returned nothing, and every
+downstream assertion — family name not returned, given name not returned,
+SSN-class identifier masked — passed because there was no record to find
+anything in.
+
+The grader does not merely fail to notice. It **writes the words "passes
+trivially on an empty response" into its own evidence and returns
+`passed: true` anyway.**
+
+This is #401 (`conformance cannot grade read auth`) in a sharper form: with
+`READ_AUTH_ENABLED=true`, read auth is *what earns the A*. Switching the
+protection on is what blinds the grader, and a grader that sees nothing passes
+everything.
+
+Grade A is a `CLAUDE.md` non-negotiable, a CI gate
+(`tests/test_guardrail_conformance.py`), and the product's public headline
+twelve days before the HIMSS Keystone webinar. Of the sixteen instances of
+this defect species found in nine days, this is the one that matters most,
+because it is the instance inside the instrument used to certify the others.
+
+Fix shape, same as #403 / #417 / #430: three states, not two. A check whose
+subject is absent is **not evaluated**, and a run containing any not-evaluated
+check cannot grade A. The regression test must assert the negative — seed a
+tenant whose read path returns empty and assert the grade is NOT A — because
+pinning only the happy path is what let this survive.


### PR DESCRIPTION
Companion to the 2026-08-05 graph review, pattern-first review, and playbook.

Re-measured on main rather than recalled: **173 modules, 328 edges, 1 cycle** (was 2), `r6.routes` importers **4** (was 8). Eight PRs merged 08-05/06; six were the same defect species the 08-02 retro named.

Two things this adds beyond a normal retro:

**Section 4 covers the production incident I caused on 08-06.** I deleted a Vercel project that was serving `app.healthclaw.io`, after writing earlier in the same session that I could not explain how Vercel was serving that hostname. It is in the retro rather than a separate postmortem because the generator is identical to the one the retro is about: a control produced nothing and the caller read it as an answer.

**Section 8 is #443.** `$conformance` returns Grade A on a run whose own evidence says the substantive check passed trivially on an empty response. Of the sixteen instances of this species found in nine days, it is the one inside the instrument used to certify the others.

Ratchets are restated with measured values. No code changes.