### PR TITLE
refactor(kernel): slice 10 — the actions blueprint gets one tenant reader

### DIFF
--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -315,9 +315,10 @@ def _view_rows(draft_qr):
 
 @actions_blueprint.route('/<action_id>/review', methods=['GET'])
 def review_form(action_id):
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
     auth_err = _require_step_up(tenant_id)
     if auth_err is not None:
         return auth_err
@@ -365,9 +366,10 @@ def _truthy(value):
 
 @actions_blueprint.route('/<action_id>/review', methods=['POST'])
 def review_submit(action_id):
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
     auth_err = _require_step_up(tenant_id)
     if auth_err is not None:
         return auth_err

--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -20,12 +20,12 @@ import hmac
 import json
 import logging
 import os
-import re
 import uuid
 
 from flask import Blueprint, jsonify, request
 
 from models import db
+from r6.access import TenantRejected, TenantSource, tenant_from_request
 from r6.actions import errors
 from r6.actions.confirmations import (ACTION_APPROVAL_AUDIENCE,
                                       APPROVED_VIA_VALUES,
@@ -50,7 +50,6 @@ actions_blueprint = Blueprint('actions', __name__, url_prefix='/r6/actions')
 # Register rate limiting (same pattern as r6_blueprint in r6/routes.py)
 rate_limit_middleware(actions_blueprint)
 
-_TENANT_PATTERN = re.compile(r'^[a-zA-Z0-9_-]{1,64}$')
 
 
 def _error(status, message):
@@ -58,10 +57,29 @@ def _error(status, message):
 
 
 def _tenant_or_none():
-    tenant_id = request.headers.get('X-Tenant-Id', '')
-    if not tenant_id or not _TENANT_PATTERN.match(tenant_id):
+    """Resolve X-Tenant-Id through the access kernel (spec §1.1, slice 10).
+
+    Returns a validated `Tenant`, or None when the header is ABSENT so every
+    handler keeps answering the 400 it always answered. A MALFORMED id now
+    raises out to the app-wide TenantRejected handler instead of collapsing
+    into the same None: the two failures were indistinguishable here, which
+    is how a blueprint ends up with one refusal message for two causes.
+
+    The accepted set does not move. The pattern this module used to keep
+    and the kernel's _TENANT_ID_PATTERN are both ``[a-zA-Z0-9_-]{1,64}``,
+    compared byte-for-byte before the swap; the local copy is deleted here
+    rather than left as a second definition of the same rule.
+
+    Returning the Tenant rather than the string is the point: require_grant
+    raises TypeError on a bare string, so the type is what proves the format
+    check ran. Handlers take ``.id`` where they need the string.
+    """
+    try:
+        return tenant_from_request(sources=(TenantSource.HEADER,))
+    except TenantRejected as exc:
+        if exc.reason == TenantRejected.MALFORMED:
+            raise
         return None
-    return tenant_id
 
 
 def _emergency_refusal_or_none(tenant_id, text):
@@ -213,9 +231,10 @@ def propose_rx_transfer():
     Schedule II medications are refused with an explanation (never
     transferable; see rx_transfer.py).
     """
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
     tenant_id = authorize_tenant_read(tenant_id)
     if tenant_id is None:
         return _error(401, 'authentication required for this tenant')
@@ -297,9 +316,10 @@ def propose_rx_transfer():
 
 @actions_blueprint.route('/propose', methods=['POST'])
 def propose_action():
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
 
     # propose has no step-up gate at all — the tenant header is the whole
     # credential — so this parse is reachable by anyone who can name a
@@ -352,9 +372,10 @@ def commit_action(action_id):
     patient's out-of-band channels. The old X-Human-Confirmed header gate is
     gone — any caller could spoof a header; nobody can spoof the patient
     tapping Approve in their own dashboard/Telegram."""
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
 
     # Gate: step-up token (ALWAYS destructure the tuple)
     step_up_token = request.headers.get('X-Step-Up-Token')
@@ -454,9 +475,10 @@ def confirm_action(action_id):
          (issued and consumed at the same instant, one transaction) is the
          CONSENT RECORD — the durable who/when/via artifact of the approval.
     """
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
 
     # Pure input validation FIRST: a 400 on a malformed body must not burn
     # the single-use credential consumed just below. Everything that touches
@@ -602,9 +624,10 @@ def issue_action_approval_token(action_id):
     an agent that can obtain a normal tenant write token cannot mint its own
     approval credential.
     """
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
 
     expected = os.environ.get('INTERNAL_TOKEN_MINT_SECRET', '')
     provided = request.headers.get('X-Internal-Secret', '')
@@ -638,9 +661,10 @@ def issue_action_approval_token(action_id):
 
 @actions_blueprint.route('/<action_id>', methods=['GET'])
 def action_status(action_id):
-    tenant_id = _tenant_or_none()
-    if not tenant_id:
+    tenant = _tenant_or_none()
+    if tenant is None:
         return _error(400, 'X-Tenant-Id header is required')
+    tenant_id = tenant.id
 
     # Read-auth: for non-public tenants (when the flag is on) require a
     # tenant-bound token/bearer, same posture as FHIR + SMBP reads.

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1022,7 +1022,12 @@ def test_outcome_response_is_the_shipped_shape_with_a_status(app):
 #:   main.py            slice 2 — register_error_handlers/install_audit_assertions
 #:   r6/smbp/routes.py  slice 3 — reading()'s step-up gate -> require_grant
 _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
-                     'r6/fasten/routes.py', 'r6/wearables/routes.py'}
+                     'r6/fasten/routes.py', 'r6/wearables/routes.py',
+                     # slice 10: _tenant_or_none resolves through the kernel.
+                     # r6/actions/review.py imports that helper rather than
+                     # the kernel, so it is not on this list — the blueprint
+                     # has one tenant reader, which is the property.
+                     'r6/actions/routes.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():

