### PR TITLE
refactor(kernel): slice 6 — the three routes.py write gates, and the #478 leak

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -37,7 +37,8 @@ from r6.validator import R6Validator
 from r6.audit import add_audit_event, record_audit_event
 from r6.redaction import apply_patient_controlled_redaction
 from r6.redaction import apply_redaction
-from r6.access import TenantSource, tenant_from_request
+from r6.access import (Scope, TenantSource, require_grant,
+                       tenant_from_request)
 from r6.stepup import validate_step_up_token, generate_step_up_token
 from r6.oauth import register_oauth_routes
 from r6.read_auth import (
@@ -475,16 +476,14 @@ def create_resource(resource_type):
                                   f'resourceType mismatch: expected {resource_type}'), 400
 
     # Step-up authorization check with HMAC validation
-    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _operation_outcome('error', 'security',
-                                  'Write operations require X-Step-Up-Token header'), 401
-
-    valid, err = validate_step_up_token(step_up_token, tenant_id)
-    if not valid:
-        return _operation_outcome('error', 'security',
-                                  f'Step-up token rejected: {err}'), 401
+    tenant = tenant_from_request(sources=(TenantSource.HEADER,))
+    tenant_id = tenant.id
+    # Access kernel, slice 6. 401 for both halves keeps this site's dialect.
+    # The refusal text changes: the kernel names the nine causes a caller can
+    # act on and collapses 'Token tenant mismatch', which this line used to
+    # hand back verbatim (#478).
+    require_grant(scope=Scope.WRITE, tenant=tenant,
+                  absent_status=401, rejected_status=401)
 
     # Validate before storing (agent proposals must pass $validate before commit)
     validation_result = validator.validate_resource(body)
@@ -640,16 +639,14 @@ def update_resource(resource_type, resource_id):
                                   f'{resource_type} is system-managed and cannot be modified via API'), 403
 
     # Step-up authorization with HMAC validation
-    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _operation_outcome('error', 'security',
-                                  'Write operations require X-Step-Up-Token header'), 401
-
-    valid, err = validate_step_up_token(step_up_token, tenant_id)
-    if not valid:
-        return _operation_outcome('error', 'security',
-                                  f'Step-up token rejected: {err}'), 401
+    tenant = tenant_from_request(sources=(TenantSource.HEADER,))
+    tenant_id = tenant.id
+    # Access kernel, slice 6. 401 for both halves keeps this site's dialect.
+    # The refusal text changes: the kernel names the nine causes a caller can
+    # act on and collapses 'Token tenant mismatch', which this line used to
+    # hand back verbatim (#478).
+    require_grant(scope=Scope.WRITE, tenant=tenant,
+                  absent_status=401, rejected_status=401)
 
     # Unlike create, update gates before it parses, so only a token holder
     # reaches this line. That is a smaller blast radius, not a closed one: a
