### PR TITLE
feat(proxy): authenticate to an upstream FHIR server, and the Aidbox example the article promises

### DIFF
--- a/examples/aidbox-healthclaw-guardrails/.env.example
+++ b/examples/aidbox-healthclaw-guardrails/.env.example
@@ -1,0 +1,26 @@
+# Copy to .env before `docker compose up -d`.
+
+# REQUIRED. Free self-hosted key from https://aidbox.app (Aidbox account ->
+# licenses -> new self-hosted licence). Without it Aidbox starts, but every
+# API call redirects to "Log in to activate Aidbox", so the proxy reports a
+# degraded upstream rather than anything about licensing.
+AIDBOX_LICENSE=
+
+# macOS holds port 5000 for AirPlay Receiver (ControlCenter), so `up` fails
+# with "address already in use". Uncomment to move the host port; the URLs in
+# README.md then use 5099 instead of 5000.
+# HEALTHCLAW_PORT=5099
+
+# Signs step-up tokens. Any value works locally; it must be a real secret in
+# any deployment that is not this demo. Generate one with:
+#   openssl rand -hex 32
+STEP_UP_SECRET=dev-only-change-me
+
+# The credential the guardrail proxy presents to Aidbox. Must match the
+# Client secret in init-bundle/bundle.json. Change both together.
+FHIR_UPSTREAM_CLIENT_SECRET=healthclaw-secret
+
+# Aidbox's root client, used by the walkthrough to read AROUND the proxy and
+# show what the record actually contains. An agent never gets this.
+AIDBOX_CLIENT=root
+AIDBOX_SECRET=qNbQS6sw82

