### PR TITLE
refactor(kernel): slice 11a — the four MCP App pages, and the first real absent tenant

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -37,7 +37,7 @@ from r6.validator import R6Validator
 from r6.audit import add_audit_event, record_audit_event
 from r6.redaction import apply_patient_controlled_redaction
 from r6.redaction import apply_redaction
-from r6.access import (Scope, TenantSource, require_grant,
+from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
                        tenant_from_request)
 from r6.stepup import validate_step_up_token, generate_step_up_token
 from r6.oauth import register_oauth_routes
@@ -3353,6 +3353,24 @@ def compiled_truth(resource_type, resource_id):
 
 # --- MCP Apps (embedded HTML surfaces for MCP clients) ------------
 
+def _mcp_app_tenant():
+    """The tenant an MCP App page was opened with, or `''` if none was named.
+
+    Access kernel, slice 11a (spec §2.6). HEADER then QUERY: an MCP client
+    sends the header, a browser opening the same URI cannot. Absent is not an
+    error — `/mcp-apps/` is exempt and these pages render an input to type a
+    tenant into, so they must open cold. Malformed propagates to the kernel's
+    400. Both pinned in tests/test_mcp_app_tenant_goes_through_the_kernel.py.
+    """
+    try:
+        return tenant_from_request(
+            sources=(TenantSource.HEADER, TenantSource.QUERY)).id
+    except TenantRejected as exc:
+        if exc.reason == TenantRejected.ABSENT:
+            return ''
+        raise
+
+
 @r6_blueprint.route(
     '/mcp-apps/compiled-truth/<resource_type>/<resource_id>',
     methods=['GET']
@@ -3374,13 +3392,7 @@ def mcp_app_compiled_truth(resource_type, resource_id):
             f'Resource type {resource_type} is not supported',
         ), 400
 
