### PR TITLE
fix(brief): the crash was the only thing stopping the leak (#391, #382)

### DIFF
--- a/r6/brief/engine.py
+++ b/r6/brief/engine.py
@@ -73,16 +73,40 @@ class BriefResult:
 # Helpers
 # ---------------------------------------------------------------------------
 
+#: We hold a code but our terminology table cannot name it. Distinct from
+#: UNKNOWN on purpose: after #382 the brief reads REDACTED resources, so an
+#: unrecognised code arrives with its upstream text and display stripped and
+#: would otherwise be indistinguishable from a record that never had a code
+#: at all. Collapsing the two hands a clinician a document full of "Unknown"
+#: with no way to tell an absent entry from a stripped one — the #376 hole
+#: that #382 warns the naive fix creates.
+UNLABELLED = "Recorded, name unavailable"
+
+#: No code element at all. There is nothing to name.
+UNKNOWN = "Unknown"
+
+
 def _code_text(resource: dict) -> str:
-    """Best human-readable label from a FHIR code element."""
+    """Best human-readable label from a FHIR code element.
+
+    Three outcomes, never two: a label we can stand behind, a code we hold
+    but cannot name, or nothing recorded. `text` and `coding[].display` are
+    read only because `apply_redaction` has already replaced them with
+    server-derived values keyed by code (r6/terminology.py) — on an
+    unredacted resource these are the two fields that carry PHI, which is
+    why `_resources_for` must never hand this function raw feed data.
+    """
     code = resource.get("code") or resource.get("medicationCodeableConcept") or {}
     text = code.get("text", "")
     if text:
         return text
-    for coding in code.get("coding", []):
-        if coding.get("display"):
+    codings = code.get("coding") or []
+    for coding in codings:
+        if isinstance(coding, dict) and coding.get("display"):
             return coding["display"]
-    return "Unknown"
+    if any(isinstance(c, dict) and c.get("code") for c in codings):
+        return UNLABELLED
+    return UNKNOWN
 
 
 def _onset_display(resource: dict) -> str:

--- a/r6/brief/routes.py
+++ b/r6/brief/routes.py
@@ -16,6 +16,7 @@ from flask import request, jsonify
 
 from r6.models import R6Resource
 from r6.audit import record_audit_event
+from r6.redaction import apply_redaction
 from r6.brief.engine import (
     generate_brief,
     BriefResult,
@@ -41,7 +42,22 @@ def _resources_for(tenant_id: str, resource_type: str) -> list[dict]:
         )
         .all()
     )
-    return [r.resource for r in rows]
+    # Two defects, one line, and they MUST be fixed together (#391 + #382).
+    #
+    # `r.resource` is not an attribute of R6Resource, so this raised
+    # AttributeError and the brief 500'd for any tenant holding data (#391).
+    # The crash is currently the only thing preventing #382: there is no
+    # `apply_redaction` anywhere in r6/brief/, and `_code_text` reads
+    # `code.text` then `coding[].display` — the two fields CLAUDE.md names
+    # because real feeds put patient names in them. Repairing the attribute
+    # alone turns a 500 into a PHI leak into a document the patient and their
+    # clinic receive.
+    #
+    # apply_redaction strips the upstream free text and then re-labels from
+    # r6/terminology.py keyed by code (r6/redaction.py calls label_codings),
+    # so the brief stays readable without any of it coming from the feed —
+    # the same pair r6/routes.py and r6/labs/routes.py use.
+    return [apply_redaction(r.to_fhir_json()) for r in rows]
 
 
 def _field_to_dict(f: BriefField) -> dict:

