### PR TITLE
feat(dashboard): publish what the harness does NOT grade (#401)

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,6 +198,7 @@ def r6_dashboard():
     zeroed summary on failure would let the template print "0 checks failed"
     over a report that was never obtained.
     """
+    from r6.conformance.probes import UNGRADED
     from r6.conformance.snapshot import guardrail_snapshot, summarize
     # ?fresh=1 bypasses the 10-minute cache. Honoured only where a run is
     # possible; guardrail_snapshot ignores it on the read-only host, which
@@ -212,6 +213,11 @@ def r6_dashboard():
         summary=summarize(snapshot['report']) if snapshot['measured'] else None,
         writes_here=not is_read_only(current_app.config),
         stateful_host=STATEFUL_HOST,
+        # Rendered whether or not the measurement arrived: what the harness
+        # never covers does not depend on today's run, and a page that drops
+        # its exclusions on a bad day is at its least honest exactly when it
+        # can least afford to be.
+        ungraded=UNGRADED,
     )
 
 

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -49,6 +49,48 @@ PROPERTIES = (
     "error_fidelity",
 )
 
+#: Guardrails this harness does NOT grade, published beside the seven it does.
+#:
+#: The grade is read as a product claim. A reader who sees "7/7, 35 checks"
+#: and no list of exclusions will assume the seven are the whole surface, and
+#: the first thing a skeptical adopter checks — can a stranger read patient
+#: records — is not among them. Printing this list on /r6-dashboard costs a
+#: paragraph; letting someone discover it themselves costs the grade's
+#: credibility entirely.
+#:
+#: It lives HERE, next to PROPERTIES, rather than in the template, because
+#: this is the file you edit when you add a property. A list of exclusions
+#: kept anywhere else drifts into claiming we still do not measure something
+#: we started measuring last month, and a stale exclusion is as dishonest as
+#: a stale claim — it just fails in the safe-looking direction.
+#:
+#: tests/test_ungraded_is_published.py fails when a key appears in both
+#: tuples, so removing a probe's entry is part of adding the probe.
+#:
+#: Source: #401 (read auth, and the list it enumerates). Read auth cannot be
+#: graded by adding a probe — the harness has no way to tell "read auth is
+#: off because this is a public demo tenant" from "off because someone
+#: disabled it", so it needs a declared-posture design first. Until that
+#: lands, the honest move is to say so.
+UNGRADED = (
+    ("read authentication",
+     "whether an unauthenticated caller can read another tenant's records. "
+     "READ_AUTH_ENABLED defaults off and is off in this harness's fixture, "
+     "so a deployment serving records to strangers scores what a gated one "
+     "scores (#401)"),
+    ("the action rail's separation",
+     "that propose, commit and confirm cannot be collapsed into one step"),
+    ("step-up refusals beyond a forged token",
+     "expired, cross-tenant, read-scope-on-write and replayed-nonce are "
+     "each verified by unit tests, none by this harness"),
+    ("redaction on $lastn and SubscriptionTopic/$list",
+     "graded on reads and searches, not on these two operations"),
+    ("rate limiting, the mint gate, and purge",
+     "no probe exercises any of them, so this grade says nothing about "
+     "whether a caller can flood the API, mint a token they should not "
+     "have, or leave data behind after a delete"),
+)
+
 _ERROR_FIDELITY_GRADE_ORDER = {"F": 0, "C": 1, "A": 2}
 _MCP_INVALID_RESOURCE = "WidgetQuintaviousZzyzxbarton"
 _MCP_HOSTILE_URL = "https://db.internal.example/patient/secret"

--- a/templates/r6_dashboard.html
+++ b/templates/r6_dashboard.html
@@ -244,6 +244,17 @@
       {% endfor %}
     {% endif %}
 
+    {# Not conditional on snapshot.measured: these hold on every run. #}
+    {% for name, why in ungraded %}
+    <div class="cf-limit">
+      {# "Not graded:" rather than "{{ name }} is not graded": the entries
+         are a mix of singular and plural ("read authentication" vs "step-up
+         refusals"), and one verb cannot agree with both. #}
+      <h3 class="cf-limit__h">Not graded: {{ name }}</h3>
+      <p class="cf-limit__b">{{ why }}</p>
+    </div>
+    {% endfor %}
+
     <div class="cf-limit">
       <h3 class="cf-limit__h">It is a self-test, not an audit</h3>
       <p class="cf-limit__b">

--- a/tests/test_ungraded_is_published.py
+++ b/tests/test_ungraded_is_published.py
@@ -1,0 +1,112 @@
+"""What the harness does not grade is published beside what it does (#401).
+
+The conformance grade is read as a product claim. "Grade A, 7/7, 35 checks"
+with no list of exclusions reads as "these seven are the surface" — and the
+first thing a skeptical adopter checks, whether a stranger can read patient
+records, is not one of them. READ_AUTH_ENABLED defaults off and is off in this
+harness's own fixture, so a deployment serving records to anyone who asks
+scores exactly what a correctly-gated one scores.
+
+That gap needs a declared-posture design before a probe can grade it (#401
+explains why adding a naive probe reproduces the #213 defect). Until then the
+honest move is to say so, on the page that publishes the grade.
+
+The failure mode this file guards is the SECOND one: a stale exclusion. A
+list of "we do not measure X" that outlives the probe for X is as dishonest as
+a stale claim — it just fails in the direction that looks modest, so nobody
+goes looking for it.
+"""
+
+import html as html_mod
+import re
+from pathlib import Path
+
+from r6.conformance.probes import PROPERTIES, UNGRADED
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_no_property_is_both_graded_and_listed_as_ungraded():
+    """MUTATION: add 'phi_redaction' to UNGRADED -> red.
+
+    Removing an entry from UNGRADED is part of adding the probe that grades
+    it. This is the line that makes that a rule rather than a hope.
+    """
+    graded = {p.replace('_', ' ') for p in PROPERTIES}
+    listed = {name.lower() for name, _ in UNGRADED}
+    both = {n for n in listed if n in graded}
+    assert not both, (
+        f'{sorted(both)} appear in both PROPERTIES and UNGRADED. If the '
+        'probe now grades it, delete the UNGRADED entry in the same PR.')
+
+
+def test_every_entry_says_what_is_not_covered():
+    """A name with no explanation is a word, not a disclosure."""
+    for name, why in UNGRADED:
+        assert name.strip(), 'an UNGRADED entry has no name'
+        assert len(why.strip()) > 40, (
+            f'{name!r} is listed as ungraded without saying what that means '
+            'for a reader')
+
+
+def test_read_auth_is_named_explicitly():
+    """The one an adopter checks first, and the reason #401 exists.
+
+    Pinned by name rather than by count so that trimming the list cannot
+    quietly drop the entry that matters most.
+    """
+    names = ' '.join(name for name, _ in UNGRADED).lower()
+    whys = ' '.join(why for _, why in UNGRADED).lower()
+    assert 'read auth' in names, 'read authentication is no longer listed'
+    assert '#401' in whys, 'the read-auth entry no longer cites its issue'
+
+
+class TestThePagePublishesThem:
+
+    def test_each_ungraded_entry_reaches_the_dashboard(self, client):
+        """MUTATION: drop the {% for %} over `ungraded` -> red."""
+        # Unescaped before comparing: Jinja renders the apostrophe in "the
+        # action rail's separation" as &#39;, so a raw substring test fails on
+        # a page that is perfectly correct. Comparing against the wrong
+        # representation of the thing you are checking is the same mistake as
+        # not checking at all — it just fails loudly instead of quietly.
+        html = html_mod.unescape(
+            client.get('/r6-dashboard').data.decode())
+        for name, _ in UNGRADED:
+            assert name in html, f'{name!r} is not on the page'
+
+    def test_they_survive_a_failed_measurement(self, client, monkeypatch):
+        """The exclusions do not depend on today's run.
+
+        A page that drops its scope limits when the fetch fails is at its
+        least honest exactly when it has least to show — the state where a
+        reader most needs to know what was never covered.
+
+        MUTATION: move the {% for %} inside `{% if snapshot.measured %}` -> red.
+        """
+        from r6.conformance import snapshot as snap
+
+        def boom(*a, **k):
+            raise snap.HarnessUnavailable('no measurement in this test')
+        monkeypatch.setattr(snap, 'local_report', boom)
+        monkeypatch.setattr(snap, 'remote_report', boom)
+
+        html = html_mod.unescape(
+            client.get('/r6-dashboard').data.decode())
+        assert 'No measurement. This is not a pass.' in html
+        for name, _ in UNGRADED:
+            assert name in html, (
+                f'{name!r} vanished from the page when the run failed')
+
+
+def test_the_issue_is_still_open_or_the_entry_is_gone():
+    """Documentation-only: the read-auth entry cites #401, so the two move
+    together. Asserted as a source-level cross-reference rather than a
+    network call — a test that reaches GitHub fails on a plane.
+    """
+    probes = (ROOT / 'r6' / 'conformance' / 'probes.py').read_text()
+    block = re.search(r'UNGRADED = \((.*?)\n\)\n', probes, re.S)
+    assert block, 'UNGRADED tuple not found'
+    assert '#401' in block.group(1), (
+        'the read-auth exclusion no longer points at the issue that explains '
+        'why it cannot simply be probed')


### PR DESCRIPTION
/r6-dashboard prints "Grade A · 7/7 properties · 35 checks". A reader takes
that as the surface. It is not.

The first thing a skeptical adopter checks is whether a stranger can read
patient records, and the harness does not grade that at all.
READ_AUTH_ENABLED defaults off and is off in the harness's own fixture, so a
deployment serving records to anyone who asks scores exactly what a correctly
gated one scores (#401). Four more guardrails are ungraded for less alarming
reasons. None of them were on the page.

The page's whole thesis is that it shows you what was measured. A measurement
report that omits its exclusions is making the strongest claim on the page by
implication, which is the one kind of claim it promised not to make.

So the exclusions render beside the results, in the same section as the
harness's own caveats, at the same weight as the grade.

WHERE THE LIST LIVES IS THE DESIGN. UNGRADED sits in r6/conformance/probes.py
directly beneath PROPERTIES — the file you edit when you add a probe. Kept in
the template instead, it drifts into claiming we still do not measure
something we started measuring last month. A stale exclusion is as dishonest
as a stale claim; it just fails in the modest-looking direction, so nobody
goes looking for it.

tests/test_ungraded_is_published.py makes that a rule rather than a hope:
- a key cannot appear in both PROPERTIES and UNGRADED, so deleting the entry
  is part of adding the probe
- every entry must say what it means for a reader, not just name a thing
- read auth must stay named, and must keep citing #401
- the entries must reach the page, AND must survive a failed measurement —
  a page that drops its scope limits when the fetch fails is at its least
  honest exactly when it has least to show

This does not fix #401. That needs the declared-posture design the issue
describes, and adding a probe that passes when read auth is off would
reproduce the #213 defect. This makes the gap visible to the reader who would
otherwise find it themselves, which is the part that should not wait.

Two things my own guards caught while writing this:
- 'rate limiting, the mint gate, and purge' was listed with the explanation
  'no probe exercises any of them' — 30 characters, and the test requiring an
  entry to say what it means for a reader rejected it. It now says what a
  reader loses.
- The page test compared raw strings against rendered HTML and failed on
  "the action rail's separation", where Jinja escapes the apostrophe. The
  page was correct; the check was comparing against the wrong representation
  of the thing it was checking.

Mutations run:
- Move the {% for %} inside {% if snapshot.measured %} -> RED
  (test_they_survive_a_failed_measurement)
- Add 'phi redaction' to UNGRADED -> RED
  (test_no_property_is_both_graded_and_listed_as_ungraded)

2945 passed, 13 skipped, 1 xfailed. ruff clean.

Refs #401.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>