### PR TITLE
fix(review): an unknown approval outcome was rendering as "Submission rejected." (#419)

### DIFF
--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -253,12 +253,91 @@
             gateMsg.className = 'alert alert-success';
             gateMsg.textContent = 'Review recorded. ' + (res.b.next_step || '');
             btn.disabled = true;
-          } else {
-            gateMsg.className = 'alert alert-danger';
-            gateMsg.textContent = res.b.error || 'Submission rejected.';
+            return;
           }
+
+          // THREE answers, not two (#220, #416). `confirmed === null` means
+          // the engine never replied, so the approval MAY already have run.
+          // This branch used to fall through to the else below and print
+          // "Submission rejected." — a definite failure, for the one case
+          // the server deliberately refused to call. Told it was rejected, a
+          // reasonable person approves again, which is the double-send #416
+          // exists to prevent.
+          if (res.b.confirmed === null) {
+            btn.disabled = true;             // never invite a second send here
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent = res.b.message ||
+              'Your review was saved. We are checking whether the approval ' +
+              'went through.';
+            checkStatus();
+            return;
+          }
+
+          gateMsg.className = 'alert alert-danger';
+          // `message` first: it is the field the server uses when it has
+          // something specific to say. `error` is a machine code.
+          // The fallback fires only when the server sent NEITHER message nor
+          // error, which is precisely when we cannot say what happened to
+          // the request. It therefore states the failure to record and
+          // claims nothing about what was or was not sent.
+          gateMsg.textContent = res.b.message || res.b.error ||
+            'We could not record your review. Please try again.';
         });
     });
+
+    // Resolve the unknown outcome instead of telling the patient to go and
+    // find it themselves. #419: the copy said "check the request's status
+    // first" while `form_status` had no caller anywhere in CareAgents, so
+    // the instruction pointed at nothing.
+    //
+    // form.action is /review/<agent_id>/<action_id>/submit, which is where
+    // both ids come from; the status endpoint 404s without ?agent=.
+    function checkStatus() {
+      var parts = form.getAttribute('action').split('/');
+      var agentId = parts[2], actionId = parts[3];
+      var tries = 0;
+
+      (function poll() {
+        tries += 1;
+        fetch('/api/form/' + encodeURIComponent(actionId) +
+              '?agent=' + encodeURIComponent(agentId),
+              { credentials: 'same-origin' })
+          .then(function (r) { return r.json().then(function (b) {
+            return { ok: r.ok, b: b }; }); })
+          .then(function (res) {
+            var status = res.ok ? (res.b.status || '') : '';
+            if (status === 'completed' || status === 'sent') {
+              gateMsg.className = 'alert alert-success';
+              // "and nothing was sent twice" was in this string. A status
+              // of completed says the action completed; it says nothing
+              // about how many times it ran. Claim only what was observed.
+              gateMsg.textContent = 'Confirmed. Your approval went through.';
+              return;
+            }
+            if (status === 'pending' || status === 'approved') {
+              gateMsg.className = 'alert alert-success';
+              gateMsg.textContent =
+                'Confirmed. Your approval was recorded and is being sent.';
+              return;
+            }
+            if (tries < 4) { setTimeout(poll, 2000 * tries); return; }
+            // Still unknown after four tries. Say that, and say what we will
+            // do about it. Do NOT invite a retry: the first one may have run.
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent =
+              'We still cannot tell whether your approval went through, so ' +
+              'we have not sent it again. Your care team will see this ' +
+              'request either way. Please do not approve a second time.';
+          })
+          .catch(function () {
+            if (tries < 4) { setTimeout(poll, 2000 * tries); return; }
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent =
+              'We still cannot tell whether your approval went through, so ' +
+              'we have not sent it again. Please do not approve a second time.';
+          });
+      })();
+    }
 
     evaluate();
   })();

--- a/templates/review_base.html
+++ b/templates/review_base.html
@@ -131,6 +131,11 @@
       .alert { padding: .9rem 1.1rem; border-radius: 12px;
                border: 1px solid var(--hairline); border-left-width: 4px;
                background: var(--card); }
