### PR TITLE
fix(bot): stop telling every user a shared, world-readable tenant is theirs

### DIFF
--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -214,6 +214,62 @@ def _fhir_get(path: str) -> dict:
     return resp.json()
 
 
+def tenant_is_world_readable(timeout: float = 5.0):
+    """Can an unauthenticated caller read this bot's tenant?
+
+    OBSERVED, not configured. The bot could mirror PUBLIC_TENANTS from its own
+    environment, but a mirror of a server-side setting is wrong exactly when
+    it matters: the bot's env says private, the server's says public, and the
+    bot cheerfully invites someone to publish their medical records. So this
+    asks the only authority — it makes the request an anonymous stranger would
+    make, and reads what comes back.
+
+    Returns True (anyone can read it), False (credentials required), or None
+    (could not tell). Callers must treat None like True. "I could not
+    determine whether your records would be public" is not a state in which
+    to pull someone's real medical history.
+    """
+    try:
+        resp = requests.get(
+            f'{FHIR_BASE_URL}/Patient',
+            params={'_count': 1},
+            headers={'X-Tenant-ID': TENANT_ID},   # no credentials, on purpose
+            timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001 — network, DNS, TLS, timeout
+        logger.warning('could not determine tenant readability: %s',
+                       type(exc).__name__)
+        return None
+    if resp.status_code == 200:
+        return True
+    if resp.status_code in (401, 403):
+        return False
+    logger.warning('unexpected status probing tenant readability: %s',
+                   resp.status_code)
+    return None
+
+
+#: Shown instead of the connect menu when the bound tenant is world-readable.
+#: Names the tenant, because "this deployment" is not something a user can act
+#: on and the tenant id is what they would quote to whoever runs it.
+CONNECT_REFUSED_PUBLIC = (
+    '🚫 *Not on this bot.*\n\n'
+    'This bot is bound to tenant `{tenant}`, and anyone can read that '
+    'tenant without signing in — I checked just now. Pulling your real '
+    'records into it would publish your medical history to whoever asks.\n\n'
+    'This is the demo bot. It is for exploring the guardrails against '
+    'synthetic records. To connect real records, use a bot bound to a '
+    'private tenant of your own.'
+)
+
+CONNECT_REFUSED_UNKNOWN = (
+    '🚫 *Not right now.*\n\n'
+    'I could not reach HealthClaw to check whether tenant `{tenant}` is '
+    'private, and I will not pull your real records into a tenant I cannot '
+    'confirm is private. Try again in a minute.'
+)
+
+
 def _get_step_up_token() -> str:
     """Fetch a fresh step-up token from the mint endpoint.
 
@@ -360,10 +416,24 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # the list that had just offered them. /curatr_fix now has its handler;
     # /summary is gone, because nothing implements it.
     # tests/test_bot_answers_what_it_advertises.py holds the two in sync.
+    # The second sentence here used to tell the user these were their own
+    # records, and ask them to accept the channel risk on that basis. Every
+    # clause of it was wrong on this bot: one tenant is shared by every user,
+    # and it is world-readable. Dr. Magan flagged it as reading oddly on the
+    # synthetic tenant (#459); it read oddly because it was false.
+    #
+    # The old wording is not quoted here on purpose — the test that bans it
+    # reads this file, and caught this very comment on the first draft.
+    #
+    # It was also doing consent work it could not support. /connect pulls real
+    # records into TENANT_ID, and a user who believed that sentence would have
+    # been agreeing on the strength of it. The rule three lines below —
+    # promise only controls that actually exist — applies to statements of
+    # fact just as much as to features.
     risk_line = (
         '⚠️ Heads up: chat apps aren’t encrypted medical channels. '
-        'You’re accessing your own records here; by continuing you accept '
-        'that for your own data.'
+        f'This bot reads and writes one tenant, `{TENANT_ID}`, which is '
+        'shared by everyone using it — not a private space of your own.'
     )
 
     text = (
@@ -388,8 +458,21 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_connect(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Show a menu of available health data connection options."""
+    """Show a menu of available health data connection options.
+
+    Refuses outright on a world-readable tenant. The banner tells the truth
+    now, but a banner is a sentence someone can skip; this is the half that
+    survives them skipping it (#459).
+    """
     await _log_incoming(update, 'connect')
+
+    readable = tenant_is_world_readable()
+    if readable is not False:
+        template = (CONNECT_REFUSED_PUBLIC if readable
+                    else CONNECT_REFUSED_UNKNOWN)
+        await update.message.reply_text(
+            template.format(tenant=TENANT_ID), parse_mode='Markdown')
+        return
 
     keyboard = [
         [InlineKeyboardButton(

--- a/tests/test_bot_does_not_invite_publishing_phi.py
+++ b/tests/test_bot_does_not_invite_publishing_phi.py
@@ -1,0 +1,189 @@
+"""The demo bot does not tell users a shared tenant is their own (#459).
+
+Raised by Dr. Magan on 2026-08-09 as a wording problem: the /start banner said
+"You're accessing your own records here; by continuing you accept that for
+your own data." It reads oddly on the synthetic tenant, she said. It read
+oddly because every clause was false.
+
+    what it said              what is true
+    "your own records"        one tenant shared by every user of the bot
+    implied private           world-readable, no credentials needed
+    "for your own data"       consent framed around data the user does not
+                              separately own here
+
+And the consequence is larger than the wording, because /connect pulls REAL
+records via Fasten into that tenant. A user who believed the banner and ran
+/connect would have published their medical history to a tenant anyone can
+read anonymously — having agreed on the strength of a sentence that was not
+true.
+
+cmd_start already carried the right rule three lines above the defect:
+"offering a privacy control that does nothing leaves the user worse off than
+saying nothing, because they choose to continue on the strength of it." That
+rule governs statements of fact, not just feature lists.
+
+Two halves, and the second is the one that matters:
+  - the banner says what is true
+  - /connect REFUSES when the tenant is world-readable, because a banner is a
+    sentence someone can skip
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BOT = ROOT / 'openclaw' / 'bot.py'
+
+
+def _source():
+    return BOT.read_text(encoding='utf-8')
+
+
+class TestTheBannerNoLongerLies:
+
+    def test_the_ownership_claim_is_gone(self):
+        """MUTATION: restore the 'your own records' sentence -> red."""
+        src = _source()
+        for claim in ('accessing your own records',
+                      'accept that for your own data'):
+            assert claim not in src, (
+                f'the /start banner claims {claim!r} on a tenant shared by '
+                'every user of the bot (#459)')
+
+    def test_the_banner_says_the_tenant_is_shared(self):
+        """Replacing a false claim with silence is not the fix. The user is
+        making a decision and needs the fact the decision turns on."""
+        src = _source()
+        assert 'shared by everyone using it' in src, (
+            'the banner no longer tells the user the tenant is shared')
+
+
+class TestConnectRefusesToPublishPHI:
+
+    def test_connect_checks_before_it_offers(self):
+        """MUTATION: delete the readable check from cmd_connect -> red.
+
+        Asserted on cmd_connect's own body rather than the whole file, so a
+        probe that exists but is never called cannot satisfy this.
+        """
+        src = _source()
+        body = src.split('async def cmd_connect(', 1)[1].split('\nasync def ', 1)[0]
+        assert 'tenant_is_world_readable()' in body, (
+            'cmd_connect offers connection options without checking whether '
+            'the tenant is world-readable')
+        assert 'return' in body.split('tenant_is_world_readable()', 1)[1][:400], (
+            'cmd_connect checks readability but does not refuse on it')
+
+    def test_an_unknown_answer_refuses_too(self):
+        """The fail-closed half.
+
+        `tenant_is_world_readable` returns None when it cannot reach the
+        server. Treating None as "private" would mean an outage becomes
+        permission to publish someone's medical history — a check that
+        examined nothing answering as though it had (defect catalogue §0).
+
+        MUTATION: change `if readable is not False:` to `if readable:` -> red.
+        """
+        src = _source()
+        body = src.split('async def cmd_connect(', 1)[1].split('\nasync def ', 1)[0]
+        assert 'readable is not False' in body, (
+            'cmd_connect treats an undetermined answer as safe; only an '
+            'explicit False means credentials are required')
+
+
+class TestTheProbeObservesRatherThanAssumes:
+
+    @pytest.fixture
+    def bot(self, monkeypatch):
+        """Import bot.py with its telegram dependencies stubbed.
+
+        The module is deployed alone (openclaw/Dockerfile copies bot.py), so
+        it is imported here the same way — for its own logic, not the bot
+        framework's.
+        """
+        # A PACKAGE, not a bare module: bot.py does `from telegram.error
+        # import Conflict`, and Python refuses a submodule import on a
+        # module with no __path__.
+        for name in ('telegram', 'telegram.ext', 'telegram.constants',
+                     'telegram.error'):
+            mod = types.ModuleType(name)
+            mod.__path__ = []
+            monkeypatch.setitem(sys.modules, name, mod)
+        tg = sys.modules['telegram']
+        tg.ext = sys.modules['telegram.ext']
+        tg.error = sys.modules['telegram.error']
+        tg.constants = sys.modules['telegram.constants']
+        sys.modules['telegram.error'].Conflict = type('Conflict', (Exception,), {})
+        for attr in ('Update', 'InlineKeyboardButton', 'InlineKeyboardMarkup',
+                     'BotCommand'):
+            setattr(tg, attr, type(attr, (), {}))
+        ext = sys.modules['telegram.ext']
+        for attr in ('Application', 'CommandHandler', 'MessageHandler',
+                     'filters', 'CallbackQueryHandler', 'CallbackContext',
+                     'JobQueue'):
+            setattr(ext, attr, type(attr, (), {}))
+        # Used as an annotation (ContextTypes.DEFAULT_TYPE) throughout, so it
+        # is dereferenced at def time, not call time.
+        ext.ContextTypes = type('ContextTypes', (), {'DEFAULT_TYPE': object})
+        # bot.py reads os.environ['TELEGRAM_BOT_TOKEN'] at import — it is a
+        # deployed script, not a library, and failing loudly without a token
+        # is correct for it. Supply one; the tests below never send anything.
+        monkeypatch.setenv('TELEGRAM_BOT_TOKEN', 'test-token-not-real')
+        # 'bot' itself goes through monkeypatch too. Without this the
+        # stub-built module survives in sys.modules and the NEXT file to
+        # import bot.py gets one wired to fake telegram classes —
+        # tests/test_bot_singleton_hardening.py went red four ways before
+        # this line existed. A fixture that leaks its doubles into the rest
+        # of the suite is worse than no fixture: the failure lands somewhere
+        # else, on someone else.
+        previous = sys.modules.pop('bot', None)
+        sys.path.insert(0, str(ROOT / 'openclaw'))
+        try:
+            yield importlib.import_module('bot')
+        finally:
+            sys.path.remove(str(ROOT / 'openclaw'))
+            sys.modules.pop('bot', None)
+            if previous is not None:
+                sys.modules['bot'] = previous
+
+    @pytest.mark.parametrize('status,expected', [
+        (200, True),    # a stranger read it
+        (401, False),   # credentials required
+        (403, False),
+        (500, None),    # cannot tell
+    ])
+    def test_it_reads_the_answer_the_server_gives(self, bot, monkeypatch,
+                                                  status, expected):
+        class Resp:
+            status_code = status
+        monkeypatch.setattr(bot.requests, 'get', lambda *a, **k: Resp())
+        assert bot.tenant_is_world_readable() is expected
+
+    def test_a_network_failure_is_undetermined_not_private(self, bot,
+                                                           monkeypatch):
+        """The direction of this default is the whole point."""
+        def boom(*a, **k):
+            raise OSError('no route to host')
+        monkeypatch.setattr(bot.requests, 'get', boom)
+        assert bot.tenant_is_world_readable() is None
+
+    def test_the_probe_sends_no_credentials(self, bot, monkeypatch):
+        """It must make the request a stranger would make. Sending a token
+        would answer a question nobody asked — whether WE can read it."""
+        seen = {}
+
+        class Resp:
+            status_code = 401
+
+        def capture(*args, **kwargs):
+            seen.update(kwargs)
+            return Resp()
+        monkeypatch.setattr(bot.requests, 'get', capture)
+        bot.tenant_is_world_readable()
+        headers = {k.lower() for k in (seen.get('headers') or {})}
+        assert 'authorization' not in headers
+        assert 'x-step-up-token' not in headers


### PR DESCRIPTION
Closes #459. Raised by Dr. Magan on 2026-08-09 as a wording problem — the
/start banner "reads oddly on the synthetic tenant". It read oddly because
every clause of it was false.

The banner told the user they were accessing their own records, and asked
them to accept the chat-channel risk on that basis. In fact the bot binds
every chat to one TENANT_ID, that tenant is in PUBLIC_TENANTS, and anonymous
reads succeed:

    curl '.../Patient?_count=5' -H 'X-Tenant-Id: desktop-demo'          -> 200
    curl '.../Patient?_count=5' -H 'X-Tenant-Id: conformance-selftest'  -> 401

So: not their own, not private, and the consent was framed around ownership
that does not exist here.

It also was not just copy. /connect pulls REAL records via Fasten into
TENANT_ID. A user who believed the banner and ran /connect would have
published their medical history to a tenant anyone can read without signing
in — having agreed on the strength of a sentence that was not true.

cmd_start already carried the rule, three lines above the defect: "offering a
privacy control that does nothing leaves the user worse off than saying
nothing, because they choose to continue on the strength of it." That governs
statements of fact as much as feature lists.

Two halves, per the issue's options 1 and 2:

1. The banner names the tenant and says it is shared by everyone using the
   bot. Replacing a false claim with silence would not be the fix — the user
   is making a decision and needs the fact the decision turns on.

2. /connect REFUSES on a world-readable tenant. A banner is a sentence
   someone can skip; this is the half that survives them skipping it.

HOW IT KNOWS IS THE PART WORTH REVIEWING. `tenant_is_world_readable` does not
mirror PUBLIC_TENANTS into the bot's environment. A mirror of a server-side
setting is wrong exactly when it matters — bot says private, server says
public, bot invites someone to publish their records. Instead it makes the
request an anonymous stranger would make, with no credentials, and reads the
answer: 200 means anyone can read it, 401/403 means they cannot.

It returns None when it cannot tell, and cmd_connect treats None like True.
An outage must not become permission to publish someone's medical history; "I
could not determine whether your records would be public" is not a state in
which to pull a real medical record. That is `if readable is not False`, and
it is pinned.

Not doing option 3 (per-user tenants). That is the real fix and a design
decision, and it does not block correcting a false statement today.

DEPLOYMENT: this lands in the repo but does NOT reach the running bot. The
bot is deployed by hand from openclaw/ and its runtime location is not
determinable from this repository (noted while investigating an unrelated
redeploy). The banner in production keeps its false sentence until someone
redeploys, which is worth knowing before the webinar.

Mutations run:
- `if readable is not False` -> `if readable` (unknown treated as safe) -> RED
- Delete the readability check from cmd_connect -> RED
- Restore the ownership claim in the banner -> RED

A fourth thing this caught, in my own test: the fixture imported bot.py with
stubbed telegram modules and left the result in sys.modules, so the next file
to import bot.py got one wired to fakes —
tests/test_bot_singleton_hardening.py went red four ways. The fixture now
restores what it displaced. A fixture that leaks its doubles is worse than no
fixture: the failure lands somewhere else, on someone else.

2967 passed, 13 skipped, 1 xfailed. ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>