### PR TITLE
fix(conformance): a passing check no longer prints a failure sentence (#443)

### DIFF
--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -103,9 +103,54 @@ def _synthetic_observation(subject_ref: str = "Patient/conformance-subject"):
 
 @dataclass
 class Check:
+    """One assertion in the scorecard, with its two halves kept apart.
+
+    `observed` is what the probe MEASURED — "status 200", "grade A",
+    "id=None". It is true whichever way the check went, so it is safe beside
+    a PASS.
+
+    `on_failure` says what a failure would MEAN — "PHI leaked into audit",
+    "no disclaimer on the response". It is a sentence about a world in which
+    `passed` is False.
+
+    Both used to share one `detail` field. The text renderer hid that field on
+    a pass, which kept one output honest and left every other consumer to
+    rediscover the rule; none did. Fifteen checks shipped emitting
+
+        {"name": "no raw SSN in the audit trail",
+         "passed": true, "detail": "PHI leaked into audit"}
+
+    Two readers hit it independently and both concluded the deployment was
+    leaking PHI. The second was the physician advisor, about thirty hours
+    before a demo recording. The checks were right; the report was not.
+
+    Splitting the field is what makes the report unable to say it. A consumer
+    that prints everything it is handed now prints only true sentences,
+    without having to know this rule.
+    """
+
     name: str
     passed: bool
-    detail: str = ""
+    #: Third positional on purpose. The measurement is both the common case
+    #: and the safe one, so the thirty-odd sites that pass one positionally
+    #: are correct untouched — and a failure explanation has to be named to
+    #: get in, which is exactly where the author should have to think.
+    observed: str = ""
+    on_failure: str = ""
+
+    @property
+    def detail(self) -> str:
+        """Both halves as one string, true of THIS run.
+
+        Kept because `detail` is the key partner scripts already read, and
+        derived rather than stored so it cannot drift from the two halves it
+        summarises.
+        """
+        if self.passed or not self.on_failure:
+            return self.observed
+        if not self.observed:
+            return self.on_failure
+        return f"{self.observed}; {self.on_failure}"
 
 
 @dataclass
@@ -176,7 +221,14 @@ class ConformanceReport:
                 {"key": r.key, "property": r.property, "passed": r.passed,
                  "grade": r.grade, "coverage": r.coverage,
                  "profiles": r.profiles, "note": r.note,
-                 "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail}
+                 # `on_failure` is withheld on a pass rather than left to the
+                 # consumer to suppress. That was the bug: the rule existed
+                 # only inside render(), so every other reader of this JSON
+                 # printed a failure sentence next to a PASS.
+                 "checks": [{"name": c.name, "passed": c.passed,
+                             "observed": c.observed,
+                             "on_failure": "" if c.passed else c.on_failure,
+                             "detail": c.detail}
                             for c in r.checks]}
                 for r in self.results
             ],
@@ -214,7 +266,12 @@ class ConformanceReport:
                         f"          checks: {', '.join(profile_checks)}")
             for c in r.checks:
                 mark = "✓" if c.passed else "✗"
-                suffix = f" — {c.detail}" if c.detail and not c.passed else ""
+                # No `and not c.passed` here any more. `detail` is now true of
+                # this run either way, so the text and the JSON can share one
+                # rule instead of disagreeing about the same report. It also
+                # earns the reader something: a passing check now shows the
+                # status it actually got back, not just a tick.
+                suffix = f" — {c.detail}" if c.detail else ""
                 lines.append(f"        {mark} {c.name}{suffix}")
         return "\n".join(lines)
 
@@ -471,8 +528,9 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
         # here for the absences to mean anything.
         Check("the redacted record is still returned",
               _is_resource(body, "Patient", pid),
-              "the read did not return the Patient that was asked for; every "
-              "absence check below passes trivially on an empty response"),
+              on_failure="the read did not return the Patient that was asked "
+                         "for; every absence check below passes trivially on "
+                         "an empty response"),
         Check("family name not returned in full", _FAMILY not in blob),
         Check("given name not returned in full", _GIVEN not in blob),
         Check("SSN-class identifier masked", _SSN not in blob),
