### PR TITLE
refactor(kernel): slice 5d — the confirm gate, unblocked by the ruling

### DIFF
--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -492,34 +492,29 @@ def confirm_action(action_id):
         return _error(400, 'approved_via must be one of: %s'
                       % ', '.join(APPROVED_VIA_VALUES))
 
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _error(401, 'Action confirm requires X-Step-Up-Token header')
-    # NOT MIGRATED, deliberately (kernel slice 5).
-    #
-    # This endpoint's wire contract includes the REASON a token was refused:
-    # tests/actions/test_confirm_is_commit.py pins 'already used (replay)',
-    # 'audience mismatch' and 'operation mismatch' in the response body. The
-    # kernel renders one uniform OperationOutcome and logs the specific
-    # reason rather than returning it, so migrating this site would drop
-    # three deliberately-pinned diagnostics.
-    #
-    # Protocol rule 4: a behaviour change is a failure, not a merge conflict,
-    # and the fix is never to edit the test to match. Whether a step-up
-    # refusal should tell the caller WHY is an owner decision (spec Open
-    # Question 1's neighbour), so it gets its own slice and its own ruling.
+    # Access kernel, slice 5d. Slice 5 left this gate behind because the
+    # kernel collapsed every refusal into 'Invalid step-up token' and this
+    # endpoint's contract names the cause. The owner ruled on 2026-08-10 —
+    # always tell why — so the three reasons this contract pins ('already
+    # used (replay)', 'audience mismatch', 'operation mismatch') now survive
+    # the kernel. The one reason it withholds, 'Token tenant mismatch', was
+    # never part of this contract.
     #
     # consume_nonce: the action-bound confirm token is a SINGLE-USE execution
     # credential (spec v3). Commit uses a separate generic write token;
     # only the human's Approve surface can mint this credential, and confirm
