### PR TITLE
feat: two drift guards — the demo tenant's shape, and routes.py's size

### DIFF
--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -195,6 +195,40 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     check("healthclaw: records are readable", total > 0 and labelled == total,
           f"{labelled}/{total} labelled")
 
+    # --- the demo tenant's shape (#457, docs/defect-catalogue.md §10) --------
+    # Deployment truth is not code truth, and nothing was reconciling them.
+    # railway.toml runs a pre-deploy seed and its own comment called that seed
+    # idempotent; it was not, and the demo tenant reached 19 Patients against
+    # a seed set of one. Separately, running the conformance harness against
+    # this tenant leaves a probe Patient behind each time. Neither source
+    # showed up in any check, because every other check here is satisfied
+    # just as well by a tenant with twenty patients in it.
+    #
+    # A physician advisor found it, on camera, the day before a launch
+    # recording: "/conditions shows about a dozen duplicate Type 2 diabetes
+    # mellitus entries".
+    #
+    # This watches the CONSEQUENCE rather than the mechanism. A count is
+    # observable from outside; "did the pre-deploy step run" is not, and the
+    # count is what a viewer of the demo actually sees.
+    r = get(f"{HEALTHCLAW}/r6/fhir/Patient?_count=200", timeout,
+            headers={"X-Tenant-Id": DEMO_TENANT})
+    patients = None
+    if getattr(r, "status_code", None) == 200:
+        try:
+            patients = len(r.json().get("entry") or [])
+        except ValueError:
+            patients = None
+    # `is not None` rather than a truthiness test: zero patients is a real
+    # failure (an empty demo), and `if patients:` would report it as
+    # unreadable instead. The read failing and the tenant being empty are
+    # different alarms.
+    check("healthclaw: the demo tenant is one patient",
+          patients == 1,
+          f"{patients} Patient(s) in {DEMO_TENANT}"
+          if patients is not None else
+          f"could not read the tenant ({getattr(r, 'status_code', r)})")
+
     # --- the consumer app ----------------------------------------------------
     r = get(f"{CAREAGENTS}/healthz", timeout)
     body = {}

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -272,6 +272,9 @@ def _prod_watch_with(payload, expect, demo_handshake=None):
     def get(url, timeout, **kw):
         if "$conformance" in url:
             return _Resp(200, {"grade": "A"})
+        if "Patient" in url:
+            return _Resp(200, {"entry": [
+                {"resource": {"resourceType": "Patient", "id": "demo-1"}}]})
         if "Condition" in url:
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
@@ -310,15 +313,24 @@ TIP = "4f2a91cbeef1a9d3c05e7b21fd8460ac9e13d7f5"
 def test_a_current_build_is_counted_as_a_real_check():
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [TIP])
-    assert code == 0 and "all 11 checks passing" in out
+    # MOVED PIN 11 -> 12: prod_watch gained the demo-tenant shape check
+    # (#457, catalogue §10). The number is the point of this test — it
+    # asserts the script counts an asserted build as a real check rather
+    # than inflating the total — so it moves by exactly one here and the
+    # property is unchanged.
+    assert code == 0 and "all 12 checks passing" in out
 
 
 def test_an_unasserted_build_never_inflates_the_count():
-    # The script's honesty property. "all 10 checks passing" must stay
+    # The script's honesty property. "all 11 checks passing" must stay
     # literally true when nothing pinned the build.
+    #
+    # MOVED PIN 10 -> 11, same reason as above: one new check, and the gap
+    # between this number and the one above is still exactly one, which is
+    # the property being pinned.
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [])
-    assert code == 0 and "all 10 checks passing" in out
+    assert code == 0 and "all 11 checks passing" in out
 
 
 class _Refused:
@@ -343,7 +355,7 @@ def test_a_demo_server_that_stops_serving_keyless_callers_is_an_outage():
                                  demo_handshake=_Refused())
     assert code == 1, "a demo server refusing keyless callers must be an outage"
     assert "serves an unauthenticated handshake" in out
-    assert "all 11 checks passing" not in out
+    assert "all 12 checks passing" not in out
 
 
 @pytest.mark.parametrize("supplied", ["", ",", " ", ",,"])

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -38,12 +38,17 @@ class _Resp:
         return self._payload
 
 