@@ -496,8 +554,8 @@ def probe_phi_redaction(client, ctx) -> ProbeResult:
         # scored A.
         Check("the search returns the resource it was asked for",
               _bundle_contains(body, "Patient", pid),
-              "the searchset did not contain the Patient; an empty Bundle "
-              "passes every redaction check in this block"),
+              on_failure="the searchset did not contain the Patient; an empty "
+                         "Bundle passes every redaction check in this block"),
         Check("family name not returned in full (search)", _FAMILY not in sblob),
         Check("given name not returned in full (search)", _GIVEN not in sblob),
         Check("SSN-class identifier masked (search)", _SSN not in sblob),
@@ -574,10 +632,11 @@ def probe_audit_trail(client, ctx) -> ProbeResult:
     r.checks += [
         Check("AuditEvent endpoint readable", readable, f"status {st}"),
         Check("resource READ is recorded in the audit trail", read_audited,
-              "no AuditEvent with action=R references the resource that was "
-              "read (a create event alone does not demonstrate read auditing)"),
+              on_failure="no AuditEvent with action=R references the resource "
+                         "that was read (a create event alone does not "
+                         "demonstrate read auditing)"),
         Check("no raw SSN in the audit trail", _SSN not in blob,
-              "PHI leaked into audit"),
+              on_failure="PHI leaked into audit"),
     ]
     return r
 
@@ -602,15 +661,16 @@ def probe_step_up_enforcement(client, ctx) -> ProbeResult:
                              "Content-Type": "application/fhir+json"},
         _synthetic_patient())
     r.checks.append(Check("write with a forged step-up token is rejected (401)",
-                          status == 401,
-                          f"status {status}; a token that is not the one this "
-                          f"deployment issued authorized a write"))
+                          status == 401, f"status {status}",
+                          on_failure="a token that is not the one this "
+                                     "deployment issued authorized a write"))
 
     pid, status = _create_synthetic(client, ctx)
     r.checks.append(Check("write carrying a valid step-up token is accepted",
                           bool(pid) and status in (200, 201),
-                          f"status {status}; the gate refuses authorized "
-                          f"writes too, so its 401s prove nothing"))
+                          f"status {status}",
+                          on_failure="the gate refuses authorized writes too, "
+                                     "so its 401s prove nothing"))
     return r
 
 
@@ -638,8 +698,9 @@ def probe_human_in_the_loop(client, ctx) -> ProbeResult:
     oid = body.get("id") if isinstance(body, dict) else None
     r.checks.append(Check("confirmed clinical write is accepted",
                           bool(oid) and status in (200, 201),
-                          f"status {status}; the gate blocks confirmed writes "
-                          f"too, so its 428s prove nothing"))
+                          f"status {status}",
+                          on_failure="the gate blocks confirmed writes too, "
+                                     "so its 428s prove nothing"))
     r.note = ("the confirmation header is supplied by the probe: this grades "
               "the gate, not the human attestation behind it (#214)")
     return r
@@ -667,8 +728,9 @@ def probe_tenant_isolation(client, ctx) -> ProbeResult:
     r.checks.append(Check(
         "resource IS readable from its own tenant",
         status == 200 and _is_resource(body, "Patient", pid),
-        f"status {status}; a deployment that returns nothing to anyone passes "
-        f"the isolation check above without isolating anything"))
+        f"status {status}",
+        on_failure="a deployment that returns nothing to anyone passes the "
+                   "isolation check above without isolating anything"))
     return r
 
 
@@ -688,7 +750,7 @@ def probe_medical_disclaimer(client, ctx) -> ProbeResult:
     has = isinstance(body, dict) and (
         "_disclaimer" in body or "disclaimer" in blob.lower())
     r.checks.append(Check("clinical read carries a medical disclaimer", has,
-                          "no disclaimer on the response"))
+                          on_failure="no disclaimer on the response"))
     # Two-sided (#213). The check above is a substring test, so an error page
     # that happens to say "disclaimer" satisfies it, and so does a response
     # that is nothing BUT a disclaimer. The disclaimer has to be attached to
@@ -696,8 +758,9 @@ def probe_medical_disclaimer(client, ctx) -> ProbeResult:
     r.checks.append(Check(
         "the disclaimer accompanies the clinical record, not an error",
         status == 200 and _is_resource(body, "Observation", oid),
-        f"status {status}; the disclaimer was not attached to the Observation "
-        f"that was read"))
+        f"status {status}",
+        on_failure="the disclaimer was not attached to the Observation that "
+                   "was read"))
     r.note = f"Observation/{oid}"
     return r
 

