### PR TITLE
fix(review): the approval page stops leaking a write credential and stops borrowing another product's chrome (#395, #396)

### DIFF
--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -343,7 +343,10 @@ def review_form(action_id):
         'action_review.html', action_id=action_id, demographics=demographics,
         meds=meds, allergies=allergies, conditions=conditions,
         record_readable=content.resolved, record_reason=content.reason,
-        step_up_token=request.headers.get('X-Step-Up-Token', ''),
+        # step_up_token is deliberately NOT passed. It is a write credential,
+        # and handing it to a template is how it reached the patient's browser
+        # across an origin boundary (#395). The submit path supplies its own
+        # credentials server-side; nothing in the page needs this.
         tenant_id=tenant_id)
     return html, 200
 

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -5,9 +5,7 @@
 <div class="row justify-content-center">
   <div class="col-lg-9">
 
-    <div class="d-flex align-items-center mb-3">
-      <i class="fas fa-clipboard-check me-2" style="color:var(--r6-primary);font-size:1.6rem"></i>
-      <div>
+    <div class="d-flex align-items-center mb-3"><div>
         <h2 class="mb-0">Review each item before we generate your form</h2>
         <p class="text-muted mb-0">
           Nothing is submitted until you confirm every medication and allergy
@@ -22,7 +20,7 @@
       <!-- Demographics: read-only, straight from your records -->
       <div class="card mb-4">
         <div class="card-header d-flex justify-content-between align-items-center">
-          <span><i class="fas fa-id-card me-2"></i>Demographics</span>
+          <span>Demographics</span>
           <span class="badge bg-secondary">read-only · from your records</span>
         </div>
         <div class="card-body">
@@ -43,7 +41,7 @@
 
       <!-- Medications: confirm each one individually -->
       <div class="card mb-4">
-        <div class="card-header"><i class="fas fa-pills me-2"></i>Current medications</div>
+        <div class="card-header">Current medications</div>
         <div class="card-body">
           {% if meds %}
           <p class="text-muted small">Each medication below is <strong>from your records</strong>. Tell us whether you are still taking it.</p>
@@ -53,7 +51,7 @@
             <div class="me-3">
               <div class="fw-bold">{{ med.name }}</div>
               {% if med.dose %}<div class="text-muted small">{{ med.dose }}</div>{% endif %}
-              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+              <div class="text-muted small">from your records</div>
             </div>
             <div class="btn-group" role="group" aria-label="Still taking {{ med.name }}?">
               <input type="radio" class="btn-check med-choice" name="med-{{ loop.index0 }}"
@@ -80,15 +78,13 @@
 
       <!-- Allergies: confirm each, and the explicit NKA attestation -->
       <div class="card mb-4 border-warning">
