### PR TITLE
fix(seed): the response note kept promising what the docstring had stopped promising

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -2316,7 +2316,8 @@ def seed_tenant():
         'tenant_id': tenant_id,
         'created_count': count,
         'step_up_token': token,
-        'note': 'Use step_up_token for write operations. Re-seed anytime to add more resources.'
+        'note': ('Use step_up_token for write operations. Re-seeding the built-in '
+                 'set is a no-op; supply a bundle to add resources.')
     }), 201
 
 

--- a/tests/test_seed_endpoint_is_idempotent.py
+++ b/tests/test_seed_endpoint_is_idempotent.py
@@ -121,14 +121,28 @@ def test_no_surface_still_claims_ids_are_generated_fresh_each_call():
 
     MUTATION: restore "IDs are generated fresh each call" anywhere -> red.
     """
+    # Every phrasing that promises appending, not just the one the docstring
+    # used. The first version of this guard checked only "generated fresh
+    # each call" and so missed the endpoint's own RESPONSE note, which went
+    # on telling live callers "Re-seed anytime to add more resources" after
+    # the docstring four lines above it had been corrected.
+    #
+    # A guard aimed at one sentence protects that sentence, not the claim.
+    STALE = (
+        "generated fresh each call",
+        "add more resources",
+        "appends new resources",
+    )
     root = Path(__file__).resolve().parents[1]
     offenders = []
     for path in list(root.glob("r6/**/*.py")) + [root / "railway.toml"]:
         text = path.read_text(encoding="utf-8", errors="replace")
         # Rejoin adjacent string literals so a reflowed line does not hide it.
         joined = re.sub(r'"\s*\n\s*"', "", text)
-        if "generated fresh each call" in joined:
-            offenders.append(str(path.relative_to(root)))
+        joined = re.sub(r"'\s*\n\s*'", "", joined)
+        for phrase in STALE:
+            if phrase in joined:
+                offenders.append(f"{path.relative_to(root)}: {phrase!r}")
 
     assert not offenders, (
         f"these files still describe the pre-#457 behaviour: {offenders}. "


### PR DESCRIPTION
#464 corrected the seed endpoint's docstring. Four lines below it, the JSON the endpoint actually **returns** still said:

```json
"note": "Use step_up_token for write operations. Re-seed anytime to add more resources."
```

So every live caller kept being told the old behaviour while the source comment above them told the truth. The docstring is read by developers; the note is read by the API. Fixing one and not the other moved the wrong claim rather than removing it.

## The guard is why this shipped

My check in #464 searched for the exact string `generated fresh each call` and nothing else. It went green while the endpoint's own response contradicted the docstring it was guarding.

That is the same mistake one level up: **a guard aimed at one sentence protects that sentence, not the claim.** It now covers every phrasing that promises appending, and joins single-quoted implicit concatenations as well as double — which is precisely how the note slipped past the first pass.

| mutation | result |
|---|---|
| restore the shipped note wording | **RED** |

## Verified against production

After the demo-tenant cleanup, seeding twice in a row:

```
Patient 1 · Condition 1 · Observation 3 · MedicationRequest 1     (unchanged)
```

## Verification

- 2868 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