@@ -3531,22 +3528,16 @@ def share_bundle():
         'MedicationRequest', 'Immunization', 'Observation', 'Coverage',
     ]
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant = tenant_from_request(sources=(TenantSource.HEADER,))
+    tenant_id = tenant.id
 
     # Step-up required — this bundle carries identified patient data
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _operation_outcome(
-            'error', 'security',
-            '$share-bundle requires X-Step-Up-Token header'
-        ), 401
-
-    valid, err = validate_step_up_token(step_up_token, tenant_id)
-    if not valid:
-        return _operation_outcome(
-            'error', 'security',
-            f'Step-up token rejected: {err}'
-        ), 401
+    # Access kernel, slice 6. 401 for both halves keeps this site's dialect.
+    # The refusal text changes: the kernel names the nine causes a caller can
+    # act on and collapses 'Token tenant mismatch', which this line used to
+    # hand back verbatim (#478).
+    require_grant(scope=Scope.WRITE, tenant=tenant,
+                  absent_status=401, rejected_status=401)
 
     body = request.get_json(silent=True) or {}
     patient_id = body.get('patient_id') or None

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -1105,9 +1105,28 @@ def test_step_up_validation_turned_off_no_longer_scores_a(
     authorizes a write. The missing-header 401 still fires, so the old harness
     saw nothing wrong.
     """
+    # BOTH modules, and the migration is why.
+    #
+    # r6/routes.py does `from r6.stepup import validate_step_up_token`, so the
+    # name is bound at import time and patching r6.stepup would not reach the
+    # call sites that still call it directly.
+    #
+    # The gates migrated in kernel slice 6 (create, update, $share-bundle) no
+    # longer consult that name at all. They go through require_grant, which
+    # resolves the validator as a MODULE ATTRIBUTE on r6.stepup — deliberately,
+    # so that monkeypatching by module path keeps working (r6/access.py §1.0).
+    #
+    # Patching only r6.routes stopped switching the guardrail off when those
+    # three moved: the writes were still refused, the grade stayed A, and this
+    # test failed. It failed rather than passing vacuously, which is the right
+    # way round — but a test that cannot break the thing it is trying to break
+    # proves nothing about the harness. Patch both, and this keeps grading the
+    # harness for as long as the migration takes.
     import r6.routes
-    monkeypatch.setattr(r6.routes, "validate_step_up_token",
-                        lambda *a, **k: (True, ""))
+    import r6.stepup
+    for module in (r6.routes, r6.stepup):
+        monkeypatch.setattr(module, "validate_step_up_token",
+                            lambda *a, **k: (True, ""))
 
     report = run_conformance(FlaskProbeClient(client),
                              _ctx(None, tenant_id, step_up_token))

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -129,7 +129,11 @@ def _report(sites, pin, what):
 #: The fourth, `confirm`, is deliberately NOT migrated: its wire contract
 #: includes the REASON a token was refused, and the kernel's uniform
 #: OperationOutcome does not carry it. See the comment at that call site.
-_STEP_UP_CALLSITES = 16
+#: 16 -> 13: kernel slice 6 migrated the three r6/routes.py write gates —
+#: create, update and $share-bundle. Those three also carried the #478 leak:
+#: they interpolated the validator's raw reason into the response, including
+#: 'Token tenant mismatch', which the kernel withholds.
+_STEP_UP_CALLSITES = 13
 
 
 def test_direct_step_up_validation_only_decreases():
@@ -299,7 +303,10 @@ def test_soft_delete_blind_query_files_only_decrease():
 #: record the one line and why rather than to smuggle it in. The following
 #: batches remove code from this module; this is the only batch that adds a
 #: line to it.
-_GOD_MODULE_LINES = 3931
+#: 3931 -> 3922: slice 6 replaced three nine-line hand-rolled step-up gates
+#: with a two-line require_grant call each. The module shrinks for the first
+#: time since the kernel migration began.
+_GOD_MODULE_LINES = 3922
 
 
 def test_the_god_module_only_shrinks():

--- a/tests/test_write_gate_reveals_no_foreign_token.py
+++ b/tests/test_write_gate_reveals_no_foreign_token.py
@@ -1,0 +1,106 @@
+"""A write refusal never says the token belongs to a different tenant (#478).
+
+Before slice 6, the FHIR write gates in r6/routes.py answered a rejected token
+with the validator's raw reason interpolated into the body:
+
+    return _operation_outcome('error', 'security',
+                              f'Step-up token rejected: {err}'), 401
+
+One of the eleven values `err` takes is 'Token tenant mismatch'. Presenting a
+correctly-signed token for tenant A while claiming tenant B got that answer
+back, which separates "a real credential issued elsewhere" from "junk" — the
+distinction a caller probing with a token they should not have is trying to
+draw. r6/read_auth.py:262 has always withheld it; these sites did not.
+
+The kernel classifies that reason as withheld (r6/access._WITHHELD_REASONS),
+so migrating the gates closes the leak. This file is the pin: it fails if a
+write path ever again tells a caller *why* in a way that describes someone
+else's credential.
+
+It asserts on the REFUSAL TEXT rather than on which function the handler
+calls. A future rewrite that stops using require_grant is fine; a future
+rewrite that starts naming the tenant mismatch is not.
+
+MUTATION: add 'Token tenant mismatch' to r6/access._PUBLIC_REASONS -> every
+test here reddens. Verified.
+"""
+
+import json
+
+import pytest
+
+from r6.stepup import generate_step_up_token
+
+#: Substrings that would mean the response described the OTHER tenant's token
+#: rather than the caller's request. 'mismatch' alone is not banned — an
+#: audience or operation mismatch is the caller's own token and is published
+#: deliberately (owner ruling, 2026-08-10).
+FORBIDDEN = ('tenant mismatch', 'Tenant mismatch', 'Token tenant')
+
+
+def _foreign_token_headers(tenant_id):
+    """A valid token for someone else, presented as this tenant."""
+    return {'X-Tenant-Id': tenant_id,
+            'X-Step-Up-Token': generate_step_up_token('some-other-tenant'),
+            'Content-Type': 'application/json'}
+
+
+def _assert_refused_without_naming_the_other_tenant(resp):
+    assert resp.status_code == 401, (
+        f'a foreign token must be refused, got {resp.status_code}')
+    body = resp.get_data(as_text=True)
+    for phrase in FORBIDDEN:
+        assert phrase not in body, (
+            f'the refusal contains {phrase!r}, which tells the caller their '
+            'token is valid for a different tenant (#478)')
+
+
+class TestForeignTokenIsRefusedWithoutExplanation:
+
+    def test_create(self, client, tenant_id):
+        resp = client.post(
+            '/r6/fhir/Patient',
+            data=json.dumps({'resourceType': 'Patient'}),
+            headers=_foreign_token_headers(tenant_id))
+        _assert_refused_without_naming_the_other_tenant(resp)
+
+    def test_update(self, client, tenant_id, sample_patient, auth_headers):
+        created = client.post('/r6/fhir/Patient',
+                              data=json.dumps(sample_patient),
+                              content_type='application/json',
+                              headers=auth_headers)
+        assert created.status_code == 201
+        pid = created.get_json()['id']
+        resp = client.put(f'/r6/fhir/Patient/{pid}',
+                          data=json.dumps({'resourceType': 'Patient',
+                                           'id': pid}),
+                          headers=_foreign_token_headers(tenant_id))
+        _assert_refused_without_naming_the_other_tenant(resp)
+
+    def test_share_bundle(self, client, tenant_id):
+        resp = client.post('/r6/fhir/$share-bundle',
+                           data=json.dumps({'patient_id': 'anything'}),
+                           headers=_foreign_token_headers(tenant_id))
+        _assert_refused_without_naming_the_other_tenant(resp)
+
+
+class TestTheCallersOwnReasonSurvives:
+    """The ruling's other half. Withholding one reason must not quietly
+    collapse the rest back into 'Invalid step-up token'."""
+
+    @pytest.mark.parametrize('path,method', [
+        ('/r6/fhir/Patient', 'post'),
+        ('/r6/fhir/$share-bundle', 'post'),
+    ])
+    def test_an_expired_token_says_it_expired(self, client, tenant_id,
+                                              path, method):
+        expired = generate_step_up_token(tenant_id, ttl_seconds=-10)
+        resp = getattr(client, method)(
+            path,
+            data=json.dumps({'resourceType': 'Patient'}),
+            headers={'X-Tenant-Id': tenant_id,
+                     'X-Step-Up-Token': expired,
+                     'Content-Type': 'application/json'})
+        assert resp.status_code == 401
+        assert 'expired' in resp.get_data(as_text=True).lower(), (
+            'an expired token is the caller\'s own; the ruling says tell them')


### PR DESCRIPTION
create, update and $share-bundle each hand-rolled the same nine lines: read
X-Step-Up-Token, refuse if absent, destructure the validator's tuple, refuse
if invalid. All three now call require_grant. 401 on both halves keeps each
site's dialect exactly; the kernel takes the statuses rather than choosing
them.

CLOSES #478. Those three lines were the leak:

    return _operation_outcome('error', 'security',
                              f'Step-up token rejected: {err}'), 401

`err` can be 'Token tenant mismatch'. Presenting a correctly-signed token for
tenant A while claiming tenant B got that answer back — which tells a caller
holding a credential they should not have that it is VALID and merely issued
elsewhere, separating "a real token I stole" from "junk". r6/read_auth.py:262
has always withheld that; these sites did not. The kernel classifies it in
_WITHHELD_REASONS (#475), so migrating closes it. The other nine reasons still
reach the caller, per the owner ruling.

tests/test_write_gate_reveals_no_foreign_token.py pins the outcome rather than
the mechanism: a foreign token is refused on all three paths without the
response naming the mismatch, and an expired token still says "expired". A
future rewrite that stops using require_grant is fine; one that starts naming
the tenant mismatch is not.

A conformance test had to be repaired, and it is the interesting part of this
PR. test_step_up_validation_turned_off_no_longer_scores_a switches the
guardrail off and asserts the grade drops below A. It did that by patching
`r6.routes.validate_step_up_token`. The migrated gates no longer consult that
name — require_grant resolves the validator as a module attribute on r6.stepup
(r6/access.py §1.0, deliberately, so module-path patching keeps working). So
the patch stopped switching anything off, the writes were still refused, and
the grade held at A.

The test FAILED rather than passing vacuously, which is the right way round —
but a test that cannot break the thing it is trying to break proves nothing
about the harness. It now patches both modules, and says why, so it keeps
grading the harness for as long as the migration takes. This is the shape
worth watching in the remaining slices: a test pinned to which function the
code calls rather than to what the code does.

Ratchets, both lowered to the measurement:
- _STEP_UP_CALLSITES 16 -> 13
- _GOD_MODULE_LINES 3931 -> 3922. The module SHRINKS for the first time since
  the kernel migration began: nine lines of gate become two, three times over.
  My first draft of the explanatory comment was fifteen lines repeated three
  times and pushed it to 3946; the ratchet caught that, and the answer was a
  shorter comment rather than a bigger pin.

Mutations run:
- Add 'Token tenant mismatch' to _PUBLIC_REASONS -> RED on all three write
  paths (test_write_gate_reveals_no_foreign_token), and correctly GREEN on the
  two expired-token cases, which test a different property.
- Patch only r6.routes in the conformance test -> RED
  (test_step_up_validation_turned_off_no_longer_scores_a). Observed as this
  change's own initial failure, not a synthetic mutation.

2939 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>