--- a/r6/conformance/routes.py
+++ b/r6/conformance/routes.py
@@ -87,7 +87,13 @@ def register_conformance_routes(blueprint, deps):
             results = [
                 ProbeResult(
                     p["key"], p["property"],
-                    [Check(c["name"], c["passed"], c["detail"]) for c in p["checks"]],
+                    # Rehydrate the two halves, not the derived `detail`.
+                    # Feeding `detail` back in as the measurement would put a
+                    # failure sentence into `observed`, where it prints on a
+                    # pass — the exact bug, reintroduced by the cache path.
+                    [Check(c["name"], c["passed"], c.get("observed", ""),
+                           on_failure=c.get("on_failure", ""))
+                     for c in p["checks"]],
                     note=p.get("note", ""),
                     grade=p.get("grade"),
                     coverage=p.get("coverage", "full"),

--- a/tests/test_conformance_report_never_contradicts_itself.py
+++ b/tests/test_conformance_report_never_contradicts_itself.py
@@ -1,0 +1,240 @@
+"""A passing check must not print a sentence describing a failure.
+
+The scorecard shipped with fifteen checks that read, in JSON:
+
+    {"name": "no raw SSN in the audit trail",
+     "passed": true,
+     "detail": "PHI leaked into audit"}
+
+The checks were right. The report was not. `detail` carried two different
+things in one field — what the probe MEASURED ("status 200") and what a
+failure would MEAN ("PHI leaked into audit") — and the JSON emitted it beside
+`passed` without distinguishing them. The text renderer hid `detail` on a pass,
+which kept that one output honest and left every other consumer to rediscover
+the rule on its own. None did.
+
+Two readers hit it independently and both concluded the deployment was leaking
+PHI. The second was the physician advisor about to record a demo, roughly
+thirty hours before the recording. That is the cost being guarded against here:
+not a wrong grade, a report that reads as the opposite of the truth to the
+person best placed to act on it.
+
+These tests are behavioural — they run the real harness and read what it
+actually emits — because the defect was invisible in the probe logic and
+visible only in the output.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from r6.conformance.probes import Check
+
+#: Words that only make sense about a check that FAILED. If one of these turns
+#: up in a passing check's rendered output, the report is contradicting itself.
+#:
+#: Deliberately drawn from the sentences that actually shipped, not invented:
+#: an aspirational list of "bad words" would drift, and a check that fires on
+#: ordinary phrasing gets switched off.
+_FAILURE_WORDS = (
+    "leaked",
+    "did not",
+    "does not",
+    "no auditevent",
+    "no disclaimer",
+    "prove nothing",
+    "authorized a write",
+    "was not attached",
+    "passes trivially",
+    "without isolating",
+)
+
+
+def _contradictions(text: str) -> list[str]:
+    lowered = text.lower()
+    return [w for w in _FAILURE_WORDS if w in lowered]
+
+
+#: Separates a check's name from its detail in the text scorecard.
+_SEP = " — "
+
+
+def _detail_of(line: str) -> str:
+    """The detail half of a rendered check line, or "" if it has none.
+
+    Scanning the whole line was wrong on the first run: the check named "the
+    upstream display did not survive" states a desired outcome, and "did not"
+    in a NAME is not a contradiction. Only the detail is a claim about how
+    this run went.
+    """
+    _, sep, detail = line.partition(_SEP)
+    return detail if sep else ""
+
+
+# --- the type itself --------------------------------------------------------
+
+def test_the_measurement_is_the_third_positional_argument():
+    """The safe field is the easy one to reach.
+
+    Thirty-odd call sites pass a measurement positionally. Making `observed`
+    third means every one of them is correct without being touched, and a
+    failure explanation has to be named to get in — which is where the
+    author has to think about it.
+
+    MUTATION: swap the order of `observed` and `on_failure` -> red.
+    """
+    c = Check("some check", True, "status 200")
+    assert c.observed == "status 200"
+    assert c.on_failure == ""
+
+
+def test_detail_on_a_passing_check_is_only_the_measurement():
+    """MUTATION: return `on_failure` unconditionally from `detail` -> red."""
+    c = Check("no raw SSN in the audit trail", True,
+              "status 200", on_failure="PHI leaked into audit")
+    assert c.detail == "status 200"
+    assert "leaked" not in c.detail
+
+
+def test_detail_on_a_failing_check_carries_both_halves():
+    """The explanation is the whole reason it exists — it must survive a fail.
+
+    MUTATION: drop `on_failure` from the failing branch of `detail` -> red.
+    """
+    c = Check("no raw SSN in the audit trail", False,
+              "status 200", on_failure="PHI leaked into audit")
+    assert "status 200" in c.detail
+    assert "PHI leaked into audit" in c.detail
+
+
+def test_detail_is_derived_and_cannot_be_set_independently():
+    """One owner. A stored `detail` is a third copy that drifts from two.
+
+    MUTATION: make `detail` a dataclass field again -> red.
+    """
+    with pytest.raises((AttributeError, TypeError)):
+        Check("x", True, "status 200", detail="something else")  # type: ignore[call-arg]
+
+
+# --- what the live harness actually emits -----------------------------------
+
+@pytest.fixture
+def report(client):
+    return client.get("/r6/fhir/$conformance?fresh=1").get_json()
+
+
+def test_the_harness_produced_something_to_check(report):
+    """A pass over an empty scorecard is not a pass.
+
+    The defect this file exists for lived in fifteen checks. A guard that
+    silently examined zero of them would print the same word as one that
+    examined all of them — the failure shape this repo keeps finding.
+    """
+    checks = [c for p in report["properties"] for c in p["checks"]]
+    assert len(checks) >= 30, f"only {len(checks)} checks ran; the harness is not exercising the stack"
+    assert any(c["passed"] for c in checks), "no check passed, so nothing here is being tested"
+
+
+def test_no_passing_check_carries_a_failure_explanation_in_json(report):
+    """The defect, stated as a property of the JSON a consumer reads.
+
+    MUTATION: emit `on_failure` unconditionally in `to_dict` -> red on 15 checks.
+    """
+    offenders = []
+    for prop in report["properties"]:
+        for c in prop["checks"]:
+            if not c["passed"]:
+                continue
+            # The name states what SHOULD be true and may legitimately be
+            # phrased in the negative ("the upstream display did not
+            # survive"). Only the values are claims about this run.
+            values = {k: v for k, v in c.items() if k != "name"}
+            words = _contradictions(json.dumps(values))
+            if words:
+                offenders.append(f"{prop['key']}/{c['name']}: {words} in {values}")
+
+    assert not offenders, (
+        "these checks PASSED while their own payload describes a failure:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_no_passing_check_carries_a_failure_explanation_in_text(client):
+    """The same property of the human scorecard, which is what gets screenshotted."""
+    text = client.get("/r6/fhir/$conformance?format=text").get_data(as_text=True)
+
+    offenders = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("✓"):
+            continue
+        words = _contradictions(_detail_of(stripped))
+        if words:
+            offenders.append(f"{stripped}  ->  {words}")
+
+    assert not offenders, (
+        "these lines mark a check PASSED and then describe a failure:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_the_two_formats_agree_about_every_check(client):
+    """JSON and text are two renderers of one fact, so they must not disagree.
+
+    They did. The text renderer suppressed `detail` on a pass and the JSON did
+    not, so the same run said different things depending on which URL you
+    opened. Whichever rule is right, one rule has to own it — the shape
+    docs/2026-08-02-retro.md describes.
+
+    MUTATION: re-add `and not c.passed` to the text renderer's detail
+    suffix -> red.
+    """
+    body = client.get("/r6/fhir/$conformance").get_json()
+    text = client.get("/r6/fhir/$conformance?format=text").get_data(as_text=True)
+
+    missing = []
+    for prop in body["properties"]:
+        for c in prop["checks"]:
+            if not c["detail"]:
+                continue
+            if c["detail"] not in text:
+                missing.append(f"{prop['key']}/{c['name']}: {c['detail']!r}")
+
+    assert not missing, (
+        "the JSON states a detail the text scorecard does not:\n  "
+        + "\n  ".join(missing))
+
+
+def test_the_failure_explanations_still_exist_where_they_belong():
+    """Suppressing the sentences on a pass must not delete them.
+
+    The cheap way to make every test above green is to remove the
+    explanations entirely, which would cost the report the thing that makes a
+    FAIL actionable. These are the five that mattered most; they are asserted
+    against the probe source so the guard survives a run in which they all
+    pass.
+
+    MUTATION: delete any of these strings from probes.py -> red.
+    """
+    import pathlib
+    import re
+
+    source = pathlib.Path(
+        __file__).resolve().parents[1].joinpath("r6/conformance/probes.py").read_text()
+    # Python joins adjacent string literals, so a sentence long enough to wrap
+    # is stored as `"...asked " \n "for; ..."` and a naive substring search
+    # misses it. Rejoin them first — otherwise this guard would go red on
+    # reflowing a line, which is how a gate that fires on ordinary work gets
+    # switched off.
+    source = re.sub(r'"\s*\n\s*"', "", source)
+
+    for sentence in (
+        "PHI leaked into audit",
+        "no disclaimer on the response",
+        "no AuditEvent with action=R references the resource",
+        "the read did not return the Patient that was asked for",
+        "authorized a write",
+    ):
+        assert sentence in source, (
+            f"the failure explanation {sentence!r} is gone from probes.py — a "
+            f"FAIL now says only what status came back, not what it means")

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -683,7 +683,12 @@ def test_proxy_profile_does_not_echo_malformed_audit_codes():
             return next(responses)
 
     _, checks = _proxy_profile(Client(), ProbeContext("tenant", "token"))
-    assert hostile not in json.dumps([check.detail for check in checks])
+    # Both halves, not the derived `detail`. `detail` returns only `observed`
+    # on a passing check, so scanning it alone would let a hostile token sit
+    # unnoticed in `on_failure` for as long as that check kept passing — and
+    # the leak would surface on the day it started failing.
+    assert hostile not in json.dumps(
+        [[check.observed, check.on_failure] for check in checks])
 
 
 def test_error_fidelity_crash_still_runs_configured_optional_profiles():


### PR DESCRIPTION
## The defect

Fifteen checks in the live scorecard shipped reading, in JSON:

```json
{"name": "no raw SSN in the audit trail",
 "passed": true, "detail": "PHI leaked into audit"}
```

Others included `"passed": true, "detail": "no disclaimer on the response"` and `"passed": true, "detail": "no AuditEvent with action=R references the resource that was read"`.

The checks were right. The report was not.

`Check.detail` carried two different things in one field: what the probe **measured** (`status 200`, `grade A`) and what a failure would **mean** (`PHI leaked into audit`). `render()` suppressed the field on a pass, which kept the text output honest and left every other consumer to rediscover that rule on its own. None did — so the JSON, which is what an agent or a partner script reads, printed the failure sentence next to the PASS flag.

## Why it mattered now

Two readers hit it independently and both concluded the deployment was leaking PHI. The second was Dr. Magan, the physician advisor, roughly thirty hours before a demo recording that would have shown `PASS: PHI leaked into audit` on camera.

I closed #443 as invalid earlier this week on the grounds that the guard logic was correct. It was. That was the wrong place to stop: when the best-informed reader misreads a safety report, the report is the defect. This is the same shape as `docs/2026-08-02-retro.md` — one control quietly doing two things — one layer up, in the output rather than the logic.

## The fix

| field | meaning | on a pass |
|---|---|---|
| `observed` | what was measured | shown — a passing check now states the status it got back |
| `on_failure` | what a failure would mean | withheld by the serialiser |
| `detail` | derived, both halves, true of this run | kept so partner scripts keep working |

`observed` is the **third positional argument** on purpose. The ~30 sites that pass a measurement are correct untouched; a failure explanation has to be named to get in, which is where the author has to think about it.

The two renderers also disagreed about the same report depending on which URL you opened. They now share one rule.

### Before / after

```
- ✓ no raw SSN in the audit trail                     (JSON: detail "PHI leaked into audit")
+ ✓ no raw SSN in the audit trail
- ✓ write with a forged step-up token is rejected     (JSON: "...authorized a write")
+ ✓ write with a forged step-up token is rejected (401) — status 401
```

## Guards

`tests/test_conformance_report_never_contradicts_itself.py` — behavioural, run against the real harness, because the defect was invisible in the probe logic and visible only in the output. All four mutations verified red:

| mutation | result |
|---|---|
| `to_dict` emits `on_failure` on a pass | RED |
| `render` hides detail on a pass again | RED |
| `detail` returns `on_failure` unconditionally | RED |
| `observed`/`on_failure` order swapped | RED |

Plus a guard that the explanations still **exist**, closing the cheap fix (delete them and every other test goes green while a FAIL stops being actionable), and a vacuity check that refuses to pass on an empty scorecard.

The test caught its own false positive on the first run: the check named *"the upstream display did not survive"* states a desired outcome, so the scan now reads details, not names.

Widened the existing hostile-token PHI guard to scan both halves — `detail` returns only `observed` on a pass, so scanning it alone would have let a hostile token sit in `on_failure` until the day that check started failing.

## Verification

- 2827 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean
- Grade A 7/7 unchanged; no probe logic touched, so no grade moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)