### PR TITLE
fix(dashboard): name the deployment that was measured, not "local(test-client)"

### DIFF
--- a/templates/r6_dashboard.html
+++ b/templates/r6_dashboard.html
@@ -60,11 +60,16 @@
   <div class="cf-prov">
     <div class="cf-prov__cell">
       <div class="cf-prov__k">Measured against</div>
-      <div class="cf-prov__v">{{ report.target or snapshot.origin }}</div>
+      {# NOT report.target. That field says 'local(test-client)' because the
+         harness drives the app in-process, which is true and useless once the
+         report crosses a host boundary: healthclaw.io rendered "measured
+         against local(test-client)", local to a machine the reader cannot
+         identify. The deployment is the fact a reader needs. #}
+      <div class="cf-prov__v">{{ snapshot.origin if snapshot.remote else 'this deployment' }}</div>
     </div>
     <div class="cf-prov__cell">
-      <div class="cf-prov__k">Reported by</div>
-      <div class="cf-prov__v">{{ snapshot.origin }}</div>
+      <div class="cf-prov__k">This page</div>
+      <div class="cf-prov__v">{{ 'fetched that report' if snapshot.remote else 'ran the report itself' }}</div>
     </div>
     <div class="cf-prov__cell">
       <div class="cf-prov__k">Tenant</div>

--- a/tests/test_r6_dashboard.py
+++ b/tests/test_r6_dashboard.py
@@ -113,8 +113,20 @@ class TestDashboardPage:
         """A grade with no provenance is a number someone typed."""
         html = client.get('/r6-dashboard').data.decode()
         assert 'Measured against' in html
-        assert 'Reported by' in html
+        assert 'This page' in html
         assert '/r6/fhir/$conformance' in html
+
+    def test_the_measured_host_is_never_reported_as_local(self, client):
+        """MUTATION: render report.target in the 'Measured against' cell -> red.
+
+        report.target is 'local(test-client)' because the harness drives the
+        app in-process. That is true and unusable once the report crosses a
+        host: healthclaw.io shipped "Measured against local(test-client)",
+        which names a machine the reader cannot identify. Verified against
+        production before it was changed.
+        """
+        html = client.get('/r6-dashboard').data.decode()
+        assert 'local(test-client)' not in html
 
     def test_dashboard_carries_no_client_side_demo_script(self, client):
         """MUTATION: re-add the r6-dashboard.js <script> tag -> red.


### PR DESCRIPTION
Caught on the live page an hour after #474 shipped. healthclaw.io rendered:

    Measured against   local(test-client)
    Reported by        https://app.healthclaw.io

`report.target` is the harness's own description of how it drives the app —
in-process, through a Flask test client — which is accurate and unusable the
moment the report crosses a host boundary. It named a machine the reader
cannot identify, on the row whose entire job is telling them which deployment
this grade describes.

The two rows also said nearly the same thing. Now:

    Measured against   https://app.healthclaw.io   (or "this deployment")
    This page          fetched that report          (or "ran the report itself")

Which deployment was graded, and whether this page measured it or went and
got it. Those are the two separate facts a reader needs.

Mutations run:
- Render report.target in the "Measured against" cell -> RED
  (test_the_measured_host_is_never_reported_as_local)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>