--- a/tests/test_redaction_probes_multistep.py
+++ b/tests/test_redaction_probes_multistep.py
@@ -95,6 +95,9 @@ from tests.test_redaction_coverage_inventory import (
 # grep for a marker finds every probe that watches that field.
 SUBJECT_LABEL_MARKER = "PHISUBJECTLABELMARKER"
 MED_TEXT_MARKER = "PHIMEDTEXTMARKER"
+#: The brief reads medicationCodeableConcept.coding[].display when there
+#: is no .text, so the two need separate markers to tell which arrived.
+MED_DISPLAY_MARKER = "PHIMEDDISPLAYMARKER"
 ALLERGY_TEXT_MARKER = "PHIALLERGYTEXTMARKER"
 COMPONENT_DISPLAY_MARKER = "PHICOMPONENTDISPLAYMARKER"
 EFFECTIVE_MARKER = "PHIEFFECTIVEMARKER"
@@ -105,7 +108,8 @@ COND_NOTE_MARKER = "PHICONDNOTEMARKER"
 
 ALL_MARKERS = (
     NAME_MARKER, SUBJECT_LABEL_MARKER, OBS_DISPLAY_MARKER, OBS_TEXT_MARKER,
-    MED_TEXT_MARKER, ALLERGY_TEXT_MARKER, COMPONENT_DISPLAY_MARKER,
+    MED_TEXT_MARKER, MED_DISPLAY_MARKER, ALLERGY_TEXT_MARKER,
+    COMPONENT_DISPLAY_MARKER,
     EFFECTIVE_MARKER, OBS_NOTE_MARKER, COND_TEXT_MARKER, COND_DISPLAY_MARKER,
     COND_NOTE_MARKER,
 )
@@ -658,3 +662,110 @@ def test_curatr_scores_the_unredacted_resource(
     # And the response itself is still redacted — the ordering fix must not
     # have been achieved by dropping the redaction.
     assert _markers_in(response.get_data(as_text=True)) == set()
+
+
+# ---------------------------------------------------------------------------
+# AppointmentBrief (#382). Not on #282's list of eight, so neither this file
+# nor the inventory has ever measured it.
+#
+# Until #434 the route registered at /r6/fhir/fhir/AppointmentBrief and no
+# client could reach it (#386), so the unredacted read below was latent.
+# Fixing the path armed it. That is why this probe is being added now rather
+# than with the rest of #282: the leak did not change, its reachability did.
+# ---------------------------------------------------------------------------
+
+BRIEF_URL = "/r6/fhir/AppointmentBrief"
+
+
+def _marked_medication_request():
+    """`_code_text` reads medicationCodeableConcept for MedicationRequest."""
+    return {
+        "resourceType": "MedicationRequest", "id": "probe-medreq-1",
+        "status": "active", "intent": "order",
+        "medicationCodeableConcept": {
+            "coding": [{"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                        "code": "860975", "display": MED_DISPLAY_MARKER}],
+            "text": MED_TEXT_MARKER},
+        "subject": {"reference": PROBE_PATIENT_REF},
+    }
+
+
+def _marked_active_condition():
+    """`build_problems` keeps only conditions whose clinicalStatus is active
+    (engine.py:199). The shared `_marked_condition` has no clinicalStatus, so
+    seeding it alone leaves the problems section EMPTY and every assertion
+    about Condition labelling passes while measuring nothing."""
+    condition = dict(_marked_condition())
+    condition["id"] = "probe-cond-brief-1"
+    condition["clinicalStatus"] = {"coding": [{
+        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+        "code": "active"}]}
+    return condition
+
+
+@pytest.fixture
+def brief_resources(app, tenant_headers):
+    with app.app_context():
+        _store(_marked_patient(), tenant_headers["X-Tenant-Id"])
+        _store(_marked_active_condition(), tenant_headers["X-Tenant-Id"])
+        _store(_marked_medication_request(), tenant_headers["X-Tenant-Id"])
+
+
+def test_the_brief_probe_actually_reaches_the_brief(
+        client, tenant_headers, brief_resources):
+    """Control. A 404 or a 400 here makes every marker assertion below pass
+    while measuring nothing — the failure mode #386 hid behind for weeks."""
+    response = client.get(BRIEF_URL, headers=tenant_headers)
+    assert response.status_code == 200, response.get_data(as_text=True)[:400]
+
+
+def test_appointment_brief_carries_no_upstream_free_text(
+        client, tenant_headers, brief_resources):
+    """#382 closed: the brief reads REDACTED resources.
+
+    `_resources_for` now returns `apply_redaction(r.to_fhir_json())`. That
+    fixes the #391 crash (`r.resource` is not an attribute) and the missing
+    redaction in the SAME change, because repairing the attribute alone turns
+    a 500 into a leak — the crash was the only thing preventing it.
+
+    MUTATION: drop `apply_redaction` and keep `to_fhir_json` -> COND_TEXT and
+    MED_TEXT arrive and this goes red.
+    """
+    response = client.get(BRIEF_URL, headers=tenant_headers)
+    assert response.status_code == 200, response.get_data(as_text=True)[:400]
+    text = response.get_data(as_text=True)
+    assert _markers_in(text) == set(), (
+        "upstream free text reached the brief: %s" % sorted(_markers_in(text)))
+
+
+def test_a_recognised_code_still_reads_as_a_name(
+        client, tenant_headers, brief_resources):
+    """The positive half, and the reason this is not a one-line fix.
+
+    Redaction strips `text` and `display`; `r6/terminology.py` puts back a
+    label keyed by code. Asserting only that the markers are gone is what let
+    #376 hide — a document full of "Unknown" passes a leak check perfectly.
+
+    RxNorm 860975 is in the terminology table, so the medication line must
+    carry the SERVER's name for it. That the marker is absent is asserted
+    above; that a real name is present is asserted here, and neither
+    assertion can stand in for the other.
+    """
+    response = client.get(BRIEF_URL, headers=tenant_headers)
+    text = response.get_data(as_text=True)
+    assert "Metformin" in text, (
+        "the medication degraded to an unnamed entry: redaction stripped the "
+        "feed's text and nothing put a server-derived label back, which is "
+        "the #376 hole #382 warns the naive fix creates: " + text[:600])
+    assert MED_TEXT_MARKER not in text
+
+
+def test_an_unnameable_code_is_not_reported_as_no_data(app, tenant_headers):
+    """Three states, not two. A code we hold but cannot label must not read
+    the same as a record that never had a code."""
+    from r6.brief.engine import UNKNOWN, UNLABELLED, _code_text
+
+    assert _code_text({"code": {"coding": [{"system": "urn:oid:1.2.3",
+                                            "code": "ZZ99"}]}}) == UNLABELLED
+    assert _code_text({}) == UNKNOWN
+    assert UNLABELLED != UNKNOWN


### PR DESCRIPTION
Closes #391 and #382 in one PR, because fixing either alone is a defect.

## Why they cannot be separated

`r6/brief/routes.py:44` read `r.resource`, an attribute `R6Resource` does not have, so the AppointmentBrief **500'd for any tenant holding data** (#391). That is a one-word fix.

Fixing only that word ships a PHI leak. There is no `apply_redaction` anywhere in `r6/brief/`, and `_code_text` reads `code.text` then `coding[].display` — the two fields CLAUDE.md names because real feeds put patient names in them. The brief goes to the patient and their clinic, outside the redacted FHIR read path (#382).

**The crash was load-bearing.** Anyone picking up #391 as an easy one-liner ships the leak. That is the #414 shape with the dependency running backwards, and nothing in either issue said so.

## The fix

```python
return [apply_redaction(r.to_fhir_json()) for r in rows]
```

`apply_redaction` strips the feed's free text; `label_codings` puts back a server-derived name keyed by code — the pair `r6/routes.py` and `r6/labs/routes.py` already use.

#382 warns the naive fix creates a #376-shaped hole: with text and display stripped, an unrecognised code renders "Unknown" and a clinician cannot tell a stripped entry from an absent one. So `_code_text` returns **three states**: `UNLABELLED` for a code we hold but cannot name, `UNKNOWN` only when there is no code element at all.

## Probes

This site was on neither redaction inventory — it was not among #282's original eight. Two findings while writing the probes, both of which would have shipped a measurement of nothing:

| | |
|---|---|
| the positive assertion was an OR chain | passed trivially. Replaced after reading the real response body: RxNorm 860975 must render as the server's `Metformin 500 mg` **and** the marker must be absent |
| the problems section came back empty | `build_problems` keeps only `clinicalStatus` active (engine.py:199) and the shared `_marked_condition` has none, so the probe measured one resource type while claiming two |

Mutations both red: dropping `apply_redaction` fails the leak probe; collapsing `UNLABELLED` into `UNKNOWN` fails the three-state test.

Full suite `2741 passed, 12 skipped, 1 xfailed`; ruff clean; isolated worktree.

## Note

#435/#387 (the care-gaps `due` key) touches the same module and is next, rebased on this.