### PR TITLE
refactor(kernel): slice 10a — four tenant reads, and a pin on the other 27

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -37,6 +37,7 @@ from r6.validator import R6Validator
 from r6.audit import add_audit_event, record_audit_event
 from r6.redaction import apply_patient_controlled_redaction
 from r6.redaction import apply_redaction
+from r6.access import TenantSource, tenant_from_request
 from r6.stepup import validate_step_up_token, generate_step_up_token
 from r6.oauth import register_oauth_routes
 from r6.read_auth import (
@@ -474,7 +475,7 @@ def create_resource(resource_type):
                                   f'resourceType mismatch: expected {resource_type}'), 400
 
     # Step-up authorization check with HMAC validation
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     step_up_token = request.headers.get('X-Step-Up-Token')
     if not step_up_token:
         return _operation_outcome('error', 'security',
@@ -560,7 +561,7 @@ def read_resource(resource_type, resource_id):
         return _operation_outcome('error', 'not-supported',
                                   f'Resource type {resource_type} is not supported'), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # --- Upstream proxy mode: fetch from real FHIR server ---
     proxy = get_proxy_for_request()
@@ -639,7 +640,7 @@ def update_resource(resource_type, resource_id):
                                   f'{resource_type} is system-managed and cannot be modified via API'), 403
 
     # Step-up authorization with HMAC validation
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     step_up_token = request.headers.get('X-Step-Up-Token')
     if not step_up_token:
         return _operation_outcome('error', 'security',
@@ -870,7 +871,7 @@ def search_resources(resource_type):
             'error', 'not-supported',
             'Resource type is not supported.')), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # --- Upstream proxy mode: forward search to real FHIR server ---
     proxy = get_proxy_for_request()

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1032,7 +1032,13 @@ _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
                      # blueprint. review.py imports the kernel directly for
                      # _require_step_up rather than going through routes.py,
                      # so it is named here in its own right.
-                     'r6/actions/review.py'}
+                     'r6/actions/review.py',
+                     # slice 10a: the four FHIR resource handlers (create,
+                     # read, update, search) read the tenant through the
+                     # kernel. This is the god module's FIRST kernel import
+                     # and the remaining 20 raw reads in it are pinned by
+                     # tests/test_ratchets.py::_RAW_TENANT_READS.
+                     'r6/routes.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -293,7 +293,13 @@ def test_soft_delete_blind_query_files_only_decrease():
 #: This is a CEILING, not a target. Lower it when Workstream B lands a module;
 #: raising it needs a reason in the diff.
 #: Playbook chunk B (docs/2026-08-05-healthclaw-2.0-playbook.md).
-_GOD_MODULE_LINES = 3930
+#: 3930 -> 3931: slice 10a swapped four raw tenant reads 1:1 and added the
+#: module's first `from r6.access import ...` line. A ratchet that only
+#: shrinks cannot tell decomposition from growth, and the honest move is to
+#: record the one line and why rather than to smuggle it in. The following
+#: batches remove code from this module; this is the only batch that adds a
+#: line to it.
+_GOD_MODULE_LINES = 3931
 
 
 def test_the_god_module_only_shrinks():
@@ -315,11 +321,69 @@ def test_the_god_module_only_shrinks():
 # The ratchets themselves
 # ---------------------------------------------------------------------------
 
