### PR TITLE
fix(rate-limit): one bucket for the whole internet on Vercel, and a throttled liveness probe

### DIFF
--- a/r6/rate_limit.py
+++ b/r6/rate_limit.py
@@ -69,23 +69,58 @@ def _prune_memory_buckets(now):
             _rate_limits.pop(key, None)
 
 
+#: How many trusted proxies append to X-Forwarded-For before the request
+#: reaches this process. Railway is 1. Vercel is 2 — its edge appends the
+#: client and a second internal hop appends the edge. Configured rather than
+#: sniffed on purpose: every header that could reveal the platform is one the
+#: caller can also send, and trusting one would reopen #339.
+_DEFAULT_TRUSTED_PROXY_HOPS = 1
+
+#: The bucket for "the proxy chain is not the shape we were told it is". A
+#: real key would be a guess; sharing one bucket across every such request is
+#: the honest cost of not knowing, and it is visibly named so an operator can
+#: see it in Redis rather than inferring it from a throttling report.
+_UNIDENTIFIED_CLIENT = 'unidentified'
+
+
+def _trusted_proxy_hops():
+    """Configured proxy depth, never below 1 and never a crash."""
+    raw = os.environ.get('TRUSTED_PROXY_HOPS', '').strip()
+    try:
+        hops = int(raw)
+    except ValueError:
+        return _DEFAULT_TRUSTED_PROXY_HOPS
+    return hops if hops >= 1 else _DEFAULT_TRUSTED_PROXY_HOPS
+
+
 def _client_ip():
     """
     Best-effort client IP for rate-limit keying. Used only as a rate-limit
     bucket key — never for auth.
 
-    Behind a single trusted proxy (Railway/Vercel edge), the LAST entry in
-    X-Forwarded-For is the IP appended by that trusted proxy — i.e. the real
-    peer it saw. The leftmost entries are attacker-controllable: a client can
-    inject "X-Forwarded-For: spoofed" and split the bucket arbitrarily. Taking
-    the rightmost hop removes that spoofing surface for our 1-proxy topology.
-    (If proxy depth changes, count back that many hops instead.)
+    Each trusted proxy APPENDS the peer it saw, so with N trusted proxies the
+    real client is the Nth entry from the right. The leftmost entries are
+    attacker-controllable: a client can inject "X-Forwarded-For: spoofed" and
+    split the bucket arbitrarily, which is why we never read from the left.
+
+    This used to hardcode N=1 and describe it as correct for "Railway/Vercel
+    edge". It is correct for Railway and wrong for Vercel, where the rightmost
+    hop is Vercel's own internal address — a CONSTANT. Measured in production
+    on 2026-08-06, that collapsed every untenanted request on the internet
+    into one 120/min bucket and throttled the liveness probe along with
+    everyone else. A key resolver that cannot identify the client must say so
+    rather than return a value that reads like an identity.
     """
     fwd = request.headers.get('X-Forwarded-For', '')
     if fwd:
         hops = [h.strip() for h in fwd.split(',') if h.strip()]
-        if hops:
-            return hops[-1]
+        depth = _trusted_proxy_hops()
+        if len(hops) < depth:
+            # Shorter than the topology we were configured for: something
+            # other than the expected chain delivered this request. Guessing
+            # here hands the caller a key it controls.
+            return _UNIDENTIFIED_CLIENT
+        return hops[-depth]
     return request.remote_addr or 'unknown'
 
 
@@ -222,6 +257,13 @@ def rate_limit_middleware(blueprint):
         """Block requests that exceed the rate limit."""
         # Skip rate limiting for metadata (discovery)
         if request.path.endswith('/metadata'):
+            return None
+        # Liveness is exempt. prod_watch asks /health whether the process is
+        # alive; throttling it converts load into a false outage report, and
+        # on 2026-08-06 it did exactly that — the monitor read "busy" as
+        # "down" and paged on a system that was serving. A liveness probe
+        # that can be throttled is not a liveness probe.
+        if request.path.endswith('/health'):
             return None
         if request.path.endswith('/oauth-authorization-server'):
             return None

