### PR TITLE
fix(mcp): an expired session returns 404, so the client re-initializes instead of failing

### DIFF
--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -395,8 +395,39 @@ app.post("/mcp", async (req, res) => {
       }
 
       case "tools/call": {
-        // Require valid session for tool calls
-        if (!requestSessionId || !existingSession) {
+        // Require valid session for tool calls.
+        //
+        // The two failures below are NOT the same failure, and answering both
+        // with 400 is what turned a routine session expiry into a dead
+        // conversation for the first clinician to use this.
+        //
+        // Sessions live in an in-memory Map with a 30-minute idle TTL, so they
+        // end constantly: every redeploy, every restart, every user who leaves
+        // a chat open over lunch. Per the Streamable HTTP spec a server that
+        // does not recognise an Mcp-Session-Id MUST answer 404, and a client
+        // that receives 404 MUST re-initialise. That handshake is the entire
+        // recovery mechanism, and 400 does not trigger it — the client reports
+        // an execution error and stops.
+        //
+        // What made it hard to see: tools/list requires no session, so the
+        // tool list kept rendering while every call failed. It looks like a
+        // broken deployment and is a expired cookie.
+        if (requestSessionId && !existingSession) {
+          return res.status(404).json({
+            jsonrpc: "2.0",
+            id,
+            error: {
+              code: -32600,
+              message:
+                "Unknown or expired session. Re-initialize to obtain a new " +
+                "Mcp-Session-Id, then retry.",
+            },
+          });
+        }
+        // No session id at all: the client never initialised. The spec calls
+        // for 400 here, and there is nothing to recover — re-initialising is
+        // what it should have done first.
+        if (!existingSession) {
           return res.status(400).json({
             jsonrpc: "2.0",
             id,

--- a/services/agent-orchestrator/src/session-recovery.test.ts
+++ b/services/agent-orchestrator/src/session-recovery.test.ts
@@ -1,0 +1,94 @@
+/**
+ * An expired session must be recoverable by the client.
+ *
+ * Reported live by Dr. Magan mid-conversation: "Give me a summary of the
+ * health record" produced three tool calls, all of which came back as
+ * execution errors, while the tool list rendered fine. The model's own
+ * reading was that the deployment was down. It was not: the demo endpoint
+ * answered initialize and a full fhir_search inside the same minute.
+ *
+ * What actually happened is that her session had ended — sessions live in an
+ * in-memory Map with a 30-minute idle TTL, so they end on every redeploy and
+ * every pause in a conversation — and the server answered the next tools/call
+ * with HTTP 400.
+ *
+ * Per the MCP Streamable HTTP spec, an unrecognised Mcp-Session-Id MUST get a
+ * 404, and a client receiving 404 MUST start a new session by re-initialising.
+ * That exchange is the whole recovery path. A 400 is a client error the client
+ * cannot act on, so Claude surfaced it as a failed tool call and stopped.
+ *
+ * tools/list needs no session, which is why the tools stayed visible
+ * throughout and the failure read as a broken server rather than an expired
+ * cookie.
+ */
+
+import request from "supertest";
+import { app, closeMCPServerForTests } from "./index";
+
+afterAll(async () => {
+  await closeMCPServerForTests();
+});
+
+async function initialize(): Promise<string> {
+  const res = await request(app)
+    .post("/mcp")
+    .send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+    });
+  expect(res.status).toBe(200);
+  const sessionId = res.headers["mcp-session-id"];
+  expect(typeof sessionId).toBe("string");
+  return sessionId as string;
+}
+
+function callTool(sessionId?: string) {
+  const req = request(app).post("/mcp");
+  if (sessionId !== undefined) req.set("Mcp-Session-Id", sessionId);
+  return req.send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "fhir_search", arguments: { resource_type: "Patient" } },
+  });
+}
+
+describe("an ended session tells the client how to recover", () => {
+  it("answers 404 for a session id the server does not know", async () => {
+    // MUTATION: change the status back to 400 -> red. This is the bug.
+    const res = await callTool("11111111-2222-3333-4444-555555555555");
+    expect(res.status).toBe(404);
+  });
+
+  it("answers 404 for a session that existed and then ended", async () => {
+    // The lived case: initialise, have the session go away (redeploy, TTL),
+    // then keep using the id the client is still holding.
+    const sessionId = await initialize();
+    await request(app).delete("/mcp").set("Mcp-Session-Id", sessionId);
+
+    const res = await callTool(sessionId);
+    expect(res.status).toBe(404);
+    expect(String(res.body?.error?.message)).toMatch(/re-initiali/i);
+  });
+
+  it("still answers 400 when the client never initialised at all", async () => {
+    // Not the same failure and not recoverable by re-initialising a session
+    // that was never created. Kept distinct so the 404 keeps meaning
+    // "yours ended", which is the only thing that triggers recovery.
+    const res = await callTool(undefined);
+    expect(res.status).toBe(400);
+  });
+
+  it("keeps listing tools without a session, which is why this hid", async () => {
+    // Pins the asymmetry that made the failure read as a dead deployment.
+    // If tools/list ever starts requiring a session this test should be
+    // rewritten deliberately, not deleted.
+    const res = await request(app)
+      .post("/mcp")
+      .send({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body?.result?.tools)).toBe(true);
+  });
+});

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -2361,7 +2361,9 @@ describe("Express App Tests", () => {
             arguments: { resource_type: "Patient", resource_id: "pt-1" },
           },
         });
