### PR TITLE
fix(deps): clear the js-yaml advisory that has been red on every PR

### DIFF
--- a/services/agent-orchestrator/package-lock.json
+++ b/services/agent-orchestrator/package-lock.json
@@ -4426,9 +4426,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
`GHSA-5p4m-2wfm-xmqj` (high) — quadratic CPU consumption in `!!omap` resolution.

**Not exposure.** Dev-only and transitive:

```
ts-jest -> @jest/transform -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config -> js-yaml
```

`ts-jest` is in `devDependencies`, so this never reaches the shipped image.

**Why fix it anyway.** `dependency-audit` is not a required check, so this sat red on main and on every PR opened tonight — #431, #434, #444, #445. A gate that is permanently red is a gate nobody reads, and the next advisory would have landed in a check everyone had learned to skip.

`3.15.0 -> 3.15.1`, one transitive lockfile entry, outside the advisory range. `npm audit --audit-level=high` reports 0 vulnerabilities; node suite `192 passed, 7 suites`.

Companion to making `dependency-audit` a required check, which is the actual fix for the class.