--- a/tests/test_tenant_format_blueprints.py
+++ b/tests/test_tenant_format_blueprints.py
@@ -213,3 +213,33 @@ def test_wearables_still_refuses_an_absent_tenant_header_in_its_own_dialect(
     resp = client.post("/wearables/sync-now")
     assert resp.status_code == 400
     assert resp.get_json() == {"error": "X-Tenant-Id required"}
+
+
+# ---------------------------------------------------------------------------
+# actions — every route behind _tenant_or_none (kernel slice 10)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tenant", MALFORMED)
+def test_actions_propose_refuses_a_malformed_tenant_id(client, tenant):
+    """MUTATION: return the raw header from _tenant_or_none -> red.
+
+    Before slice 10 this blueprint collapsed ABSENT and MALFORMED into the
+    same `None`, so both answered the same 400 with the same message. The
+    status is unchanged; what changes is that a malformed id is now refused
+    by the kernel and says so, instead of being reported as a missing
+    header.
+    """
+    resp = client.post("/r6/actions/propose", json={},
+                       headers={"X-Tenant-Id": tenant})
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+
+
+def test_actions_still_refuses_an_absent_tenant_header_in_its_own_dialect(client):
+    """The absent case must not move — six handlers answer it.
+
+    MUTATION: let TenantRejected('absent') propagate out of
+    _tenant_or_none -> red (the body becomes an OperationOutcome).
+    """
+    resp = client.post("/r6/actions/propose", json={})
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "X-Tenant-Id header is required"}


### PR DESCRIPTION
Access kernel **slice 10** ([spec §2.6](docs/2026-08-03-access-kernel-spec.md)) for `r6/actions`. One guard, one blueprint, one PR.

## Why this lands before slice 5

I started on slice 5 (the step-up migration) and could not do it. `require_grant` takes a `Tenant` and **raises `TypeError` on a bare string** — deliberately, because the type is what proves the format check ran. `_tenant_or_none` returned a string.

Shipping both guards in one diff would have broken protocol rule 3, so the **order** changed rather than the rule. Slice 5 follows on top of this.

## What moves

`_tenant_or_none` resolves through `tenant_from_request` and returns a validated `Tenant`. Six call sites in `routes.py` and two in `review.py` bind `tenant` and take `.id`, leaving the ~100 downstream uses of the string untouched.

The accepted set does not move: this module's `_TENANT_PATTERN` and the kernel's `_TENANT_ID_PATTERN` are both `[a-zA-Z0-9_-]{1,64}`, compared byte-for-byte before the swap. The local copy is **deleted** rather than left as a second definition of the same rule (rule 8), and the now-unused `re` import goes with it.

## The one behaviour change, stated plainly

`ABSENT` and `MALFORMED` used to collapse into the same `None`, so a malformed tenant id was reported as a *missing header*. Malformed now raises to the app-wide handler and says what is actually wrong. **Both still answer 400.** Same precedent as smbp (slice 3) and wearables (slice 9).

## What the suite caught

**22 tests went red on the first full run.** `r6/actions/review.py` imports the private `_tenant_or_none` across a module boundary, and its two call sites still expected a string — so `validate_step_up_token` compared a token against a `Tenant` object and answered `"Token tenant mismatch"`.

That is exactly the cross-module private-symbol coupling the 08-02 audit inventoried (34 sites). It was found by the pins, not by review, which is the argument for pins-before-moves in one line. Both sites are in the same blueprint, so they are in scope here.

## Mutations

| mutation | result |
|---|---|
| return the raw header from `_tenant_or_none` | **RED** |
| let the absent case raise instead of answering its own 400 | **RED** |

New pins in `tests/test_tenant_format_blueprints.py` cover both halves, and `r6/actions/routes.py` joins `_ADOPTION_ALLOWED` — adoption is a reviewable list, added in the PR that earns it. `review.py` is deliberately *not* on that list: it imports the helper, not the kernel, so the blueprint has one tenant reader.

## Verification

- 2880 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean
- Write-guard matrix unedited and green (rule 4); conformance untouched (rule 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
