### PR TITLE
fix(connect): handle the error event Fasten actually emits, and stop assuming TEFCA (#326)

### DIFF
--- a/app.py
+++ b/app.py
@@ -215,7 +215,19 @@ def fasten_connect(tenant_id):
         'fasten_connect.html',
         tenant_id=tenant_id,
         fasten_public_key=os.environ.get('FASTEN_PUBLIC_KEY', '').strip(),
-        tefca_mode=os.environ.get('FASTEN_TEFCA_MODE', 'true').strip().lower() == 'true',
+        # Opt-IN, not opt-out. This defaulted to 'true', so any deployment
+        # that never set the variable requested TEFCA IAS — a mode that
+        # requires per-account provisioning with Fasten ("additional fees
+        # involved with TEFCA IAS in live mode", their TEFCA IAS guide) AND
+        # third-party cookies in the embed frame. Where either is missing the
+        # patient meets fasten_unauthorized_client inside Fasten's iframe at
+        # the first identity step, and we cannot intercept or explain it
+        # (#326).
+        #
+        # A capability this process cannot verify from the inside must be
+        # declared by whoever knows it is provisioned, not assumed by the
+        # default. Deployments that ARE entitled set FASTEN_TEFCA_MODE=true.
+        tefca_mode=os.environ.get('FASTEN_TEFCA_MODE', 'false').strip().lower() == 'true',
     )
 
 

--- a/templates/fasten_connect.html
+++ b/templates/fasten_connect.html
@@ -419,9 +419,32 @@
         type === 'authorization.complete' || oid) {
       backdrop.classList.remove('open');
       await _registerConnection(payload);
-    } else if (type === 'widget.error' || type === 'error') {
+    } else if (type === 'widget.config_error') {
+      // The REAL event name. This branch used to test 'widget.error' and
+      // 'error', neither of which Fasten emits — read out of the shipped
+      // bundle (cdn.fastenhealth.com/connect/v4), whose only widget events
+      // are widget.close, widget.complete and widget.config_error. So every
+      // configuration refusal fell through both branches and produced
+      // nothing from us: the patient saw Fasten's own opaque "Oops!
+      // Something went wrong" inside the iframe and this page stayed
+      // silent, still showing the modal (#326).
+      //
+      // fasten_unauthorized_client on "retrieving vault profile" — the
+      // reported failure — arrives here. We cannot say WHY (the entitlement
+      // lives in Fasten's account, not in anything we can read), so this
+      // says what we know and what to do, and never guesses at a cause.
       backdrop.classList.remove('open');
-      showStatus('Widget error: ' + (data.message || 'unknown'), 'error');
+      var detail = data.message || (data.data && data.data.message) ||
+                   data.error_type || '';
+      showStatus(
+        'The records widget refused this configuration' +
+        (detail ? ' (' + detail + ')' : '') +
+        '. Identity verification is unavailable right now — this is a ' +
+        'problem on our side, not with your records. Please tell us you ' +
+        'saw this so we can chase it.', 'error');
+    } else if (type === 'widget.close') {
+      // Dismissal is not failure and must not be reported as one.
+      backdrop.classList.remove('open');
     }
   });
 })();

