### PR TITLE
fix(demo): the tenant stops duplicating itself, and the bot answers what it advertises

### DIFF
--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -27,6 +27,7 @@ STEP_UP_SECRET       HMAC secret for step-up tokens.
 
 import json
 import logging
+import re
 import os
 import time
 from collections import deque
@@ -352,6 +353,13 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # that does nothing leaves the user worse off than saying nothing, because
     # they choose to continue on the strength of it. If summary-only ships,
     # add it back here and to the privacy policy's mitigations list together.
+    #
+    # The SAME rule governs the command list below, and it was broken there:
+    # /summary and /curatr_fix were both listed with no handler registered,
+    # so each answered 'Unknown command. Try /start for the command list.' —
+    # the list that had just offered them. /curatr_fix now has its handler;
+    # /summary is gone, because nothing implements it.
+    # tests/test_bot_answers_what_it_advertises.py holds the two in sync.
     risk_line = (
         '⚠️ Heads up: chat apps aren’t encrypted medical channels. '
         'You’re accessing your own records here; by continuing you accept '
@@ -367,7 +375,6 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         '/hbo\\_connect — authorize Health Bank One (OAuth)\n'
         '/hbo\\_pull — pull + ingest HBO verified records\n'
         '/dashboard — open the command center (signed 24h link)\n'
-        '/summary — high-level review of your record\n'
         '/conditions — list Conditions\n'
         '/labs — recent lab results\n'
         '/curatr — run Curatr data-quality evaluation\n'
@@ -810,6 +817,188 @@ async def cmd_hbo_pull(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     _thr.Thread(target=_run_pull, daemon=True).start()
 
 
+# ---------------------------------------------------------------------------
+# Plain text
+# ---------------------------------------------------------------------------
+
+#: A blood-pressure reading in ordinary phrasing: "150/94", "150 over 94",
+#: "my blood pressure this morning was 150 over 94".
+#:
+#: The separator must be `/` or the word `over`, and both numbers must be
+#: plausible cuff readings. A bare `\d+/\d+` also matches "see you on 10/11"
+#: and "9 over 10", and putting a triage band on a date is worse than not
+#: answering.
+_BP_RE = re.compile(
+    r'\b(?P<sys>[6-9]\d|1\d\d|2[0-5]\d)\s*(?:/|\s+over\s+)\s*'
+    r'(?P<dia>[3-9]\d|1[0-5]\d)\b',
+    re.IGNORECASE,
+)
+
+#: Red-flag symptoms in the words a patient actually types, mapped to the
+#: triage module's keys. classify() treats ANY of these as an emergency
+#: regardless of the number, because they are stroke and heart-attack signs.
+_SYMPTOM_PHRASES = (
+    ('chest_pain', ('chest pain', 'chest pressure', 'chest tightness')),
+    ('shortness_of_breath', ('short of breath', 'shortness of breath',
+                             'can\'t breathe', 'trouble breathing')),
+    ('one_sided_weakness', ('one side', 'weakness on', 'face droop',
+                            'arm is weak', 'numb on one')),
+    ('trouble_speaking', ('slurred', 'trouble speaking', 'can\'t speak')),
+    ('vision_change', ('vision change', 'blurred vision', 'lost vision',
+                       'double vision')),
+    ('severe_headache', ('worst headache', 'severe headache',
+                         'terrible headache')),
+    ('confusion', ('confused', 'confusion', 'disoriented')),
+)
+
+
+def _parse_bp(text: str):
+    """Return (systolic, diastolic) from ordinary phrasing, or None.
+
+    None means "this is not a reading", not "this failed" — the caller still
+    answers. Returning None for anything unclear is deliberate: a wrong parse
+    attaches a clinical triage band to a sentence that was never a
+    measurement.
+    """
+    if not text:
+        return None
+    m = _BP_RE.search(text)
+    if not m:
+        return None
+    systolic, diastolic = int(m.group('sys')), int(m.group('dia'))
+    if systolic <= diastolic:
+        return None
+    return systolic, diastolic
+
+
+def _symptoms_in(text: str) -> list:
+    lowered = (text or '').lower()
+    return [key for key, phrases in _SYMPTOM_PHRASES
+            if any(p in lowered for p in phrases)]
+
+
+async def on_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Answer a plain sentence.
+
+    Before this existed, main() registered a single MessageHandler on
+    filters.COMMAND, so typed text reached nothing and the user got silence.
+    The physician advisor hit it rehearsing the launch demo and read it,
+    reasonably, as a phrasing problem — silence cannot tell you which.
+
+    A recognised reading is classified SERVER-SIDE by r6/smbp/triage.py, the
+    shared 2025 AHA/ACC decision logic the clinician report and the flags also
+    use. This container ships only bot.py (see openclaw/Dockerfile), so the
+    thresholds are not importable here — and copying them in is precisely the
+    drift that module exists to prevent. If the server cannot be reached, this
+    says so and stops. It never guesses a band: a made-up "you are fine" is
+    the one output worse than an error.
+    """
+    text = (update.effective_message.text if update and update.effective_message
+            else '') or ''
+    agent_id = 'health-advisor'
+    _persist_turn(update, agent_id, 'user', text)
+
+    reading = _parse_bp(text)
+    if reading is None:
+        await _reply(
+            update,
+            'I can log a blood-pressure reading if you send one — for '
+            'example "150 over 94" or "150/94". For anything else, /start '
+            'lists what I can do.',
+            agent_id,
+        )
+        return
+
+    systolic, diastolic = reading
+    symptoms = _symptoms_in(text)
+
+    try:
+        triage = _smbp_reading(systolic, diastolic, symptoms)
+    except Exception as exc:
+        logger.error('smbp reading failed: %s', exc)
+        await _reply(
+            update,
+            f'I read that as *{systolic}/{diastolic}* but could not reach the '
+            'service that classifies it, so I have not logged it and I will '
+            'not guess. Please try again shortly.',
+            agent_id, parse_mode='Markdown')
+        return
+
+    lines = [f'Recorded: *{systolic}/{diastolic}* mmHg.']
+    if triage.get('emergency'):
+        lines.append(
+            '\U0001F6A8 You mentioned a symptom that needs emergency care now. '
+            '*Call 911.* Do not wait for another reading.')
+    else:
+        lines.append(_BAND_LINES.get(
+            triage.get('band'),
+            'Logged. Your care team will see this in the report.'))
+    lines.append('_This logs and routes; it is not medical advice or a '
+                 'diagnosis._')
+
+    await _reply(update, '\n\n'.join(lines), agent_id, parse_mode='Markdown')
+
+
+def _smbp_reading(systolic: int, diastolic: int, symptoms: list) -> dict:
+    """POST the reading to /r6/smbp/reading and return its triage block.
+
+    The server owns classification, persistence and the audit event. Raises on
+    any failure so the caller can say nothing rather than something wrong.
+    """
+    patient_ref = _first_patient_ref()
+    resp = requests.post(
+        f'{FHIR_BASE_URL.replace("/r6/fhir", "")}/r6/smbp/reading',
+        json={
+            'patient_ref': patient_ref,
+            'systolic': systolic,
+            'diastolic': diastolic,
+            'effective': _now_iso(),
+            'symptoms': symptoms,
+        },
+        headers={
+            'X-Tenant-Id': TENANT_ID,
+            'X-Step-Up-Token': _get_step_up_token(),
+            'X-Agent-Id': 'health-advisor',
+        },
+        timeout=15,
+    )
+    resp.raise_for_status()
+    triage = (resp.json() or {}).get('triage')
+    if not isinstance(triage, dict) or 'band' not in triage:
+        raise RuntimeError('smbp response carried no triage band')
+    return triage
+
+
+def _now_iso() -> str:
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+
+
+def _first_patient_ref() -> str:
+    """The tenant's Patient, as `Patient/<id>`."""
+    bundle = _fhir_get('Patient?_count=1')
+    entries = bundle.get('entry') or []
+    if not entries:
+        raise RuntimeError('no Patient in this tenant to attach the reading to')
+    return f"Patient/{(entries[0].get('resource') or {}).get('id')}"
+
+
+#: One line per triage band. Navigation only — what happens next, never what
+#: the reading means clinically. The bands themselves are owned by
+#: r6/smbp/triage.py and must not be re-derived here.
+_BAND_LINES = {
+    'at_goal': 'That is within the home target range (under 130/80). '
+               'Keep logging.',
+    'stage1': 'That is Stage 1 (130–139 / 80–89). Worth logging and raising '
+              'at your next visit.',
+    'stage2': 'That is Stage 2 (140 or above / 90 or above). This is a '
+              'timely follow-up with your care team, not the emergency '
+              'department.',
+    'crisis': 'That is in the crisis range (180 or above / 120 or above). '
+              'Rest five minutes and take it again. If it stays this high, '
+              'contact your care team today.',
+}
+
+
 async def unknown_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     agent_id = 'health-advisor'
     if update and update.effective_message:
@@ -835,12 +1024,18 @@ def main() -> None:
     app.add_handler(CommandHandler('conditions', cmd_conditions))
     app.add_handler(CommandHandler('labs', cmd_labs))
     app.add_handler(CommandHandler('curatr', cmd_curatr))
+    # Advertised on /start since it shipped; never registered until now.
+    app.add_handler(CommandHandler('curatr_fix', _curatr_fix))
     app.add_handler(CommandHandler('approve', cmd_approve))
     app.add_handler(CommandHandler('token', cmd_token))
     app.add_handler(CommandHandler('dashboard', cmd_dashboard))
     app.add_handler(CommandHandler('hbo_connect', cmd_hbo_connect))
     app.add_handler(CommandHandler('hbo_pull', cmd_hbo_pull))
     app.add_handler(MessageHandler(filters.COMMAND, unknown_command))
+    # Plain text, registered LAST so it cannot shadow a command. Without this
+    # the bot answered nothing at all to a typed sentence (see
+    # tests/test_bot_answers_what_it_advertises.py).
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))
     app.add_error_handler(_on_error)
 
     _preflight_singleton_check()