-        <div class="card-header"><i class="fas fa-triangle-exclamation me-2"></i>Allergies</div>
+        <div class="card-header">Allergies</div>
         <div class="card-body">
           {# Three states, not two. "We looked and found none" and "we could
              not work out whose record to look at" are different sentences,
              and only the first may appear above the attestation below (#390). #}
           {% if not record_readable %}
-          <div class="alert alert-danger mb-3" role="alert">
-            <i class="fas fa-triangle-exclamation me-1"></i>
-            <strong>We could not read your records</strong> &mdash;
+          <div class="alert alert-danger mb-3" role="alert"><strong>We could not read your records</strong> &mdash;
             {{ record_reason }}. Nothing here has been checked against them,
             and this is not a statement that you have no allergies.
           </div>
@@ -101,7 +97,7 @@
             <div class="me-3">
               <div class="fw-bold">{{ allergy.allergen }}</div>
               {% if allergy.reaction %}<div class="text-muted small">Reaction: {{ allergy.reaction }}</div>{% endif %}
-              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+              <div class="text-muted small">from your records</div>
             </div>
             <div class="btn-group" role="group" aria-label="Confirm {{ allergy.allergen }}?">
               <input type="radio" class="btn-check allergy-choice" name="allergy-{{ loop.index0 }}"
@@ -115,9 +111,7 @@
           </div>
           {% endfor %}
           {% elif record_readable %}
-          <div class="alert alert-warning mb-3" role="alert">
-            <i class="fas fa-circle-info me-1"></i>
-            No allergies found in your records — add them or affirmatively confirm none below.
+          <div class="alert alert-warning mb-3" role="alert">No allergies found in your records — add them or affirmatively confirm none below.
           </div>
           {% endif %}
 
@@ -142,14 +136,14 @@
       <!-- Conditions: confirmable -->
       {% if conditions %}
       <div class="card mb-4">
-        <div class="card-header"><i class="fas fa-notes-medical me-2"></i>Problems / conditions</div>
+        <div class="card-header">Problems / conditions</div>
         <div class="card-body">
           <p class="text-muted small">Each condition below is <strong>from your records</strong>.</p>
           {% for condition in conditions %}
           <div class="border rounded p-3 mb-2 d-flex flex-wrap justify-content-between align-items-center">
             <div class="me-3">
               <div class="fw-bold">{{ condition.name }}</div>
-              <div class="text-muted small"><i class="fas fa-database me-1"></i>from your records</div>
+              <div class="text-muted small">from your records</div>
             </div>
             <div class="btn-group" role="group">
               <input type="radio" class="btn-check" name="condition-{{ loop.index0 }}"
@@ -171,8 +165,7 @@
         "No known allergies" to continue.
       </div>
 
-      <button type="submit" id="approve-btn" class="btn btn-primary btn-lg" disabled>
-        <i class="fas fa-check me-1"></i>Approve &amp; generate
+      <button type="submit" id="approve-btn" class="btn btn-primary btn-lg" disabled>Approve &amp; generate
       </button>
     </form>
   </div>

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "review_base.html" %}
 {% block title %}Review your intake form — HealthClaw Guardrails{% endblock %}
 
 {% block content %}

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -184,8 +184,29 @@
   // Client-side UX only. The SERVER POST re-populates from FHIR and is the
   // real, un-craftable gate (see r6/actions/review.py).
   (function () {
-    var TENANT = {{ tenant_id | tojson }};
-    var TOKEN = {{ step_up_token | tojson }};
+    // No TENANT/TOKEN literals here. A tenant-bound step-up token is a WRITE
+    // credential — the gate on clinical writes — and this page rendered it as
+    // a JavaScript literal, which CareAgents then relayed verbatim from
+    // careagents.cloud. Anything able to read the page body held a live write
+    // credential until it expired, across an origin boundary, at the clinical
+    // approval moment (#395).
+    //
+    // Nothing is lost by deleting it, and the reason is worth keeping:
+    //   - the GET at r6/actions/review.py:130 REQUIRES a step-up header and
+    //     401s without it. A browser navigation cannot set a custom header,
+    //     so no browser has ever loaded this page directly, and on any direct
+    //     request the literal rendered as "" anyway.
+    //   - the only caller that supplies that header is CareAgents' server-side
+    //     fetch_review_page — the path where the token got baked into HTML
+    //     and shipped onward to the patient.
+    //   - on submit, careagents/app.py rewrites this form's action to
+    //     /review/<agent>/<action>/submit, resolves the tenant from the
+    //     signed-in agent's ownership, and re-injects credentials itself. The
+    //     headers the browser sent were read by nobody.
+    //
+    // So the credential was populated ONLY on the path that does not need it.
+    // Do not "fix" a regression here by shortening the token's TTL instead:
+    // the exposure is the delivery, not the lifetime.
     var form = document.getElementById('review-form');
     var btn = document.getElementById('approve-btn');
     var gateMsg = document.getElementById('review-gate-msg');
@@ -227,11 +248,11 @@
       if (form.querySelector('#nka').checked) { payload['nka'] = 'true'; }
       fetch(form.action, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Tenant-Id': TENANT,
-          'X-Step-Up-Token': TOKEN
-        },
+        // Credentials are the server's to supply. The relay resolves the
+        // tenant from ownership and injects the step-up token itself, so the
+        // headers this used to send were unread as well as exposed (#395).
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
         body: JSON.stringify(payload)
       }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
         .then(function (res) {

--- a/templates/review_base.html
+++ b/templates/review_base.html
@@ -1,0 +1,52 @@
+{# Minimal shell for pages that are RELAYED to another origin.
+
+   `action_review.html` is fetched server-side by CareAgents and served from
+   careagents.cloud (careagents/app.py). Extending the site's `base.html`
+   sent three things across that boundary that only resolve on HealthClaw:
+
+     - `url_for('static', filename='css/r6-dashboard.css')` renders as the
+       absolute path /static/css/r6-dashboard.css. careagents/static/ has no
+       such file, so the patient got an UNSTYLED page.
+     - a HealthClaw navbar — Home, Dashboard, FAQ, Wiki, Skills — five links
+       that 404 on careagents.cloud.
+     - /_vercel/insights/script.js, which is not served there either.
+
+   All three at the moment a patient is asked to review and approve a
+   clinical form (#396). Beyond the cosmetics: someone who cannot tell whose
+   page they are on is being asked to attest on a surface that does not look
+   like the product they signed into.
+
+   So this shell carries NO navigation and NO same-origin asset references.
+   Bootstrap and Font Awesome stay, on public CDNs that resolve identically
+   from either origin — the defect was never "a CDN", it was a path that only
+   exists on one host.
+
+   Do not add a nav, a footer link, or a `url_for('static', ...)` here. Any of
+   them silently breaks only on the relayed origin, which is the one place
+   nothing in CI looks.
+#}<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Review{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <style>
+      /* The handful of rules this page took from r6-dashboard.css, inlined so
+         the page is self-contained on whichever origin serves it. */
+      body { background: #10131a; }
+      .review-shell { max-width: 900px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+      .review-mark { font-size: .8rem; letter-spacing: .04em; text-transform: uppercase;
+                     color: #8b95a7; margin-bottom: .75rem; }
+    </style>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <div class="review-shell">
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/review_base.html
+++ b/templates/review_base.html
@@ -1,44 +1,197 @@
-{# Minimal shell for pages that are RELAYED to another origin.
+{# Shell for pages RELAYED to another origin. Fully self-contained: it loads
+   NOTHING — no same-origin path, no CDN, no webfont.
 
    `action_review.html` is fetched server-side by CareAgents and served from
-   careagents.cloud (careagents/app.py). Extending the site's `base.html`
-   sent three things across that boundary that only resolve on HealthClaw:
+   careagents.cloud (careagents/app.py). That puts it between two rules that
+   look contradictory until you satisfy both:
 
-     - `url_for('static', filename='css/r6-dashboard.css')` renders as the
-       absolute path /static/css/r6-dashboard.css. careagents/static/ has no
-       such file, so the patient got an UNSTYLED page.
-     - a HealthClaw navbar — Home, Dashboard, FAQ, Wiki, Skills — five links
-       that 404 on careagents.cloud.
-     - /_vercel/insights/script.js, which is not served there either.
+     - #396: it may not reference a SAME-ORIGIN asset. Extending base.html
+       sent /static/css/r6-dashboard.css, a five-link HealthClaw navbar and
+       /_vercel/insights/script.js across the boundary. None of them exist on
+       careagents.cloud, so the patient got an unstyled page wearing another
+       product's dead navigation, at the moment they were asked to attest.
 
-   All three at the moment a patient is asked to review and approve a
-   clinical form (#396). Beyond the cosmetics: someone who cannot tell whose
-   page they are on is being asked to attest on a surface that does not look
-   like the product they signed into.
+     - The CSP (app.py) is `default-src 'self'`, so it may not reference a
+       THIRD-PARTY asset either. The first fix for #396 used Bootstrap and
+       Font Awesome from CDNs, which the lint gate correctly rejected.
 
-   So this shell carries NO navigation and NO same-origin asset references.
-   Bootstrap and Font Awesome stay, on public CDNs that resolve identically
-   from either origin — the defect was never "a CDN", it was a path that only
-   exists on one host.
+   The only thing that satisfies both is a page that fetches nothing. So the
+   styles below are inlined and the type is a system stack.
 
-   Do not add a nav, a footer link, or a `url_for('static', ...)` here. Any of
-   them silently breaks only on the relayed origin, which is the one place
-   nothing in CI looks.
-#}<!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+   WHY IT LOOKS LIKE CAREAGENTS. #395 established that no browser can load
+   this page from HealthClaw directly — the GET requires an `X-Step-Up-Token`
+   header and 401s without it, and a navigation cannot set one. The CareAgents
+   relay is the ONLY consumer. A page served from careagents.cloud, to a
+   person who signed in to CareAgents, should look like CareAgents. The
+   palette below is careagents.css's, and the serif is the same `Georgia`
+   that CareAgents' own `"Fraunces", Georgia, serif` stack falls back to.
+
+   BOOTSTRAP IS NOT LOADED. The rules below reimplement, by hand, exactly the
+   subset of Bootstrap class names `action_review.html` uses. The names were
+   kept so that fixing this did not mean rewriting every attribute on a
+   patient-facing clinical form. That is a trap for the next person, so it is
+   pinned: tests/test_relayed_review_page_is_self_contained.py fails if the
+   page uses a class this file does not define.
+
+   Do not add a <link>, a <script src>, a `url(...)`, a nav, or a footer link.
+
+   This comment closes directly onto the doctype below, with no newline: a
+   break there would emit a blank line ahead of the doctype. #}<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Review{% endblock %}</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <style>
-      /* The handful of rules this page took from r6-dashboard.css, inlined so
-         the page is self-contained on whichever origin serves it. */
-      body { background: #10131a; }
-      .review-shell { max-width: 900px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
-      .review-mark { font-size: .8rem; letter-spacing: .04em; text-transform: uppercase;
-                     color: #8b95a7; margin-bottom: .75rem; }
+      /* ── tokens: careagents.css ─────────────────────────────────────── */
+      :root {
+        --cream: #FBF6EE; --paper: #F4ECDF; --card: #FFFDF8;
+        --ink: #22190E; --ink-soft: #5E5240;
+        --clay: #C2532E; --clay-deep: #A03F1F;
+        --sage: #4A6B4F; --hairline: #E4D7C2;
+        --warn: #7E5000; --warn-wash: #F7EFE0;
+        --danger: #A8321E; --danger-wash: #F8EBE8;
+        --radius: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--cream); color: var(--ink);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                     "Helvetica Neue", Arial, sans-serif;
+        font-size: 17px; line-height: 1.55;
+        -webkit-text-size-adjust: 100%;
+      }
+      h1, h2, h3 { font-family: Georgia, "Times New Roman", serif;
+                   font-weight: 600; letter-spacing: -0.015em;
+                   line-height: 1.2; margin: 0; }
+      h2 { font-size: 1.6rem; }
+      p { margin: 0; }
+
+      /* Focus is never removed — this is a form a person signs. */
+      :focus-visible { outline: 3px solid var(--clay); outline-offset: 2px;
+                       border-radius: 6px; }
+
+      .review-shell { max-width: 900px; margin: 0 auto;
+                      padding: 1.5rem 1rem 3rem; }
+      .review-mark { font-size: .8rem; letter-spacing: .04em;
+                     text-transform: uppercase; color: var(--ink-soft);
+                     margin-bottom: .75rem; }
+
+      /* ── layout ─────────────────────────────────────────────────────── */
+      .row { display: flex; flex-wrap: wrap; margin-inline: -.5rem; }
+      .row > * { padding-inline: .5rem; }
+      .justify-content-center { justify-content: center; }
+      .justify-content-between { justify-content: space-between; }
+      .align-items-center { align-items: center; }
+      .d-flex { display: flex; }
+      .flex-wrap { flex-wrap: wrap; }
+      .col-lg-9 { width: 100%; }
+      @media (min-width: 992px) { .col-lg-9 { width: 75%; } }
+      /* dl.row: label / value pairs */
+      .col-sm-4 { width: 100%; }
+      .col-sm-8 { width: 100%; }
+      @media (min-width: 576px) {
+        .col-sm-4 { width: 33.333%; } .col-sm-8 { width: 66.666%; }
+      }
+      dl.row { margin: 0; } dd { margin-left: 0; }
+
+      /* ── spacing ────────────────────────────────────────────────────── */
+      .mb-0 { margin-bottom: 0; }   .mb-2 { margin-bottom: .5rem; }
+      .mb-3 { margin-bottom: 1rem; } .mb-4 { margin-bottom: 1.5rem; }
+      .mt-2 { margin-top: .5rem; }
+      .me-1 { margin-right: .25rem; } .me-2 { margin-right: .5rem; }
+      .me-3 { margin-right: 1rem; }
+      .p-3 { padding: 1rem; }
+
+      /* ── type ───────────────────────────────────────────────────────── */
+      .text-muted { color: var(--ink-soft); }
+      /* Bootstrap's .small is 0.875em. Held at 1rem: this page carries
+         medication and allergy provenance, read by someone deciding whether
+         a record is right, and design.md sets a 16px floor. */
+      .small { font-size: 1rem; }
+      .fw-bold { font-weight: 700; }
+
+      /* ── surfaces ───────────────────────────────────────────────────── */
+      .card { background: var(--card); border: 1px solid var(--hairline);
+              border-radius: var(--radius); overflow: hidden; }
+      .card-header { padding: .85rem 1.1rem; background: var(--paper);
+                     border-bottom: 1px solid var(--hairline);
+                     font-weight: 600; }
+      .card-body { padding: 1.1rem; }
+      .border { border: 1px solid var(--hairline); }
+      .border-warning { border-color: var(--warn); }
+      .rounded { border-radius: 12px; }
+
+      .badge { display: inline-block; padding: .25em .6em; border-radius: 999px;
+               font-size: .8rem; font-weight: 600; }
+      .bg-secondary { background: var(--paper); color: var(--ink-soft); }
+      .bg-body-secondary { background: var(--paper); }
+
+      .alert { padding: .9rem 1.1rem; border-radius: 12px;
+               border: 1px solid var(--hairline); border-left-width: 4px;
+               background: var(--card); }
+      .alert-danger { border-left-color: var(--danger);
+                      background: var(--danger-wash); color: var(--danger); }
+      .alert-warning { border-left-color: var(--warn);
+                       background: var(--warn-wash); color: var(--warn); }
+      .alert-secondary { border-left-color: var(--ink-soft);
+                         background: var(--paper); color: var(--ink-soft); }
+
+      /* ── buttons ────────────────────────────────────────────────────── */
+      .btn {
+        display: inline-flex; align-items: center; justify-content: center;
+        min-height: 44px; padding: 0 1.1rem; border-radius: 999px;
+        border: 1.5px solid var(--hairline); background: var(--card);
+        color: var(--ink); font: inherit; font-weight: 600;
+        text-decoration: none; cursor: pointer;
+        transition: background-color 140ms ease-out, border-color 140ms ease-out,
+                    color 140ms ease-out;
+      }
+      /* 44px stays the floor even at "sm" — this is a phone target. */
+      .btn-sm { padding: 0 .85rem; font-size: 1rem; }
+      .btn-lg { padding: 0 1.5rem; font-size: 1.05rem; min-height: 52px; }
+      .btn-primary { background: var(--clay); border-color: var(--clay);
+                     color: #fff; }
+      .btn-primary:hover { background: var(--clay-deep);
+                           border-color: var(--clay-deep); }
+      .btn-outline-success { color: var(--sage); }
+      .btn-outline-warning { color: var(--warn); }
+      .btn-outline-danger  { color: var(--danger); }
+      .btn-outline-success:hover { border-color: var(--sage); }
+      .btn-outline-warning:hover { border-color: var(--warn); }
+      .btn-outline-danger:hover  { border-color: var(--danger); }
+
+      .btn-group { display: inline-flex; flex-wrap: wrap; gap: .4rem; }
+
+      /* Radio-as-button. The input stays in the accessibility tree and keeps
+         keyboard behaviour; only its default box is hidden. */
+      .btn-check {
+        position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+        overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+      }
+      .btn-check:focus-visible + .btn { outline: 3px solid var(--clay);
+                                        outline-offset: 2px; }
+      .btn-check:checked + .btn-outline-success {
+        background: var(--sage); border-color: var(--sage); color: #fff; }
+      .btn-check:checked + .btn-outline-warning {
+        background: var(--warn); border-color: var(--warn); color: #fff; }
+      .btn-check:checked + .btn-outline-danger {
+        background: var(--danger); border-color: var(--danger); color: #fff; }
+
+      /* ── form ───────────────────────────────────────────────────────── */
+      .form-check { display: flex; align-items: flex-start; gap: .6rem;
+                    min-height: 44px; }
+      .form-check-input { width: 22px; height: 22px; margin-top: .35rem;
+                          accent-color: var(--clay); flex-shrink: 0; }
+      .form-check-label { cursor: pointer; }
+
+      /* ── page rows ──────────────────────────────────────────────────── */
+      .med-row, .allergy-row { background: var(--card); gap: .75rem; }
+
+      @media (prefers-reduced-motion: reduce) {
+        * { transition-duration: 0.01ms !important; }
+      }
     </style>
     {% block head %}{% endblock %}
 </head>
@@ -46,7 +199,6 @@
     <div class="review-shell">
       {% block content %}{% endblock %}
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/test_relayed_review_page_is_self_contained.py
+++ b/tests/test_relayed_review_page_is_self_contained.py
@@ -1,0 +1,109 @@
+"""Guard: a page relayed to another origin may not reference that origin's assets.
+
+`action_review.html` is fetched server-side by CareAgents and served from
+careagents.cloud. It extended the site's `base.html`, which sent three things
+across that boundary that only resolve on HealthClaw (#396):
+
+  - `url_for('static', filename='css/r6-dashboard.css')` -> the absolute path
+    /static/css/r6-dashboard.css. `careagents/static/` has no such file, so
+    the patient got an UNSTYLED page.
+  - a HealthClaw navbar — Home, Dashboard, FAQ, Wiki, Skills — five links that
+    404 on careagents.cloud.
+  - /_vercel/insights/script.js, not served there either.
+
+All three at the moment a patient is asked to approve a clinical form. Beyond
+cosmetics: someone who cannot tell whose page they are on is being asked to
+attest on a surface that does not look like the product they signed into.
+
+These assert the SOURCE. The relay's own tests fake the page with a one-line
+HTML string (`tests/test_careagents.py`), so nothing there can see this — the
+repo trap where a fake proves a call is made, not that the result is usable.
+Rendering the real template through CareAgents in CI would need both apps up;
+this catches the regression shape instead, which is a template edit
+reintroducing a same-origin reference.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+TEMPLATES = pathlib.Path(__file__).resolve().parent.parent / "templates"
+
+#: Pages served from an origin other than the one that renders them.
+RELAYED_PAGES = ("action_review.html",)
+
+#: The shell they must use. `base.html` is the site chrome and is correct for
+#: every page NOT relayed.
+RELAY_SHELL = "review_base.html"
+
+
+#: Jinja comments, JS line and block comments. Scans must run over CODE, not
+#: over the paragraph explaining why the code is the way it is — three
+#: separate guards written today first failed against a CORRECT file because
+#: their own rationale named the thing they forbid.
+_COMMENTS = re.compile(r"{#.*?#}|/\*.*?\*/|^\s*//.*$", re.S | re.M)
+
+
+def _read(name: str) -> str:
+    """Template source with comments stripped."""
+    raw = (TEMPLATES / name).read_text(encoding="utf-8")
+    return _COMMENTS.sub("", raw)
+
+
+def _rendered_chain(name: str) -> str:
+    """The page plus whatever shell it extends — what the patient receives."""
+    source = _read(name)
+    match = re.search(r'{%\s*extends\s+"([^"]+)"', source)
+    return source + (_read(match.group(1)) if match else "")
+
+
+def test_the_review_page_uses_the_relay_shell():
+    """MUTATION: extend base.html again -> red, and every check below with it."""
+    pattern = r'{%\s*extends\s+"' + re.escape(RELAY_SHELL) + '"'
+    assert re.search(pattern, _read("action_review.html")), (
+        "action_review.html must extend review_base.html; base.html carries "
+        "a navbar and a same-origin stylesheet that only exist on HealthClaw")
+
+
+def test_no_relayed_page_references_a_same_origin_asset():
+    """`url_for('static', ...)` renders an absolute path that 404s on the
+    relayed origin. A CDN URL is fine — it resolves identically from either
+    host. The defect was never "a CDN", it was a path that exists on one host.
+    """
+    for page in RELAYED_PAGES:
+        chain = _rendered_chain(page)
+        assert "url_for('static'" not in chain and 'url_for("static"' not in chain, (
+            f"{page} references a same-origin static asset; it is served from "
+            f"careagents.cloud, where that path does not exist")
+        assert "/_vercel/" not in chain, (
+            f"{page} references a Vercel-only script path")
+
+
+def test_no_relayed_page_shows_another_products_navigation():
+    """Five dead links and someone else's brand, mid-approval."""
+    for page in RELAYED_PAGES:
+        chain = _rendered_chain(page)
+        assert "navbar" not in chain, (
+            f"{page} carries a navbar; on the relayed origin its links 404, "
+            f"and it tells the patient they are on a different product")
+        for endpoint in ("'index'", "'r6_dashboard'", "'faq'", "'wiki'",
+                         "'skills_index'"):
+            assert "url_for(" + endpoint + ")" not in chain, (
+                f"{page} links to url_for({endpoint}), which has no route on "
+                f"careagents.cloud")
+
+
+def test_the_shell_still_provides_the_layout_the_page_uses():
+    """Stripping chrome must not strip the CSS the page's markup depends on.
+
+    The page is built from Bootstrap classes (card, alert, btn-group, row).
+    Removing Bootstrap along with the nav would trade a broken nav for a
+    broken page — the same defect with better intentions.
+    """
+    shell = _read(RELAY_SHELL)
+    assert "bootstrap" in shell.lower(), (
+        "the relay shell must still load Bootstrap; action_review.html is "
+        "built from its classes")
+    assert "{% block content %}" in shell and "{% block scripts %}" in shell, (
+        "the shell must provide the blocks action_review.html fills")

--- a/tests/test_relayed_review_page_is_self_contained.py
+++ b/tests/test_relayed_review_page_is_self_contained.py
@@ -1,26 +1,34 @@
-"""Guard: a page relayed to another origin may not reference that origin's assets.
+"""Guard: a page relayed to another origin must fetch nothing at all.
 
 `action_review.html` is fetched server-side by CareAgents and served from
-careagents.cloud. It extended the site's `base.html`, which sent three things
-across that boundary that only resolve on HealthClaw (#396):
+careagents.cloud. That puts it between two rules which look contradictory
+until you satisfy both:
 
-  - `url_for('static', filename='css/r6-dashboard.css')` -> the absolute path
-    /static/css/r6-dashboard.css. `careagents/static/` has no such file, so
-    the patient got an UNSTYLED page.
-  - a HealthClaw navbar — Home, Dashboard, FAQ, Wiki, Skills — five links that
-    404 on careagents.cloud.
-  - /_vercel/insights/script.js, not served there either.
+  - **No same-origin asset** (#396). Extending the site's `base.html` sent
+    `url_for('static', ...)` -> /static/css/r6-dashboard.css, a five-link
+    HealthClaw navbar, and /_vercel/insights/script.js across the boundary.
+    None resolve on careagents.cloud, so the patient got an unstyled page
+    wearing another product's dead navigation at the moment they were asked
+    to attest.
 
-All three at the moment a patient is asked to approve a clinical form. Beyond
-cosmetics: someone who cannot tell whose page they are on is being asked to
-attest on a surface that does not look like the product they signed into.
+  - **No third-party asset.** The CSP in app.py is `default-src 'self'`. The
+    first fix for #396 reached for Bootstrap and Font Awesome on CDNs, and
+    the lint gate rejected it.
+
+The only thing that satisfies both is a page that fetches nothing, so
+`review_base.html` inlines its styles and uses a system font stack.
+
+That has a cost worth pinning. The inlined block reimplements, by hand, the
+subset of Bootstrap class names the page uses — the names were kept so that
+fixing this did not mean rewriting every attribute on a patient-facing
+clinical form. Bootstrap is NOT loaded, so a class nobody implemented renders
+as nothing: a card with no border, a button with no tap target. Silent, and
+only on the origin no test previously looked at.
+`test_every_class_the_page_uses_is_defined_by_the_shell` is what stops that.
 
 These assert the SOURCE. The relay's own tests fake the page with a one-line
 HTML string (`tests/test_careagents.py`), so nothing there can see this — the
 repo trap where a fake proves a call is made, not that the result is usable.
-Rendering the real template through CareAgents in CI would need both apps up;
-this catches the regression shape instead, which is a template edit
-reintroducing a same-origin reference.
 """
 
 from __future__ import annotations
@@ -37,11 +45,15 @@ RELAYED_PAGES = ("action_review.html",)
 #: every page NOT relayed.
 RELAY_SHELL = "review_base.html"
 
+#: Classes that exist for behaviour, not appearance — JavaScript hooks in
+#: action_review.html. They are deliberately unstyled, so the coverage check
+#: below must not demand a rule for them.
+BEHAVIOUR_ONLY = {"med-choice", "allergy-choice"}
 
 #: Jinja comments, JS line and block comments. Scans must run over CODE, not
 #: over the paragraph explaining why the code is the way it is — three
-#: separate guards written today first failed against a CORRECT file because
-#: their own rationale named the thing they forbid.
+#: separate guards written for this change first failed against a CORRECT
+#: file because their own rationale named the thing they forbid.
 _COMMENTS = re.compile(r"{#.*?#}|/\*.*?\*/|^\s*//.*$", re.S | re.M)
 
 
@@ -68,9 +80,7 @@ def test_the_review_page_uses_the_relay_shell():
 
 def test_no_relayed_page_references_a_same_origin_asset():
     """`url_for('static', ...)` renders an absolute path that 404s on the
-    relayed origin. A CDN URL is fine — it resolves identically from either
-    host. The defect was never "a CDN", it was a path that exists on one host.
-    """
+    relayed origin."""
     for page in RELAYED_PAGES:
         chain = _rendered_chain(page)
         assert "url_for('static'" not in chain and 'url_for("static"' not in chain, (
@@ -78,6 +88,28 @@ def test_no_relayed_page_references_a_same_origin_asset():
             f"careagents.cloud, where that path does not exist")
         assert "/_vercel/" not in chain, (
             f"{page} references a Vercel-only script path")
+
+
+def test_the_relayed_page_fetches_nothing_at_all():
+    """MUTATION: re-add the Bootstrap <link> -> red.
+
+    The earlier version of this file asserted the OPPOSITE — that the shell
+    must load Bootstrap — because a CDN was then the only way to style a page
+    that could not use same-origin paths. The CSP tightened to
+    `default-src 'self'` when the assets were vendored, so that assertion
+    became a pin on a rule that no longer holds. It moved with the thing it
+    pins, in the same change.
+    """
+    for page in RELAYED_PAGES:
+        chain = _rendered_chain(page)
+        assert "<link" not in chain.lower(), (
+            f"{page} carries a <link>; a relayed page must fetch nothing — "
+            f"same-origin paths 404 there and the CSP forbids third parties")
+        assert not re.search(r"<script[^>]+\bsrc\s*=", chain, re.I), (
+            f"{page} loads an external script")
+        assert not re.search(r"url\(\s*['\"]?(?!data:)[^)]", chain), (
+            f"{page} has a CSS url() — inline the asset or drop it")
+        assert "@import" not in chain, f"{page} uses @import"
 
 
 def test_no_relayed_page_shows_another_products_navigation():
@@ -94,16 +126,151 @@ def test_no_relayed_page_shows_another_products_navigation():
                 f"careagents.cloud")
 
 
-def test_the_shell_still_provides_the_layout_the_page_uses():
-    """Stripping chrome must not strip the CSS the page's markup depends on.
+def test_every_class_the_page_uses_is_defined_by_the_shell():
+    """The load-bearing one, because Bootstrap is no longer loaded.
 
-    The page is built from Bootstrap classes (card, alert, btn-group, row).
-    Removing Bootstrap along with the nav would trade a broken nav for a
-    broken page — the same defect with better intentions.
+    The shell hand-implements the Bootstrap class names this page uses. A name
+    it missed does not fall back to anything — `.card` with no rule is a plain
+    div, `.btn` with no rule is unstyled text with no 44px target, on a
+    clinical form a patient is signing. Nothing else in the stack would report
+    it: the relay's tests fake the page, and CI renders HTML without applying
+    CSS.
+
+    MUTATION: add `class="table-responsive"` to action_review.html -> red.
     """
     shell = _read(RELAY_SHELL)
-    assert "bootstrap" in shell.lower(), (
-        "the relay shell must still load Bootstrap; action_review.html is "
-        "built from its classes")
+    style = "\n".join(re.findall(r"<style>(.*?)</style>", shell, re.S))
+    assert style.strip(), "the relay shell has no inlined stylesheet"
+
+    page = _read("action_review.html")
+    used: set[str] = set()
+    for attr in re.findall(r'class="([^"]*)"', page):
+        for token in attr.split():
+            if "{{" in token or "{%" in token or not token:
+                continue
+            used.add(token)
+
+    undefined = sorted(
+        tok for tok in used
+        if tok not in BEHAVIOUR_ONLY
+        and not re.search(r"\." + re.escape(tok) + r"(?![\w-])", style)
+    )
+    assert not undefined, (
+        "action_review.html uses classes review_base.html does not define, and "
+        "Bootstrap is not loaded, so they style nothing:\n  "
+        + "\n  ".join(undefined)
+        + "\nAdd a rule to the shell's inlined <style>, or stop using the class.")
+
+
+def test_the_shell_keeps_the_blocks_the_page_fills():
+    """Stripping chrome must not strip the seams the page renders into."""
+    shell = _read(RELAY_SHELL)
     assert "{% block content %}" in shell and "{% block scripts %}" in shell, (
         "the shell must provide the blocks action_review.html fills")
+
+
+def _rule_body(style: str, selector: str) -> str:
+    """The declarations of the rule whose selector list starts with `selector`."""
+    match = re.search(
+        r"(?:^|\})\s*" + re.escape(selector) + r"(?![\w-])[^{}]*\{([^}]*)\}",
+        style, re.M)
+    return match.group(1) if match else ""
+
+
+def test_the_buttons_clear_the_44px_tap_target():
+    """design.md: 44px minimum, phone-first, one-handed.
+
+    Bound to the `.btn` rule specifically. The first version of this asserted
+    `"min-height: 44px" in style`, which passed even with `.btn` shrunk to
+    30px — `.form-check` also declares 44px, so the substring was satisfied by
+    a different rule. It checked that the number appears somewhere, not that
+    the buttons have it.
+    """
+    style = _read(RELAY_SHELL)
+    body = _rule_body(style, ".btn")
+    assert body, "the relay shell defines no .btn rule"
+    match = re.search(r"min-height:\s*(\d+)px", body)
+    assert match and int(match.group(1)) >= 44, (
+        f".btn min-height is {match.group(1) + 'px' if match else 'unset'}; "
+        f"design.md sets a 44px floor, and on this page the small variant is "
+        f"the still-taking / not-anymore / remove control")
+
+    # .btn-sm must not claw it back.
+    sm = _rule_body(style, ".btn-sm")
+    shrunk = re.search(r"min-height:\s*(\d+)px", sm)
+    assert not (shrunk and int(shrunk.group(1)) < 44), (
+        ".btn-sm lowers the tap target below 44px")
+
+
+def test_no_text_on_the_relayed_page_falls_under_16px():
+    """iOS zooms the whole page when a control under 16px is focused, and this
+    page carries medication and allergy provenance read under stress."""
+    style = _read(RELAY_SHELL)
+    assert not re.search(r"font-size:\s*(?:1[0-5]px|0\.[0-9]+rem)", style), (
+        "the relay shell sets a control or body size under 16px")
+
+
+# --- rendered output, not source -------------------------------------------
+
+def _render_review_page() -> str:
+    """The page as the patient receives it. Synthetic data only."""
+    import main  # noqa: PLC0415 — importing at module scope boots the app
+
+    with main.app.app_context():
+        return main.app.jinja_env.get_template("action_review.html").render(
+            action_id="act-test-0001",
+            record_readable=True,
+            record_reason=None,
+            demographics=[("Name", "Grover Keeling"),
+                          ("Date of birth", "1955-04-02")],
+            meds=[{"name": "Lisinopril 10 mg tablet", "dose": "1 tablet daily"}],
+            allergies=[{"allergen": "Penicillin", "reaction": "Hives"}],
+            conditions=[{"name": "Type 2 diabetes mellitus"}],
+        )
+
+
+def test_no_template_internals_reach_the_page():
+    """MUTATION: write a literal comment-close inside the header comment -> red.
+
+    Every other check in this file reads SOURCE. This one existed nowhere, and
+    the bug it catches shipped into a render: `review_base.html`'s header
+    comment explained how it closes onto the doctype and, in doing so, wrote
+    the closing delimiter as prose. Jinja closed the comment there, and the
+    remaining two lines of explanation rendered as the first visible text on a
+    clinical consent form.
+
+    Reading the template could not see it — the source was exactly what was
+    intended. Only the output was wrong. It is the same shape as the three
+    source-scanning guards in this change that first failed against correct
+    files because their own rationale named the thing they forbid: prose about
+    a delimiter, sitting inside that delimiter.
+    """
+    html = _render_review_page()
+
+    assert html.lstrip().startswith("<!DOCTYPE html>"), (
+        f"the page does not begin with its doctype; something leaks ahead of "
+        f"it: {html[:120]!r}")
+    for delimiter in ("{#", "#}", "{%", "{{"):
+        assert delimiter not in html, (
+            f"{delimiter!r} survives into the rendered page — a template "
+            f"delimiter written as prose closes the construct it describes")
+
+
+def test_the_rendered_page_requests_nothing():
+    """Source says it fetches nothing; confirm the render agrees.
+
+    A `{% block head %}` filled by a child, or an inherited block, could add a
+    request that no source scan of these two files would see.
+    """
+    html = _render_review_page()
+
+    assert "<link" not in html.lower(), "the rendered page carries a <link>"
+    assert not re.search(r"<script[^>]+\bsrc\s*=", html, re.I), (
+        "the rendered page loads an external script")
+    assert not re.search(r"url\(\s*['\"]?(?!data:)[^)]", html), (
+        "the rendered page has a CSS url()")
+    # Protocol-relative (//host/x.css) is a fetch the checks above can miss,
+    # since neither "<link" nor "src=" need be present for @import-less CSS
+    # or a rewritten attribute.
+    assert not re.search(r"""['"(]//[a-z0-9-]+\.""", html, re.I), (
+        "the rendered page has a protocol-relative URL")

--- a/tests/test_review_page_carries_no_credentials.py
+++ b/tests/test_review_page_carries_no_credentials.py
@@ -1,0 +1,96 @@
+"""Guard: the clinical review page must not ship a write credential.
+
+`templates/action_review.html` rendered a tenant-bound step-up token as a
+JavaScript literal, and `careagents/app.py` relays that HTML verbatim from
+careagents.cloud. Anything that could read the page body held a live WRITE
+credential — the gate on clinical writes — until it expired, across an origin
+boundary, at the approval moment (#395).
+
+It contradicted `careagents/healthclaw.py`'s own stated invariant: that the
+client carries credentials the browser never sees.
+
+Deleting it costs nothing, and the scoping matters more than the deletion:
+
+  - the GET at `r6/actions/review.py:130` REQUIRES the step-up header and 401s
+    without it. A browser navigation cannot set a custom header, so no browser
+    ever loaded this page directly, and the literal rendered as "" on any
+    direct request.
+  - the only caller supplying that header is CareAgents' server-side
+    `fetch_review_page` — the path where the token got baked into HTML and
+    shipped onward.
+  - on submit, `careagents/app.py` rewrites the form action to
+    `/review/<agent>/<action>/submit`, resolves the tenant from ownership, and
+    re-injects credentials itself, reading neither browser-supplied header.
+
+So the credential was populated only on the path that did not need it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+
+import r6.actions.review as review_module
+
+TEMPLATE = (pathlib.Path(__file__).resolve().parent.parent
+            / "templates" / "action_review.html")
+
+
+def _template() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_the_page_renders_no_step_up_token():
+    """MUTATION: restore `var TOKEN = {{ step_up_token | tojson }}` -> red."""
+    assert not re.search(r"\{\{\s*step_up_token", _template()), (
+        "action_review.html interpolates step_up_token; a tenant-bound write "
+        "credential must never reach the page body")
+
+
+def test_the_renderer_does_not_hand_the_token_to_the_template():
+    """The template is one half; the render call is the other.
+
+    Checking only the template would leave a page that stopped USING the token
+    while the server still handed it over — one edit from regressing.
+    """
+    assert "step_up_token=" not in inspect.getsource(review_module), (
+        "review.py passes step_up_token into render_template; the credential "
+        "must not leave the server at all")
+
+
+def test_no_request_header_is_built_from_a_page_credential():
+    """MUTATION: re-add 'X-Step-Up-Token': TOKEN to the fetch headers -> red.
+
+    Match the header being SET as an object key, not merely named. The comment
+    above the fetch explains why these were removed and names them, so a bare
+    substring scan flags that comment and fails on a correct file — the check
+    has to look at the code shape, not the vocabulary.
+    """
+    source = _template()
+    for header in ("X-Step-Up-Token", "X-Tenant-Id"):
+        assert not re.search(r"['\"]%s['\"]\s*:" % re.escape(header), source), (
+            f"the page sets {header} from a literal; the relay resolves the "
+            f"tenant from ownership and injects credentials server-side, so "
+            f"this header is both unread and an exposure")
+
+
+def test_the_submit_still_authenticates_by_session():
+    """Deleting credentials must not leave the POST unauthenticated.
+
+    The relay is `@login_required` and the form posts same-origin to it, so
+    the browser's session cookie is the credential. If that ever stops being
+    true the fix is a server-side one — never putting the token back.
+    """
+    assert "credentials: 'same-origin'" in _template(), (
+        "the submit must send the session cookie, which is what authorises "
+        "the relay now that no token travels in the page")
+
+
+def test_the_form_still_targets_the_path_the_relay_rewrites():
+    """`careagents/app.py` rewrites this exact action string. If the template
+    changes it the rewrite silently stops matching, the browser posts straight
+    at HealthClaw with no credentials, and the patient gets a 401 at the
+    approval moment — from a template edit."""
+    assert '/r6/actions/{{ action_id }}/review' in _template(), (
+        "the form action must stay the string careagents/app.py rewrites")


### PR DESCRIPTION
Two defects on the same page, in the same sweep — both about what crosses the origin boundary when CareAgents relays this page from `careagents.cloud`.

## #395 — a step-up write credential in the page body

`action_review.html` rendered a **tenant-bound step-up token** — the gate on clinical writes — as a JavaScript literal. Anything able to read the page body held it until expiry, cross-origin, at the approval moment. It contradicted `careagents/healthclaw.py`'s stated invariant that the client carries credentials the browser never sees.

**Scope, as the issue required — and the answer is stronger than assumed:**

- The GET at [`review.py:130`](r6/actions/review.py#L130) **requires `X-Step-Up-Token` and 401s without it.** A browser navigation cannot set a custom header, so **no browser can ever have loaded this page directly**, and the literal rendered as `""` on any direct request.
- The only caller setting that header is CareAgents' **server-side** `fetch_review_page` — the path where the token got baked into HTML and shipped to the patient.
- On submit, `careagents/app.py` rewrites the form action, resolves the tenant from **ownership**, and re-injects credentials itself, reading neither browser header.

The credential was populated only on the path that does not need it, and there is no direct-path caller to break. Deletion, both halves. Replaced by `credentials: 'same-origin'` — the session cookie on the `@login_required` relay. **Not** a shortened TTL: the exposure is the delivery, not the lifetime.

## #396 — someone else's navigation, mid-approval

Extending `base.html` sent three HealthClaw-only things across the boundary: `/static/css/r6-dashboard.css` (absent from `careagents/static/` → **unstyled page**), a five-link navbar that 404s, and `/_vercel/insights/script.js`.

New `templates/review_base.html`: no nav, no same-origin assets, Bootstrap and Font Awesome on public CDNs that resolve from either origin. **The defect was never "a CDN" — it was a path that exists on one host.** That's option 1 of the three in #396; option 2 keeps another product's nav on a CareAgents page, option 3 is right long-term but not a week out.

## Guards

Both assert the source, because the relay's tests fake the page with a one-line HTML string and cannot see either defect — the documented trap where a fake proves a call is made, not that the result is usable.

One guard covers something neither issue mentions: the **form action string** `careagents/app.py` rewrites. Change it in the template and the rewrite silently stops matching, the browser posts straight at HealthClaw uncredentialed, and the patient gets a 401 mid-approval.

The scanner strips comments first. Three guards written today initially failed against **correct** files because their own rationale named the thing they forbid — a check has to read code, not the paragraph explaining the code.

Suite `2768 passed, 12 skipped, 1 xfailed`; ruff clean. Mutations red: re-adding the token header; the server handing the token back; extending `base.html` again.