--- a/tests/test_fasten_widget_events.py
+++ b/tests/test_fasten_widget_events.py
@@ -1,0 +1,135 @@
+"""Guard: the connect page handles the events Fasten actually emits.
+
+Reported twice on `/connect/<tenant>`: choosing CLEAR errors instantly with
+`fasten_unauthorized_client` / "An error occurred while retrieving vault
+profile", and the page itself says nothing — the patient sees only Fasten's
+own "Oops! Something went wrong" inside the iframe (#326).
+
+The handler branched on `widget.error` and `error`. Neither exists. Read out
+of the shipped bundle at `cdn.fastenhealth.com/connect/v4`, the widget's only
+events are:
+
+    widget.close  widget.complete  widget.config_error
+
+so every configuration refusal fell through both branches and produced
+nothing. A control that produced nothing, and the page read it as "no news"
+— docs/2026-08-06-two-generators-three-laws.md, Generator A.
+
+These assert the SOURCE, for the reason `test_fasten_dialog_reachable.py`
+gives: the widget is a third-party bundle we cannot render in CI. That is a
+real limit. This catches the regression shape we hit — a handler that names
+events the vendor does not send — not every way an error can be swallowed.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+
+TEMPLATE = (pathlib.Path(__file__).resolve().parent.parent
+            / "templates" / "fasten_connect.html")
+
+#: Every event name the v4 bundle emits. If Fasten adds one, this list is
+#: what to update — and the assertion below is what will notice.
+FASTEN_WIDGET_EVENTS = ("widget.close", "widget.complete", "widget.config_error")
+
+
+def _source() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_the_config_error_event_is_handled_by_its_real_name():
+    """MUTATION: rename the branch back to 'widget.error' -> red."""
+    assert "'widget.config_error'" in _source(), (
+        "widget.config_error is the only error event Fasten emits; a handler "
+        "that does not name it swallows every configuration refusal")
+
+
+def test_no_branch_waits_for_an_event_fasten_never_sends():
+    """A branch on a non-existent name is dead code that reads as coverage.
+
+    'widget.error' and 'error' were both handled and neither is emitted, so
+    the page looked like it reported widget failures and never had.
+    """
+    # Match the COMPARISON, not the bare string. `'error'` is also the status
+    # kind passed to showStatus, and the phantom names are quoted in the
+    # comment that explains why they were removed — a substring scan flags
+    # both and fails on a correct file. First draft of this test did exactly
+    # that.
+    source = _source()
+    for phantom in ("widget.error", "error"):
+        pattern = r"type\s*===\s*'%s'" % re.escape(phantom)
+        assert not re.search(pattern, source), (
+            f"a branch tests type === '{phantom}', which Fasten never emits "
+            f"(v4 emits only {', '.join(FASTEN_WIDGET_EVENTS)}) — it can "
+            f"never run and hides the absence of real error handling")
+
+
+def test_dismissing_the_widget_is_not_reported_as_an_error():
+    """widget.close is the patient closing the modal. Telling them something
+    went wrong because they changed their mind is its own defect."""
+    source = _source()
+    close_at = source.find("'widget.close'")
+    assert close_at != -1, "widget.close must be handled"
+    branch = source[close_at:close_at + 400]
+    assert "showStatus" not in branch, (
+        "the widget.close branch must not raise a status message")
+
+
+def test_the_error_message_does_not_blame_the_patients_records():
+    """The cause lives in Fasten's account entitlement or the browser's
+    cookie policy. Neither is a fact about this person's health records, and
+    saying otherwise sends them to their provider over our configuration."""
+    source = _source()
+    at = source.find("'widget.config_error'")
+    # Wide enough to reach the message. A window that stops short fails on a
+    # correct file, which is a probe measuring its own truncation.
+    branch = source[at:at + 2500]
+    assert "not with your records" in branch, (
+        "the message must state this is not a problem with the patient's "
+        "records, because the patient cannot tell and will assume it is")
+
+
+def test_tefca_mode_is_opt_in():
+    """A capability this process cannot verify must not be the default.
+
+    TEFCA IAS needs per-account provisioning with Fasten AND third-party
+    cookies. Defaulting it on meant any unset deployment failed at the first
+    identity step with a vendor error we cannot intercept (#326).
+
+    MUTATION: flip the default back to 'true' -> red.
+    """
+    app_source = (pathlib.Path(__file__).resolve().parent.parent
+                  / "app.py").read_text(encoding="utf-8")
+    match = re.search(r"FASTEN_TEFCA_MODE',\s*'(\w+)'", app_source)
+    assert match, "the FASTEN_TEFCA_MODE default moved; update this guard"
+    assert match.group(1) == "false", (
+        "FASTEN_TEFCA_MODE must default to false — entitlement is declared "
+        "by the deployment that has it, never assumed")
+
+
+def test_the_embed_url_sends_what_the_official_component_sends():
+    """Our iframe is hand-rolled, so nothing else pins it to the contract.
+
+    Read out of the v4 bundle, the component's TEFCA branch sets exactly
+    `tefca-mode` and `search-only=false` (identity-request-uri and
+    tefca-csp-prompt-force are optional and default to null/false). If our
+    URL drifts from that, the widget is being asked for something the
+    supported integration never asks for.
+    """
+    source = _source()
+    assert "tefca-mode=true&search-only=false" in source, (
+        "TEFCA mode must send both params, as the official component does")
+    assert "public-id={{ fasten_public_key }}" in source
+
+
+def test_the_page_still_renders_with_tefca_off(monkeypatch):
+    """Turning the mode off must not take the connect flow down with it —
+    that fallback is the interim mitigation in #326."""
+    monkeypatch.setenv("FASTEN_TEFCA_MODE", "false")
+    assert os.environ["FASTEN_TEFCA_MODE"] == "false"
+    source = _source()
+    assert "{% if tefca_mode %}" in source, (
+        "the TEFCA params must stay behind the flag so turning it off "
+        "degrades to standard provider search rather than breaking the embed")


### PR DESCRIPTION
Two testers hit `fasten_unauthorized_client` / "An error occurred while retrieving vault profile" the instant they choose CLEAR — and **our page said nothing.** They saw only Fasten's opaque "Oops! Something went wrong" inside the iframe, with our modal still open behind it.

## Why we were silent

The handler branched on `widget.error` and `error`. **Neither exists.** Read out of the shipped bundle at `cdn.fastenhealth.com/connect/v4`, the widget emits exactly three events:

```
widget.close   widget.complete   widget.config_error
```

Every configuration refusal fell through both branches and produced nothing, and the page read that as no news. Generator A from the two-generators doc, living in our own error handling.

## Changes

- **`widget.config_error`** handled by its real name. The message says what we know — the widget refused the configuration, identity verification is unavailable, **and this is not a problem with your records**. It does not guess at a cause, because the cause lives in Fasten's account, not anywhere we can read.
- **`widget.close`** handled, so dismissing the modal stops being indistinguishable from failure.
- **`FASTEN_TEFCA_MODE` now defaults to `false`.** It defaulted **true**, so any deployment that never set it requested TEFCA IAS — which needs per-account provisioning with Fasten (*"additional fees involved with TEFCA IAS in live mode"*, their guide) **and** third-party cookies in the embed frame. A capability this process cannot verify must be declared by whoever knows it's provisioned.

## What I deliberately did NOT change

I was about to migrate us to the supported `<fasten-stitch-element>`, on the theory that a hand-rolled iframe was the bug. **The bundle disproves it.** Its TEFCA branch:

```js
this.tefcaMode && (t.set("tefca-mode", …), t.set("search-only", "false"),
  this.tefcaCspPromptForce && t.set("tefca-csp-prompt-force", …),
  this.identityRequestUri && t.set("identity-request-uri", …))
```

It builds the same embed URL with the same params and mounts it in a `<dialog>` — no `window.open`, no Storage Access API, two `iframe` references. Identical third-party cookie exposure. Migrating would not have fixed this, and finding that out cost an hour instead of costing connect-flow surgery twelve days before the webinar.

## What remains, and it is not ours

Either **Fasten account entitlement** for TEFCA IAS in live mode, or **third-party cookie policy** in the tester's browser. The discriminating test and the support message are in #326.

`tests/test_fasten_widget_events.py` pins the event contract so the next drift is a red build rather than another silent failure. Two of its assertions were wrong on first run — a substring scan that flagged my own explanatory comment, and a slice window too short to reach the message — both fixed; a probe that cannot fail correctly is the thing we keep rediscovering.

Suite `2759 passed, 12 skipped, 1 xfailed`; ruff clean. Mutations red: renaming the branch back to `widget.error`, and defaulting TEFCA back on.