--- a/r6/seed.py
+++ b/r6/seed.py
@@ -20,6 +20,14 @@ logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Built-in demo resources: Patient + Condition (ICD-9) + 3 Obs + MedRequest
+#
+# EVERY resource here carries a fixed `id`, and that is load-bearing rather
+# than tidy. railway.toml runs `seed-demo --tenant-id desktop-demo` before
+# every deploy. A resource without an id takes a generated UUID, so it was
+# inserted again on each of those deploys: production reached 19 Patients and
+# 12 diabetes Conditions against a seed set of one and one. Adding a resource
+# here without an id silently restores that, for that resource alone.
+# tests/test_demo_tenant_stays_one_patient.py holds the line.
 # ---------------------------------------------------------------------------
 
 def _built_in_resources() -> list[dict]:
@@ -28,6 +36,7 @@ def _built_in_resources() -> list[dict]:
     return [
         {
             "resourceType": "Patient",
+            "id": "demo-patient-rivera",
             "name": [{"use": "official", "family": "Rivera", "given": ["Maria", "Elena"]}],
             "birthDate": "1985-03-15",
             "gender": "female",
@@ -37,6 +46,7 @@ def _built_in_resources() -> list[dict]:
         },
         {
             "resourceType": "Condition",
+            "id": "demo-condition-dm2",
             "clinicalStatus": {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active"}]},
             "verificationStatus": {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/condition-ver-status", "code": "confirmed"}]},
             "code": {"coding": [{"system": "http://hl7.org/fhir/sid/icd-9-cm", "code": "250.00", "display": "Diabetes mellitus without mention of complication"}]},
@@ -44,6 +54,7 @@ def _built_in_resources() -> list[dict]:
         },
         {
             "resourceType": "Observation",
+            "id": "demo-obs-glucose",
             "status": "final",
             "code": {"coding": [{"system": "http://loinc.org", "code": "2339-0", "display": "Glucose [Mass/volume] in Blood"}]},
             "subject": {"reference": "Patient/__PATIENT_ID__"},
@@ -52,6 +63,7 @@ def _built_in_resources() -> list[dict]:
         },
         {
             "resourceType": "Observation",
+            "id": "demo-obs-a1c",
             "status": "final",
             "code": {"coding": [{"system": "http://loinc.org", "code": "4548-4", "display": "Hemoglobin A1c/Hemoglobin.total in Blood"}]},
             "subject": {"reference": "Patient/__PATIENT_ID__"},
@@ -60,6 +72,7 @@ def _built_in_resources() -> list[dict]:
         },
         {
             "resourceType": "Observation",
+            "id": "demo-obs-bp",
             "status": "final",
             "code": {"coding": [{"system": "http://loinc.org", "code": "55284-4", "display": "Blood pressure systolic and diastolic"}]},
             "subject": {"reference": "Patient/__PATIENT_ID__"},
@@ -71,6 +84,7 @@ def _built_in_resources() -> list[dict]:
         },
         {
             "resourceType": "MedicationRequest",
+            "id": "demo-medreq-metformin",
             "status": "active",
             "intent": "order",
             "subject": {"reference": "Patient/__PATIENT_ID__"},
@@ -100,6 +114,7 @@ def seed_demo_data(tenant_id: str = 'desktop-demo', resources: list[dict] | None
 
     patient_id = None
     created = 0
+    skipped = 0
 
     for resource in resources:
         rtype = resource.get('resourceType')
@@ -110,14 +125,38 @@ def seed_demo_data(tenant_id: str = 'desktop-demo', resources: list[dict] | None
         if patient_id and rtype != 'Patient':
             resource_str = resource_str.replace('__PATIENT_ID__', patient_id)
 
+        # Skip what is already seeded, rather than inserting and catching the
+        # primary-key collision below. The collision path logged a warning and
+        # carried on, which is indistinguishable in a deploy log from a seed
+        # that had nothing to do — so the one resource that DID have a stable
+        # id failed quietly on every deploy while the six without ids
+        # duplicated loudly in the UI and nowhere else.
+        rid = resource.get('id')
+        # `is_deleted=False` is load-bearing, not defensive. A soft-deleted
+        # row is a tombstone: if the demo patient has been purged, this must
+        # seed a live one rather than see the tombstone, decide the tenant is
+        # already seeded, and leave the demo empty. That is #422's shape
+        # (soft-deleted rows counted as present) in a second place, and
+        # tests/test_ratchets.py caught it here before it shipped.
+        existing = (R6Resource.query
+                    .filter_by(tenant_id=tenant_id, resource_type=rtype,
+                               id=rid, is_deleted=False)
+                    .first()) if rid else None
+        if existing is not None:
+            # Resolve the placeholder against the patient already on file, or
+            # every later resource in this pass points at nothing.
+            if rtype == 'Patient':
+                patient_id = str(existing.id)
+            skipped += 1
+            continue
+
         try:
             r = R6Resource(
                 resource_type=rtype,
                 resource_json=resource_str,
                 # Preserve the FHIR logical id as the PK so consumers can resolve
                 # the resource by it (e.g. GET /Questionnaire/healthclaw-intake).
-                # Resources without an `id` fall back to a generated UUID.
-                resource_id=resource.get('id'),
+                resource_id=rid,
                 tenant_id=tenant_id,
             )
             db.session.add(r)
@@ -143,11 +182,15 @@ def seed_demo_data(tenant_id: str = 'desktop-demo', resources: list[dict] | None
             logger.error("Seed aborted: audit trail unavailable for %s", rtype)
             raise
         except Exception as e:
-            # A fixed-id resource re-seeded onto an existing PK raises here.
-            # Roll back the failed insert so it can't poison the final commit;
-            # prior resources are already durable (record_audit_event commits).
+            # Already-seeded resources no longer reach this branch, so anything
+            # landing here is unexpected. Roll back the failed insert so it
+            # can't poison the final commit; prior resources are already
+            # durable (record_audit_event commits).
             db.session.rollback()
             logger.warning("Seed failed for %s: %s", rtype, e)
 
     db.session.commit()
+    if skipped:
+        logger.info("Seed complete for %s: %d created, %d already present",
+                    tenant_id, created, skipped)
     return created

--- a/tests/test_bot_answers_what_it_advertises.py
+++ b/tests/test_bot_answers_what_it_advertises.py
@@ -1,0 +1,243 @@
+"""The bot must answer every command it lists, and answer a plain sentence.
+
+Two findings from the physician advisor's dry run before the launch recording,
+both of which read as "the product is broken" on camera:
+
+  1. "The conversational BP flow seems not to answer. I sent 'my blood
+     pressure this morning was 150 over 94' and got no reply, so I suspect it
+     wants different phrasing or something isn't wired on this tenant."
+
+     It was not phrasing. `main()` registered exactly one MessageHandler, on
+     `filters.COMMAND`. Nothing was listening for text, so a sentence typed at
+     the bot reached no handler and produced silence — the failure mode that
+     looks identical to a hung backend.
+
+  2. "/start" advertises twelve commands. Two of them, /summary and
+     /curatr_fix, had no handler at all and fell through to "Unknown command.
+     Try /start for the command list." — which is the list that had just
+     offered them.
+
+The triage this file exercises is r6/smbp/triage.py, which already existed and
+is the advisor's own 2025 AHA/ACC spec. Nothing here invents clinical logic;
+the bug was that no wire ran from a typed sentence to that module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'test-token-for-advertised-commands')
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "openclaw"))
+
+import bot  # noqa: E402
+
+BOT_SOURCE = (Path(__file__).parent.parent / "openclaw" / "bot.py").read_text()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _update(text: str):
+    """A minimal Update carrying a text message."""
+    return SimpleNamespace(
+        effective_message=SimpleNamespace(text=text),
+        effective_chat=SimpleNamespace(id=4242),
+        effective_user=SimpleNamespace(username="advisor", id=99),
+        message=SimpleNamespace(text=text),
+    )
+
+
+# --- every advertised command has a handler --------------------------------
+
+def _advertised() -> set[str]:
+    return {c.replace("\\", "")
+            for c in re.findall(r"'(/[a-z_\\]+) —", BOT_SOURCE)}
+
+
+def _registered() -> set[str]:
+    return {f"/{m}" for m in re.findall(r"CommandHandler\('([a-z_]+)'", BOT_SOURCE)}
+
+
+def test_the_start_menu_is_not_empty():
+    """A menu that lists nothing would satisfy the check below trivially."""
+    assert len(_advertised()) >= 8, f"/start lists only {_advertised()}"
+
+
+def test_every_command_on_the_start_menu_has_a_handler():
+    """MUTATION: delete the /summary CommandHandler -> red.
+
+    The advisor films /start first. A command list that answers "Unknown
+    command" for its own entries is the worst possible opening frame.
+    """
+    dead = _advertised() - _registered()
+    assert not dead, (
+        f"/start advertises commands with no handler: {sorted(dead)}. "
+        f"Each one answers 'Unknown command. Try /start for the command "
+        f"list.' — which is the list that just offered it.")
+
+
+# --- a plain sentence gets an answer ---------------------------------------
+
+def test_a_text_handler_is_registered_at_all():
+    """MUTATION: drop the TEXT MessageHandler from main() -> red.
+
+    This is the defect itself: the only MessageHandler filtered on COMMAND,
+    so typed text reached nothing.
+    """
+    assert re.search(r"MessageHandler\(\s*filters\.TEXT", BOT_SOURCE), (
+        "no MessageHandler for plain text — a sentence typed at the bot "
+        "produces silence, which is indistinguishable from a hung backend")
+
+
+@pytest.mark.parametrize("text,systolic,diastolic", [
+    ("my blood pressure this morning was 150 over 94", 150, 94),
+    ("BP 150/94", 150, 94),
+    ("150 over 94", 150, 94),
+    ("my bp was 128/78 today", 128, 78),
+    ("blood pressure 182 over 121", 182, 121),
+])
+def test_a_reading_is_parsed_out_of_ordinary_phrasing(text, systolic, diastolic):
+    """The advisor's exact sentence is the first case.
+
+    MUTATION: drop the 'over' alternative from the pattern -> red.
+    """
+    assert bot._parse_bp(text) == (systolic, diastolic)
+
+
+@pytest.mark.parametrize("text", [
+    "hello",
+    "what are my labs?",
+    "thanks!",
+    "",
+    # Not a BP: a date, a ratio, a score. Reading these as a BP would put a
+    # triage band on something that is not a measurement.
+    "see you on 10/11",
+    "I rate it 9 over 10",
+])
+def test_text_that_is_not_a_reading_is_not_parsed_as_one(text):
+    """MUTATION: widen the pattern to bare `\\d+/\\d+` -> red on the date."""
+    assert bot._parse_bp(text) is None
+
+
+def _say(text, triage=None, fail=False):
+    """Drive on_text with the server call stubbed; return what was replied."""
+    sent = []
+    ctx = patch.object(bot, '_smbp_reading', side_effect=RuntimeError("down")) \
+        if fail else patch.object(bot, '_smbp_reading', return_value=triage)
+    with patch.object(bot, '_reply', side_effect=lambda u, t, a, **k: sent.append(t)), \
+         patch.object(bot, '_persist_turn'), ctx:
+        _run(bot.on_text(_update(text), None))
+    return sent
+
+
+def test_the_band_comes_from_the_server_not_from_this_container():
+    """openclaw/Dockerfile copies only bot.py, so r6.smbp.triage is not
+    importable here. Re-deriving the 2025 thresholds in the bot is exactly the
+    drift that module exists to prevent, so the reply must be built from what
+    the server returned.
+
+    MUTATION: compute the band locally from the numbers -> red.
+    """
+    sent = _say("bp 150/94", {"band": "at_goal", "emergency": False})
+    body = " ".join(sent).lower()
+    assert "target range" in body, (
+        f"the reply ignored the server's band and decided for itself: {sent}")
+
+
+def test_a_stage_two_reading_is_answered_with_the_triage_band():
+    """The advisor's exact sentence, answered."""
+    sent = _say("my blood pressure this morning was 150 over 94",
+                {"band": "stage2", "emergency": False})
+    assert sent, "the advisor's sentence still produces no reply"
+    body = " ".join(sent).lower()
+    assert "150" in body and "94" in body, f"the reading is not echoed back: {sent}"
+    assert "stage 2" in body, f"150/94 is Stage 2 under the 2025 line: {sent}"
+
+
+def test_an_unreachable_server_is_reported_not_guessed():
+    """The one output worse than an error is an invented reassurance.
+
+    MUTATION: fall back to a locally computed band on failure -> red.
+    """
+    sent = _say("bp 150/94", fail=True)
+    body = " ".join(sent).lower()
+    assert sent, "a failed classification produced silence"
+    assert "not logged" in body or "could not reach" in body, (
+        f"the failure was not reported: {sent}")
+    for band_word in ("stage 1", "stage 2", "target range", "crisis"):
+        assert band_word not in body, (
+            f"a band was stated despite the classifier being unreachable: {sent}")
+
+
+def test_a_red_flag_symptom_routes_to_emergency_regardless_of_the_number():
+    """The one case where being wrong is dangerous, so it is pinned.
+
+    triage.classify evaluates symptoms FIRST and independently: a red-flag
+    symptom is 911 even at a normal reading. A handler that checked the number
+    first would reassure a symptomatic patient.
+
+    MUTATION: pass symptoms=None from on_text -> red (see the companion
+    assertion on _symptoms_in below).
+    """
+    sent = _say("bp 118/76 and I have chest pain",
+                {"band": "at_goal", "emergency": True})
+    body = " ".join(sent).lower()
+    assert "911" in body, (
+        f"a red-flag symptom at a normal reading must route to 911, not "
+        f"reassurance: {sent}")
+
+
+def test_text_that_is_not_a_reading_gets_a_reply_rather_than_silence():
+    """Silence is the bug. Anything the bot cannot parse still gets an answer.
+
+    MUTATION: return early without replying when _parse_bp is None -> red.
+    """
+    sent = _say("what are my labs?")
+    assert sent, "unparsed text produces no reply at all — the original defect"
+
+
+def test_the_bot_does_not_hand_out_clinical_advice():
+    """triage.py is 'administrative logic only'; the wire must not add advice.
+
+    The reply may state a band and a next step. It must not tell the patient
+    what to take or what they have.
+
+    MUTATION: add 'you should take' copy to the reply -> red.
+    """
+    sent = _say("bp 150/94", {"band": "stage2", "emergency": False})
+    # Scan everything EXCEPT the disclaimer. The disclaimer says "not medical
+    # advice or a diagnosis", so a stem match on "diagnos" flags the one line
+    # whose whole job is to deny what the guard is looking for.
+    body = " ".join(
+        line for line in " ".join(sent).splitlines()
+        if "not medical advice" not in line.lower()).lower()
+    for phrase in ("you should take", "you have hypertension", "diagnos",
+                   "prescrib", "mg of", "start taking"):
+        assert phrase not in body, (
+            f"the reply gives clinical advice ({phrase!r}); this surface is a "
+            f"navigator, not a clinician: {sent}")
+
+
+def test_the_symptoms_are_extracted_and_handed_to_the_classifier():
+    """The symptom axis only works if the words reach the server.
+
+    MUTATION: call _smbp_reading with symptoms=[] -> red.
+    """
+    with patch.object(bot, '_smbp_reading',
+                      return_value={"band": "at_goal", "emergency": True}) as call, \
+         patch.object(bot, '_reply'), patch.object(bot, '_persist_turn'):
+        _run(bot.on_text(_update("bp 118/76 and I have chest pain"), None))
+
+    assert call.call_args is not None, "_smbp_reading was never called"
+    assert "chest_pain" in call.call_args.args[2], (
+        f"the endorsed symptom never reached the classifier: {call.call_args}")

--- a/tests/test_demo_tenant_stays_one_patient.py
+++ b/tests/test_demo_tenant_stays_one_patient.py
@@ -1,0 +1,142 @@
+"""Re-seeding the demo tenant must not create a second synthetic patient.
+
+`railway.toml` runs `seed-demo --tenant-id desktop-demo` as a pre-deploy
+command on EVERY deploy, and its own comment calls that seeding "idempotent".
+It was not. Six of the seven built-in resources carry no fixed `id`, so each
+one took a fresh UUID and was inserted again: one more Maria Rivera, one more
+diabetes Condition, one more A1c, one more metformin order, per deploy.
+
+By 2026-08-10 the production demo tenant held 19 Patients, 12 Conditions, 40
+Observations and 11 MedicationRequests, against a seed set of one, one, three
+and one. The physician advisor preparing the launch demo found it from the
+outside — "/conditions shows about a dozen duplicate Type 2 diabetes mellitus
+entries and the labs repeat too, so it seems the tenant may have been seeded
+more than once" — which is exactly what had happened, about a dozen times.
+
+The failure was silent because the only resource that DID carry a fixed id
+collided on the primary key, and that collision was caught and logged as a
+warning. The one resource that would have shouted was the one being handled
+quietly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from models import db
+from r6.models import R6Resource
+from r6.seed import _built_in_resources, seed_demo_data
+
+_TENANT = "reseed-guard-tenant"
+
+
+def _counts(tenant: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for row in R6Resource.query.filter_by(tenant_id=tenant).all():
+        out[row.resource_type] = out.get(row.resource_type, 0) + 1
+    return out
+
+
+@pytest.fixture
+def seeded(app):
+    with app.app_context():
+        R6Resource.query.filter_by(tenant_id=_TENANT).delete()
+        db.session.commit()
+        yield
+        R6Resource.query.filter_by(tenant_id=_TENANT).delete()
+        db.session.commit()
+
+
+def test_the_seed_set_is_not_empty():
+    """A re-seed guard that seeds nothing would pass every assertion below."""
+    resources = _built_in_resources()
+    assert len(resources) >= 6, f"only {len(resources)} built-in resources"
+    assert any(r.get("resourceType") == "Patient" for r in resources)
+
+
+def test_seeding_twice_leaves_one_patient(app, seeded):
+    """MUTATION: drop the fixed ids from _built_in_resources -> red.
+
+    This is the defect exactly: run the pre-deploy command twice, get two
+    patients.
+    """
+    with app.app_context():
+        seed_demo_data(tenant_id=_TENANT)
+        first = _counts(_TENANT)
+        seed_demo_data(tenant_id=_TENANT)
+        second = _counts(_TENANT)
+
+    assert first == second, (
+        f"re-seeding changed the tenant.\n  after one seed:  {first}\n"
+        f"  after two seeds: {second}\n"
+        f"Every deploy runs this command, so a difference here is a duplicate "
+        f"per deploy on the tenant the launch demo is recorded against.")
+    assert second.get("Patient") == 1, (
+        f"the demo tenant holds {second.get('Patient')} Patients; the demo "
+        f"narrates one person")
+
+
+def test_seeding_ten_times_still_leaves_one_patient(app, seeded):
+    """Production reached 19 Patients, not 2. One repeat would not have caught it late."""
+    with app.app_context():
+        for _ in range(10):
+            seed_demo_data(tenant_id=_TENANT)
+        counts = _counts(_TENANT)
+
+    assert counts.get("Patient") == 1, f"10 seeds produced {counts}"
+    assert counts.get("Condition") == 1, (
+        f"10 seeds produced {counts.get('Condition')} Conditions — this is the "
+        f"'about a dozen duplicate Type 2 diabetes mellitus entries' the "
+        f"advisor saw on camera")
+
+
+def test_every_seeded_resource_carries_a_stable_id():
+    """The mechanism, pinned so it cannot regress by omission.
+
+    A resource without an `id` gets a generated UUID, which is what made
+    re-seeding additive. Adding a new demo resource without an id would
+    silently restore the bug for that resource alone.
+
+    MUTATION: delete the `id` from any built-in resource -> red.
+    """
+    missing = [r.get("resourceType") for r in _built_in_resources()
+               if not r.get("id")]
+    assert not missing, (
+        f"these seeded resources have no fixed id, so each deploy inserts "
+        f"another copy: {missing}")
+
+
+def test_reseeding_does_not_orphan_the_clinical_references(app, seeded):
+    """The subject references must still point at the patient that exists.
+
+    A dedupe that keeps the first Patient but re-points nothing would leave
+    Conditions referencing a row that is no longer there, which reads on
+    camera as an empty record rather than a duplicated one.
+
+    MUTATION: give the Patient a stable id but leave __PATIENT_ID__
+    unresolved -> red.
+    """
+    import json
+
+    with app.app_context():
+        seed_demo_data(tenant_id=_TENANT)
+        seed_demo_data(tenant_id=_TENANT)
+
+        patients = R6Resource.query.filter_by(
+            tenant_id=_TENANT, resource_type="Patient").all()
+        assert len(patients) == 1
+        pid = str(patients[0].id)
+
+        dangling = []
+        for row in R6Resource.query.filter_by(tenant_id=_TENANT).all():
+            if row.resource_type == "Patient":
+                continue
+            blob = row.resource_json or ""
+            if "__PATIENT_ID__" in blob:
+                dangling.append(f"{row.resource_type}/{row.id}: placeholder unresolved")
+                continue
+            subject = (json.loads(blob).get("subject") or {}).get("reference")
+            if subject and subject != f"Patient/{pid}":
+                dangling.append(f"{row.resource_type}/{row.id}: subject {subject}")
+
+    assert not dangling, "clinical resources point at a patient that is not there:\n  " + "\n  ".join(dangling)

--- a/tests/test_seed_demo.py
+++ b/tests/test_seed_demo.py
@@ -25,16 +25,26 @@ def test_seeded_questionnaire_resolves_by_logical_id(app):
         assert q.to_fhir_json()["id"] == "healthclaw-intake"
 
 
-def test_seeded_patient_still_gets_generated_id(app):
-    # Resources without an explicit `id` (Patient, Condition, ...) keep a
-    # generated UUID PK — the fix must not force ids onto id-less resources.
+def test_seeded_patient_now_has_a_stable_id(app):
+    # MOVED PIN. This asserted the OPPOSITE until 2026-08-10: that the Patient
+    # kept a generated UUID because "the fix must not force ids onto id-less
+    # resources". That was right about the mechanism and wrong about the
+    # demo tenant, and the pin is what made the consequence invisible.
+    #
+    # railway.toml re-seeds desktop-demo before every deploy. A generated id
+    # means a NEW patient each time: production reached 19 Patients, 12
+    # duplicate diabetes Conditions and 40 Observations before the physician
+    # advisor found it while rehearsing the launch demo. The stable id is now
+    # the thing being protected.
+    #
+    # A resource genuinely without an `id` still gets a UUID; that path is
+    # unchanged and covered by the custom-resources test below.
     with app.app_context():
         seed_demo_data("t-seed-2")
         patients = R6Resource.query.filter_by(
             resource_type="Patient", tenant_id="t-seed-2").all()
         assert len(patients) == 1
-        assert patients[0].id != "healthclaw-intake"
-        assert len(patients[0].id) >= 32  # uuid4 hex-ish
+        assert patients[0].id == "demo-patient-rivera"
 
 
 def test_reseed_is_idempotent_for_fixed_id_resources(app):


### PR DESCRIPTION
Three findings from Dr. Magan's dry run before the launch recording. All three read on camera as "the product is broken."

## 1. The demo tenant duplicates itself on every deploy

> "/conditions shows about a dozen duplicate Type 2 diabetes mellitus entries and the labs repeat too, so it seems the tenant may have been seeded more than once."

It had — about a dozen times. `railway.toml` runs `seed-demo --tenant-id desktop-demo` as a pre-deploy command on **every deploy**, and its own comment calls that seeding "idempotent". It was not: six of the seven built-in resources carried no fixed `id`, so each took a fresh UUID and was inserted again.

Production right now:

| resource | in the tenant | in the seed set |
|---|---:|---:|
| Patient | **19** | 1 |
| Condition | **12** | 1 |
| Observation | **40** | 3 |
| MedicationRequest | **11** | 1 |

Every deploy added a whole new synthetic patient with their own diabetes, labs and metformin order.

The failure was silent in a specific way worth naming: the one resource that *did* carry a stable id (`healthclaw-intake`) collided on the primary key every single deploy and was swallowed as a `logger.warning`. The component that could have shouted was the one being handled quietly; the six that duplicated did it somewhere only a human reading the UI would ever look. A physician advisor found it from the outside.

**Fix:** every seeded resource carries a stable id, and the seed skips what is already present rather than inserting and catching the collision.

## 2. A typed sentence got no reply at all

> "The conversational BP flow seems not to answer. I sent 'my blood pressure this morning was 150 over 94' and got no reply, so I suspect it wants different phrasing or something isn't wired on this tenant."

Not phrasing. `main()` registered exactly one `MessageHandler`, on `filters.COMMAND`. Nothing was listening for text, so the message reached no handler and produced silence — indistinguishable from a hung backend, which is exactly why she could not tell which it was.

Plain text now routes to `on_text`. A recognised reading is classified **server-side** by `r6/smbp/triage.py`, the shared 2025 AHA/ACC logic the clinician report and flags already use. `openclaw/Dockerfile` ships only `bot.py`, so those thresholds are not importable in that container — and copying them in is precisely the drift that module exists to prevent.

Two behaviours pinned because getting them wrong is dangerous rather than merely broken:

- **Unreachable classifier means say so, never guess.** An invented "you are fine" is the one output worse than an error.
- **Red-flag symptom means 911 regardless of the number.** `classify()` evaluates symptoms first and independently; a handler that checked the number first would reassure a symptomatic patient at 118/76.

The parser refuses `see you on 10/11` and `I rate it 9 over 10`. Putting a triage band on a date is worse than not answering.

## 3. /start advertised two commands that did not exist

`/summary` and `/curatr_fix` were both on the menu with no handler, so each answered *"Unknown command. Try /start for the command list."* — the list that had just offered them. `/start` is the first thing the recording shows.

`/curatr_fix` now has its handler (the function existed, reachable only as `/curatr fix`). `/summary` is removed, because nothing implements it. `cmd_start` already carried a comment saying this text must promise only controls that exist; the rule was being applied to the risk banner and not to the command list three lines below it.

## Two things the suite caught in this change

- **`test_ratchets.py` flagged my own existence check as soft-delete-blind.** A tombstoned demo patient would have read as "already seeded" and left the tenant empty — #422's shape in a second place. Now filters `is_deleted=False`.
- **`test_seed_demo.py` pinned the opposite behaviour** ("the Patient keeps a generated UUID"). Moved in this PR per the repo rule, with the reason recorded: the pin was right about the mechanism and was what kept the consequence invisible.

## Verification

- 2844 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean
- Guards mutation-tested: drop the fixed ids, drop the TEXT handler, compute the band locally, swallow the failure — each goes red

## Not fixed here

Filed separately: `/curatr` evaluates a single Observation so it cannot see the duplicates; the `/start` banner's "your own records" on a shared public tenant; the validator reporting "validation passed" after checking two fields.

**Production still holds the 19 patients** — this stops the bleeding, it does not clean up. That needs a separate, authorized purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