--- a/examples/aidbox-healthclaw-guardrails/README.md
+++ b/examples/aidbox-healthclaw-guardrails/README.md
@@ -1,0 +1,176 @@
+# HealthClaw Guardrails in front of Aidbox
+
+Aidbox holds the record. An AI agent talks to a guardrail proxy in front of
+it, and the proxy enforces four things the FHIR authorization model does not
+express: redact on read, audit every access, step up on writes, and hold
+anything irreversible for a human.
+
+```text
+AI agent ──▶ MCP server ──▶ Guardrail proxy ──▶ Aidbox
+  :3001                        :5000              :8080
+                                 │
+                          PHI redaction
+                          Audit trail
+                          Step-up auth
+                          Human-in-the-loop
+                          Tenant isolation
+```
+
+Nothing about the Aidbox side is unusual, and that is the point. The guardrail
+layer is additive; the FHIR server underneath keeps behaving like a FHIR
+server, and still holds the complete, fully-identified record.
+
+Companion to the article *"We standardized how to get health data. We never
+standardized what an agent may do with it."*
+
+## Run it
+
+You need a free Aidbox licence from [aidbox.app](https://aidbox.app)
+(Aidbox account → licenses → new self-hosted licence).
+
+```bash
+cp .env.example .env     # paste AIDBOX_LICENSE, set STEP_UP_SECRET
+docker compose up -d
+./scripts/seed-aidbox.sh # 1 Patient, 1 Condition, 3 Observations
+./scripts/walkthrough.sh # the five steps below, asserted
+```
+
+Two things that will bite you before anything interesting happens:
+
+- **No licence, no API.** Without `AIDBOX_LICENSE` Aidbox starts and looks
+  healthy, then answers every API call with a 302 to a browser page reading
+  "Log in to activate Aidbox". Through the proxy that surfaces as a degraded
+  upstream, which says nothing about licensing. Compose refuses to start
+  without the variable for exactly this reason.
+- **macOS holds port 5000.** AirPlay Receiver (ControlCenter) listens there,
+  so `up` fails with "address already in use". Set `HEALTHCLAW_PORT=5099` in
+  `.env` and read `:5099` for `:5000` throughout.
+
+One more, if you also develop HealthClaw itself: **running this example makes
+120 of HealthClaw's own tests fail.** `FHIR_VALIDATOR_URL` defaults to
+`http://localhost:8080`, and the availability probe treats anything answering
+`/health` as a FHIR validator — which Aidbox, on that port, is not. The
+failures present as `assert 422 == 201` on ordinary writes and point nowhere
+near the cause. `docker compose stop aidbox` before running the suite, or set
+`FHIR_VALIDATOR_URL` to something unreachable. Tracked as
+[#488](https://github.com/aks129/HealthClawGuardrails/issues/488).
+
+From a HealthClaw checkout you can build the two images instead of pulling
+them:
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
+```
+
+## What each step shows
+
+### 1. The same read, with and without governance
+
+Direct to Aidbox, the record is fully identified, as it should be:
+
+```bash
+curl -u "$AIDBOX_CLIENT:$AIDBOX_SECRET" http://localhost:8080/fhir/Patient/pt-demo
+```
+
+```json
+{ "resourceType": "Patient", "id": "pt-demo",
+  "name": [{"given": ["Maria"], "family": "Alvarez"}],
+  "identifier": [{"system": "urn:mrn", "value": "MRN-88214"}],
+  "birthDate": "1974-03-11",
+  "address": [{"line": ["221 Baker St"], "city": "Pittsburgh"}] }
+```
+
+Through the proxy, same resource, same Aidbox:
+
+```bash
+curl -H "X-Tenant-Id: demo" http://localhost:5000/r6/fhir/Patient/pt-demo
+```
+
+The name is reduced to initials, the MRN is masked, the address and phone are
+gone, and the birth date is truncated to a year.
+
+Aidbox still holds the complete record. Redaction is a property of the path
+the agent uses, not a modification of the data. `walkthrough.sh` asserts this
+by looking for the distinctive values themselves rather than for a mask
+string, because a redactor that returned `***masked***` and nothing else
+would satisfy the lazier check.
+
+### 2. The read left a record
+
+```bash
+curl -H "X-Tenant-Id: demo" "http://localhost:5000/r6/fhir/AuditEvent?_count=1"
+```
+
+An AuditEvent naming the tenant, the agent, the resource and the time, with no
+PHI in the detail — so the record you hand a reviewer is safe to hand over.
+
+### 3. A write, blocked twice
+
+Recording a blood pressure, with no step-up token, returns **401**. Mint a
+token and retry: **428**, pending human confirmation. Only after confirmation
+does the Observation reach Aidbox, which you can verify by querying Aidbox
+directly, going around the proxy:
+
+```bash
+curl -u "$AIDBOX_CLIENT:$AIDBOX_SECRET" \
+  "http://localhost:8080/fhir/Observation?subject=Patient/pt-demo&code=85354-9"
+```
+
+That sequence is the whole argument. The agent did useful work. It could not
+finish alone.
+
+### 4. Grade the deployment
+
+```bash
+curl "http://localhost:5000/r6/fhir/\$conformance?format=text"
+```
+
+Seven properties, 35 checks, run against the deployment that is actually
+running. The same harness runs in HealthClaw's CI as a merge gate, so a
+regression shows up as a grade change rather than an incident.
+
+## How the two servers are wired
+
+The proxy holds its own Aidbox credential — the `healthclaw` Client in
+[`init-bundle/bundle.json`](init-bundle/bundle.json) — so the agent never
+receives, and never needs, an Aidbox credential:
+
+```yaml
+healthclaw:
+  environment:
+    FHIR_UPSTREAM_URL: http://aidbox:8080/fhir
+    FHIR_UPSTREAM_CLIENT_ID: healthclaw
+    FHIR_UPSTREAM_CLIENT_SECRET: ${FHIR_UPSTREAM_CLIENT_SECRET}
+    STEP_UP_SECRET: ${STEP_UP_SECRET}
+    READ_AUTH_ENABLED: "true"
+```
+
+The AccessPolicy scopes that Client to `/fhir/*`. An agent that gets past the
+proxy still has no route to Aidbox's admin surface, `$sql`, or the Client that
+authorizes it.
+
+`FHIR_LOCAL_BASE_URL` makes the proxy rewrite Aidbox's base URL out of every
+response. An agent that learns the real endpoint will try to route around the
+guardrails, so it is never told what it is.
+
+## What this example does not show
+
+- **A licence check is not a guardrail.** Everything above assumes Aidbox is
+  reachable. The proxy's failure mode when it is not is a degraded health
+  check and a 502, not a silent empty bundle — but that is a different
+  property from the four this example demonstrates.
+- **Redaction is a compensating control, not a de-identification
+  determination.** A record with a rare diagnosis and an unusual date
+  sequence is not made unlinkable by masking a name. What changes is the
+  default.
+- **The clinical-write human gate is a header today** (`X-Human-Confirmed`),
+  which the caller that sets it can spoof. It is documented as a compensating
+  control rather than proof a human acted; the action rail's separate
+  approval endpoint is the real mechanism. HealthClaw tracks this as a known
+  gap.
+
+## Links
+
+- HealthClaw Guardrails: <https://github.com/aks129/HealthClawGuardrails> (MIT)
+- Live conformance grade: <https://app.healthclaw.io/r6/fhir/$conformance>
+- Aidbox: <https://aidbox.app>

--- a/examples/aidbox-healthclaw-guardrails/docker-compose.build.yaml
+++ b/examples/aidbox-healthclaw-guardrails/docker-compose.build.yaml
@@ -1,0 +1,16 @@
+# Build from a HealthClaw Guardrails checkout instead of the published images.
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d
+#
+# The paths below are relative to THIS directory, so this override only works
+# inside the HealthClaw repo. Standalone copies of the example (in the Aidbox
+# examples repo, say) use docker-compose.yaml on its own and pull from ghcr.
+services:
+  healthclaw:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+
+  mcp:
+    build:
+      context: ../../services/agent-orchestrator

--- a/examples/aidbox-healthclaw-guardrails/docker-compose.yaml
+++ b/examples/aidbox-healthclaw-guardrails/docker-compose.yaml
@@ -1,0 +1,115 @@
+volumes:
+  postgres_data: {}
+
+services:
+  postgres:
+    image: postgres:18
+    volumes:
+      - postgres_data:/var/lib/postgresql:delegated
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: aidbox
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: aidbox
+      POSTGRES_PASSWORD: hb1NnSed7w
+
+  # The system of record. Holds the COMPLETE, fully-identified resource.
+  # Nothing below ever modifies it: redaction is a property of the path the
+  # agent takes, not an edit to the data.
+  aidbox:
+    image: healthsamurai/aidboxone:edge
+    pull_policy: always
+    depends_on:
+      - postgres
+    ports:
+      - 8080:8080
+    volumes:
+      - ./init-bundle:/app/init-bundle:ro
+    environment:
+      # Without this, Aidbox boots but every API call 302s to a browser page
+      # reading "Log in to activate Aidbox", including the proxy's own
+      # /metadata probe — which surfaces as a degraded health check rather
+      # than as "you have no licence". Free key at https://aidbox.app.
+      BOX_LICENSE: ${AIDBOX_LICENSE:?get a free licence at https://aidbox.app and put it in .env}
+      BOX_ADMIN_PASSWORD: uN6jhgu8eo
+      BOX_BOOTSTRAP_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1
+      BOX_DB_DATABASE: aidbox
+      BOX_DB_HOST: postgres
+      BOX_DB_PASSWORD: hb1NnSed7w
+      BOX_DB_PORT: "5432"
+      BOX_DB_USER: aidbox
+      BOX_FHIR_COMPLIANT_MODE: true
+      BOX_FHIR_CORRECT_AIDBOX_FORMAT: true
+      BOX_FHIR_SCHEMA_VALIDATION: true
+      BOX_ROOT_CLIENT_SECRET: qNbQS6sw82
+      BOX_SECURITY_AUDIT_LOG_ENABLED: true
+      BOX_SECURITY_DEV_MODE: true
+      BOX_SETTINGS_MODE: read-write
+      BOX_WEB_BASE_URL: http://localhost:8080
+      BOX_WEB_PORT: 8080
+      BOX_INIT_BUNDLE: file:///app/init-bundle/bundle.json
+    healthcheck:
+      test: curl -f http://localhost:8080/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 90
+      start_period: 30s
+
+  # The guardrail layer. Every agent-facing read and write goes through here.
+  healthclaw:
+    image: ghcr.io/aks129/healthclaw-guardrails:latest
+    depends_on:
+      aidbox:
+        condition: service_healthy
+    ports:
+      # On macOS, port 5000 is held by AirPlay Receiver (ControlCenter) unless
+      # you turn it off, so `up` fails with "address already in use". Set
+      # HEALTHCLAW_PORT=5099 in .env and use that port in the curls below.
+      - ${HEALTHCLAW_PORT:-5000}:5000
+    # init-db first. Without it the first request fails as an AuditWriteError
+    # wrapping an OperationalError — a missing schema that reads like an audit
+    # bug and has cost more than one person an afternoon.
+    command: >
+      sh -c "flask --app main init-db &&
+             gunicorn main:app --bind 0.0.0.0:5000 --workers 2 --timeout 300"
+    environment:
+      PORT: "5000"
+
+      # Point the guardrails at Aidbox. The proxy holds its OWN credential —
+      # the `healthclaw` Client created by init-bundle/bundle.json — so the
+      # agent never receives, and never needs, an Aidbox credential.
+      FHIR_UPSTREAM_URL: http://aidbox:8080/fhir
+      FHIR_UPSTREAM_CLIENT_ID: healthclaw
+      FHIR_UPSTREAM_CLIENT_SECRET: ${FHIR_UPSTREAM_CLIENT_SECRET:-healthclaw-secret}
+
+      # Responses are rewritten so this base URL, and never Aidbox's, is what
+      # the agent sees. An agent that learns the real endpoint will try to
+      # route around the proxy.
+      FHIR_LOCAL_BASE_URL: http://localhost:5000/r6/fhir
+
+      STEP_UP_SECRET: ${STEP_UP_SECRET:?set STEP_UP_SECRET in .env}
+      READ_AUTH_ENABLED: "true"
+      APP_ENV: development
+      DATABASE_URL: sqlite:////tmp/healthclaw.db
+    healthcheck:
+      test: curl -f http://localhost:5000/r6/fhir/health || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 15s
+
+  # What the agent actually connects to.
+  mcp:
+    image: ghcr.io/aks129/healthclaw-mcp-server:latest
+    depends_on:
+      healthclaw:
+        condition: service_healthy
+    ports:
+      - 3001:3001
+    environment:
+      PORT: "3001"
+      FHIR_BASE_URL: http://healthclaw:5000/r6/fhir
+      TENANT_ID: demo

--- a/examples/aidbox-healthclaw-guardrails/init-bundle/bundle.json
+++ b/examples/aidbox-healthclaw-guardrails/init-bundle/bundle.json
@@ -1,0 +1,31 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": { "method": "PUT", "url": "Client/healthclaw" },
+      "resource": {
+        "resourceType": "Client",
+        "id": "healthclaw",
+        "secret": "healthclaw-secret",
+        "grant_types": ["basic"]
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "AccessPolicy/healthclaw-fhir-only" },
+      "resource": {
+        "resourceType": "AccessPolicy",
+        "id": "healthclaw-fhir-only",
+        "description": "The guardrail proxy reads and writes FHIR, and nothing else. It has no route to Aidbox's own admin surface, so an agent that gets past the proxy still cannot reach $sql, the console, or the Client that authorises it.",
+        "engine": "matcho",
+        "matcho": {
+          "uri": "#/fhir/.*",
+          "client": { "id": "healthclaw" }
+        },
+        "link": [
+          { "id": "healthclaw", "resourceType": "Client" }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/aidbox-healthclaw-guardrails/scripts/seed-aidbox.sh
+++ b/examples/aidbox-healthclaw-guardrails/scripts/seed-aidbox.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Seed Aidbox with one synthetic patient: one Patient, three Observations,
+# one Condition. Written straight to Aidbox, NOT through the guardrail proxy,
+# because the point of the walkthrough is to compare the two paths over the
+# same stored bytes.
+#
+# Everything here is synthetic. Maria Alvarez does not exist.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+[ -f .env ] && set -a && . ./.env && set +a
+
+AIDBOX_URL="${AIDBOX_URL:-http://localhost:8080}"
+AIDBOX_CLIENT="${AIDBOX_CLIENT:-root}"
+AIDBOX_SECRET="${AIDBOX_SECRET:-qNbQS6sw82}"
+
+echo "Seeding ${AIDBOX_URL} ..."
+
+response=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  -X POST "${AIDBOX_URL}/fhir" \
+  -H 'Content-Type: application/json' \
+  -d @- <<'JSON'
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": { "method": "PUT", "url": "/Patient/pt-demo" },
+      "resource": {
+        "resourceType": "Patient",
+        "id": "pt-demo",
+        "name": [{ "given": ["Maria"], "family": "Alvarez" }],
+        "identifier": [{ "system": "urn:mrn", "value": "MRN-88214" }],
+        "gender": "female",
+        "birthDate": "1974-03-11",
+        "telecom": [{ "system": "phone", "value": "555-867-5309" }],
+        "address": [{ "line": ["221 Baker St"], "city": "Pittsburgh", "state": "PA", "postalCode": "15213" }]
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Condition/cond-demo" },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "cond-demo",
+        "subject": { "reference": "Patient/pt-demo" },
+        "clinicalStatus": {
+          "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/condition-clinical", "code": "active" }]
+        },
+        "code": {
+          "coding": [{ "system": "http://hl7.org/fhir/sid/icd-10-cm", "code": "E11.9", "display": "Type 2 diabetes mellitus without complications" }]
+        },
+        "onsetDateTime": "2019-06-01"
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-a1c" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-a1c",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4", "display": "Hemoglobin A1c/Hemoglobin.total in Blood" }] },
+        "valueQuantity": { "value": 8.1, "unit": "%", "system": "http://unitsofmeasure.org", "code": "%" }
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-glucose" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-glucose",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "2339-0", "display": "Glucose [Mass/volume] in Blood" }] },
+        "valueQuantity": { "value": 180, "unit": "mg/dL", "system": "http://unitsofmeasure.org", "code": "mg/dL" }
+      }
+    },
+    {
+      "request": { "method": "PUT", "url": "/Observation/obs-ldl" },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-ldl",
+        "status": "final",
+        "subject": { "reference": "Patient/pt-demo" },
+        "effectiveDateTime": "2026-07-14",
+        "category": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "laboratory" }] }],
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "13457-7", "display": "Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation" }] },
+        "valueQuantity": { "value": 142, "unit": "mg/dL", "system": "http://unitsofmeasure.org", "code": "mg/dL" }
+      }
+    }
+  ]
+}
+JSON
+)
+
+# A transaction Bundle returns 200 even when an entry failed, so check the
+# entries rather than the status code. Reporting a seed that did not happen
+# as a success is the failure mode this whole example is about.
+python3 - "$response" <<'PY'
+import json, sys
+body = json.loads(sys.argv[1])
+entries = body.get("entry", [])
+if not entries:
+    print("SEED FAILED: no entries in the response", file=sys.stderr)
+    print(json.dumps(body, indent=2)[:2000], file=sys.stderr)
+    sys.exit(1)
+bad = [e for e in entries
+       if not str((e.get("response") or {}).get("status", "")).startswith(("200", "201"))]
+if bad:
+    print(f"SEED FAILED: {len(bad)} of {len(entries)} entries rejected", file=sys.stderr)
+    print(json.dumps(bad, indent=2)[:2000], file=sys.stderr)
+    sys.exit(1)
+print(f"Seeded {len(entries)} resources: 1 Patient, 1 Condition, 3 Observations.")
+PY

--- a/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
+++ b/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# The five-step walkthrough from the article, as something you can run.
+#
+# Each step prints what it asked for and what came back. Steps that assert a
+# guardrail FAIL LOUDLY when the guardrail does not hold — a walkthrough that
+# prints "OK" whatever happens is a demo of itself, not of the system.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+[ -f .env ] && set -a && . ./.env && set +a
+
+AIDBOX_URL="${AIDBOX_URL:-http://localhost:8080}"
+AIDBOX_CLIENT="${AIDBOX_CLIENT:-root}"
+AIDBOX_SECRET="${AIDBOX_SECRET:-qNbQS6sw82}"
+HC="http://localhost:${HEALTHCLAW_PORT:-5000}"
+TENANT="${TENANT:-demo}"
+
+fail=0
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; fail=1; }
+
+# ---------------------------------------------------------------------------
+step "1. The same resource, both ways"
+
+direct=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  "${AIDBOX_URL}/fhir/Patient/pt-demo")
+echo "  direct from Aidbox:"
+echo "$direct" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('name','identifier','birthDate','address')})[:300])"
+
+proxied=$(curl -sS -H "X-Tenant-Id: ${TENANT}" \
+  "${HC}/r6/fhir/Patient/pt-demo")
+echo "  through the guardrail proxy:"
+echo "$proxied" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('name','identifier','birthDate','address','meta')})[:300])"
+
+# The assertion is on the distinctive values, not on the shape of the mask:
+# checking for '***masked***' would pass if redaction were replaced by a
+# function that returned that string and nothing else.
+python3 - "$direct" "$proxied" <<'PY'
+import json, sys
+direct, proxied = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+raw = json.dumps(proxied)
+leaked = [tok for tok in ("Alvarez", "Maria", "MRN-88214", "221 Baker St",
+                          "555-867-5309", "1974-03-11") if tok in raw]
+if leaked:
+    print(f"  \033[31mFAIL\033[0m identifiers survived redaction: {leaked}")
+    sys.exit(1)
+if "Alvarez" not in json.dumps(direct):
+    print("  \033[31mFAIL\033[0m Aidbox did not return the identified record; "
+          "is the seed loaded?")
+    sys.exit(1)
+print("  \033[32mPASS\033[0m Aidbox holds the full record; the agent's path does not")
+PY
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "2. The read left a record"
+
+audit=$(curl -sS -H "X-Tenant-Id: ${TENANT}" "${HC}/r6/fhir/AuditEvent?_count=1")
+echo "$audit" | python3 -c "
+import json,sys
+b=json.load(sys.stdin)
+n=b.get('total', len(b.get('entry',[])))
+print(f'    AuditEvent entries: {n}')
+raw=json.dumps(b)
+for tok in ('Alvarez','MRN-88214','221 Baker St'):
+    if tok in raw:
+        print(f'  \033[31mFAIL\033[0m PHI in the audit trail: {tok}'); sys.exit(1)
+if not b.get('entry'):
+    print('  \033[31mFAIL\033[0m the read emitted no AuditEvent'); sys.exit(1)
+print('  \033[32mPASS\033[0m audit written, and PHI-free')
+"
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "3. A write, blocked twice"
+
+body='{"resourceType":"Observation","status":"final",
+       "subject":{"reference":"Patient/pt-demo"},
+       "effectiveDateTime":"2026-08-11",
+       "code":{"coding":[{"system":"http://loinc.org","code":"85354-9"}]},
+       "valueQuantity":{"value":128,"unit":"mmHg"}}'
+
+code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  -H "X-Tenant-Id: ${TENANT}" -H 'Content-Type: application/fhir+json' \
+  -d "$body" "${HC}/r6/fhir/Observation")
+echo "    no step-up token          -> HTTP ${code}"
+[ "$code" = "401" ] && ok "refused without a step-up credential" \
+                    || bad "expected 401 without a step-up token, got ${code}"
+
+token=$(curl -sS -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: ${TENANT}" -d "{\"tenant_id\":\"${TENANT}\"}" \
+  "${HC}/r6/fhir/internal/step-up-token" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+
+if [ -z "$token" ]; then
+  bad "could not mint a step-up token"
+else
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "X-Tenant-Id: ${TENANT}" -H "X-Step-Up-Token: ${token}" \
+    -H 'Content-Type: application/fhir+json' \
+    -d "$body" "${HC}/r6/fhir/Observation")
+  echo "    step-up, no human         -> HTTP ${code}"
+  [ "$code" = "428" ] && ok "held for human confirmation" \
+                      || bad "expected 428 pending confirmation, got ${code}"
+fi
+
+# ---------------------------------------------------------------------------
+step "4. Grade the deployment"
+
+curl -sS "${HC}/r6/fhir/\$conformance?format=text" | sed -n '1,4p' | sed 's/^/    /'
+grade=$(curl -sS "${HC}/r6/fhir/\$conformance" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('grade',''), d['score']['passed'], d['score']['total'])" 2>/dev/null)
+echo "    grade: ${grade}"
+case "$grade" in
+  "A 7 7") ok "Grade A, 7/7" ;;
+  *)       bad "expected 'A 7 7', got '${grade}'" ;;
+esac
+
+# ---------------------------------------------------------------------------
+if [ "$fail" -ne 0 ]; then
+  printf '\n\033[31mWalkthrough FAILED.\033[0m A guardrail this example claims did not hold.\n'
+  exit 1
+fi
+printf '\n\033[32mWalkthrough passed.\033[0m The agent did useful work and could not finish alone.\n'

--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -346,13 +346,21 @@ class FHIRUpstreamProxy:
     """
 
     def __init__(self, upstream_url: str, local_base_url: str = '',
-                 caller_auth: bool = False):
+                 caller_auth: bool = False,
+                 basic_auth: tuple[str, str] | None = None):
         self.upstream_url = upstream_url.rstrip('/')
         self.local_base_url = local_base_url.rstrip('/')
         # True when the CALLER's own credential is forwarded upstream (SHARP
         # mode) — upstream 401/403 then belong to the caller and pass
         # through, instead of mapping to 502 (proxy-credential failure).
         self.caller_auth = caller_auth
+        # HTTP Basic to the upstream, when the upstream requires a credential
+        # of its own (Aidbox Client, HAPI behind basic auth, ...). This is the
+        # PROXY's credential, not the caller's, which is why caller_auth stays
+        # False: a 401 from upstream means OUR credential is wrong, and
+        # handing that to the caller as "re-authenticate" would send them
+        # round a loop they cannot exit. Never logged — see _redacted_auth.
+        self.basic_auth = basic_auth
         self._client = httpx.Client(
             base_url=self.upstream_url,
             timeout=_UPSTREAM_TIMEOUT,
@@ -360,6 +368,7 @@ class FHIRUpstreamProxy:
             # initial URL; following a 3xx would let a validated public host
             # redirect the server to cloud metadata / internal IPs.
             follow_redirects=False,
+            auth=basic_auth,
             headers={
                 'Accept': 'application/fhir+json, application/json',
                 'User-Agent': f'HealthClaw-Guardrails/{__version__}',
@@ -589,12 +598,51 @@ class MedplumProxy(FHIRUpstreamProxy):
 _proxy_instance: FHIRUpstreamProxy | None = None
 
 
+def _upstream_basic_auth() -> tuple[str, str] | None:
+    """The proxy's own HTTP Basic credential for the upstream, or None.
+
+    Aidbox, and most FHIR servers that are not public sandboxes, refuse an
+    anonymous request. Before this existed, `FHIR_UPSTREAM_URL` sent no
+    credential at all, so "a proxy in front of any FHIR server" was true only
+    of servers that needed no credential — the sandboxes it was tested
+    against. Every secured upstream answered 401, which the sanitizer then
+    correctly reported as a 502.
+
+    HALF-CONFIGURED IS AN ERROR, AND IT SAYS SO. A typo in one of the two
+    variable names would otherwise fall back to anonymous, and anonymous
+    against a secured upstream is a wall of 502s whose cause is nowhere in
+    the logs. Configuration that is half-present is more likely a mistake
+    than an intention, so it is named at ERROR and the credential is not
+    attached — the request still fails, but the reason is on the first line
+    of the log instead of being inferred from a status code.
+
+    The secret is never logged, here or anywhere else in this module.
+    """
+    client_id = os.environ.get('FHIR_UPSTREAM_CLIENT_ID', '').strip()
+    client_secret = os.environ.get('FHIR_UPSTREAM_CLIENT_SECRET', '').strip()
+    if client_id and client_secret:
+        logger.info('FHIR upstream proxy: authenticating as client %r',
+                    client_id)
+        return (client_id, client_secret)
+    if client_id or client_secret:
+        missing = ('FHIR_UPSTREAM_CLIENT_SECRET' if client_id
+                   else 'FHIR_UPSTREAM_CLIENT_ID')
+        logger.error(
+            'FHIR upstream proxy: %s is set but %s is not — connecting '
+            'ANONYMOUSLY. A secured upstream will refuse every request.',
+            'FHIR_UPSTREAM_CLIENT_ID' if client_id
+            else 'FHIR_UPSTREAM_CLIENT_SECRET',
+            missing)
+    return None
+
+
 def get_proxy() -> FHIRUpstreamProxy | None:
     """
     Return the proxy singleton, or None if no upstream is configured.
 
     Priority:
-      1. FHIR_UPSTREAM_URL — generic upstream proxy (no auth)
+      1. FHIR_UPSTREAM_URL — generic upstream proxy (optional HTTP Basic via
+         FHIR_UPSTREAM_CLIENT_ID + FHIR_UPSTREAM_CLIENT_SECRET)
       2. MEDPLUM_BASE_URL  — Medplum proxy (OAuth2 client-credentials)
     """
     global _proxy_instance
@@ -605,7 +653,8 @@ def get_proxy() -> FHIRUpstreamProxy | None:
 
     upstream_url = os.environ.get('FHIR_UPSTREAM_URL', '').strip()
     if upstream_url:
-        _proxy_instance = FHIRUpstreamProxy(upstream_url, local_base)
+        _proxy_instance = FHIRUpstreamProxy(
+            upstream_url, local_base, basic_auth=_upstream_basic_auth())
         return _proxy_instance
 
     medplum_url = os.environ.get('MEDPLUM_BASE_URL', '').strip()

--- a/tests/test_upstream_proxy_authenticates.py
+++ b/tests/test_upstream_proxy_authenticates.py
@@ -1,0 +1,144 @@
+"""The upstream proxy can present a credential to the server it proxies.
+
+Written for the Aidbox integration example (examples/aidbox-healthclaw-
+guardrails), and it exists because building that example found the claim
+"a proxy in front of any FHIR server" to be narrower than it sounded.
+
+`FHIR_UPSTREAM_URL` mode sent no credential. That is fine against the four
+upstreams it had been tested against — HAPI's public server, SMART Health
+IT, a local HAPI, and a Medplum instance that gets its token by a different
+path entirely. All of them serve an anonymous read. Aidbox does not, and
+neither does any other FHIR server configured the way you would configure
+one that holds real records. Against those the proxy sent no Authorization
+header, took a 401, and reported a 502.
+
+So the guardrail layer could not sit in front of a secured FHIR server,
+which is the only kind worth guarding.
+"""
+
+import httpx
+import pytest
+
+from r6 import fhir_proxy
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    fhir_proxy.reset_proxy()
+    yield
+    fhir_proxy.reset_proxy()
+
+
+class TestTheCredentialReachesTheUpstream:
+
+    def test_basic_auth_is_sent_when_both_halves_are_configured(
+            self, monkeypatch):
+        """MUTATION: drop `auth=basic_auth` from the httpx client -> red.
+
+        Asserted on the wire, not on the constructor argument: the point is
+        that the upstream receives an Authorization header, and only a
+        request can show that.
+        """
+        monkeypatch.setenv('FHIR_UPSTREAM_URL', 'http://aidbox:8080/fhir')
+        monkeypatch.setenv('FHIR_UPSTREAM_CLIENT_ID', 'healthclaw')
+        monkeypatch.setenv('FHIR_UPSTREAM_CLIENT_SECRET', 'not-a-real-secret')
+
+        proxy = fhir_proxy.get_proxy()
+        assert proxy is not None
+
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen['authorization'] = request.headers.get('authorization')
+            return httpx.Response(200, json={'resourceType': 'CapabilityStatement',
+                                             'fhirVersion': '4.0.1'})
+
+        proxy._client = httpx.Client(
+            base_url=proxy.upstream_url,
+            auth=proxy.basic_auth,
+            transport=httpx.MockTransport(handler),
+        )
+        proxy.healthy()
+
+        assert seen['authorization'] is not None, (
+            'the upstream request carried no Authorization header')
+        assert seen['authorization'].startswith('Basic ')
+
+    def test_no_credential_is_sent_when_none_is_configured(self, monkeypatch):
+        """The default has to stay anonymous. A public sandbox upstream must
+        keep working for everyone who already points at one."""
+        monkeypatch.setenv('FHIR_UPSTREAM_URL', 'https://hapi.fhir.org/baseR4')
+        monkeypatch.delenv('FHIR_UPSTREAM_CLIENT_ID', raising=False)
+        monkeypatch.delenv('FHIR_UPSTREAM_CLIENT_SECRET', raising=False)
+
+        proxy = fhir_proxy.get_proxy()
+        assert proxy is not None
+        assert proxy.basic_auth is None
+
+
+class TestHalfConfiguredIsLoud:
+    """A typo in one variable name must not degrade to anonymous in silence.
+
+    This is the defect shape the retro names: a control that looks like one
+    thing and quietly does another. Anonymous-against-a-secured-upstream
+    fails, but it fails as a wall of 502s whose cause appears nowhere.
+    """
+
+    @pytest.mark.parametrize('present,missing', [
+        ('FHIR_UPSTREAM_CLIENT_ID', 'FHIR_UPSTREAM_CLIENT_SECRET'),
+        ('FHIR_UPSTREAM_CLIENT_SECRET', 'FHIR_UPSTREAM_CLIENT_ID'),
+    ])
+    def test_it_names_the_variable_you_forgot(self, monkeypatch, caplog,
+                                              present, missing):
+        """MUTATION: return None without logging -> red."""
+        monkeypatch.setenv('FHIR_UPSTREAM_URL', 'http://aidbox:8080/fhir')
+        monkeypatch.delenv('FHIR_UPSTREAM_CLIENT_ID', raising=False)
+        monkeypatch.delenv('FHIR_UPSTREAM_CLIENT_SECRET', raising=False)
+        monkeypatch.setenv(present, 'something')
+
+        with caplog.at_level('ERROR'):
+            auth = fhir_proxy._upstream_basic_auth()
+
+        assert auth is None, 'half a credential must not be sent as a whole one'
+        assert missing in caplog.text, (
+            f'the log does not name {missing}, so the operator has to guess')
+
+    def test_the_secret_is_never_logged(self, monkeypatch, caplog):
+        """THE ONE PROPERTY of this module's logging.
+
+        MUTATION: log the credential tuple instead of the client id -> red.
+        """
+        secret = 'sup3rs3cret-value-that-must-not-appear'
+        monkeypatch.setenv('FHIR_UPSTREAM_URL', 'http://aidbox:8080/fhir')
+        monkeypatch.setenv('FHIR_UPSTREAM_CLIENT_ID', 'healthclaw')
+        monkeypatch.setenv('FHIR_UPSTREAM_CLIENT_SECRET', secret)
+
+        with caplog.at_level('DEBUG'):
+            auth = fhir_proxy._upstream_basic_auth()
+
+        assert auth == ('healthclaw', secret)
+        assert secret not in caplog.text
+
+
+class TestAnUpstreamRefusalIsNotTheCallersProblem:
+
+    def test_a_401_from_upstream_is_not_handed_back_as_re_authenticate(self):
+        """The proxy's credential is not the caller's.
+
+        With `caller_auth=False` an upstream 401 maps to 502: our credential
+        is wrong, and telling the caller to re-authenticate would send them
+        round a loop they have no way to exit. This pins that adding Basic
+        auth did not quietly flip that mapping.
+
+        MUTATION: construct the proxy with caller_auth=True when basic_auth
+        is set -> red.
+        """
+        proxy = fhir_proxy.FHIRUpstreamProxy(
+            'http://aidbox:8080/fhir', basic_auth=('healthclaw', 'secret'))
+        assert proxy.caller_auth is False
+
+        body, status = fhir_proxy.sanitize_upstream_error(
+            httpx.Response(401, json={'resourceType': 'OperationOutcome'}),
+            caller_auth=proxy.caller_auth)
+        assert status == 502
+        assert body['resourceType'] == 'OperationOutcome'


### PR DESCRIPTION
The Health Samurai article says the example "lives at aidbox-integrations/
healthclaw-guardrails". It did not exist, and building it found the article's
central claim to be narrower than it reads.

THE GAP: "A PROXY IN FRONT OF ANY FHIR SERVER" MEANT ANY UNSECURED ONE

FHIR_UPSTREAM_URL mode sent no credential. That is fine against the four
upstreams it was tested against — HAPI's public server, SMART Health IT, a
local HAPI, and Medplum, which gets its token another way entirely. All serve
an anonymous read. Aidbox does not, and neither does any FHIR server
configured the way you would configure one holding real records. Against
those the proxy sent no Authorization header, took a 401, and reported a 502.

So the guardrail layer could not sit in front of a secured FHIR server, which
is the only kind worth guarding.

FHIR_UPSTREAM_CLIENT_ID + FHIR_UPSTREAM_CLIENT_SECRET now supply HTTP Basic.
caller_auth stays False: the credential is the PROXY's, so an upstream 401
means OUR credential is wrong, and telling the caller to re-authenticate
sends them round a loop they cannot exit. Half-configured is an ERROR naming
the variable you forgot — a typo in one name would otherwise degrade to
anonymous, and anonymous against a secured upstream is a wall of 502s with
the cause nowhere in the logs. The secret is never logged; a test pins that.

THE EXAMPLE

examples/aidbox-healthclaw-guardrails/ — compose (Aidbox + guardrails + MCP),
an init bundle creating the Client and an AccessPolicy scoping it to /fhir/*,
a seed script, and walkthrough.sh running the article's five steps as
ASSERTIONS. A walkthrough that prints OK whatever happens demos itself.

The redaction assertion looks for the values themselves (Alvarez, MRN-88214,
221 Baker St) rather than for a mask string, because a redactor that returned
'***masked***' and nothing else would satisfy the lazier check.

Ships with published images so it works standalone in the Aidbox repo;
docker-compose.build.yaml builds from a HealthClaw checkout instead.

THREE THINGS FOUND BY RUNNING IT, ALL OF WHICH THE ARTICLE'S READERS WILL HIT

  - No AIDBOX_LICENSE: Aidbox boots, reports healthy, then 302s every API
    call to "Log in to activate Aidbox" — which reaches the reader as a
    degraded upstream, saying nothing about licensing. Compose now refuses to
    start without it.
  - macOS holds port 5000 (AirPlay Receiver). Every curl in the article uses
    :5000. HEALTHCLAW_PORT moves the host port.
  - APP_ENV: demo is rejected by the runtime validator. Correct of it; my
    compose was wrong.

VERIFIED, AND WHAT WAS NOT

Verified live: the stack builds and starts, the built image carries the new
code, and the proxy logs `authenticating as client 'healthclaw'` on its first
upstream call — Basic auth reaches Aidbox. Compose validates and fails loudly
without a licence.

NOT verified: the walkthrough end to end, which needs an Aidbox licence key
this environment does not have. Steps 1-4 are written and asserted but have
not been run green. Said plainly here rather than implied by silence.

Gates: 2996 passed, 13 skipped, 1 xfailed. ruff clean. See #488 — running
this example makes 120 of our own tests fail, and that is a defect on main,
not in this change.