### PR TITLE
refactor(kernel): slice 4 — wearables sync-now adopts require_grant

### DIFF
--- a/r6/wearables/routes.py
+++ b/r6/wearables/routes.py
@@ -20,10 +20,10 @@ from flask import Blueprint, Response, current_app, jsonify, redirect, request
 from markupsafe import escape
 
 from models import db
-from r6.access import TenantRejected, TenantSource, tenant_from_request
+from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
+                       tenant_from_request)
 from r6.audit import record_audit_event
 from r6.read_auth import authorize_tenant_read
-from r6.stepup import validate_step_up_token
 from r6.wearables.client import WearablesClient
 from r6.wearables.models import SUPPORTED_PROVIDERS, WearableConnection
 from r6.wearables.poller import run_once
@@ -258,27 +258,42 @@ def sync_now():
     # The absent-header 400 is unchanged; a MALFORMED id now raises out to the
     # app-wide handler instead of being carried into the sweep and the audit.
     try:
-        tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
+        tenant = tenant_from_request(sources=(TenantSource.HEADER,))
     except TenantRejected as exc:
         if exc.reason == TenantRejected.MALFORMED:
             raise
         return jsonify({'error': 'X-Tenant-Id required'}), 400
-    token = request.headers.get('X-Step-Up-Token')
-    if not token:
-        return jsonify({'error': 'X-Step-Up-Token required'}), 403
-    valid, err = validate_step_up_token(token, tenant_id)
-    if not valid:
-        return jsonify({'error': f'token rejected: {err}'}), 403
+
+    # Access kernel, slice 4 (docs/2026-08-03-access-kernel-spec.md §2.5).
+    # This site exists in the slice order to prove the MINORITY dialect
+    # survives migration: the same failure answers 401 at nine sites and 403
+    # at three, and normalizing that is the founder's call, not this
+    # migration's. So both statuses are passed explicitly and the wire
+    # behaviour is unchanged — 403 with no token, 403 with a bad one.
+    #
+    # Scope.WRITE, not TENANT_BOUND: validate_step_up_token's require_scope
+    # defaults to 'write', so the two-argument call this replaces was already
+    # demanding a write-scoped token. Reading the default rather than the
+    # call site is the difference between preserving behaviour and guessing
+    # at it.
+    grant = require_grant(
+        scope=Scope.WRITE,
+        tenant=tenant,
+        absent_status=403,
+        rejected_status=403,
+    )
 
     # Scope the sweep to the authenticated tenant. run_once() defaults to a