+      /* The happy path sets this from JS (className = 'alert alert-success'),
+         so it never appeared in the HTML the class-coverage guard read, and
+         a successful approval rendered with no styling at all. */
+      .alert-success { border-left-color: var(--ok, #2E7D32);
+                       background: #F2F7F2; }
       .alert-danger { border-left-color: var(--danger);
                       background: var(--danger-wash); color: var(--danger); }
       .alert-warning { border-left-color: var(--warn);

--- a/tests/test_review_says_what_it_knows.py
+++ b/tests/test_review_says_what_it_knows.py
@@ -1,0 +1,192 @@
+"""The approval page must never report an unknown outcome as a rejection.
+
+#220 and #416 established the three-answer contract for a clinical approval:
+
+    confirmed True   the engine confirmed it
+    confirmed False  nothing was sent; retrying is safe
+    confirmed None   the engine never answered; it MAY have run
+
+`careagents/app.py` gets this right and answers 502 with `confirmed: null`
+and a `message` explaining the uncertainty.
+
+The page then threw it away. Its submit handler read:
+
+    gateMsg.textContent = res.b.error || 'Submission rejected.';
+
+The 502 body carries `message`, not `error`. So the one outcome the backend
+took two issues to model honestly rendered to the patient as the words
+"Submission rejected." — a definite failure, for an approval that may
+already have executed. Told their approval was rejected, a reasonable person
+approves again. That is the double-send #416 exists to prevent, reintroduced
+in the last four lines of the journey.
+
+#419 filed the other half: the message told the patient to "check the
+request's status first", and nothing in CareAgents let them do that. The
+status endpoint existed with no caller.
+
+These tests cover both, and the third defect found alongside them: the shell
+never defined `.alert-success`, so the happy path rendered unstyled.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PAGE = ROOT / "templates/action_review.html"
+SHELL = ROOT / "templates/review_base.html"
+
+
+@pytest.fixture(scope="module")
+def page() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def shell() -> str:
+    return SHELL.read_text(encoding="utf-8")
+
+
+def _submit_handler(page: str) -> str:
+    """The body of the fetch().then() that renders the submit response."""
+    start = page.index("form.addEventListener('submit'")
+    return page[start:page.index("evaluate();", start)]
+
+
+def _code_only(js: str) -> str:
+    """Strip `//` comments.
+
+    The guards below look for strings the page must not PRINT. A comment
+    quoting the old wording to explain why it was removed is documentation,
+    not a defect, and the first version of this file went red on its own
+    explanation. Scan what runs.
+    """
+    return "\n".join(re.sub(r"//.*$", "", line) for line in js.splitlines())
+
+
+def test_there_is_a_submit_handler_to_examine(page):
+    """A pass over a handler that no longer exists is not a pass."""
+    body = _submit_handler(page)
+    assert "fetch(" in body and "gateMsg" in body, "the submit handler moved"
+
+
+# --- the severe one: unknown must not render as rejected -------------------
+
+def test_the_failure_branch_renders_the_message_the_server_sent(page):
+    """MUTATION: drop `res.b.message` from the fallback chain -> red.
+
+    The 502 body sets `message`. Reading only `error` fell through to the
+    literal string below.
+    """
+    body = _code_only(_submit_handler(page))
+    # Presence anywhere is not enough: `res.b.message` also appears in the
+    # confirmed-null branch, so the first version of this guard stayed green
+    # when the failure branch was reverted to reading `error` alone. Pin the
+    # ORDER of the fallback chain instead.
+    assert re.search(r"res\.b\.message\s*\|\|\s*res\.b\.error", body), (
+        "the failure branch does not fall back through `message` before "
+        "`error`; `message` is the field the server uses when it has "
+        "something specific to say")
+
+
+def test_no_branch_can_call_an_unknown_outcome_a_rejection(page):
+    """MUTATION: restore `'Submission rejected.'` as an unguarded fallback -> red.
+
+    A fallback string is fine. A fallback string that asserts an OUTCOME is
+    not, because it fires exactly when the server declined to assert one.
+    """
+    body = _code_only(_submit_handler(page))
+    for claim in ("Submission rejected", "was rejected", "did not go through",
+                  "nothing was sent"):
+        assert claim not in body, (
+            f"the page can print {claim!r} without knowing it. On a 502 the "
+            f"server said `confirmed: null` on purpose; the page must not "
+            f"convert that into a definite failure.")
+
+
+def test_the_unconfirmed_case_is_handled_separately_from_a_plain_error(page):
+    """null is a third answer, not a flavour of false.
+
+    MUTATION: delete the `confirmed === null` branch -> red.
+    """
+    body = _code_only(_submit_handler(page))
+    assert re.search(r"if\s*\(\s*res\.b\.confirmed\s*===\s*null\s*\)", body), (
+        "no branch distinguishes `confirmed: null` from an ordinary failure, "
+        "so the three-answer contract collapses back to two")
+
+
+# --- #419: every instruction must be one the patient can carry out ---------
+
+def test_the_page_can_actually_check_the_status_it_talks_about(page):
+    """The filed defect. The copy said "check the request's status first"
+    and `form_status` had no caller anywhere in CareAgents.
+
+    MUTATION: remove the status fetch -> red.
+    """
+    body = _code_only(_submit_handler(page))
+    assert "/api/form/" in body, (
+        "nothing on this page calls the status endpoint, so an instruction "
+        "to check the status has no destination (#419)")
+
+
+def test_the_status_call_passes_the_agent_the_endpoint_requires(page):
+    """`form_status` 404s without ?agent=. A call that always 404s is not a
+    status surface, it is a status-shaped hole.
+
+    MUTATION: drop the agent query parameter -> red.
+    """
+    body = _code_only(_submit_handler(page))
+    call = body[body.index("/api/form/"):]
+    assert "agent=" in call[:400], (
+        "the status call omits ?agent=, which form_status requires; it would "
+        "404 every time and look like 'no status available'")
+
+
+def test_the_page_does_not_instruct_an_action_with_no_destination(page):
+    """The general form of #419, as a property of the whole page.
+
+    Any imperative pointing the patient somewhere must correspond to
+    something on the page. This is deliberately narrow: it checks the
+    specific instruction that shipped, not English generally.
+
+    MUTATION: reinstate the copy without adding the status call -> red.
+    """
+    body = _submit_handler(page)
+    instructs_lookup = "check the request's status" in body.lower()
+    if instructs_lookup:
+        assert "/api/form/" in body, (
+            "the page tells the patient to check the status and provides no "
+            "way to do it")
+
+
+# --- the third defect, found alongside -------------------------------------
+
+def test_every_class_the_javascript_assigns_is_defined_by_the_shell(page, shell):
+    """The class-coverage guard read the HTML and not the script.
+
+    `gateMsg.className = 'alert alert-success'` is set from JS on the happy
+    path, and `.alert-success` was never defined in the self-contained shell,
+    so a successful approval rendered unstyled. The existing guard could not
+    see it because the class name appears only inside a string literal.
+
+    MUTATION: delete `.alert-success` from review_base.html -> red.
+    """
+    assigned = set()
+    for m in re.finditer(r"""className\s*=\s*['"]([^'"]+)['"]""", page):
+        assigned.update(m.group(1).split())
+    # Ternaries assign from either arm: className = ok ? 'a b' : 'c d'
+    for m in re.finditer(r"""className\s*=\s*[^;]*?\?\s*['"]([^'"]+)['"]\s*:\s*['"]([^'"]+)['"]""", page):
+        assigned.update(m.group(1).split())
+        assigned.update(m.group(2).split())
+
+    assert assigned, "no JS-assigned classes found; the guard is looking at nothing"
+
+    defined = set(re.findall(r"\.([a-zA-Z][\w-]*)\s*(?:,|\{)", shell))
+    missing = sorted(c for c in assigned if c not in defined)
+    assert not missing, (
+        f"the script assigns classes the shell never defines: {missing}. "
+        f"The relayed page loads no other stylesheet, so these render as "
+        f"nothing at all.")


### PR DESCRIPTION
Closes #419.

#419 filed a copy defect: the unconfirmed message told the patient to "check the request's status first" while `form_status` had no caller anywhere in CareAgents. That is real and is fixed here.

Reading the page to fix it surfaced something worse in the same four lines.

## The severe one

`careagents/app.py` models the three-answer contract correctly (#220, #416):

| `confirmed` | meaning |
|---|---|
| `true` | the engine confirmed it |
| `false` | nothing was sent; retrying is safe |
| `null` | the engine never answered; **it may already have run** |

The 502 carries that `null` plus a `message`. The page rendered:

```js
gateMsg.textContent = res.b.error || 'Submission rejected.';
```

`error` is absent on that body. So the one outcome the backend took two issues to model honestly reached the patient as the words **"Submission rejected."** — a definite failure, for an approval that may already have executed.

Told an approval was rejected, a reasonable person approves again. That is the double-send #416 exists to prevent, reintroduced at the last render step of the journey.

## Three fixes

1. **`confirmed === null` gets its own branch.** It disables the button, shows the server's message, and then *resolves* the uncertainty by polling `/api/form/<action_id>?agent=<agent_id>` — the endpoint that existed with no caller. The instruction now has a destination, which is option 1 in #419 rather than the copy-only fallback. After four attempts it says plainly that the outcome is still unknown and that we have not re-sent.

2. **The failure branch falls back through `message` before `error`**, and its last-resort string no longer asserts an outcome. It fires only when the server sent neither field, which is exactly when we cannot say what happened.

3. **`.alert-success` was never defined in the shell.** The happy path sets it from JS, so a successful approval rendered unstyled — and no existing guard could see it, because the class name appears only inside a string literal.

## Two claims of my own, removed under the same rule

- *"and nothing was sent twice"* followed a status of `completed`. That status says the action completed; it says nothing about how many times it ran.
- *"Nothing was sent."* sat in a fallback that fires when the server said nothing at all.

Both were caught by the guard written for this PR, applied to the code the PR added.

## Mutation testing found two of my guards blind

| mutation | first pass | after |
|---|---|---|
| render only `error` again | **GREEN — blind** | RED |
| delete the `confirmed === null` branch | **GREEN — blind** | RED |
| drop `?agent=` | RED | RED |
| remove the status fetch | RED | RED |
| delete `.alert-success` | RED | RED |

Both blind spots had the same cause: the guards searched the handler *including comments*, and my own explanatory comments quoted the exact patterns they looked for. They now strip comments and read code, and the first pins the fallback **order** rather than mere presence of `res.b.message` (which also appears in the null branch).

## Verification

- 2876 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