-    # spends it so a captured token cannot authorize another execution.
-    valid, err = validate_step_up_token(
-        step_up_token, tenant_id, consume_nonce=True,
-        require_audience=ACTION_APPROVAL_AUDIENCE,
-        require_operation=action_id,
+    # spends it so a captured token cannot authorize another execution. It
+    # stays behind the body validation above so a 400 on a malformed request
+    # does not burn the credential.
+    require_grant(
+        scope=Scope.WRITE,
+        tenant=tenant,
+        audience=ACTION_APPROVAL_AUDIENCE,
+        operation=action_id,
+        consume_nonce=True,
+        absent_status=401,
+        rejected_status=401,
     )
-    if not valid:
-        return _error(401, 'Step-up token rejected: %s' % err)
 
     # (a) Load, tenant-scoped.
     action = ProposedAction.query.filter_by(

--- a/tests/actions/test_confirm_is_commit.py
+++ b/tests/actions/test_confirm_is_commit.py
@@ -323,6 +323,23 @@ def test_confirm_rejects_unknown_approval_channel(client, tenant_headers,
 # step-up nonce consumption at confirm (single-use execution credential)
 # ---------------------------------------------------------------------------
 
+
+def _refusal_text(resp):
+    """The refusal reason, whatever envelope the endpoint answers in.
+
+    /confirm used to answer {'error': '...'} from this blueprint's _error
+    helper. Kernel slice 5d moved its step-up gate to require_grant, which
+    renders a FHIR OperationOutcome — the same change the three gates in
+    slice 5 made. The REASON is what this file pins and the reason survives;
+    only the envelope moved, so these assertions read either shape rather
+    than pinning one.
+    """
+    body = resp.get_json() or {}
+    if 'error' in body:
+        return body['error']
+    return ' '.join(i.get('diagnostics', '')
+                    for i in body.get('issue', []))
+
 def test_same_token_cannot_confirm_twice(client, tenant_headers, auth_headers,
                                          app, action_registry, fake_providers,
                                          monkeypatch):
@@ -343,7 +360,7 @@ def test_same_token_cannot_confirm_twice(client, tenant_headers, auth_headers,
     # the already-spent action state is considered.
     second = _confirm(client, auth_headers, first_action, headers=approval)
     assert second.status_code == 401
-    assert 'already used (replay)' in second.get_json()['error']
+    assert 'already used (replay)' in _refusal_text(second)
     assert len(fake_providers) == 1   # nothing executed
     with app.app_context():
         row = db.session.get(ProposedAction, second_action)
@@ -360,7 +377,7 @@ def test_generic_commit_token_cannot_confirm(
     assert _commit(client, auth_headers, action_id).status_code == 202
     resp = _confirm(client, auth_headers, action_id, headers=auth_headers)
     assert resp.status_code == 401
-    assert 'audience mismatch' in resp.get_json()['error']
+    assert 'audience mismatch' in _refusal_text(resp)
     assert fake_providers == []
 
     # The rejected generic token was not consumed; the separately minted,
@@ -383,7 +400,7 @@ def test_action_bound_token_cannot_confirm_a_different_action(
     wrong_action = _confirm(client, auth_headers, second_action,
                             headers=approval)
     assert wrong_action.status_code == 401
-    assert 'operation mismatch' in wrong_action.get_json()['error']
+    assert 'operation mismatch' in _refusal_text(wrong_action)
     assert fake_providers == []
 
 

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -133,7 +133,11 @@ def _report(sites, pin, what):
 #: create, update and $share-bundle. Those three also carried the #478 leak:
 #: they interpolated the validator's raw reason into the response, including
 #: 'Token tenant mismatch', which the kernel withholds.
-_STEP_UP_CALLSITES = 13
+#: 13 -> 12: slice 5d took the actions `confirm` gate, the one slice 5 left
+#: behind. It was blocked on whether a refusal may state its reason; the
+#: owner ruled yes (#475), so the three reasons its contract pins survive
+#: the kernel.
+_STEP_UP_CALLSITES = 12
 
 
 def test_direct_step_up_validation_only_decreases():


### PR DESCRIPTION
Slice 5 (#469) migrated three of the four step-up gates in the actions
blueprint and named the fourth as deliberately left behind:

    # NOT MIGRATED, deliberately (kernel slice 5).
    # This endpoint's wire contract includes the REASON a token was refused
    # ... migrating this site would drop three deliberately-pinned
    # diagnostics.
    # Whether a step-up refusal should tell the caller WHY is an owner
    # decision, so it gets its own slice and its own ruling.

The owner ruled on 2026-08-10: always tell why (#475). So the three reasons
this contract pins — 'already used (replay)', 'audience mismatch',
'operation mismatch' — now survive require_grant. The one reason the kernel
withholds, 'Token tenant mismatch', was never part of this contract.

That dependency is not an argument in a commit message; it is a mutation.
Reverting _public_reason to the pre-ruling behaviour (always
'Invalid step-up token') reddens exactly the three tests that blocked this
slice, and nothing else. Verified.

What actually changes on the wire is the ENVELOPE, not the reason. /confirm
answered {'error': '...'} from this blueprint's own _error helper; it now
answers a FHIR OperationOutcome, the same shape the three gates in slice 5
moved to. Status stays 401 for both halves.

Checked the one real consumer before writing any of this.
careagents/healthclaw.py:374 reads r.status_code on the failure path and only
decodes the body on success — it never touches ['error'], so the envelope
change does not reach it. The three tests did, and their assertions now read
either shape through a helper rather than pinning one, because the reason is
what this file is for.

_STEP_UP_CALLSITES 13 -> 12. Every step-up gate in the actions blueprint now
goes through the kernel.

Mutations run:
- Revert _public_reason to always-generic -> RED on exactly the three
  contract tests (test_same_token_cannot_confirm_twice,
  test_generic_commit_token_cannot_confirm,
  test_action_bound_token_cannot_confirm_a_different_action)

2939 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>