-    # global sweep (the background poller relies on it); passing tenant_id
-    # here keeps this patient-triggered endpoint from touching other tenants
-    # (issue #311).
-    summary = run_once(current_app, tenant_id=tenant_id)
+    # global sweep (the background poller relies on it); passing the GRANT's
+    # tenant here keeps this patient-triggered endpoint from touching other
+    # tenants (issue #311). grant.tenant_id rather than the header: the
+    # handler must not be able to sweep a tenant the grant did not authorize
+    # (spec §3(e)).
+    summary = run_once(current_app, tenant_id=grant.tenant_id)
     record_audit_event(
         'update', 'WearableConnection', None,
         agent_id=request.headers.get('X-Agent-Id', 'wearable-manual-sync'),
-        tenant_id=tenant_id,
+        tenant_id=grant.tenant_id,
         detail=(
             f"manual sync: checked={summary.get('connections_checked')} "
             f"ingested={summary.get('observations_ingested')} "

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -119,7 +119,12 @@ def _report(sites, pin, what):
 #: silently misreads as authorized (#307). r6/access.py itself is excluded —
 #: it is the one module that is *supposed* to call this.
 #: Playbook chunks A2, A3, A6.
-_STEP_UP_CALLSITES = 20
+#:
+#: 20 -> 19: kernel slice 4 migrated `/wearables/sync-now`. That slice's job
+#: was to prove the MINORITY 403 dialect survives migration without being
+#: normalized, so require_grant carries absent_status=403 and
+#: rejected_status=403 and the wire behaviour is byte-identical.
+_STEP_UP_CALLSITES = 19
 
 
 def test_direct_step_up_validation_only_decreases():

--- a/tests/test_wearables.py
+++ b/tests/test_wearables.py
@@ -389,6 +389,30 @@ class TestWearableRoutes:
         resp = client.post('/wearables/sync-now', headers=tenant_headers)
         assert resp.status_code == 403
 
+    def test_sync_now_refuses_a_read_scoped_token(self, client):
+        """A read token must not drive a write sweep.
+
+        sync-now ingests Observations into the tenant, so it has always
+        demanded a write-capable token — `validate_step_up_token`'s
+        `require_scope` defaults to 'write', and the two-argument call this
+        endpoint used took that default silently.
+
+        Kernel slice 4 made the requirement explicit as `Scope.WRITE`. That
+        made it something a reader could get wrong, and nothing in the suite
+        would have noticed: swapping in Scope.TENANT_BOUND left every other
+        wearables test green. This is the pin for the property the default
+        was providing by accident.
+
+        MUTATION: scope=Scope.TENANT_BOUND in wearables.sync_now -> red.
+        """
+        from r6.stepup import generate_step_up_token
+
+        resp = client.post('/wearables/sync-now', headers={
+            'X-Tenant-Id': 'tenant-a',
+            'X-Step-Up-Token': generate_step_up_token('tenant-a', scope='read'),
+        })
+        assert resp.status_code == 403
+
 
 # ─────────────────────────────────────────────
 # MCP App tests


### PR DESCRIPTION
Access kernel **slice 4** ([spec §2.5](docs/2026-08-03-access-kernel-spec.md)). One call site, one blueprint, one guard — protocol rule 3.

## Why this site is fourth

Slice 4 exists in the order to prove the **minority status dialect survives migration without being normalized**. The same failure answers 401 at nine sites and 403 at three. Deciding which is correct is the founder's call (spec Open Question 1), not this migration's — so `require_grant` carries `absent_status=403, rejected_status=403` and the wire behaviour is unchanged.

## Two things read rather than assumed

**`Scope.WRITE`, not `TENANT_BOUND`.** `validate_step_up_token`'s `require_scope` **defaults to `'write'`**, so the two-argument call this replaces was already demanding a write-capable token. Reading the default rather than the call site is the difference between preserving behaviour and guessing at it.

**`run_once(tenant_id=grant.tenant_id)`**, not the header value (spec §3(e)) — a handler must not be able to sweep a tenant the grant did not authorize.

The raw `from r6.stepup import validate_step_up_token` goes with the call site in the same PR (protocol rule 8). Wearables no longer references it.

## Mutation results

| mutation | result |
|---|---|
| normalize the 403 dialect to 401 | **RED** |
| accept a read-scoped token | **RED** — after the new pin below |
| swap `grant.tenant_id` for `tenant.id` | **GREEN**, and correctly so |

The third is **not** a coverage gap, and I'd rather record that than claim five-of-five. `require_grant` returns a `Grant` only when the token is bound to this tenant, so `grant.tenant_id == tenant.id` here by construction and no observable behaviour differs. The change is shape — it makes the wrong thing unavailable later, when a handler reads a tenant from somewhere else.

## A hole this slice opened, and closed

Making the scope explicit turned a silent default into something a reader can get wrong — and **nothing in the suite would have caught it**. Swapping `Scope.WRITE` for `Scope.TENANT_BOUND` left every wearables test green, meaning a read-scoped token could have driven a write sweep that ingests Observations.

Added `test_sync_now_refuses_a_read_scoped_token` to pin the property the default had been providing by accident.

## Ratchet

`_STEP_UP_CALLSITES` 20 → 19, with the reason recorded inline.

## Verification

- 2877 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean
- Conformance untouched (protocol rule 6); write-guard matrix unedited and green (rule 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