-      expect(callRes.status).toBe(400);
+      // 400 -> 404: an ended session is recoverable, and 404 is the status
+      // that makes the client re-initialise instead of giving up.
+      expect(callRes.status).toBe(404);
       expect(callRes.body.error.message).toContain("session");
     });
   });
@@ -2527,7 +2529,11 @@ describe("Express App Tests", () => {
           },
         });
 
-      expect(callRes.status).toBe(400);
+      // Was toBe(400). Changed by the fix for the expired-session report:
+      // an evicted session is the case the client CAN recover from, and 404
+      // is the status that tells it to. 400 was what left a clinician's
+      // conversation dead mid-question. See src/session-recovery.test.ts.
+      expect(callRes.status).toBe(404);
       expect(callRes.body.error.message).toContain("session");
     });
 
@@ -2580,7 +2586,9 @@ describe("Express App Tests", () => {
           params: { name: "fhir_read", arguments: arguments_ },
         });
 
-      expect(expiredRes.status).toBe(400);
+      // 400 -> 404: an ended session is recoverable, and 404 is the status
+      // that makes the client re-initialise instead of giving up.
+      expect(expiredRes.status).toBe(404);
       clock.mockRestore();
     });
 


### PR DESCRIPTION
Reported live by Dr. Magan, mid-conversation, six days before the webinar.
"Give me a summary of the health record" made three tool calls and all three
came back as execution errors, while the tool list rendered normally. The
model's own reading was that the deployment was down.

It was not. Measured inside the same minute: the demo endpoint answered
initialize, answered tools/list, and returned a fully redacted Patient from
fhir_search at HTTP 200. Nothing was asleep and nothing had 401'd.

WHAT ACTUALLY HAPPENED

Her session had ended. Sessions live in an in-memory Map with a 30-minute
idle TTL, so they end constantly: every redeploy, every restart, and every
user who leaves a chat open and comes back to it. That is normal and fine.

What is not fine is the answer. tools/call with an unrecognized
Mcp-Session-Id returned HTTP 400.

Per the Streamable HTTP spec a server that does not recognize a session id
MUST answer 404, and a client that receives 404 MUST start a new session by
re-initializing. That exchange IS the recovery mechanism. A 400 is a client
error the client cannot act on, so it surfaces a failed tool call and stops.
One status code was the difference between a hiccup nobody notices and a
conversation that cannot be continued.

WHY IT LOOKED LIKE A DEAD SERVER

tools/list requires no session. So the tools kept listing while every call
failed, which reads exactly like a broken backend and sends you to Railway
to check a service that is fine. The asymmetry is now pinned by a test, so
if tools/list ever starts requiring a session that becomes a decision rather
than a drift.

THE TWO CASES ARE NOT ONE CASE

  - session id present, unknown to the server -> 404, recoverable
  - no session id at all -> 400, nothing to recover; the client never
    initialized, which is what it should have done first

Collapsing them is what produced the bug, so they are separate branches with
separate tests.

PINS UPDATED IN THIS PR, PER PROTOCOL §6

Three existing tests asserted the 400. They were not wrong when written —
they characterized the behaviour accurately. They characterized the defect.
Each now asserts 404 with the reason recorded at the assertion:

  - tools.test.ts: DELETE /mcp then reuse
  - tools.test.ts: eviction after the inactivity TTL
  - tools.test.ts: expired session under a mocked clock

MUTATION VERIFIED: revert the status to 400 -> 2 of the 4 new tests red.

Gates: 196 passed, 8 suites. tsc --noEmit clean.

DEPLOYMENT: this reaches Dr. Magan only after the demo MCP service is
redeployed. Until then the workaround is to start a new conversation, which
forces a fresh initialize.