-    # Tenant is required but arrives as either header or ?tenant_id= query.
-    # MCP clients that open resource URIs in a browser won't send headers.
-    tenant_id = (
-        request.headers.get('X-Tenant-Id')
-        or request.args.get('tenant_id')
-        or ''
-    )
+    tenant_id = _mcp_app_tenant()
 
     html = render_template(
         'mcp_apps/compiled_truth.html',
@@ -3406,11 +3418,7 @@ def mcp_app_care_gaps():
     SmartHealthConnect's care-gaps view (archived); data path rebuilt on
     the engine's own operation so redaction + audit apply by construction.
     """
-    tenant_id = (
-        request.headers.get('X-Tenant-Id')
-        or request.args.get('tenant_id')
-        or ''
-    )
+    tenant_id = _mcp_app_tenant()
     html = render_template(
         'mcp_apps/care_gaps.html',
         tenant_id=tenant_id,
@@ -3437,11 +3445,7 @@ def mcp_app_lab_trends():
     threshold re-implemented in a browser. Reference ranges live in exactly
     one place (r6/labs/interpret.py) and this view is not a second one.
     """
-    tenant_id = (
-        request.headers.get('X-Tenant-Id')
-        or request.args.get('tenant_id')
-        or ''
-    )
+    tenant_id = _mcp_app_tenant()
     html = render_template(
         'mcp_apps/lab_trends.html',
         tenant_id=tenant_id,
@@ -3462,11 +3466,7 @@ def mcp_app_wearables():
     sync, observation count, and Connect / Sync / Re-auth actions. Linked
     from the `wearables_sync_status` MCP tool via `_meta.ui.resourceUri`.
     """
-    tenant_id = (
-        request.headers.get('X-Tenant-Id')
-        or request.args.get('tenant_id')
-        or ''
-    )
+    tenant_id = _mcp_app_tenant()
     html = render_template(
         'mcp_apps/wearables.html',
         tenant_id=tenant_id,

--- a/tests/test_mcp_app_lab_trends.py
+++ b/tests/test_mcp_app_lab_trends.py
@@ -53,16 +53,46 @@ def test_both_trailing_slash_forms_work(client):
     assert client.get("/r6/fhir/mcp-apps/lab-trends/").status_code == 200
 
 
-def test_the_tenant_arrives_from_the_query_and_is_escaped(client):
-    """The tenant reaches the page as a value, never as markup.
+def test_the_tenant_arrives_from_the_query(client):
+    """The tenant named in the query string is the one the page renders."""
+    r = client.get("/r6/fhir/mcp-apps/lab-trends?tenant_id=desktop-demo")
+    assert r.status_code == 200
+    assert "desktop-demo" in r.get_data(as_text=True)
 
-    MUTATION: render tenant_id with |safe -> red.
+
+def test_a_tenant_that_is_not_a_tenant_never_reaches_the_page(client):
+    """Rewritten by access-kernel slice 11a, and the reason is recorded here
+    rather than in a commit message nobody reads at the failure.
+
+    This used to assert that `"><script>x` rendered ESCAPED at 200. That was
+    a true and useful pin while the handler passed any string through to the
+    template. The handler now reads its tenant through the access kernel,
+    which refuses anything failing [a-zA-Z0-9_-]{1,64} — the same pattern
+    enforce_tenant_id applies everywhere else — so the hostile value is
+    refused at 400 and never reaches a template at all.
+
+    The escaping is still there and still required; it is now the second line
+    rather than the only one. It is pinned by
+    test_the_template_escapes_the_tenant_it_is_given below, which reads the
+    template rather than the response, because no request can carry a value
+    that would demonstrate it end to end any more.
     """
     r = client.get("/r6/fhir/mcp-apps/lab-trends?tenant_id=%22%3E%3Cscript%3Ex")
-    body = r.get_data(as_text=True)
-    assert r.status_code == 200
-    assert "<script>x" not in body
-    assert "&#34;&gt;&lt;script&gt;x" in body or "&quot;&gt;&lt;script&gt;x" in body
+    assert r.status_code == 400
+    assert "<script>x" not in r.get_data(as_text=True)
+
+
+def test_the_template_escapes_the_tenant_it_is_given():
+    """MUTATION: render tenant_id with |safe -> red.
+
+    Asserted against the template source. The route can no longer deliver a
+    value that proves this at the HTTP boundary, and a guard that cannot fail
+    is not a guard.
+    """
+    code = _code_only()
+    assert "{{ tenant_id }}" in code, "the template stopped rendering the tenant"
+    assert "tenant_id | safe" not in code
+    assert "tenant_id|safe" not in code
 
 
 def test_the_page_renders_without_a_tenant_rather_than_erroring(client):

--- a/tests/test_mcp_app_tenant_goes_through_the_kernel.py
+++ b/tests/test_mcp_app_tenant_goes_through_the_kernel.py
@@ -1,0 +1,138 @@
+"""The four MCP App pages read their tenant through the access kernel.
+
+Access kernel, slice 11a (docs/2026-08-03-access-kernel-spec.md §2.6). These
+are the multi-source sites: `(HEADER, QUERY)`, no default. Slice 11 is one
+site per PR because each one has a different source order and each is a
+behaviour risk, and this one carries the risk the other ten do not.
+
+WHY THIS SLICE IS NOT INERT LIKE 10a/10b
+
+Every site in slices 9 and 10 sits behind `enforce_tenant_id`, which has
+already required the header and format-checked it with the same pattern the
+kernel uses. Migrating one of those re-validates a value that cannot fail.
+
+`/mcp-apps/` is an EXEMPT prefix. The hook returns early, so these four
+handlers are the only tenant readers in r6/routes.py reachable with no
+tenant at all — and that is deliberate: three of the four templates render
+an input for the reader to type one into. A page whose job is to be opened
+cold must not 400 when it is opened cold. So `absent` is caught and becomes
+`''`, exactly as before.
+
+THE ONE DELIBERATE BEHAVIOUR CHANGE
+
+A malformed tenant used to reach the template and render escaped, at 200. It
+is now refused at 400. That is a change, so it is pinned here rather than
+discovered later, and the pin it invalidates
+(test_the_tenant_arrives_from_the_query_and_is_escaped) is rewritten in this
+same PR with its reason, per the working protocol §6.
+
+The reasoning: `[A-Za-z0-9_-]{1,64}` is the pattern `enforce_tenant_id`
+applies to every other route in the app. A tenant that fails it cannot be
+used anywhere, so a page rendered around one is a page whose every fetch is
+already doomed — it just fails later, in a browser console, instead of here
+where the reason is legible. The templates keep their escaping; it is now
+defence in depth rather than the only thing between a query string and the
+markup.
+"""
+
+import re
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROUTES = ROOT / 'r6' / 'routes.py'
+
+#: Every MCP App page, with the marker that proves the template rendered.
+PAGES = (
+    ('/r6/fhir/mcp-apps/care-gaps', 'care-gaps'),
+    ('/r6/fhir/mcp-apps/lab-trends', 'lab-trends'),
+    ('/r6/fhir/mcp-apps/wearables', 'wearables'),
+    ('/r6/fhir/mcp-apps/compiled-truth/Observation/obs-1', 'compiled-truth'),
+)
+
+
+@pytest.mark.parametrize('path,app_name', PAGES)
+def test_the_page_still_opens_cold(client, path, app_name):
+    """MUTATION: let `absent` propagate instead of returning '' -> red.
+
+    This is the property the slice exists to protect. An MCP client sends the
+    header; a person opening the same resource URI in a browser cannot.
+    """
+    r = client.get(path)
+    assert r.status_code == 200
+    assert r.headers['X-MCP-App'] == app_name
+
+
+@pytest.mark.parametrize('path,_app', PAGES)
+def test_the_query_string_still_supplies_the_tenant(client, path, _app):
+    r = client.get(f'{path}?tenant_id=desktop-demo')
+    assert r.status_code == 200
+    assert 'desktop-demo' in r.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('path,_app', PAGES)
+def test_the_header_still_wins_over_the_query(client, path, _app):
+    """The declared order is (HEADER, QUERY), which is the order these four
+    handlers already used. `sources` is an ordered tuple precisely so a
+    migration cannot quietly reverse a precedence.
+
+    MUTATION: swap the tuple to (QUERY, HEADER) -> red.
+    """
+    r = client.get(f'{path}?tenant_id=from-query',
+                   headers={'X-Tenant-Id': 'from-header'})
+    body = r.get_data(as_text=True)
+    assert r.status_code == 200
+    assert 'from-header' in body
+    assert 'from-query' not in body
+
+
+@pytest.mark.parametrize('path,_app', PAGES)
+def test_a_malformed_tenant_is_refused_rather_than_rendered(client, path,
+                                                            _app):
+    """The deliberate delta. Documented in this module's docstring.
+
+    MUTATION: catch MALFORMED as well as ABSENT and return '' -> red.
+    """
+    r = client.get(f'{path}?tenant_id=%22%3E%3Cscript%3Ex')
+    assert r.status_code == 400
+    assert '<script>x' not in r.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('path,_app', PAGES)
+def test_a_refusal_names_the_rule_it_applied(client, path, _app):
+    """A 400 that does not say what would have been acceptable sends the
+    reader back to the source. The kernel's own renderer prints the pattern;
+    this pins that these pages reach it rather than some local 400."""
+    r = client.get(f'{path}?tenant_id=not a tenant')
+    assert r.status_code == 400
+    assert 'a-zA-Z0-9_-' in r.get_data(as_text=True)
+
+
+def _mcp_apps_section() -> str:
+    """r6/routes.py from the MCP Apps banner to the end of the file."""
+    src = ROUTES.read_text(encoding='utf-8')
+    marker = '# --- MCP Apps (embedded HTML surfaces for MCP clients)'
+    assert marker in src, 'the MCP Apps section banner moved; fix this guard'
+    return src.split(marker, 1)[1]
+
+
+def test_no_mcp_app_handler_reads_the_header_itself():
+    """The kernel is meant to be the one tenant reader (spec §1.1).
+
+    Asserted on the section rather than the whole file because the rest of
+    r6/routes.py still has its own unmigrated sites; this pins that the four
+    migrated here do not come back. tests/test_ratchets.py holds the
+    whole-file count.
+
+    MUTATION: restore the header-or-query expression in any handler -> red.
+    """
+    section = _mcp_apps_section()
+    code = '\n'.join(line for line in section.split('\n')
+                     if not line.lstrip().startswith('#'))
+    # The helper's own docstring is prose, not a read; strip docstrings so
+    # explaining the rule cannot violate it. This file has tripped that trap
+    # three times in one week on other guards.
+    code = re.sub(r'"""(?:.|\n)*?"""', '', code)
+    assert "request.headers.get('X-Tenant-Id')" not in code
+    assert 'request.args.get(' not in code

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -336,7 +336,10 @@ def test_the_god_module_only_shrinks():
 #: Call sites that read the tenant straight off the header instead of asking
 #: the access kernel, across all of r6/. 31 -> 27 -> 9: slice 10a took create,
 #: read, update and search; slice 10b took the remaining seventeen in
-#: r6/routes.py.
+#: r6/routes.py. 9 -> 5: slice 11a took the four MCP App pages, the first
+#: multi-source sites and the first ones NOT protected by the paragraph below
+#: — they sit on the exempt /mcp-apps/ prefix, so absence is real there and
+#: is caught rather than raised.
 #:
 #: Every one of the seventeen was checked against the exempt-path list before
 #: it moved, by walking each read back to the route decorator that owns it.
@@ -373,7 +376,7 @@ def test_the_god_module_only_shrinks():
 #: behaviour change, not a refactor. Check _is_exempt_discovery_path before
 #: moving a call site, per site — that is the whole reason this is 6 PRs and
 #: not one sed.
-_RAW_TENANT_READS = 9
+_RAW_TENANT_READS = 5
 
 
 def test_raw_tenant_header_reads_only_decrease():


### PR DESCRIPTION
Access kernel, slice 11a (docs/2026-08-03-access-kernel-spec.md §2.6). The
four /mcp-apps/ handlers read their tenant through r6.access instead of off
the header. _RAW_TENANT_READS 9 -> 5.

WHY THIS ONE IS NOT INERT, UNLIKE 10a AND 10b

Every site in slices 9 and 10 sits behind enforce_tenant_id, which has
already required the header and format-checked it with the pattern the
kernel uses. Migrating one re-validates a value that cannot fail.

/mcp-apps/ is an EXEMPT prefix. The hook returns early, so these four are
the only tenant readers in r6/routes.py reachable with no tenant at all —
and that is deliberate: care_gaps.html, lab_trends.html and wearables.html
each render an input for the reader to type one into. A page whose job is to
be opened cold must not 400 when it is opened cold. So `absent` is caught
and becomes '', exactly as before.

ONE DELIBERATE BEHAVIOUR CHANGE, AND THE PIN IT INVALIDATES

A malformed tenant used to reach the template and render escaped, at 200. It
is refused at 400 now. [A-Za-z0-9_-]{1,64} is the pattern enforce_tenant_id
applies to every other route, so a tenant failing it cannot be used
anywhere: a page rendered around one is a page whose every fetch is already
doomed. It just failed later, in a browser console, instead of here where
the reason is legible.

That invalidates test_the_tenant_arrives_from_the_query_and_is_escaped,
which pinned the hostile value rendering escaped at 200. Rewritten in this
PR with the reason recorded in the test body, per the working protocol §6,
and split in two so nothing is lost:

  - the route now refuses the value (400, never reaches a template)
  - the ESCAPING is pinned against the template source, because no request
    can carry a value that demonstrates it end to end any more. A guard
    that cannot fail is not a guard.

MUTATIONS VERIFIED RED

  - catch MALFORMED as well as ABSENT and return '' -> 9 red
  - let ABSENT propagate instead of returning '' -> 4 red
  - reverse the order to (QUERY, HEADER) -> 4 red
  - restore the header-or-query expression in a handler -> 2 red

The god-module ratchet caught the first draft of this: a 25-line docstring on
the new helper grew r6/routes.py by 16 lines during a refactor meant to
shrink it. The reasoning moved to the test module, where it sits with the
pin it explains. r6/routes.py is 3922 lines, unchanged, and the pin was not
raised — the file's own rule is that raising one to make a build pass is the
edit that turns it into decoration.

Gates: 2990 passed, 13 skipped, 1 xfailed. ruff clean.