-def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A"):
+def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A",
+              demo_patients=1):
     def get(url, timeout, **kw):
         if url.endswith("/r6/fhir/health"):
             return _Resp(200)
         if "$conformance" in url:
             return _Resp(200, {"grade": grade})
+        if "Patient" in url:
+            return _Resp(200, {"entry": [
+                {"resource": {"resourceType": "Patient", "id": f"p{i}"}}
+                for i in range(demo_patients)]})
         if "Condition" in url:
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
@@ -411,3 +416,47 @@ def test_an_unreachable_endpoint_is_not_reported_as_a_stale_build(monkeypatch,
     # The misdirection itself: no redeploy prescribed for an outage.
     out = capsys.readouterr().out
     assert "RELEASING.md" not in out and "auto-deploy" not in out
+
+
+# --- the demo tenant's shape (#457, catalogue §10) ---------------------------
+
+def test_a_single_patient_demo_tenant_passes():
+    """The state the demo is supposed to be in."""
+    prod_watch.run(timeout=1, expect_sha=[])
+    name = "healthclaw: the demo tenant is one patient"
+    assert _named(name) and _named(name)[0][1] is True, _named(name)
+
+
+def test_a_duplicated_demo_tenant_is_a_hard_failure(monkeypatch):
+    """19 Patients is what production actually held on 2026-08-10.
+
+    Every other check in this file passes just as well against that tenant,
+    which is why a physician advisor found it on camera instead of a machine
+    finding it a month earlier.
+
+    MUTATION: drop the demo-tenant check from run() -> red.
+    """
+    monkeypatch.setattr(prod_watch, "get", _fake_get(demo_patients=19))
+    rc = prod_watch.run(timeout=1, expect_sha=[])
+
+    name = "healthclaw: the demo tenant is one patient"
+    entry = _named(name)
+    assert entry, "the demo-tenant check did not run"
+    assert entry[0][1] is False
+    assert "19" in entry[0][2]
+    assert rc == 1, "a duplicated demo tenant must be a hard failure, not a warning"
+
+
+def test_an_empty_demo_tenant_is_a_failure_not_a_pass(monkeypatch):
+    """Zero is a real failure, and a different one from "cannot read".
+
+    MUTATION: use `if patients:` instead of `is not None` -> red, because an
+    empty tenant would then be reported as an unreadable one.
+    """
+    monkeypatch.setattr(prod_watch, "get", _fake_get(demo_patients=0))
+    prod_watch.run(timeout=1, expect_sha=[])
+
+    entry = _named("healthclaw: the demo tenant is one patient")
+    assert entry and entry[0][1] is False
+    assert "0 Patient(s)" in entry[0][2], (
+        f"an empty tenant must report as empty, not as unreadable: {entry}")

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -268,6 +268,38 @@ def test_soft_delete_blind_query_files_only_decrease():
         'A resource query that ignores is_deleted reads deleted rows.')
 
 
+#: r6/routes.py, in lines. The 08-02 audit's Workstream B is to decompose it
+#: into a package; that work is sequenced after the access kernel and has not
+#: started. In the meantime the file has been going the wrong way — 3,762
+#: lines at the audit, 3,905 at the 08-05 pattern review, 3,930 today, against
+#: a plan whose whole purpose is to shrink it.
+#:
+#: Nobody decided to grow it. Each PR added twenty lines to the only module
+#: where the thing they needed already lived, which is exactly how it reached
+#: 3,900 in the first place. A number that can only go down makes that visible
+#: in the PR that does it rather than in the next audit.
+#:
+#: This is a CEILING, not a target. Lower it when Workstream B lands a module;
+#: raising it needs a reason in the diff.
+#: Playbook chunk B (docs/2026-08-05-healthclaw-2.0-playbook.md).
+_GOD_MODULE_LINES = 3930
+
+
+def test_the_god_module_only_shrinks():
+    """MUTATION: add a line to r6/routes.py -> red.
+
+    The one ratchet that fires on ordinary feature work, deliberately. If a
+    change genuinely belongs in routes.py the pin moves up in the same PR
+    with the reason; the point is that it is a decision rather than a drift.
+    """
+    lines = len((REPO_ROOT / 'r6/routes.py').read_text(encoding='utf-8').splitlines())
+    assert lines <= _GOD_MODULE_LINES, (
+        f'r6/routes.py is {lines} lines, pinned at {_GOD_MODULE_LINES}.\n'
+        f'  Workstream B exists to shrink this file. If the change truly '
+        f'belongs here, raise the pin in this PR and say why; if it belongs '
+        f'in a new module, that is the refactor starting.')
+
+
 # ---------------------------------------------------------------------------
 # The ratchets themselves
 # ---------------------------------------------------------------------------
