### PR TITLE
fix(validator): say what was checked, and stop saying "validation passed"

### DIFF
--- a/r6/validator.py
+++ b/r6/validator.py
@@ -46,6 +46,89 @@ R6_RESOURCE_TYPES = [
 _AVAILABILITY_TTL = 60
 
 
+# --- What the fallback validator actually checked -------------------------
+#
+# The success message used to read "Structural validation passed (R4/R6,
+# external validator unavailable)". A physician advisor running the launch
+# prompts read that, reasonably, as validation having passed — and it was
+# printed over an Observation with no effective[x], category, performer or
+# subject, because _validate_observation checks exactly two fields (#460).
+#
+# The parenthetical was true and did no work: it hung off a sentence that had
+# already asserted the resource passed, so it read as a footnote about
+# thoroughness rather than "almost nothing was examined". That is the
+# error_fidelity property the conformance grade claims, failing inside the
+# validator — a check that examined two fields printing the word a full
+# profile validation would print.
+#
+# The fields are DERIVED from each validator's own `expression` entries, not
+# listed by hand. A hand-kept list is a second source of truth, and it drifts
+# in the direction of claiming coverage that is not there.
+
+
+def _snake(resource_type):
+    out = []
+    for i, ch in enumerate(resource_type):
+        if ch.isupper() and i:
+            out.append('_')
+        out.append(ch.lower())
+    return ''.join(out)
+
+
+def _checked_expressions(resource_type):
+    """FHIRPath expressions the fallback validator has a check for.
+
+    Read out of the validator's own source. Every check in this module tags
+    its issue with `expression`, so the set of expressions a method can emit
+    IS the set of elements it inspects. Returns () for a type with no
+    per-type validator — which is itself worth saying out loud.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    method = getattr(R6Validator, f'_validate_{_snake(resource_type)}', None)
+    if method is None:
+        return ()
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(method)))
+    except (OSError, SyntaxError, TypeError):  # pragma: no cover
+        return ()
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            if (isinstance(key, ast.Constant) and key.value == 'expression'
+                    and isinstance(value, ast.List)):
+                for item in value.elts:
+                    if isinstance(item, ast.Constant) and isinstance(item.value, str):
+                        found.add(item.value)
+    return tuple(sorted(found))
+
+
+def _coverage_note(resource_type):
+    """One sentence naming what ran and what did not.
+
+    Deliberately never says "validation passed". The caller still gets
+    `valid: true`; what changes is that the human-readable line can no longer
+    be mistaken for profile validation.
+    """
+    checked = _checked_expressions(resource_type)
+    if checked:
+        ran = 'Checked for presence: ' + ', '.join(checked) + '.'
+    else:
+        ran = (f'No {resource_type}-specific checks exist in this validator; '
+               'only the base resource shape was examined.')
+    return (
+        f'{ran} NOT checked: profile conformance (US Core or any other), '
+        'terminology bindings, cardinality, value domains, references, and '
+        'every element not named above. No StructureDefinition was consulted '
+        '— the external validator is unavailable, so this is a '
+        'required-field check, not FHIR validation.'
+    )
+
+
 class R6Validator:
     """Validates FHIR R6 resources."""
 
@@ -215,7 +298,7 @@ class R6Validator:
             issues.append({
                 'severity': 'information',
                 'code': 'informational',
-                'diagnostics': 'Structural validation passed (R4/R6, external validator unavailable)'
+                'diagnostics': _coverage_note(resource_type),
             })
 
         return {

--- a/tests/test_validator_says_what_it_checked.py
+++ b/tests/test_validator_says_what_it_checked.py
@@ -1,0 +1,117 @@
+"""The validator names what it examined, and does not say "passed" (#460).
+
+Found by Dr. Magan on 2026-08-10, running the prompt sequence for the launch
+video: the validator accepted an Observation with no effective[x], category,
+performer or subject, and reported
+
+    "Structural validation passed (R4/R6, external validator unavailable)"
+
+_validate_observation checks exactly two fields. The parenthetical was true
+and did no work — it hung off a clause that had already asserted the resource
+passed, so it read as a footnote about thoroughness rather than "almost
+nothing was examined".
+
+This is the error_fidelity property the conformance grade claims, failing
+inside the validator: a check that examined two fields printing the word a
+full profile validation would print. docs/defect-catalogue.md §1.
+
+ASSERTED ON EMITTED OUTPUT, NOT ON SOURCE TEXT. r6/validator.py quotes the old
+sentence in a comment in order to explain it, and a source-level ban would
+match that comment — the §4 trap this repo keeps stepping in. What must never
+come back is the CLAIM reaching a caller, so that is what is checked.
+"""
+
+import pytest
+
+from r6.validator import R6Validator, _checked_expressions, _coverage_note
+
+
+@pytest.fixture
+def validator():
+    return R6Validator()
+
+
+def _info(result):
+    """The informational diagnostics from a clean validation."""
+    return ' '.join(
+        i.get('diagnostics', '')
+        for i in result['operation_outcome']['issue']
+        if i.get('severity') == 'information')
+
+
+class TestTheClaimIsGone:
+
+    def test_a_thin_observation_is_not_told_validation_passed(self, validator):
+        """MUTATION: restore the old diagnostics string -> red.
+
+        This is Dr. Magan's exact resource: status and code, nothing else. It
+        is still accepted — that is a separate decision (#460 item 3) — but
+        the caller is no longer told it passed validation.
+        """
+        result = validator.validate_resource({
+            'resourceType': 'Observation',
+            'status': 'final',
+            'code': {'coding': [{'system': 'http://loinc.org', 'code': '2339-0'}]},
+        })
+        assert result['valid'] is True
+        text = _info(result)
+        assert 'validation passed' not in text.lower(), (
+            'the caller is still told validation passed after two required-'
+            'field checks')
+
+    def test_it_names_the_fields_it_checked(self, validator):
+        result = validator.validate_resource({
+            'resourceType': 'Observation',
+            'status': 'final',
+            'code': {'coding': [{'code': 'x'}]},
+        })
+        text = _info(result)
+        assert 'Observation.status' in text
+        assert 'Observation.code' in text
+
+    def test_it_names_what_it_did_not_check(self, validator):
+        """The half a reader needs to decide whether this is enough."""
+        result = validator.validate_resource({
+            'resourceType': 'Observation',
+            'status': 'final',
+            'code': {'coding': [{'code': 'x'}]},
+        })
+        text = _info(result).lower()
+        for missing in ('profile conformance', 'terminology binding',
+                        'cardinality', 'structuredefinition'):
+            assert missing in text, f'{missing!r} is not disclosed'
+
+
+class TestTheListIsDerivedNotTyped:
+
+    def test_expressions_come_from_the_validator_itself(self):
+        """MUTATION: add a check for Observation.subject to
+        _validate_observation -> this list grows without anyone editing it.
+
+        A hand-kept list of "what we check" is a second source of truth, and
+        it drifts in the direction of claiming coverage that is not there.
+        """
+        assert _checked_expressions('Observation') == (
+            'Observation.code', 'Observation.status')
+        # A type with more checks, to prove the extraction is not hardcoded.
+        condition = _checked_expressions('Condition')
+        assert 'Condition.subject' in condition
+        assert len(condition) > 2
+
+    def test_a_type_with_no_validator_says_so(self):
+        """Silence about an unvalidated type is the original defect in
+        miniature: nothing was checked, and the old message would still have
+        said validation passed."""
+        assert _checked_expressions('Basic') == ()
+        note = _coverage_note('Basic').lower()
+        assert 'no basic-specific checks' in note
+        assert 'passed' not in note
+
+    def test_every_dispatched_type_produces_a_usable_note(self):
+        """Whatever the type, the note names something and discloses the
+        gap — no resource type gets a blank reassurance."""
+        from r6.validator import R6_RESOURCE_TYPES
+        for rtype in R6_RESOURCE_TYPES:
+            note = _coverage_note(rtype)
+            assert 'NOT checked' in note, rtype
+            assert 'validation passed' not in note.lower(), rtype


### PR DESCRIPTION
Closes #460. Found by Dr. Magan on 2026-08-10, running the launch-video
prompt sequence.

She proposed an Observation with no effective[x], category, performer or
subject. It was accepted, and the response said:

    Structural validation passed (R4/R6, external validator unavailable)

_validate_observation checks two fields: status and code. The parenthetical
was true and did no work — it hangs off a clause that has already asserted
the resource passed, so it reads as a footnote about thoroughness rather than
"almost nothing was examined".

That is the error_fidelity property the conformance grade claims, failing
inside the validator. A check that examined two fields was printing the word
a full profile validation would print. docs/defect-catalogue.md §1.

The response now reads:

    Checked for presence: Observation.code, Observation.status. NOT checked:
    profile conformance (US Core or any other), terminology bindings,
    cardinality, value domains, references, and every element not named
    above. No StructureDefinition was consulted — the external validator is
    unavailable, so this is a required-field check, not FHIR validation.

`valid: true` is unchanged. Whether propose-stage should accept an undated
Observation at all is #460 item 3 and a separate decision — this PR is about
not overclaiming while that stands.

THE FIELD LIST IS DERIVED, NOT TYPED. Every check in r6/validator.py tags its
issue with `expression: ['Observation.status']`, so the set of expressions a
method can emit IS the set of elements it inspects; _checked_expressions
reads them out of the method's own AST. A hand-kept list would be a second
source of truth, and it drifts in the direction of claiming coverage that is
not there — which is the defect being fixed, one level up.

Verified live rather than asserted: adding a subject check to
_validate_observation grows the reported list to three with no other edit.

A type with no per-type validator says so out loud ("No Basic-specific checks
exist in this validator") instead of inheriting a reassurance it never
earned.

tests/test_validator_says_what_it_checked.py asserts on EMITTED OUTPUT, not
on source text. r6/validator.py quotes the old sentence in a comment in order
to explain it, and a source-level ban would match that comment — the §4 trap
this repo keeps stepping in. What must never reach a caller is the claim, so
the claim is what is checked.

Mutations run:
- Restore the old diagnostics string -> RED (3 tests)
- Add an Observation.subject check -> the reported list grows to three
  unaided, which is the property test_expressions_come_from_the_validator_
  itself exists to prove

2957 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>