### PR TITLE
refactor(kernel): slice 10b — the remaining seventeen tenant reads in routes.py

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -1202,7 +1202,7 @@ def validate_resource(resource_type):
 
     result = validator.validate_resource(body, mode=mode, profile=profile)
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     record_audit_event('validate', resource_type, body.get('id'),
                        agent_id=request.headers.get('X-Agent-Id'),
                        tenant_id=tenant_id,
@@ -1236,7 +1236,7 @@ def ingest_context():
         return _operation_outcome('error', 'invalid',
                                   f'Bundle.type "{bundle_type}" is not a valid FHIR Bundle type'), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # In hardened deployments, bundle ingestion is a write boundary—not a
     # read-shaped convenience operation. Public/demo tenants remain usable in
@@ -1299,7 +1299,7 @@ def get_context(context_id):
     If ?_include=resources is passed, the actual resource data is included
     (redacted, filtered to context membership only).
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     envelope = ContextEnvelope.query.filter_by(
         context_id=context_id, tenant_id=tenant_id
     ).first()
@@ -1351,7 +1351,7 @@ def get_context(context_id):
 @r6_blueprint.route('/AuditEvent', methods=['GET'])
 def search_audit_events():
     """Search AuditEvent records, optionally filtered by context-id."""
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     agent_id = request.headers.get('X-Agent-Id')
     modifier_keys = [key for key in request.args if ':' in key]
     ignored_params = [key for key in request.args
@@ -1483,7 +1483,7 @@ def import_stub():
 
     source_version = request.args.get('source-version', 'R4')
     entries = body.get('entry', [])
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     result = {
         'resourceType': 'OperationOutcome',
@@ -1536,7 +1536,7 @@ def observation_stats():
     Limitations: only supports valueQuantity (not valueCodeableConcept,
     valueString, etc.). No percentile or median. No component support.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     code = request.args.get('code')
     patient_ref = request.args.get('patient')
 
@@ -1624,7 +1624,7 @@ def observation_lastn():
     Returns the most recent observations grouped by code, optionally
     filtered by patient and code. Default N=1.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     code = request.args.get('code')
     patient_ref = request.args.get('patient')
     max_n = request.args.get('max', 1, type=int)
@@ -1697,7 +1697,7 @@ def list_subscription_topics():
     Introduced in R5, maturing in R6. Topics define subscribable events.
     This endpoint supports discovery only — no notification dispatch.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # Query stored SubscriptionTopics for this tenant
     topics = R6Resource.query.filter_by(
@@ -1738,7 +1738,7 @@ def evaluate_permission():
     action, and resource, returns whether the action is permitted or denied
     based on stored Permission resources.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     body = request.get_json(silent=True)
     if not body:
         return _operation_outcome('error', 'invalid', 'Request body must be valid JSON'), 400
@@ -1839,7 +1839,7 @@ def deidentify_endpoint(resource_type, resource_id):
         return _operation_outcome('error', 'not-supported',
                                   f'Resource type {resource_type} is not supported'), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     resource = R6Resource.query.filter_by(
         id=resource_id, resource_type=resource_type,
         is_deleted=False, tenant_id=tenant_id
@@ -1880,7 +1880,7 @@ def export_audit():
     context_id = request.args.get('context-id')
     count = request.args.get('_count', 1000, type=int)
     count = max(1, min(count, 10000))
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # Enforce tenant isolation on audit export
     query = AuditEventRecord.query.filter_by(
@@ -2611,7 +2611,7 @@ def audit_stream():
     Server-Sent Events stream for real-time audit trail.
     Clients receive new AuditEvents as they are created.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     def generate():
         last_id = None
@@ -3012,7 +3012,7 @@ def curatr_evaluate(resource_type, resource_id):
             f'Resource type {resource_type} is not supported'
         ), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     resource = R6Resource.query.filter_by(
         id=resource_id, resource_type=resource_type,
         is_deleted=False, tenant_id=tenant_id
@@ -3083,7 +3083,7 @@ def curatr_apply_fix(resource_type, resource_id):
             f'Resource type {resource_type} is not supported'
         ), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     step_up_token = request.headers.get('X-Step-Up-Token')
     if not step_up_token:
         return _operation_outcome(
@@ -3224,7 +3224,7 @@ def compiled_truth(resource_type, resource_id):
             f'Resource type {resource_type} is not supported',
         ), 400
 
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
     if not tenant_id:
         return _operation_outcome(
             'error', 'security',
@@ -3678,7 +3678,7 @@ def fhir_inventory():
 
     Read-only: tenant isolation + audit apply, no step-up required.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # Efficient grouped count: one query, GROUP BY resource_type.
     rows = (
@@ -3755,7 +3755,7 @@ def fhir_profile_adherence():
 
     Read-only: tenant isolation + audit apply, no step-up required.
     """
-    tenant_id = request.headers.get('X-Tenant-Id')
+    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
 
     # Distinct types present for this tenant, with totals.
     type_rows = (

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -330,9 +330,18 @@ def test_the_god_module_only_shrinks():
 
 
 #: Call sites that read the tenant straight off the header instead of asking
-#: the access kernel, across all of r6/. 31 -> 27: slice 10a migrated create,
-#: read, update and search in r6/routes.py, which is also that module's first
-#: r6.access import.
+#: the access kernel, across all of r6/. 31 -> 27 -> 9: slice 10a took create,
+#: read, update and search; slice 10b took the remaining seventeen in
+#: r6/routes.py.
+#:
+#: Every one of the seventeen was checked against the exempt-path list before
+#: it moved, by walking each read back to the route decorator that owns it.
+#: The first version of that walker matched only single-line decorators, fell
+#: back to an earlier unrelated route, and reported three curatr endpoints as
+#: sitting on the exempt /demo/ prefix. They are not — they are
+#: /<resource_type>/<resource_id>/$curatr-*. The walker was fixed and re-run
+#: before anything moved. A migration tool that is wrong in the SAFE
+#: direction on Tuesday is wrong in the other direction on Wednesday.
 #:
 #: This counts the whole package, not just r6/routes.py. The first draft
 #: scanned only the god module and pinned 20; the scan then reported 27 and
@@ -360,7 +369,7 @@ def test_the_god_module_only_shrinks():
 #: behaviour change, not a refactor. Check _is_exempt_discovery_path before
 #: moving a call site, per site — that is the whole reason this is 6 PRs and
 #: not one sed.
-_RAW_TENANT_READS = 27
+_RAW_TENANT_READS = 9
 
 
 def test_raw_tenant_header_reads_only_decrease():


### PR DESCRIPTION
_RAW_TENANT_READS 27 -> 9. Every raw `request.headers.get('X-Tenant-Id')` in
r6/routes.py is gone except the two that should stay: enforce_tenant_id and
authenticate_read, the before_request hooks. Those ARE the enforcement point;
reading the header is their job.

Each of the seventeen was checked against the exempt-path list before it
moved, because that check is the only thing separating a refactor from a
behaviour change. On a gated route the hook has already required the header
and format-checked it with the same pattern the kernel uses, so the kernel
call re-validates a value that cannot fail — inert. On an EXEMPT route the
hook returns early, the header may legitimately be absent, and the kernel
would raise TenantRejected where the old code got None.

    line  route                                             status
    1205  /<resource_type>/$validate                        gated
    1239  /Bundle/$ingest-context                           gated
    1302  /context/<context_id>                             gated
    1354  /AuditEvent                                       gated
    1486  /$import-stub                                     gated
    1539  /Observation/$stats                               gated
    1627  /Observation/$lastn                               gated
    1700  /SubscriptionTopic/$list                          gated
    1741  /Permission/$evaluate                             gated
    1842  /<resource_type>/<resource_id>/$deidentify        gated
    1883  /AuditEvent/$export                               gated
    2614  /AuditEvent/$stream                               gated
    3015  /<resource_type>/<resource_id>/$curatr-evaluate   gated
    3086  /<resource_type>/<resource_id>/$curatr-apply-fix  gated
    3227  /<resource_type>/<resource_id>/$compiled-truth    gated
    3681  /$inventory                                       gated
    3758  /$profile-adherence                               gated

THE TOOL THAT BUILT THAT TABLE WAS WRONG THE FIRST TIME, and it is the reason
this is one PR rather than four. It walked each read back to the nearest route
decorator, matching only single-line ones. Three curatr endpoints use a
multi-line `@r6_blueprint.route(` with the path on the following line, so the
walker skipped past them to an earlier unrelated decorator and reported all
three as sitting on the exempt /demo/ prefix. They are not.

That error was in the safe direction — it would have made me skip three sites
that were fine to migrate. It would not have been safe the other way round,
and a tool that mis-attributes routes has no idea which direction it is wrong
in. The walker was fixed to read the whole decorator and re-run before
anything moved.

The table is in this description on purpose: four PRs of identical mechanical
edits give a reviewer nothing to check, while one PR with the exemption
analysis lets them check the thing that actually matters.

Mutations run:
- Revert any one migrated read -> RED
  (test_raw_tenant_header_reads_only_decrease)

2939 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>