### PR TITLE
fix(conformance): the CLI defaults to the self-test tenant, and says it writes

### DIFF
--- a/scripts/guardrail_conformance.py
+++ b/scripts/guardrail_conformance.py
@@ -8,13 +8,32 @@ real, not marketing.
 Usage:
     python scripts/guardrail_conformance.py \
         --base-url https://app.healthclaw.io \
-        --tenant desktop-demo \
         --step-up-token <token>          # mint via POST /r6/fhir/internal/step-up-token
     # For protected MCP coverage, also set MCP_AUTH_TOKEN and pass --mcp-url.
     # add --json for machine-readable output; exits non-zero if grade < A.
 
-The probes create SYNTHETIC data (obviously-fake PHI); a live run never touches
-real patient records.
+The probes WRITE. They create synthetic Patients and Observations in the tenant
+they grade, and they do not remove them.
+
+That is why --tenant now defaults to the dedicated self-test tenant instead of
+being required. The example above used to name the public demo tenant, and
+anyone who followed it left probe patients in the tenant the product demos
+from: six of them accumulated in production, and a physician advisor found the
+resulting mess on camera the day before a launch recording (#463).
+
+The demo tenant is not named anywhere in this file on purpose. A tenant id
+written here is one somebody will paste, and the test that enforces that
+caught this very paragraph on its first draft.
+
+The self-conformance ENDPOINT already had this right — r6/conformance/routes.py
+writes to a dedicated tenant "so a caller's data is never touched." The two
+paths now agree, and share one constant.
+
+This docstring used to close by promising a live run leaves real patient
+records alone. Read carefully, that was about the DATA the probes send, which
+is obviously fake. Read the way anyone actually reads it, it said the run is
+harmless to whatever tenant you point it at. It is not, and that gap between
+the two readings is the whole defect.
 """
 
 import argparse
@@ -30,13 +49,17 @@ from r6.conformance import (  # noqa: E402
     ProbeContext,
     run_conformance,
 )
+from r6.conformance.snapshot import SELFTEST_TENANT  # noqa: E402
 
 
 def main():
     ap = argparse.ArgumentParser(description="HealthClaw guardrail conformance scorecard")
     ap.add_argument("--base-url", required=True, help="e.g. https://app.healthclaw.io")
-    ap.add_argument("--tenant", required=True,
-                    help="tenant id (a public/synthetic tenant is fine)")
+    ap.add_argument("--tenant", default=SELFTEST_TENANT,
+                    help=(f"tenant to grade (default: {SELFTEST_TENANT}). "
+                          "THE PROBES WRITE HERE and do not clean up. Point "
+                          "this at a tenant whose contents you do not mind "
+                          "growing — never at a demo or a real one."))
     ap.add_argument("--step-up-token", required=True,
                     help="write-capable step-up token for --tenant")
     ap.add_argument("--second-tenant", default="conformance-tenant-b",
@@ -51,6 +74,15 @@ def main():
     )
     ap.add_argument("--json", action="store_true", help="emit JSON instead of a scorecard")
     args = ap.parse_args()
+
+    # Say it out loud when the operator overrides the default. A warning they
+    # can read before the writes happen is worth more than a note in --help
+    # they read after.
+    if args.tenant != SELFTEST_TENANT:
+        print(f"warning: grading '{args.tenant}' rather than the dedicated "
+              f"'{SELFTEST_TENANT}'. This run will leave synthetic Patients "
+              f"and Observations in '{args.tenant}' and will not remove "
+              "them.", file=sys.stderr)
 
     ctx = ProbeContext(tenant=args.tenant, step_up_token=args.step_up_token,
                        second_tenant=args.second_tenant)

--- a/tests/test_conformance_cli_writes_where_it_says.py
+++ b/tests/test_conformance_cli_writes_where_it_says.py
@@ -1,0 +1,115 @@
+"""The conformance CLI does not write into a tenant by accident (#463).
+
+The probes create synthetic Patients and Observations in whatever tenant they
+grade, and never remove them. The CLI's documented example read
+`--tenant desktop-demo` — the tenant the product demos from — and `--tenant`
+was required, so following the example was the path of least resistance.
+
+Six probe patients ("Zzyzxbarton, Quintavious") accumulated in production
+desktop-demo that way. They were the second source behind a physician
+advisor's report of duplicate records on camera, the day before a launch
+recording; the first was a non-idempotent seed (#457).
+
+The self-conformance ENDPOINT never had this problem. r6/conformance/routes.py
+has always written to a dedicated tenant "so a caller's data is never touched."
+The two paths disagreed about a rule one of them had already established, and
+the one with a documented example pointing at the demo tenant was the one
+people ran by hand.
+
+MUTATION: restore `required=True` on --tenant, or point the default back at
+desktop-demo -> the tests here redden.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "guardrail_conformance.py"
+
+
+def _source():
+    return CLI.read_text(encoding="utf-8")
+
+
+def test_the_cli_and_the_endpoint_share_one_selftest_tenant():
+    """MUTATION: hardcode the tenant string in the CLI -> red.
+
+    Two copies of a tenant name drift, and the drift is invisible until one
+    of them is pointed somewhere real.
+    """
+    from r6.conformance.snapshot import SELFTEST_TENANT
+    src = _source()
+    assert "from r6.conformance.snapshot import SELFTEST_TENANT" in src, (
+        "the CLI no longer shares the endpoint's selftest tenant constant")
+    assert f'"{SELFTEST_TENANT}"' not in src, (
+        "the CLI hardcodes the selftest tenant instead of importing it")
+
+
+def test_tenant_defaults_to_the_selftest_tenant():
+    """MUTATION: `required=True` on --tenant -> red."""
+    from r6.conformance.snapshot import SELFTEST_TENANT
+    src = _source()
+    block = re.search(r'ap\.add_argument\("--tenant".*?\)\n', src, re.S)
+    assert block, "--tenant argument not found"
+    arg = block.group(0)
+    assert "default=SELFTEST_TENANT" in arg, (
+        "--tenant no longer defaults to the dedicated selftest tenant")
+    assert "required=True" not in arg, (
+        "--tenant is required again, so the documented example is once more "
+        "the thing people copy")
+    assert SELFTEST_TENANT == "conformance-selftest"
+
+
+def test_no_documented_example_points_at_a_demo_tenant():
+    """MUTATION: put `--tenant desktop-demo` back in the docstring -> red.
+
+    Checks the whole file, not just the usage block: a demo tenant in a
+    --help string or a comment gets copied just as readily.
+    """
+    src = _source()
+    for tenant in ("desktop-demo", "gigi-", "demo-tenant"):
+        assert tenant not in src, (
+            f"{tenant!r} appears in the conformance CLI. The probes write "
+            "and do not clean up, so any tenant named here is one somebody "
+            "will point them at (#463).")
+
+
+def test_the_help_text_says_the_probes_write():
+    """A flag whose help text does not mention the writes is how this
+    happened. 'a public/synthetic tenant is fine' was the old wording; it is
+    true about the DATA and silent about the side effect."""
+    src = _source()
+    block = re.search(r'ap\.add_argument\("--tenant".*?\)\n', src, re.S)
+    assert block
+    help_text = block.group(0).lower()
+    assert "write" in help_text, (
+        "--help does not tell the operator the probes write into this tenant")
+    assert "clean up" in help_text or "do not remove" in help_text, (
+        "--help does not tell the operator the probes leave the data behind")
+
+
+def test_overriding_the_default_warns_before_it_writes():
+    """MUTATION: delete the warning branch -> red."""
+    src = _source()
+    assert "if args.tenant != SELFTEST_TENANT:" in src, (
+        "the CLI no longer warns when asked to grade a different tenant")
+    warn = src.split("if args.tenant != SELFTEST_TENANT:", 1)[1][:600]
+    assert "stderr" in warn, "the warning does not go to stderr"
+    assert "will not remove" in warn or "not remove" in warn, (
+        "the warning does not say the data stays behind")
+
+
+def test_the_docstring_no_longer_claims_a_run_is_harmless():
+    """The sentence that made this defect readable as safe.
+
+    "a live run never touches real patient records" was true about the
+    synthetic data the probes send, and read by everyone as a statement about
+    the tenant. A reassurance that is technically true and practically
+    misleading is docs/defect-catalogue.md §1.
+    """
+    src = _source()
+    assert "never touches real patient records" not in src, (
+        "the docstring again claims a live run is harmless; it writes into "
+        "the tenant it grades")
+    assert "The probes WRITE" in src, (
+        "the docstring no longer leads with the fact that the probes write")


### PR DESCRIPTION
Closes #463.

The probes create synthetic Patients and Observations in the tenant they
grade and never remove them. `--tenant` was REQUIRED, and the documented
example named the public demo tenant — so the path of least resistance was to
copy the example and write into the tenant the product demos from.

Six probe patients ("Zzyzxbarton, Quintavious") accumulated in production that
way. They were the second source behind a physician advisor's report of
duplicate records on camera, the day before a launch recording; the first was
a non-idempotent seed (#457). I initially misattributed all of them to the
seed.

Three changes, which are options 1 and 2 from the issue:

- `--tenant` defaults to the dedicated self-test tenant and is no longer
  required. The constant is IMPORTED from r6/conformance/snapshot.py rather
  than retyped, so the CLI and the self-conformance endpoint cannot drift
  apart about which tenant is safe. The endpoint has always got this right —
  it writes to a dedicated tenant "so a caller's data is never touched" — and
  the two paths now agree.
- The help text leads with THE PROBES WRITE HERE and says they do not clean
  up. The old text read "a public/synthetic tenant is fine", which is true
  about the data and silent about the side effect.
- Overriding the default prints a warning to stderr naming the tenant and
  what will be left in it, before the writes happen.

Not doing option 3 (clean up after itself), for the reason the issue gives: a
probe that deletes is a probe that can delete the wrong thing.

The docstring's closing promise had to go too. It said a live run never
touches real patient records. That is true about the DATA the probes send,
and it is read by everyone as a statement about the tenant. A reassurance
that is technically true and practically misleading is
docs/defect-catalogue.md §1, and it is the sentence that made the footgun
read as safe.

tests/test_conformance_cli_writes_where_it_says.py pins all of it, including
that no demo tenant id appears anywhere in the file — because an id written
here is one somebody will paste. That test caught my own first draft of the
explanatory docstring, which quoted the old example verbatim and would have
left the string sitting in the file for the next person to copy. Same for the
"never touches real patient records" sentence, which I had reproduced in
order to explain it. Both are §4, a guard matching the prose that describes
the bug, and both were reworded rather than exempted.

Mutations run:
- Restore `required=True` on --tenant -> RED
- Put the demo tenant back in the usage example -> RED
- Delete the override warning -> RED
- Hardcode the tenant string instead of importing it -> RED (covered by
  test_the_cli_and_the_endpoint_share_one_selftest_tenant)

Verified by running the CLI: --help shows the default and the write warning;
`--tenant desktop-demo` prints the stderr warning before it starts.

2951 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>