--- a/tests/test_rate_limit_client_ip.py
+++ b/tests/test_rate_limit_client_ip.py
@@ -1,0 +1,112 @@
+"""The rate-limit bucket key must identify a client, or admit that it cannot.
+
+Measured in production on 2026-08-06: every untenanted request reaching the
+Vercel deployment shared ONE bucket, so 120 requests/minute from anywhere on
+the internet throttled everyone, including the liveness probe. The cause is
+that `_client_ip` took the rightmost X-Forwarded-For hop, which is the real
+peer behind a ONE-hop proxy (Railway) and the platform's own internal address
+behind a TWO-hop one (Vercel). The same code serves both and nothing in it
+could tell which it was running on.
+
+That is this repo's defect species aimed at its own availability: the key
+resolver produced a value that meant "I could not identify the client", and
+the limiter read it as "here is the client".
+"""
+
+import pytest
+from flask import Flask
+
+import r6.rate_limit as rate_limit
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+def _key(app, monkeypatch, headers, hops=None, remote="10.0.0.9"):
+    if hops is not None:
+        monkeypatch.setenv("TRUSTED_PROXY_HOPS", str(hops))
+    else:
+        monkeypatch.delenv("TRUSTED_PROXY_HOPS", raising=False)
+    with app.test_request_context("/r6/fhir/Patient", headers=headers,
+                                  environ_base={"REMOTE_ADDR": remote}):
+        return rate_limit.rate_limit_key()
+
+
+def test_one_hop_proxy_keys_on_the_peer_the_proxy_saw(app, monkeypatch):
+    """Railway: client value is spoofable, the appended rightmost hop is not."""
+    key = _key(app, monkeypatch,
+               {"X-Forwarded-For": "1.2.3.4, 203.0.113.7"}, hops=1)
+    assert key == "ip:203.0.113.7"
+
+
+def test_two_hop_proxy_skips_the_platforms_own_address(app, monkeypatch):
+    """Vercel: edge appends the client, a second internal hop appends itself.
+
+    MUTATION: revert to hops[-1] -> this returns the constant internal
+    address and every caller lands in one bucket.
+    """
+    key = _key(app, monkeypatch,
+               {"X-Forwarded-For": "1.2.3.4, 203.0.113.7, 10.11.12.13"},
+               hops=2)
+    assert key == "ip:203.0.113.7"
+
+
+def test_two_callers_behind_one_platform_do_not_share_a_bucket(app, monkeypatch):
+    """The property the outage violated, stated directly."""
+    first = _key(app, monkeypatch,
+                 {"X-Forwarded-For": "x, 198.51.100.1, 10.11.12.13"}, hops=2)
+    second = _key(app, monkeypatch,
+                  {"X-Forwarded-For": "x, 198.51.100.2, 10.11.12.13"}, hops=2)
+    assert first != second
+
+
+def test_a_chain_too_short_to_trust_is_unidentified_not_guessed(app, monkeypatch):
+    """Fewer hops than configured means the proxy chain is not what we think.
+
+    Returning the leftmost value here would hand the caller its own bucket
+    key, which is exactly the opt-out limiter #339 removed. The honest answer
+    is a distinct bucket that says so.
+    """
+    key = _key(app, monkeypatch, {"X-Forwarded-For": "1.2.3.4"}, hops=2)
+    assert key == "ip:unidentified"
+
+
+def test_no_forwarding_header_falls_back_to_the_socket_peer(app, monkeypatch):
+    key = _key(app, monkeypatch, {}, hops=1, remote="192.0.2.55")
+    assert key == "ip:192.0.2.55"
+
+
+def test_the_default_is_the_single_proxy_topology(app, monkeypatch):
+    """Unset config must not change behaviour for existing deployments."""
+    key = _key(app, monkeypatch, {"X-Forwarded-For": "1.2.3.4, 203.0.113.7"})
+    assert key == "ip:203.0.113.7"
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "abc", ""])
+def test_an_unusable_hop_setting_falls_back_to_one_rather_than_crashing(
+        app, monkeypatch, bad):
+    key = _key(app, monkeypatch,
+               {"X-Forwarded-For": "1.2.3.4, 203.0.113.7"}, hops=bad)
+    assert key == "ip:203.0.113.7"
+
+
+def test_liveness_is_never_throttled(app, monkeypatch):
+    """A monitor that reads "busy" as "down" is the defect, not the report.
+
+    prod_watch calls /health to ask whether the process is alive. Throttling
+    it turns load into a false outage report — and during the 08-06 incident
+    it did exactly that.
+    """
+    blueprint = Flask(__name__)
+    rate_limit.rate_limit_middleware(blueprint)
+    calls = []
+    monkeypatch.setattr(rate_limit, "check_rate_limit",
+                        lambda *a, **k: calls.append(a) or (False, 0, 0))
+
+    for path in ("/r6/fhir/health", "/r6/fhir/metadata"):
+        with blueprint.test_request_context(path):
+            for func in blueprint.before_request_funcs[None]:
+                assert func() is None, f"{path} must not be throttled"
+    assert calls == []


### PR DESCRIPTION
Found during the 2026-08-06 incident, measured not inferred.

## What happens

`_client_ip` takes the **rightmost** `X-Forwarded-For` hop, documented as correct "behind a single trusted proxy (Railway/Vercel edge)".

That is correct for Railway — one proxy appends the peer it saw, so the rightmost entry is the real client and the spoofable left side is ignored. It is **wrong for Vercel**, where a second internal hop appends Vercel's own address. That address is a constant, so every untenanted request on the internet collapses into one bucket at 120/min.

In production this throttled `/health`, which is what `prod_watch` calls to ask whether the process is alive. The monitor reported an outage on a system that was serving.

## The shape

Same species as the rest of this week, aimed at our own availability: the key resolver produced a value that meant *"I could not identify the client"*, and the limiter read it as *"here is the client"*.

## Changes

- Count back `TRUSTED_PROXY_HOPS` (default **1** — unchanged for Railway; set **2** on Vercel) instead of hardcoding the rightmost hop.
- **Configured, never sniffed.** Every header that could reveal the platform is one a caller can also send. Trusting one would reopen #339, where a varying `X-Tenant-Id` opened 150 buckets and throttled nothing.
- A chain shorter than the configured depth returns `ip:unidentified` rather than guessing. Reading from the left hands the caller its own bucket key.
- `/health` joins `/metadata` on the exemption list. A liveness probe that can be throttled is not a liveness probe.

## Verification

Both mutations go red:

| mutation | fails |
|---|---|
| `hops[-depth]` → `hops[-1]` | two-hop keying, bucket separation |
| drop the `/health` exemption | liveness |

Full suite `2748 passed, 12 skipped, 1 xfailed`; ruff clean; verified in an isolated worktree.

## Deployment note

This does not become correct on Vercel until `TRUSTED_PROXY_HOPS=2` is set there. The default keeps today's behaviour everywhere, so the PR is safe to merge before that.