+
+#: Call sites that read the tenant straight off the header instead of asking
+#: the access kernel, across all of r6/. 31 -> 27: slice 10a migrated create,
+#: read, update and search in r6/routes.py, which is also that module's first
+#: r6.access import.
+#:
+#: This counts the whole package, not just r6/routes.py. The first draft
+#: scanned only the god module and pinned 20; the scan then reported 27 and
+#: the pin was corrected to the measurement rather than the scan narrowed to
+#: the pin. r6/fasten/routes.py and r6/rate_limit.py each hold one, and they
+#: are real instances of the same thing.
+#:
+#: The floor is NOT zero. r6/routes.py:222 is `enforce_tenant_id` itself —
+#: the before_request hook that requires and validates the header for the
+#: whole blueprint. That read is the enforcement point; it is where the
+#: header is supposed to be read.
+#:
+#: Why this is safe to do in batches, and why the batches are small: every one
+#: of these sits behind `enforce_tenant_id`, the before_request hook that
+#: already requires the header and format-checks it with the SAME pattern the
+#: kernel uses (`[a-zA-Z0-9_-]{1,64}`, fullmatch, unstripped, compared before
+#: the swap). The hook also writes the synthesized SHARP tenant back into
+#: request.environ, so a downstream read sees it too. A migrated call
+#: therefore re-validates a value that cannot fail — inert by construction,
+#: which is what a migration slice should be.
+#:
+#: The exception is any handler on an EXEMPT discovery path, where the hook
+#: returns early and the header may legitimately be absent. There the kernel
+#: would raise TenantRejected where the old code got None, and that is a
+#: behaviour change, not a refactor. Check _is_exempt_discovery_path before
+#: moving a call site, per site — that is the whole reason this is 6 PRs and
+#: not one sed.
+_RAW_TENANT_READS = 27
+
+
+def test_raw_tenant_header_reads_only_decrease():
+    """MUTATION: add `request.headers.get('X-Tenant-Id')` to a handler -> red.
+
+    The kernel is meant to be the one tenant reader (spec §1.1). Without a
+    pin, the 24 that existed when the migration started would quietly become
+    25 the next time someone needed a tenant in a hurry.
+    """
+    root = pathlib.Path(__file__).resolve().parents[1]
+    needle = "request.headers.get('X-Tenant-Id')"
+    sites = []
+    for path in sorted(root.glob('r6/**/*.py')):
+        rel = path.relative_to(root).as_posix()
+        if rel == 'r6/access.py':
+            continue  # the kernel is where this read is supposed to live
+        for n, line in enumerate(path.read_text(encoding='utf-8').split('\n'), 1):
+            if needle in line and not line.lstrip().startswith('#'):
+                sites.append(f'{rel}:{n}')
+    assert len(sites) <= _RAW_TENANT_READS, _report(
+        sites, _RAW_TENANT_READS,
+        'Read the tenant through r6.access.tenant_from_request.')
+
+
 def test_every_ratchet_names_its_playbook_chunk():
     """A pin without a migration plan is a number nobody will ever lower."""
     source = pathlib.Path(__file__).read_text(encoding='utf-8')
     assert 'docs/2026-08-05-healthclaw-2.0-playbook.md' in source
     for pin in ('_STEP_UP_CALLSITES', '_ROUTES_IMPORTERS',
+                '_RAW_TENANT_READS',
                 '_POST_COMMIT_AUDIT_CALLSITES',
                 '_FILES_QUERYING_WITHOUT_SOFT_DELETE',
                 '_GOD_MODULE_LINES'):


### PR DESCRIPTION
r6/routes.py read the tenant straight off the header in 24 places. Four of
them — create, read, update and search — now ask the kernel. This is the god
module's first `from r6.access import`.

Why this is safe, and why the batch is small. Every one of these sits behind
`enforce_tenant_id`, the before_request hook that already requires the header
and format-checks it. Compared before the swap:

    hook    ^[a-zA-Z0-9_\-]{1,64}$   fullmatch, unstripped   (routes.py:100)
    kernel  [A-Za-z0-9_-]{1,64}      fullmatch, unstripped   (access.py:56)

Same accepted set. The hook also writes the synthesized SHARP tenant back
into request.environ, so a downstream read sees it too. A migrated call
therefore re-validates a value that cannot fail here — inert by construction,
which is what a migration slice should be.

The exception is any handler on an EXEMPT discovery path, where the hook
returns early and the header may legitimately be absent; there the kernel
would raise TenantRejected where the old code got None. Checked all four
against _EXEMPT_EXACT_PATHS (/metadata, /health, /$conformance) and
_EXEMPT_PATH_PREFIXES (/internal/, /.well-known/, /oauth/, /mcp-apps/,
/demo/): all four are FHIR resource routes, none exempt. That per-site check
is why this is six PRs and not one sed.

New ratchet, _RAW_TENANT_READS = 27. Without it the 24 that existed when this
migration started quietly become 25 the next time someone needs a tenant in a
hurry, and the kernel stops being the one tenant reader (spec §1.1).

Two corrections worth recording, because both were caught by running the
thing rather than reading it:

- The first draft scanned only r6/routes.py and pinned 20. The scan reported
  27 — r6/fasten/routes.py and r6/rate_limit.py each hold one, and they are
  real instances of the same shape. The pin was corrected to the measurement
  rather than the scan narrowed to the pin.
- The floor is not zero. r6/routes.py:222 is `enforce_tenant_id` itself. That
  read IS the enforcement point; it is where the header is supposed to be
  read.

_GOD_MODULE_LINES 3930 -> 3931. Four 1:1 swaps plus one import line. A
ratchet that only shrinks cannot tell decomposition from growth, so the one
line is recorded with its reason rather than smuggled in; the following
batches remove code from this module.

Mutations run:
- Revert one migrated read to request.headers.get -> RED
  (test_raw_tenant_header_reads_only_decrease)
- Import r6.access from routes.py without adding it to _ADOPTION_ALLOWED ->
  RED (test_no_request_handler_has_adopted_the_kernel) — observed as the
  initial failure of this change, not a synthetic mutation.

2922 passed, 13 skipped, 1 xfailed. ruff clean. (An earlier suite run raced
this branch's own mutation test on r6/routes.py; it was discarded and re-run
clean rather than reported.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>