### PR TITLE
feat(site): table stakes — who builds this, the security posture, and numbers that are true

### DIFF
--- a/app.py
+++ b/app.py
@@ -255,6 +255,28 @@ def wiki():
     return render_template('wiki.html')
 
 
+@web_blueprint.route('/about')
+def about():
+    """Who maintains this, under what rules, and how to engage.
+
+    Table stakes rather than marketing: the operating entity was named only in
+    Terms section 13, so every reader who needed to know who stands behind the
+    guardrails had to open the legal page to find out.
+    """
+    return render_template('about.html')
+
+
+@web_blueprint.route('/security')
+def security():
+    """Security posture — controls, what the live grade covers, and the gaps.
+
+    Deliberately states the gaps (no SOC 2, no BAA, redaction is not an Expert
+    Determination) at the same weight as the controls. An evaluator finds them
+    regardless; finding them here is worth more than finding them on a call.
+    """
+    return render_template('security.html')
+
+
 @web_blueprint.route('/privacy')
 def privacy():
     """Privacy Policy."""

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,169 @@
+{% extends "base.html" %}
+{% block surface %}surface-paper{% endblock %}
+{% block bstheme %}light{% endblock %}
+
+{% block title %}Who builds this — HealthClaw Guardrails{% endblock %}
+
+{% block head %}
+<meta name="description" content="HealthClaw Guardrails is built by Vestel AI LLC. Who maintains it, the rules it is built under, what it is not, and how to work together.">
+<style>
+  .about { max-width: 72ch; margin-inline: auto; padding-block: var(--s7); }
+  .about h2 { font-size: 1.5rem; margin-top: var(--s8); margin-bottom: var(--s4);
+              padding-bottom: var(--s2); border-bottom: 2px solid var(--rule-firm); }
+  .about h3 { font-size: 1.125rem; margin-top: var(--s6); margin-bottom: var(--s2); }
+  .about p { color: var(--ink-soft); }
+  .about p + p { margin-top: var(--s3); }
+  .about ul { padding-left: var(--s4); margin-top: var(--s3); color: var(--ink-soft); }
+  .about li { margin-bottom: var(--s2); }
+  .about li strong { color: var(--ink); }
+
+  /* The three ways to engage. One row each, so the reader finds theirs
+     without reading the other two. */
+  .paths { border-top: 2px solid var(--rule-firm); margin-top: var(--s5); }
+  .path { padding: var(--s5) 0; border-bottom: 1px solid var(--rule); }
+  .path__who { font-family: var(--mono); font-size: 0.75rem; letter-spacing: 0.08em;
+               text-transform: uppercase; color: var(--ink-faint);
+               margin-bottom: var(--s2); }
+  .path__what { font-size: 1.125rem; font-weight: 600; margin-bottom: var(--s2); }
+  .path p { margin-bottom: var(--s3); }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="about">
+
+  <span class="eyebrow">Who builds this</span>
+  <h1 class="section-title">A guardrail layer is only worth as much as the people who maintain it.</h1>
+  <p class="section-lede">
+    So this page says who does, under what rules, and what is not covered.
+    It is deliberately specific about the limits.
+  </p>
+
+  <h2 id="who">Who</h2>
+  <p>
+    HealthClaw Guardrails is built and maintained by <strong>Vestel AI LLC</strong>,
+    a limited liability company organised in the Commonwealth of Pennsylvania.
+    The maintainer is Eugene Vestel.
+  </p>
+  {# TODO(eugene): two or three sentences of background — what you worked on
+     before this, and why health data specifically. This is the paragraph a
+     partnerships lead or an investor reads first, and it is the one thing on
+     this page nobody else can write for you. Keep it factual: roles and
+     systems, not adjectives. #}
+  <p>
+    Longer-form writing on the thinking behind the project:
+    <a href="https://evestel.substack.com/p/building-a-new-empowered-health-system" target="_blank" rel="noopener">Building a New, Empowered Health System</a>
+    and
+    <a href="https://evestel.substack.com/p/how-i-build-my-personal-openclaw" target="_blank" rel="noopener">How I Build My Personal OpenClaw</a>.
+  </p>
+
+  <h2 id="how">The rules this is built under</h2>
+  <p>
+    Most of what makes a guardrail layer trustworthy is process, not code.
+    These are enforced in CI, not stated as intentions.
+  </p>
+  <ul>
+    <li><strong>Every deployment grades itself.</strong> Seven safety properties,
+      checked against synthetic data the probe creates, A–F, live and public.
+      A pull request that drops the grade cannot merge.</li>
+    <li><strong>Nobody merges their own work.</strong> A maintainer approves.
+      That gate is the point of having it.</li>
+    <li><strong>Failures get written up in public.</strong> When something breaks,
+      the retrospective goes in the repository next to the fix, including the
+      ones caused by the maintainer.</li>
+    <li><strong>Demos use synthetic data only.</strong> The public MCP endpoint is
+      pinned server-side to a synthetic tenant. It cannot serve real records
+      even if asked.</li>
+    <li><strong>A control that cannot answer must say so.</strong> "No data" and
+      "could not check" are different answers, and the second is never rendered
+      as the first.</li>
+  </ul>
+  <p>
+    <a href="{{ url_for('security') }}">The security posture page</a> covers what
+    the grade does and does not cover.
+  </p>
+
+  <h2 id="limits">What this is not</h2>
+  <p>
+    Stated plainly, because finding it out on a procurement call wastes your time
+    and mine.
+  </p>
+  <ul>
+    <li><strong>Not a large team.</strong> This is maintained by one person with
+      clinical and standards advisors. That is fine for a reference
+      implementation and a design partnership. It is a real risk if you need a
+      vendor with a support rota, and you should weigh it.</li>
+    <li><strong>Not a covered entity or business associate</strong> under HIPAA.
+      An organisation running this against real patient data owns its own
+      compliance, agreements, and controls.</li>
+    <li><strong>Not certified.</strong> There is no SOC 2 report and no HITRUST
+      certification today.</li>
+    <li><strong>Not a medical device, and not medical advice.</strong> Every
+      clinical read carries a disclaimer, enforced rather than written into a
+      style guide.</li>
+  </ul>
+
+  <h2 id="work-together">Working together</h2>
+  <p>
+    Three ways, depending on what you need. All of them start at
+    <a href="mailto:support@healthclaw.io">support@healthclaw.io</a>.
+  </p>
+
+  <div class="paths">
+    <div class="path">
+      <div class="path__who">Build on it</div>
+      <div class="path__what">Use the code. No conversation required.</div>
+      <p>
+        MIT licensed. Run it locally in ten seconds, point it at your own FHIR
+        server, or install the plugin into Claude Code. If a guardrail is missing
+        for your case, an issue or a pull request is the fastest path.
+      </p>
+      <p><a href="https://github.com/aks129/HealthClawGuardrails" target="_blank" rel="noopener">The repository</a> · <a href="{{ url_for('wiki') }}">Architecture and how-tos</a></p>
+    </div>
+
+    <div class="path">
+      <div class="path__who">Integrate or partner</div>
+      <div class="path__what">For AI platforms and health tech teams.</div>
+      <p>
+        If you are putting an agent near clinical data and need the permission,
+        redaction, and audit layer to be someone else's problem, this is the
+        layer. Useful when you want FHIR and MCP expertise applied to your
+        surface rather than rebuilt in-house.
+      </p>
+      <p>
+        Say what you are building and where it touches patient data. A short
+        technical call is usually enough to tell whether this fits.
+      </p>
+    </div>
+
+    <div class="path">
+      <div class="path__who">Pilot</div>
+      <div class="path__what">For providers and payers.</div>
+      <p>
+        Read <a href="{{ url_for('security') }}">the security posture</a> first.
+        If the gaps listed there are disqualifying for your procurement process,
+        they will be disqualifying in month three as well, and it is better to
+        know now.
+      </p>
+      <p>
+        Where a pilot does work: a scoped evaluation against synthetic or
+        de-identified data, with the conformance grade as the acceptance
+        criterion, and a written account of what the guardrails did and did not
+        cover.
+      </p>
+    </div>
+  </div>
+
+  <h2 id="advisors">Advisors</h2>
+  {# TODO(eugene): naming one clinical advisor and one standards advisor — with
+     their consent — is the single highest-credibility addition to this page.
+     "Reviewed by a practising physician" is worth more to every reader here
+     than another paragraph of architecture. Left blank rather than vague:
+     an unnamed advisory board reads as no advisory board. #}
+  <p>
+    Clinical and standards advisors review the parts of this that make claims
+    about care. Named here once they have agreed to be.
+  </p>
+
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,6 +67,12 @@
           <a class="hc-nav__link"
              href="{{ url_for('skills_index') }}"
              {% if request.path == url_for('skills_index') %}aria-current="page"{% endif %}>Skills</a>
+          <a class="hc-nav__link"
+             href="{{ url_for('security') }}"
+             {% if request.path == url_for('security') %}aria-current="page"{% endif %}>Security</a>
+          <a class="hc-nav__link"
+             href="{{ url_for('about') }}"
+             {% if request.path == url_for('about') %}aria-current="page"{% endif %}>About</a>
         </div>
       </div>
     </nav>
@@ -92,7 +98,7 @@
         <div>
           <div class="hc-foot__mark">HealthClaw Guardrails</div>
           <div>FHIR R4 US Core v9 + R6 · MCP</div>
-          <div>a <a href="https://healthclaw.io" target="_blank" rel="noopener noreferrer">healthclaw.io</a> project</div>
+          <div>Built by <a href="{{ url_for('about') }}">Vestel AI LLC</a></div>
         </div>
         <div class="hc-foot__col">
           <div class="hc-foot__h">Project</div>
@@ -101,7 +107,10 @@
           <a href="{{ url_for('r6_dashboard') }}">Dashboard</a>
         </div>
         <div class="hc-foot__col">
-          <div class="hc-foot__h">Legal</div>
+          <div class="hc-foot__h">Company</div>
+          <a href="{{ url_for('about') }}">About</a>
+          <a href="{{ url_for('security') }}">Security posture</a>
+          <div class="hc-foot__h push-4">Legal</div>
           <a href="{{ url_for('privacy') }}">Privacy Policy</a>
           <a href="{{ url_for('terms') }}">Terms &amp; Conditions</a>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
       <div class="spec__label">FHIR resource types</div>
     </div>
     <div class="spec">
-      <span class="spec__num" data-target="1665">0</span>
+      <span class="spec__num" data-target="2812">0</span>
       <div class="spec__label">Tests passing</div>
     </div>
     <div class="spec">
@@ -345,17 +345,18 @@
       <div class="card__more">Try Curatr →</div>
     </a>
 
-    <a href="{{ url_for('faq') }}" class="card">
+    <a href="{{ url_for('security') }}" class="card">
       <div class="card__kicker"><span class="seq__n">03</span></div>
       <div class="card__title">Health System / Payer</div>
-      <p class="card__body">Let AI agents touch clinical data without a compliance disaster.</p>
+      <p class="card__body">Evaluate the guardrails before an agent goes near patient or member data.</p>
       <ul class="card__list">
         <li>Vendor-neutral proxy that works with your existing FHIR stack</li>
-        <li>Tenant isolation, immutable audit, OAuth 2.1 with PKCE</li>
+        <li>Tenant isolation, append-only audit, OAuth 2.1 with PKCE</li>
         <li>Human-in-the-loop for clinical writes (the HTTP 428 pattern)</li>
-        <li>950+ tests, Playwright e2e, open source under MIT</li>
+        <li>Care-gap evaluation that shows its reasoning and records who approved it</li>
+        <li>The gaps are published too: no SOC 2, no BAA, and redaction is not an Expert Determination</li>
       </ul>
-      <div class="card__more">Architecture →</div>
+      <div class="card__more">Read the security posture →</div>
     </a>
   </div>
 </section>
@@ -562,10 +563,12 @@
     <div>
       <div class="hc-foot__mark">HealthClaw Guardrails</div>
       <div>FHIR R4 US Core v9 + R6 · MCP · MIT License</div>
-      <div>a <a href="https://healthclaw.io" target="_blank" rel="noopener">healthclaw.io</a> project</div>
+      <div>Built by <a href="{{ url_for('about') }}">Vestel AI LLC</a></div>
     </div>
     <div class="hc-foot__col">
       <div class="hc-foot__h">Project</div>
+      <a href="{{ url_for('about') }}">About</a>
+      <a href="{{ url_for('security') }}">Security posture</a>
       <a href="https://github.com/aks129/HealthClawGuardrails" target="_blank" rel="noopener">GitHub</a>
       <a href="{{ url_for('skills_index') }}">Skills</a>
       <a href="{{ url_for('r6_dashboard') }}">Dashboard</a>

--- a/templates/security.html
+++ b/templates/security.html
@@ -1,0 +1,219 @@
+{% extends "base.html" %}
+{% block surface %}surface-paper{% endblock %}
+{% block bstheme %}light{% endblock %}
+
+{% block title %}Security posture — HealthClaw Guardrails{% endblock %}
+
+{% block head %}
+<meta name="description" content="What HealthClaw enforces, what the live conformance grade covers, what it does not, and what is missing for procurement. Written so an evaluator can decide without a call.">
+<style>
+  .posture { max-width: 76ch; margin-inline: auto; padding-block: var(--s7); }
+  .posture h2 { font-size: 1.5rem; margin-top: var(--s8); margin-bottom: var(--s4);
+                padding-bottom: var(--s2); border-bottom: 2px solid var(--rule-firm); }
+  .posture h3 { font-size: 1.0625rem; margin-top: var(--s5); margin-bottom: var(--s2); }
+  .posture p { color: var(--ink-soft); }
+  .posture p + p { margin-top: var(--s3); }
+  .posture ul { padding-left: var(--s4); margin-top: var(--s3); color: var(--ink-soft); }
+  .posture li { margin-bottom: var(--s2); }
+
+  /* The properties table: what is enforced, and where it is enforced. */
+  .props { width: 100%; border-collapse: collapse; margin-top: var(--s4);
+           font-size: 0.9375rem; }
+  .props th { text-align: left; padding: var(--s2) var(--s3);
+              font-family: var(--mono); font-size: 0.75rem; font-weight: 400;
+              letter-spacing: 0.07em; text-transform: uppercase;
+              color: var(--ink-faint); border-bottom: 2px solid var(--rule-firm); }
+  .props td { padding: var(--s3); border-bottom: 1px solid var(--rule);
+              vertical-align: top; color: var(--ink-soft); }
+  .props td:first-child { font-family: var(--mono); font-size: 0.875rem;
+                          color: var(--ink); white-space: nowrap; }
+
+  /* Gaps are stated in the same visual weight as the strengths on purpose.
+     A posture page that styles its gaps as fine print is a sales page. */
+  .gap { border-left: 3px solid var(--warn); background: var(--warn-wash);
+         padding: var(--s4); border-radius: 0 var(--radius) var(--radius) 0;
+         margin-block: var(--s4); }
+  .gap p { color: var(--ink); }
+  .gap__label { font-family: var(--mono); font-size: 0.75rem;
+                letter-spacing: 0.08em; text-transform: uppercase;
+                color: var(--warn); margin-bottom: var(--s2); }
+
+  .live { border: 1px solid var(--rule-firm); border-radius: var(--radius);
+          padding: var(--s5); margin-top: var(--s5); background: var(--paper-raise); }
+  .live__grade { font-family: var(--mono); font-size: 2.5rem; line-height: 1;
+                 color: var(--ink); }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="posture">
+
+  <span class="eyebrow">Security posture</span>
+  <h1 class="section-title">What is enforced, what is verified, and what is missing.</h1>
+  <p class="section-lede">
+    Written so an evaluator can decide without a call. The gaps are listed at
+    the same weight as the controls, because you will find them anyway.
+  </p>
+
+  <h2 id="grade">The grade is a live self-test</h2>
+  <p>
+    Every deployment can grade itself A–F. The probe creates a synthetic
+    patient, drives real requests through the running stack, and checks seven
+    properties against what actually comes back. Nothing is asserted from
+    configuration.
+  </p>
+
+  {# No grade letter is printed here on purpose. Writing "A" into this page
+     would put the same fact in two places, and the copy would keep claiming A
+     on the morning the deployment earned a B. The endpoint is the only owner;
+     this panel points at it. #}
+  <div class="live">
+    <div class="card__kicker">Check it against the running deployment</div>
+    <p>
+      <a href="https://app.healthclaw.io/r6/fhir/$conformance?format=text" target="_blank" rel="noopener">app.healthclaw.io/r6/fhir/$conformance</a>
+    </p>
+    <p class="fine push-2">
+      This page prints no grade. It would be a copy of a number that changes,
+      and a stale copy always reads as the better one. The check runs on
+      request, so what you get is what is true when you ask.
+    </p>
+  </div>
+
+  <div class="gap">
+    <div class="gap__label">What the grade is not</div>
+    <p>
+      It is a self-test of the guardrail layer, not an audit, not a
+      certification, and not a HIPAA compliance determination. It says the
+      controls fired on a synthetic record a moment ago. It says nothing about
+      the organisation running the deployment, its hosting, or its staff.
+    </p>
+  </div>
+
+  <h2 id="properties">The seven properties</h2>
+  <p>
+    These are the names in the code, so a result you read here matches a result
+    you get from the endpoint.
+  </p>
+
+  <table class="props">
+    <thead>
+      <tr><th scope="col">Property</th><th scope="col">What passing means</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>phi_redaction</td><td>Names, phone numbers and identifier-class fields do not come back in full on reads or searches.</td></tr>
+      <tr><td>audit_trail</td><td>Every resource access writes an AuditEvent, and the audit detail itself carries no PHI.</td></tr>
+      <tr><td>step_up_enforcement</td><td>A write without a valid signed token is refused.</td></tr>
+      <tr><td>human_in_the_loop</td><td>A clinical write without human confirmation is blocked with a 428, and an approved one is accepted.</td></tr>
+      <tr><td>tenant_isolation</td><td>A request scoped to one tenant cannot read another's records.</td></tr>
+      <tr><td>medical_disclaimer</td><td>Clinical reads carry a disclaimer, applied by the server rather than the prompt.</td></tr>
+      <tr><td>error_fidelity</td><td>Failures are reported truthfully: an upstream auth failure is not reported as "not found", and a degraded read is not reported as an empty one.</td></tr>
+    </tbody>
+  </table>
+
+  <p class="push-5">
+    The last one is the unusual entry, and it is the one this project cares
+    about most. A guardrail that returns nothing when it could not check looks
+    identical to a guardrail that checked and found nothing. Every serious
+    defect found in this codebase has been a version of that.
+  </p>
+
+  <h2 id="phi">Where PHI can and cannot go</h2>
+  <ul>
+    <li><strong>The agent never receives raw identifiers.</strong> Redaction is
+      applied on every read path: direct reads, searches, upstream proxy
+      responses, and context envelopes.</li>
+    <li><strong>Labels are re-applied after redaction, from a terminology table
+      keyed by code</strong> — never by preserving text the upstream sent.
+      Upstream systems put patient names in display fields, so passing those
+      through to make a record readable is how a redaction layer leaks.</li>
+    <li><strong>The consumer app stores no PHI.</strong> Accounts and pointers
+      only.</li>
+    <li><strong>Consumer chat channels are not treated as covered transport.</strong>
+      Telegram, Slack and Discord are patient-directed channels, not a
+      substitute for a BAA-covered path where a covered entity is disclosing.</li>
+  </ul>
+
+  <h2 id="gaps">What is missing</h2>
+  <p>
+    If any of these is disqualifying for your process, it will still be
+    disqualifying in month three.
+  </p>
+
+  <div class="gap">
+    <div class="gap__label">No SOC 2, no HITRUST</div>
+    <p>
+      There is no third-party audit report today. What exists instead is the
+      live conformance check, a public test suite, and a public incident
+      history. That is evidence, not a substitute for an audit.
+    </p>
+  </div>
+
+  <div class="gap">
+    <div class="gap__label">Redaction is Safe-Harbor-style, not a determination</div>
+    <p>
+      Field redaction removes identifier-class fields. It is a compensating
+      control. It is not HIPAA Expert Determination and must not be described
+      as de-identified data in a filing. A profile-specific recursive allowlist
+      and an Expert Determination path are on the roadmap.
+    </p>
+  </div>
+
+  <div class="gap">
+    <div class="gap__label">Not a covered entity or business associate</div>
+    <p>
+      An organisation running this against real patient data owns its own
+      compliance, agreements and controls.
+      <a href="{{ url_for('terms') }}#hipaa">Terms, section 5</a> is the
+      governing text.
+    </p>
+  </div>
+
+  <div class="gap">
+    <div class="gap__label">One maintainer</div>
+    <p>
+      There is no support rota and no contractual response time. For a design
+      partnership that is usually acceptable. For a production dependency it is
+      a risk you should price.
+    </p>
+  </div>
+
+  <h2 id="controls">Controls that are in place</h2>
+  <ul>
+    <li>Deny by default on permission evaluation.</li>
+    <li>Signed step-up tokens with a nonce and a short expiry for writes.</li>
+    <li>Human confirmation required before a clinical write lands.</li>
+    <li>Append-only audit, with the audit detail held PHI-free.</li>
+    <li>Tenant isolation enforced server-side, never from a client-supplied
+      claim alone.</li>
+    <li>A strict content security policy: the site loads no third-party script,
+      stylesheet or font, so no outside party observes a page a patient opens.</li>
+    <li>Transport security headers, and framing denied.</li>
+  </ul>
+
+  <h2 id="disclosure">Reporting a vulnerability</h2>
+  <p>
+    Email <a href="mailto:security@healthclaw.io">security@healthclaw.io</a>.
+    Please include what you did, what you expected, and what happened. If it
+    involves patient data on a deployment you do not operate, report it without
+    retrieving more of it than the report needs.
+  </p>
+  <p>
+    Findings are fixed in the open. The repository carries the write-ups,
+    including the ones that were the maintainer's fault.
+  </p>
+
+  <h2 id="evaluating">If you are evaluating this formally</h2>
+  <p>
+    Available today, on request: the conformance output for your own
+    deployment, the test suite and its coverage of these properties, the
+    architecture documentation, and a written account of known gaps that
+    matches this page.
+  </p>
+  <p>
+    Not available today: a SOC 2 report, a signed BAA, or a penetration test
+    report from a third party. Ask anyway if you need them, because knowing who
+    is asking changes what gets built next.
+  </p>
+
+</div>
+{% endblock %}

--- a/tests/test_site_links_resolve.py
+++ b/tests/test_site_links_resolve.py
@@ -1,0 +1,92 @@
+"""Guard: every internal link on the site goes somewhere.
+
+The pages that carry the project's credibility are the ones most damaged by a
+dead link. `/security` tells an evaluator "Terms, section 5 is the governing
+text" and sends them to an anchor; if that anchor has been renamed, the reader
+lands at the top of a legal page and has to hunt. That is a small failure with
+a large effect on someone deciding whether to trust the claims around it.
+
+Two classes are checked:
+
+  - `url_for('endpoint')` naming a route that does not exist. Flask raises at
+    RENDER time, so a template nobody rendered in a test can ship broken. The
+    site has pages that no test opens.
+  - `url_for('endpoint') }}#anchor` where the target template has no element
+    with that id. Flask cannot catch this at all — the URL is valid and the
+    fragment is silently ignored by the browser.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "templates"
+
+#: `{{ url_for('faq') }}#hipaa` and friends.
+_LINK = re.compile(r"url_for\(\s*'([a-z_0-9]+)'\s*\)\s*}}(#[A-Za-z0-9_-]+)?")
+
+#: Endpoint -> template it renders. Read from app.py so a new page cannot be
+#: added to one and forgotten in the other.
+_ROUTE = re.compile(
+    r"@web_blueprint\.route\('(?P<rule>/[^']*)'\)\s*\n"
+    r"def (?P<endpoint>\w+)\([^)]*\):(?P<body>(?:\n(?:    .*)?)+?)"
+    r"(?=\n@|\n\ndef |\Z)")
+
+
+def _endpoint_templates() -> dict[str, str]:
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    out: dict[str, str] = {}
+    for m in _ROUTE.finditer(source):
+        rendered = re.search(r"render_template\(\s*'([^']+)'", m.group("body"))
+        if rendered:
+            out[m.group("endpoint")] = rendered.group(1)
+    return out
+
+
+def _ids(template: str) -> set[str]:
+    path = TEMPLATES / template
+    if not path.is_file():
+        return set()
+    return set(re.findall(r'\bid="([^"]+)"', path.read_text(encoding="utf-8")))
+
+
+def _templates() -> list[pathlib.Path]:
+    return sorted(TEMPLATES.glob("*.html"))
+
+
+def test_there_are_templates_and_routes_to_check():
+    """A pass over an empty glob is not a pass."""
+    assert len(_templates()) >= 8, "templates/ looks wrong"
+    endpoints = _endpoint_templates()
+    assert {"about", "security", "faq", "terms", "privacy"} <= set(endpoints), (
+        f"could not read the route table out of app.py; found {sorted(endpoints)}")
+
+
+@pytest.mark.parametrize("template", _templates(), ids=lambda p: p.name)
+def test_internal_anchor_links_point_at_a_real_id(template: pathlib.Path):
+    """MUTATION: change `#hipaa` in security.html to `#hippa` -> red."""
+    endpoints = _endpoint_templates()
+    source = template.read_text(encoding="utf-8")
+
+    broken: list[str] = []
+    for endpoint, fragment in _LINK.findall(source):
+        target = endpoints.get(endpoint)
+        if target is None:
+            # An endpoint outside the web blueprint (r6_dashboard, skills_index
+            # and friends live elsewhere). Route existence is Flask's job and
+            # is covered by rendering every page in the suite; only the
+            # fragment is checkable here.
+            continue
+        if not fragment:
+            continue
+        anchor = fragment.lstrip("#")
+        if anchor not in _ids(target):
+            broken.append(f"{fragment} -> {target} (no element with that id)")
+
+    assert not broken, (
+        f"{template.name} links to anchors that do not exist:\n  "
+        + "\n  ".join(broken))

--- a/tests/test_site_version_sync.py
+++ b/tests/test_site_version_sync.py
@@ -62,3 +62,71 @@ def test_readme_release_badge_matches_version():
     readme = (ROOT / "README.md").read_text()
     assert f"release-v{_version()}-" in readme, (
         "README release badge is stale vs pyproject version")
+
+
+# --- numbers the site states about itself ----------------------------------
+
+def _test_function_count() -> int:
+    """`def test_` definitions under tests/.
+
+    Deliberately static rather than a pytest collection: collecting from
+    inside a run is slow and awkward, and this only needs to be close. The
+    collected total is higher than this because of parametrisation, so this
+    count is a floor the site's claim must clear.
+    """
+    total = 0
+    for path in (ROOT / "tests").rglob("test_*.py"):
+        total += len(re.findall(r"^\s*(?:async\s+)?def test_", 
+                                path.read_text(encoding="utf-8", errors="replace"),
+                                re.MULTILINE))
+    return total
+
+
+def test_landing_test_count_is_not_stale_and_does_not_overclaim():
+    """The headline number on healthclaw.io must be true.
+
+    It was not. The spec strip said 1,665 while the suite had passed 2,780,
+    and an audience card on the SAME PAGE said "950+ tests". A reader who
+    notices two different totals in one scroll stops believing the other
+    numbers, which are the whole argument the page is making.
+
+    The band is deliberately loose. Pinning an exact count would turn every
+    added test into a failing build, and a gate that fires on ordinary work
+    gets switched off — the failure mode docs/2026-08-02-retro.md describes.
+    What this catches is the real one: a number left alone for a year.
+    """
+    html = (ROOT / "templates" / "index.html").read_text()
+    # Pair each number with ITS OWN label. Anchoring on the label alone was not
+    # enough: a lazy `.*?` starts at the first data-target on the page (the MCP
+    # tool count) and happily runs forward to "Tests passing", so the check
+    # compared 29 against 2,289 and failed for the wrong reason. Refusing to
+    # cross another data-target is what binds the two together.
+    pairs = dict(
+        (label.strip(), int(num)) for num, label in re.findall(
+            r'data-target="(\d+)"(?:(?!data-target)[\s\S])*?'
+            r'class="spec__label">([^<]+)<', html))
+    assert pairs, "the landing page no longer states any figures"
+    claimed = pairs.get("Tests passing")
+    assert claimed, f"no 'Tests passing' figure on the page; found {list(pairs)}"
+
+    floor = _test_function_count()
+    assert claimed >= floor, (
+        f"healthclaw.io claims {claimed} tests but tests/ defines {floor} test "
+        f"functions before parametrisation — the claim understates the suite "
+        f"and reads as stale")
+    assert claimed <= floor * 2, (
+        f"healthclaw.io claims {claimed} tests against {floor} test functions; "
+        f"that is more than parametrisation explains")
+
+
+def test_no_second_test_count_contradicts_the_headline():
+    """MUTATION: re-add "950+ tests" to an audience card -> red.
+
+    Two totals on one page is worse than one stale total: it tells the reader
+    the page is not maintained, without telling them which number to trust.
+    """
+    html = (ROOT / "templates" / "index.html").read_text()
+    others = re.findall(r"([\d,]+)\+?\s*(?:Python\s+)?tests\b", html, re.I)
+    assert not others, (
+        f"index.html states a test count in prose ({others}) as well as in the "
+        f"stats strip. The strip owns that number; prose citing it drifts.")


### PR DESCRIPTION
**Stacked on #453.** Base is `design/typographic-redesign`, so this reviews as its own diff. It retargets to `main` automatically when #453 merges.

A six-perspective read of the site — investor, AI platform partner, health tech buyer, provider, patient, payer — found the same three gaps blocking almost all of them. None are design problems.

---

## 1. Nobody could tell who is behind this

The operating entity, **Vestel AI LLC**, a Pennsylvania company, was named in exactly one place: Terms §13. Everywhere else the site read as an anonymous community project, while asking people to trust it with the path between an AI agent and a medical record.

That blocks the investor, the partnerships lead, and the platform team simultaneously. None of them engage with an anonymous infrastructure project.

`/about` now carries who maintains it, the rules it is built under, what it is **not**, and three explicit ways to engage (build on it / integrate / pilot).

**Two TODOs are left in the template deliberately:**
- Your background. It is the paragraph a partner or investor reads first and the one thing nobody else can write.
- An advisor name, which needs their consent before it goes on a public page.

Both are marked rather than filled with something vague. An unnamed advisory board reads as no advisory board.

## 2. The compliance gaps were discoverable but never assembled

The honest caveats already existed, scattered across README, FAQ, privacy and terms. An evaluator had to assemble them — which meant assembling them on a call, late, where it reads as evasion rather than candour.

`/security` puts them in one place, gaps at the **same visual weight as the controls**:

- the seven properties under their names in the code (`phi_redaction` … `error_fidelity`)
- where PHI can and cannot go
- what is missing: no SOC 2, no HITRUST, redaction is Safe-Harbor-*style* and not an Expert Determination, not a covered entity or business associate, one maintainer with no support rota
- what a formal evaluation can have today, and what it cannot

**The page prints no grade letter on purpose.** Writing "A" into it would put the same fact in two places, and the copy would still claim A on the morning the deployment earned a B. The endpoint is the only owner; the page points at it.

## 3. The site contradicted itself about its own numbers

| where | claimed |
|---|---|
| stats strip | 1,665 tests |
| audience card, same page | "950+ tests" |
| actual | **2,812 collected** |

A reader who spots two totals in one scroll stops believing the rest of the numbers, and the numbers are the entire argument the page makes.

Fixed and pinned: `test_site_version_sync.py` pairs each figure with its own label, and asserts the count neither understates the suite nor overclaims it, and that no second count appears in prose.

## The overclaim

The "Health System / Payer" card promised *"let AI agents touch clinical data without a compliance disaster"* and linked to the FAQ. The posture cannot support that sentence for a procurement officer — your own privacy page says you are not a covered entity or business associate.

It now says what is true, and links to `/security`.

## Also

`test_site_links_resolve.py` — an internal `#anchor` pointing at no id is invisible to Flask: the URL is valid and the browser drops the fragment silently. `/security` sends evaluators to "Terms, section 5"; that landing at the top of a legal page is a small failure with a large effect on someone deciding whether to trust the claims around it.

## Verification

2818 passed · 48 e2e passed · ruff clean. Both new pages render with zero third-party requests and are reachable from nav and footer. Mutations red for: the stale 1,665, an inflated count, a second count in prose, and a typo'd cross-page anchor.

## Still open, and not in this PR

**Payer positioning.** The site speaks no payer vocabulary — no eligibility, prior authorization, X12, member portal, Stars/HEDIS, and nothing on CMS-0057-F, which puts payer APIs and prior-auth automation on a 2027 clock. Care gaps is already a quality-measure engine framed as a consumer feature. Same code, different frame, different buyer. That is copy, not engineering, and it is the biggest remaining persona gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)