@@ -278,7 +310,8 @@ def test_every_ratchet_names_its_playbook_chunk():
     assert 'docs/2026-08-05-healthclaw-2.0-playbook.md' in source
     for pin in ('_STEP_UP_CALLSITES', '_ROUTES_IMPORTERS',
                 '_POST_COMMIT_AUDIT_CALLSITES',
-                '_FILES_QUERYING_WITHOUT_SOFT_DELETE'):
+                '_FILES_QUERYING_WITHOUT_SOFT_DELETE',
+                '_GOD_MODULE_LINES'):
         assert f'{pin} = ' in source, f'{pin} lost its pin'
 
 
@@ -287,6 +320,7 @@ def test_every_ratchet_names_its_playbook_chunk():
     ('routes.py importers', _ROUTES_IMPORTERS),
     ('post-commit audit callsites', _POST_COMMIT_AUDIT_CALLSITES),
     ('soft-delete-blind files', _FILES_QUERYING_WITHOUT_SOFT_DELETE),
+    ('god-module lines', _GOD_MODULE_LINES),
 ])
 def test_no_ratchet_is_already_at_zero(pin, value):
     """When one reaches 0, delete its ratchet and add the grep guard instead.


### PR DESCRIPTION
Both are `docs/defect-catalogue.md` shapes that had no instrument behind them until now.

## 1. The demo tenant's shape — catalogue §10 (deployment truth ≠ code truth)

`prod_watch` now checks that `desktop-demo` holds **exactly one Patient**.

`railway.toml` runs a pre-deploy seed and its own comment called that seed *idempotent*. It was not, and the tenant reached **19 Patients** against a seed set of one. Separately, running the conformance harness against the same tenant leaves a probe Patient behind on every run (#463).

Neither source appeared in any check, because **every other check in prod_watch is satisfied just as well by a tenant with twenty patients in it.** A physician advisor found it instead, the day before a launch recording: *"/conditions shows about a dozen duplicate Type 2 diabetes mellitus entries."*

This watches the **consequence**, not the mechanism. A count is observable from outside; *"did the pre-deploy step run"* is not — and the count is what a viewer of the demo actually sees.

`patients is not None` rather than a truthiness test: an empty demo and an unreadable tenant are different alarms, and `if patients:` would report the first as the second.

## 2. `r6/routes.py` only shrinks

| when | lines |
|---|---:|
| 08-02 audit | 3,762 |
| 08-05 pattern review | 3,905 |
| today | **3,930** |

Against a plan whose entire purpose is to shrink it.

**Nobody decided to grow it.** Each PR added twenty lines to the only module where the thing they needed already lived — which is exactly how it reached 3,900. A ceiling makes that a decision in the PR that does it, rather than a finding in the next audit.

This is the one ratchet that fires on ordinary feature work, deliberately. Raising it is allowed; doing it silently is not.

## What I did not add, and why (standard 29)

The plan also called for a **bot `/health` check**. The Telegram bot has no HTTP surface to probe, and as of 2026-08-10 its Railway service has **no active deployment** while the Mac mini is idle — where it runs cannot be established from this repository at all.

Inventing a check that cannot reach it would be catalogue §0: a check reporting on something it never examined. **The gap is real and stays open.**

## Moved pins (`docs/agent-task-guide.md` §6)

`tests/test_build_marker_stamp.py` counts the checks prod_watch runs, so a new check moves those numbers by one: **10 → 11** and **11 → 12**. The *gap* between them is the property being pinned and is unchanged. Its fake also predated the Patient read and now answers it.

## Mutations run

| mutation | result |
|---|---|
| drop the demo-tenant check entirely | **RED** |
| accept any non-zero patient count | **RED** |
| truthiness instead of `is not None` | **RED** |
| add a line to `r6/routes.py` | **RED** |

## Verification

- 2884 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
