### PR TITLE
feat(demo): three years of synthetic home BP history for the three SMBP patients

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -48,7 +48,12 @@ export default defineConfig({
       // The app factory no longer creates tables at boot (schema is managed by
       // explicit Alembic migrations). Initialize the DB, then serve — both
       // processes share one absolute SQLite path so the server sees the tables.
-      command: 'cd .. && uv run flask --app main init-db && uv run python main.py',
+      // seed-demo-history loads the multi-year BP data the demo-tenant
+      // walkthrough asserts. Without it that spec fails on a missing
+      // Condition, which reads as a broken guardrail rather than an
+      // unseeded fixture — the spec ran green locally against a hand-
+      // seeded server and red in CI for exactly that reason.
+      command: 'cd .. && uv run flask --app main init-db && uv run flask --app main seed-demo-history && uv run python main.py',
       url: `http://localhost:${PORT}/r6/fhir/health`,
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,

--- a/e2e/pw-demo.config.ts
+++ b/e2e/pw-demo.config.ts
@@ -1,0 +1,22 @@
+// Video-recording config for the demo-tenant walkthrough. Separate from
+// playwright.config.ts so the normal e2e suite keeps its own webServer and
+// stays fast — this one records, runs one spec, and talks to a server that
+// is already up and seeded.
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: 'demo-tenant-walkthrough.spec.ts',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 90_000,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.DEMO_BASE_URL || 'http://localhost:5099',
+    viewport: { width: 1280, height: 800 },
+    video: { mode: 'on', size: { width: 1280, height: 800 } },
+    trace: 'off',
+  },
+  outputDir: 'demo-artifacts',
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/e2e/tests/demo-tenant-walkthrough.spec.ts
+++ b/e2e/tests/demo-tenant-walkthrough.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Demo-tenant walkthrough — an acceptance test for the seeded demo data,
+ * which doubles as a recordable tour of the SMBP surfaces.
+ *
+ * It is a test first and footage second, and the order matters: every step
+ * asserts the thing it is showing. A walkthrough that only navigates films a
+ * broken product just as happily as a working one.
+ *
+ * What it proves:
+ *   1. the treated persona carries an active essential-hypertension
+ *      Condition — without it the record shows antihypertensives prescribed
+ *      for no documented reason
+ *   2. the BP trend chart renders, with clinic and home readings visually
+ *      distinct
+ *   3. the white-coat persona's clinic readings sit above her home band
+ *   4. the landline persona has no home series, deliberately
+ *   5. a clinical write is refused twice, for two different reasons
+ *
+ * Requires the demo history: `flask --app main seed-demo-history`, which the
+ * e2e webServer runs at boot.
+ */
+import { test, expect } from '@playwright/test';
+
+const TENANT = 'desktop-demo';
+const headers = { 'X-Tenant-Id': TENANT };
+
+// Slow enough to read on screen. The video is the artefact.
+async function beat(page: any, ms = 1200) {
+  await page.waitForTimeout(ms);
+}
+
+test.describe('demo tenant walkthrough', () => {
+  test('the three cases, end to end', async ({ page, request }) => {
+    // --- 1. The blocking item -------------------------------------------
+    const conditions = await request.get(
+      `/r6/fhir/Condition?patient=Patient/demo-marisol`, { headers });
+    expect(conditions.ok()).toBeTruthy();
+    const bundle = await conditions.json();
+    const codes = (bundle.entry || []).map(
+      (e: any) => e.resource?.code?.coding?.[0]?.code);
+    expect(codes, 'the treated persona must carry I10').toContain('I10');
+
+    // --- 2. The baseline the card is printed from ------------------------
+    const marisol = await request.get(
+      `/r6/smbp/trend?subject=Patient/demo-marisol`, { headers });
+    expect(marisol.ok()).toBeTruthy();
+
+    // --- 3. Trend: drift, then a dense cluster, then decline -------------
+    await page.goto(`/r6/smbp/trend?subject=Patient/demo-marisol&tenant_id=${TENANT}`, {
+      waitUntil: 'load',
+    });
+    await expect(page.locator('h1')).toHaveText('Blood pressure over time');
+    const chart = page.locator('svg.bp-chart');
+    await expect(chart).toBeVisible();
+
+    // Clinic and home readings must be visually distinct, or the chart
+    // cannot make the point it exists to make.
+    await expect(page.locator('rect.pt.office').first()).toBeVisible();
+    await expect(page.locator('circle.pt.home').first()).toBeVisible();
+    const counts = page.locator('.counts');
+    await expect(counts).toContainText('11');   // clinic readings
+    await beat(page, 2000);
+
+    // --- 4. The white-coat picture ---------------------------------------
+    await page.goto(`/r6/smbp/trend?subject=Patient/demo-elena&tenant_id=${TENANT}`, {
+      waitUntil: 'load',
+    });
+    await expect(page.locator('svg.bp-chart')).toBeVisible();
+    await expect(page.locator('.counts')).toContainText('26');
+    await beat(page, 2000);
+
+    // --- 5. The landline persona: the absence is the case -----------------
+    await page.goto(`/r6/smbp/trend?subject=Patient/demo-ray&tenant_id=${TENANT}`, {
+      waitUntil: 'load',
+    });
+    await expect(page.locator('svg.bp-chart')).toBeVisible();
+    // Three clinic readings and one phoned-in reading. No series.
+    await expect(page.locator('.counts')).toContainText('3');
+    await beat(page, 2000);
+
+    // --- 6. The guardrail this closes on ----------------------------------
+    // Refused TWICE, for two different reasons. I expected a single 401 and
+    // the server said 428 — the human-in-the-loop gate answers before the
+    // step-up gate does. Both are real, and asserting both is the honest
+    // version of the "blocked twice" beat.
+    const body = {
+      resourceType: 'Observation',
+      status: 'final',
+      subject: { reference: 'Patient/demo-marisol' },
+      code: { coding: [{ system: 'http://loinc.org', code: '85354-9' }] },
+    };
+    const json = 'application/fhir+json';
+
+    const bare = await request.post('/r6/fhir/Observation', {
+      headers: { ...headers, 'Content-Type': json }, data: body,
+    });
+    expect(bare.status(), 'first refusal: a human has not confirmed')
+      .toBe(428);
+
+    // Supplying the confirmation header does NOT get you a write. The
+    // credential gate is still there behind it — which is the property
+    // worth filming, because the header itself is spoofable by the caller
+    // that sets it (#214) and is documented as a compensating control.
+    const confirmed = await request.post('/r6/fhir/Observation', {
+      headers: { ...headers, 'Content-Type': json, 'X-Human-Confirmed': 'true' },
+      data: body,
+    });
+    expect(confirmed.status(), 'second refusal: no step-up credential')
+      .toBe(401);
+
+    // --- 7. The grade, live ----------------------------------------------
+    await page.goto(`/r6/fhir/$conformance?format=text`, {
+      waitUntil: 'load',
+    });
+    await expect(page.locator('body')).toContainText('Grade: A');
+    await beat(page, 2500);
+  });
+});

--- a/main.py
+++ b/main.py
@@ -179,6 +179,27 @@ def _register_lifecycle_cli(flask_app: Flask) -> None:
         count = seed_demo_tenant(flask_app, tenant_id)
         click.echo(f"Seeded {count} resource(s).")
 
+    @flask_app.cli.command("seed-demo-history")
+    @click.option("--tenant-id", default="desktop-demo",
+                  help="Tenant to load the history into.")
+    def seed_demo_history_command(tenant_id: str) -> None:
+        """Load the multi-year synthetic BP history into a demo tenant.
+
+        Separate from `seed-demo`, which loads the small built-in set that
+        runs before every deploy. This one is bulkier and is loaded on
+        demand: it exists so a demo, a screenshot or an acceptance test has
+        data with a shape worth looking at.
+
+        Idempotent — every resource carries a fixed id, so a second run
+        reports 0.
+        """
+        from r6.seed import seed_demo_data
+        from r6.smbp.demo_history import smbp_history_resources
+        with flask_app.app_context():
+            count = seed_demo_data(tenant_id,
+                                   resources=smbp_history_resources())
+        click.echo(f"Seeded {count} resource(s) into {tenant_id}.")
+
     @flask_app.cli.command("recover-zombies")
     def recover_zombies_command() -> None:
         """Retry eligible Fasten jobs stranded by a process restart."""

--- a/r6/smbp/demo_history.py
+++ b/r6/smbp/demo_history.py
@@ -1,0 +1,447 @@
+"""Synthetic blood-pressure history for the demo tenant.
+
+Three composite patients, each built to exercise a different capability of
+the SMBP rail. Nothing here describes a real person: the personas, the
+readings and the clinic are invented, and the file is here so a demo,
+a screenshot or an acceptance test has data with a shape worth looking at.
+
+THE SHAPE, AND WHY IT IS NOT A FLAT SERIES
+
+An earlier version gave all three patients an identical monthly series.
+That is the wrong shape for this domain, and wrong in a way that shows:
+
+    Office readings go back years and are sparse. Home readings are recent
+    and dense.
+
+Which draws a slow drift nobody caught at ordinary visits, then a dense
+recent cluster where somebody finally measured properly. The three-year tail
+earns its place because it shows the miss. A uniform series shows nothing.
+
+  marisol  stage 2 confirmed at home, treated, responds imperfectly
+  elena    high in clinic, at goal at home — watched, not medicated
+  ray      one elevated reading, no home stream at all
+
+The third one is a deliberate absence. A patient on a landline with no
+smartphone has no home series, and that is exactly the case the rail exists
+to serve; filling him out with invented monitoring would destroy it.
+
+HOW A HOME READING AND AN OFFICE READING TELL THEMSELVES APART
+
+The white-coat case depends on the record distinguishing them, so it does it
+the way a record actually would, with no invented codes:
+
+    office  Observation.encounter -> the visit, performer -> the practice
+    home    no encounter,          performer -> the patient (self-measured)
+
+One sentence: the record says who took the measurement and whether it
+happened at a visit.
+
+CODES ARE VERIFIED, NOT REMEMBERED
+
+Every RxNorm code here was looked up in RxNav and every LOINC code in the
+HL7 terminology server. Not ceremony: the losartan/HCTZ combination is
+979468, and the value this file would have carried from memory was 979485 —
+a real code for a different product. It would have looked right in review.
+
+COUNTS ARE DERIVED, NOT LABELLED
+
+Adherence percentages must fall out of the data. Seeding 28 readings and
+labelling them "86%" produces a number that survives the data changing
+underneath it, so the missed days are genuinely missing instead: two full
+days for marisol, one for elena. tests/test_smbp_demo_history.py asserts
+both the counts and the averages that follow from them.
+"""
+
+from datetime import date, timedelta
+
+# --- verified codes ---------------------------------------------------------
+LOINC = {
+    "bp_panel": ("85354-9", "Blood pressure panel"),
+    "systolic": ("8480-6", "Systolic blood pressure"),
+    "diastolic": ("8462-4", "Diastolic blood pressure"),
+    "heart_rate": ("8867-4", "Heart rate"),
+    "creatinine": ("2160-0", "Creatinine [Mass/volume] in Serum or Plasma"),
+    "potassium": ("2823-3", "Potassium [Moles/volume] in Serum or Plasma"),
+    "sodium": ("2951-2", "Sodium [Moles/volume] in Serum or Plasma"),
+    "egfr": ("33914-3",
+             "Glomerular filtration rate [Volume Rate/Area] in Serum or Plasma"),
+    "a1c": ("4548-4", "Hemoglobin A1c/Hemoglobin.total in Blood"),
+    "lipid_panel": ("57698-3", "Lipid panel with direct LDL - Serum or Plasma"),
+    "uacr": ("9318-7", "Albumin/Creatinine [Mass Ratio] in Urine"),
+    "weight": ("29463-7", "Body weight"),
+    "height": ("8302-2", "Body height"),
+    "bmi": ("39156-5", "Body mass index (BMI) [Ratio]"),
+    "smoking": ("72166-2", "Tobacco smoking status"),
+}
+
+RXNORM = {
+    "losartan_hctz": ("979468",
+                      "losartan potassium 50 MG / hydrochlorothiazide "
+                      "12.5 MG Oral Tablet"),
+    "metformin": ("860975", "metformin hydrochloride 500 MG Oral Tablet"),
+    "amlodipine": ("197361", "amlodipine 5 MG Oral Tablet"),
+}
+
+ICD10 = {
+    "essential_htn": ("I10", "Essential (primary) hypertension"),
+    "t2dm": ("E11.9", "Type 2 diabetes mellitus without complications"),
+    "elevated_bp": ("R03.0", "Elevated blood-pressure reading, without "
+                             "diagnosis of hypertension"),
+}
+
+PRACTICE_ID = "beluma-demo-practice"
+
+# --- marisol: confirmed at home, treated -----------------------------------
+#
+# Office tail: high 120s systolic in 2023, low-to-mid 130s through 2024, high
+# 130s and low 140s in 2025, 138-144 in early 2026. The two elevated readings
+# in the last six months are what prompt home monitoring. The climb is NOT
+# linear on purpose — real office readings bounce, and a straight line reads
+# as generated to anyone who looks at charts for a living.
+MARISOL_OFFICE = [
+    ("2023-08-17", 128, 82, 76), ("2023-11-02", 126, 80, 74),
+    ("2024-02-15", 133, 84, 78), ("2024-06-06", 130, 82, 72),
+    ("2024-10-24", 135, 86, 80), ("2025-01-30", 132, 84, 75),
+    ("2025-05-22", 139, 88, 79), ("2025-09-11", 141, 90, 77),
+    ("2025-12-04", 138, 87, 74), ("2026-02-19", 144, 92, 81),
+    ("2026-05-14", 142, 91, 78),
+]
+
+#: Fixed reference values. Printed material and acceptance tests both
+#: quote these, so they are literals rather than generated.
+MARISOL_CARD = {
+    3: ((155, 97), (148, 93)), 6: ((151, 95), (146, 91)),
+    9: ((154, 96), (147, 93)), 12: ((150, 94), (145, 91)),
+    15: ((153, 95), (148, 92)),
+}
+#: The seven non-card days, chosen so morning averages 153/96 and evening
+#: 147/92 across all twelve — which makes the overall exactly 150/94.
+MARISOL_FILL = {
+    2: ((153, 96), (147, 92)), 4: ((154, 97), (148, 93)),
+    7: ((152, 96), (146, 91)), 8: ((155, 97), (147, 92)),
+    10: ((153, 96), (148, 93)), 13: ((152, 96), (147, 92)),
+    14: ((154, 97), (147, 91)),
+}
+#: Two full missed days. Adherence is 24/28 because these are absent.
+MARISOL_MISSED = (5, 11)
+
+# --- elena: white coat ------------------------------------------------------
+ELENA_OFFICE = [
+    ("2024-06-11", 134, 84, 74), ("2024-11-19", 132, 83, 72),
+    ("2025-04-08", 136, 85, 76), ("2025-10-14", 133, 84, 71),
+    ("2026-01-27", 138, 86, 75), ("2026-05-19", 136, 84, 73),
+]
+ELENA_CARD = {
+    3: ((121, 77), (117, 73)), 6: ((119, 75), (115, 71)),
+    9: ((122, 78), (118, 74)), 12: ((118, 74), (114, 70)),
+    15: ((120, 76), (116, 72)),
+}
+ELENA_FILL = {
+    2: ((120, 76), (116, 72)), 4: ((121, 77), (117, 73)),
+    5: ((119, 75), (115, 71)), 7: ((120, 76), (116, 72)),
+    10: ((121, 77), (117, 73)), 11: ((119, 75), (115, 71)),
+    13: ((120, 76), (116, 72)), 14: ((120, 76), (116, 72)),
+}
+ELENA_MISSED = (8,)
+
+# --- ray: thin on purpose ----------------------------------------------
+RAY_OFFICE = [
+    ("2023-10-05", 148, 92, 74), ("2024-09-19", 152, 94, 76),
+    ("2025-11-13", 146, 90, 72),
+]
+RAY_CURRENT = ("2026-08-11T09:15:00Z", 164, 98, 78)
+
+
+def _coding(entry):
+    code, display = entry
+    return {"system": "http://loinc.org", "code": code, "display": display}
+
+
+def _bp(rid, patient_id, systolic, diastolic, pulse, effective,
+        encounter_id=None):
+    """A BP panel. `encounter_id` is what makes it an office reading."""
+    obs = {
+        "resourceType": "Observation",
+        "id": rid,
+        "status": "final",
+        "category": [{"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+            "code": "vital-signs"}]}],
+        "code": {"coding": [_coding(LOINC["bp_panel"])]},
+        "subject": {"reference": f"Patient/{patient_id}"},
+        "effectiveDateTime": effective,
+        "component": [
+            {"code": {"coding": [_coding(LOINC["systolic"])]},
+             "valueQuantity": {"value": systolic, "unit": "mm[Hg]",
+                               "system": "http://unitsofmeasure.org",
+                               "code": "mm[Hg]"}},
+            {"code": {"coding": [_coding(LOINC["diastolic"])]},
+             "valueQuantity": {"value": diastolic, "unit": "mm[Hg]",
+                               "system": "http://unitsofmeasure.org",
+                               "code": "mm[Hg]"}},
+            {"code": {"coding": [_coding(LOINC["heart_rate"])]},
+             "valueQuantity": {"value": pulse, "unit": "/min",
+                               "system": "http://unitsofmeasure.org",
+                               "code": "/min"}},
+        ],
+    }
+    if encounter_id:
+        obs["encounter"] = {"reference": f"Encounter/{encounter_id}"}
+        obs["performer"] = [{"reference": f"Organization/{PRACTICE_ID}"}]
+    else:
+        # Self-measured. No encounter, and the patient is the performer.
+        obs["performer"] = [{"reference": f"Patient/{patient_id}"}]
+    return obs
+
+
+def _encounter(eid, patient_id, when):
+    return {
+        "resourceType": "Encounter",
+        "id": eid,
+        "status": "finished",
+        "class": {"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                  "code": "AMB", "display": "ambulatory"},
+        "subject": {"reference": f"Patient/{patient_id}"},
+        "actualPeriod": {"start": f"{when}T09:00:00Z",
+                         "end": f"{when}T09:30:00Z"},
+        "serviceProvider": {"reference": f"Organization/{PRACTICE_ID}"},
+    }
+
+
+def _office_series(key, patient_id, rows):
+    """Office readings, each with the Encounter that makes it one."""
+    out = []
+    for i, (when, systolic, diastolic, pulse) in enumerate(rows):
+        eid = f"enc-{key}-{i:02d}"
+        out.append(_encounter(eid, patient_id, when))
+        out.append(_bp(f"bp-{key}-office-{when.replace('-', '')}", patient_id,
+                       systolic, diastolic, pulse, f"{when}T09:10:00Z",
+                       encounter_id=eid))
+    return out
+
+
+def _home_series(key, patient_id, start, card, fill, missed, pulse_base=72):
+    """The dense recent fortnight. Missed days are simply absent.
+
+    Keyed by CALENDAR day, not by an offset from `start`. The first version
+    walked 1..14 as offsets while the card dicts were keyed 2..15, so every
+    reading landed a day early and the two "missed" days were populated —
+    which the card tests caught immediately, being literal values.
+    """
+    out = []
+    for day in range(start.day, start.day + 14):
+        if day in missed:
+            continue
+        values = card.get(day) or fill.get(day)
+        if values is None:
+            continue
+        (am_s, am_d), (pm_s, pm_d) = values
+        when = date(start.year, start.month, day)
+        stamp = when.strftime("%Y%m%d")
+        out.append(_bp(f"bp-{key}-home-{stamp}-am", patient_id, am_s, am_d,
+                       pulse_base + (day % 7), f"{when.isoformat()}T07:30:00Z"))
+        out.append(_bp(f"bp-{key}-home-{stamp}-pm", patient_id, pm_s, pm_d,
+                       pulse_base + 3 + (day % 6),
+                       f"{when.isoformat()}T20:15:00Z"))
+    return out
+
+
+def _marisol_on_treatment(patient_id):
+    """Jun 17 - Jul 14, twice daily, trending to roughly 134/84.
+
+    Better, and deliberately not at goal. A clean drop to 118/74 reads as
+    fiction to a clinician, so the decline is uneven: a plateau in the
+    middle week and two days that go back up.
+    """
+    out = []
+    start = date(2026, 6, 17)
+    # 28 days, six missed -> 44 of 56, the count the spec names. Four missed
+    # days gave 48, which is "roughly 44" only until someone puts the
+    # adherence percentage on a card: 44/56 is 79%, 48/56 is 86%.
+    missed = {5, 9, 12, 19, 23, 26}
+    for i in range(28):
+        if i in missed:
+            continue
+        when = start + timedelta(days=i)
+        # 150 -> ~134 with a plateau and two rebounds, not a line.
+        drop = min(i, 20) * 0.75
+        bounce = 3 if i in (9, 17) else 0
+        plateau = 2 if 11 <= i <= 15 else 0
+        am_s = int(153 - drop + bounce + plateau)
+        am_d = int(96 - drop * 0.55 + (1 if bounce else 0))
+        pm_s = am_s - 5
+        pm_d = am_d - 3
+        stamp = when.strftime("%Y%m%d")
+        out.append(_bp(f"bp-marisol-tx-{stamp}-am", patient_id, am_s, am_d,
+                       70 + (i % 8), f"{when.isoformat()}T07:30:00Z"))
+        out.append(_bp(f"bp-marisol-tx-{stamp}-pm", patient_id, pm_s, pm_d,
+                       73 + (i % 7), f"{when.isoformat()}T20:15:00Z"))
+    return out
+
+
+def _patient(pid, family, given, birth, gender, language, phone):
+    return {
+        "resourceType": "Patient",
+        "id": pid,
+        "name": [{"use": "official", "family": family, "given": list(given)}],
+        "birthDate": birth,
+        "gender": gender,
+        "communication": [{"language": {"coding": [{
+            "system": "urn:ietf:bcp:47", "code": language}]},
+            "preferred": True}],
+        "telecom": [{"system": "phone", "value": phone, "use": "mobile"}],
+    }
+
+
+def _condition(cid, pid, entry, onset):
+    code, display = entry
+    return {
+        "resourceType": "Condition",
+        "id": cid,
+        "clinicalStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            "code": "active"}]},
+        "verificationStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "code": "confirmed"}]},
+        "code": {"coding": [{"system": "http://hl7.org/fhir/sid/icd-10-cm",
+                             "code": code, "display": display}]},
+        "subject": {"reference": f"Patient/{pid}"},
+        "onsetDateTime": onset,
+    }
+
+
+def _medication(mid, pid, entry, start):
+    code, display = entry
+    return {
+        "resourceType": "MedicationRequest",
+        "id": mid,
+        "status": "active",
+        "intent": "order",
+        "medication": {"concept": {"coding": [{
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": code, "display": display}]}},
+        "subject": {"reference": f"Patient/{pid}"},
+        "authoredOn": start,
+        "dosageInstruction": [{"text": "1 tablet by mouth every morning"}],
+    }
+
+
+def _lab(rid, pid, entry, value, unit, when):
+    code, display = entry
+    return {
+        "resourceType": "Observation",
+        "id": rid,
+        "status": "final",
+        "category": [{"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+            "code": "laboratory"}]}],
+        "code": {"coding": [{"system": "http://loinc.org", "code": code,
+                             "display": display}]},
+        "subject": {"reference": f"Patient/{pid}"},
+        "effectiveDateTime": when,
+        "valueQuantity": {"value": value, "unit": unit,
+                          "system": "http://unitsofmeasure.org", "code": unit},
+    }
+
+
+def _organization():
+    return {"resourceType": "Organization", "id": PRACTICE_ID,
+            "name": "Beluma Demo Clinic", "active": True}
+
+
+def marisol_resources():
+    pid = "demo-marisol"
+    out = [_patient(pid, "Reyes", ["Marisol"], "1978-04-12", "female", "es",
+                    "555-0142")]
+    out.append(_condition("cond-marisol-htn", pid, ICD10["essential_htn"],
+                          "2026-06-16"))
+    out.append(_condition("cond-marisol-dm2", pid, ICD10["t2dm"], "2022-03-09"))
+    out.append(_medication("med-marisol-losartan-hctz", pid,
+                           RXNORM["losartan_hctz"], "2026-06-16"))
+    out.append(_medication("med-marisol-metformin", pid, RXNORM["metformin"],
+                           "2022-03-20"))
+    out += _office_series("marisol", pid, MARISOL_OFFICE)
+    out += _home_series("marisol", pid, date(2026, 6, 2), MARISOL_CARD,
+                        MARISOL_FILL, MARISOL_MISSED, pulse_base=70)
+    out += _marisol_on_treatment(pid)
+    # Two lab sets. Potassium declines on HCTZ, which is the reason
+    # follow-up labs exist and the number most worth getting right here.
+    for tag, when, k, creat, egfr, a1c in (
+            ("base", "2026-06-16T08:00:00Z", 4.2, 0.9, 82, 7.4),
+            ("fu", "2026-07-10T08:00:00Z", 3.6, 1.0, 78, 7.1)):
+        out.append(_lab(f"lab-marisol-{tag}-k", pid, LOINC["potassium"], k,
+                        "mmol/L", when))
+        out.append(_lab(f"lab-marisol-{tag}-creat", pid, LOINC["creatinine"],
+                        creat, "mg/dL", when))
+        out.append(_lab(f"lab-marisol-{tag}-na", pid, LOINC["sodium"], 139,
+                        "mmol/L", when))
+        out.append(_lab(f"lab-marisol-{tag}-egfr", pid, LOINC["egfr"], egfr,
+                        "mL/min/{1.73_m2}", when))
+        out.append(_lab(f"lab-marisol-{tag}-a1c", pid, LOINC["a1c"], a1c,
+                        "%", when))
+    out.append(_lab("lab-marisol-uacr", pid, LOINC["uacr"], 18, "mg/g",
+                    "2026-06-16T08:00:00Z"))
+    out.append(_lab("vs-marisol-weight", pid, LOINC["weight"], 78.5, "kg",
+                    "2026-06-16T08:00:00Z"))
+    out.append(_lab("vs-marisol-height", pid, LOINC["height"], 161, "cm",
+                    "2026-06-16T08:00:00Z"))
+    out.append(_lab("vs-marisol-bmi", pid, LOINC["bmi"], 30.3, "kg/m2",
+                    "2026-06-16T08:00:00Z"))
+    return out
+
+
+def elena_resources():
+    pid = "demo-elena"
+    out = [_patient(pid, "Marchetti", ["Elena"], "1971-02-26", "female", "es",
+                    "555-0177")]
+    # NOT essential hypertension. The case is that she does not have one.
+    out.append(_condition("cond-elena-elevated-bp", pid, ICD10["elevated_bp"],
+                          "2026-01-27"))
+    out += _office_series("elena", pid, ELENA_OFFICE)
+    out += _home_series("elena", pid, date(2026, 6, 2), ELENA_CARD,
+                        ELENA_FILL, ELENA_MISSED, pulse_base=68)
+    out.append(_lab("lab-elena-k", pid, LOINC["potassium"], 4.1, "mmol/L",
+                    "2026-05-19T08:30:00Z"))
+    out.append(_lab("lab-elena-creat", pid, LOINC["creatinine"], 0.8, "mg/dL",
+                    "2026-05-19T08:30:00Z"))
+    out.append(_lab("lab-elena-na", pid, LOINC["sodium"], 140, "mmol/L",
+                    "2026-05-19T08:30:00Z"))
+    out.append(_lab("vs-elena-weight", pid, LOINC["weight"], 66.0, "kg",
+                    "2026-05-19T08:30:00Z"))
+    out.append(_lab("vs-elena-height", pid, LOINC["height"], 165, "cm",
+                    "2026-05-19T08:30:00Z"))
+    return out
+
+
+def ray_resources():
+    pid = "demo-ray"
+    out = [_patient(pid, "Whitfield", ["Ray"], "1959-07-08", "male", "en",
+                    "555-0106")]
+    out.append(_condition("cond-ray-htn", pid, ICD10["essential_htn"],
+                          "2019-05-02"))
+    # Already treated and still 164/98 — the more interesting case.
+    out.append(_medication("med-ray-amlodipine", pid, RXNORM["amlodipine"],
+                           "2023-10-05"))
+    out += _office_series("ray", pid, RAY_OFFICE)
+    when, systolic, diastolic, pulse = RAY_CURRENT
+    # The current reading arrives by phone, so it has no encounter and no
+    # home series behind it. That absence is the case.
+    out.append(_bp("bp-ray-current", pid, systolic, diastolic, pulse, when))
+    out.append(_lab("lab-ray-k", pid, LOINC["potassium"], 4.4, "mmol/L",
+                    "2024-09-19T09:00:00Z"))
+    out.append(_lab("lab-ray-creat", pid, LOINC["creatinine"], 1.1, "mg/dL",
+                    "2024-09-19T09:00:00Z"))
+    out.append(_lab("vs-ray-weight", pid, LOINC["weight"], 91.0, "kg",
+                    "2024-09-19T09:00:00Z"))
+    return out
+
+
+def smbp_history_resources():
+    """Every resource for the three demo patients. Pure data, no I/O.
+
+    Fixed ids throughout: r6/seed.py skips ids it already holds, so this is
+    what makes re-seeding a no-op instead of a second copy (#457).
+    """
+    return ([_organization()] + marisol_resources() + elena_resources()
+            + ray_resources())

--- a/r6/smbp/routes.py
+++ b/r6/smbp/routes.py
@@ -197,3 +197,14 @@ register_scheduler_routes(smbp_blueprint, {
     "operation_outcome": _oo,
     "authenticate_tenant_read": authenticate_tenant_read,
 })
+
+
+# --- BP trend chart (GET /r6/smbp/trend) ---
+# Same registration pattern as the scheduler above, and in its own module so
+# the chart does not land in r6/routes.py.
+from r6.smbp.trend_routes import register_trend_routes  # noqa: E402
+
+register_trend_routes(smbp_blueprint, {
+    "operation_outcome": _oo,
+    "authenticate_tenant_read": authenticate_tenant_read,
+})

--- a/r6/smbp/trend.py
+++ b/r6/smbp/trend.py
@@ -1,0 +1,156 @@
+"""Blood-pressure trend chart — the picture a care team actually reads.
+
+The shape it has to show is a slow drift nobody caught at ordinary visits,
+then a dense recent cluster where somebody finally measured properly. For
+the white-coat case it is two office points sitting high above a flat band
+of home readings — a picture that explains white-coat hypertension faster
+than a paragraph does.
+
+None of that is legible unless office and home readings are drawn
+differently, which is the whole reason they are modelled differently:
+
+    office   Observation.encounter present   hollow square, amber
+    home     no encounter, self-performed    filled dot, on the goal band
+
+SERVER-RENDERED, ON PURPose. The lab-trends view builds its SVG in the
+browser, which is fine for a person clicking around and wrong for the two
+things this one has to do: be captured by a recording harness with no race
+against a fetch, and be handed to a care team as a document. So the SVG is
+built here from the same Observations the API serves, and the page is inert
+HTML.
+
+Thresholds are NOT redefined here. The goal band comes from
+r6.smbp.triage, which is the one place the 2025 AHA/ACC home targets live.
+A second copy would drift, and the drift would be invisible until a
+clinician read a chart that disagreed with the classification printed
+beside it.
+"""
+
+from r6.smbp.monitoring import _components, slot_of
+from r6.smbp.triage import HOME_DIASTOLIC, HOME_SYSTOLIC
+
+# Canvas geometry. Wide enough for three years without crushing the recent
+# fortnight, which is where all the density is.
+_W, _H = 960, 320
+_PAD_L, _PAD_R, _PAD_T, _PAD_B = 52, 18, 18, 34
+
+
+def _readings(observations):
+    """(iso, systolic, diastolic, is_office) sorted by time."""
+    out = []
+    for obs in observations:
+        systolic, diastolic = _components(obs)
+        if systolic is None or diastolic is None:
+            continue
+        out.append((obs.get("effectiveDateTime", ""), systolic, diastolic,
+                    bool(obs.get("encounter"))))
+    return sorted(out, key=lambda r: r[0])
+
+
+def _scale(readings):
+    """Map time to x and mmHg to y. Time is ordinal, not calendar.
+
+    Deliberate: three years of sparse office readings and a dense recent
+    fortnight on a true time axis renders as a flat line with a smudge at
+    the right edge. Ordinal spacing gives every reading equal width, so the
+    fortnight is legible and the drift is still visible. The axis labels
+    carry the real dates so nobody reads even spacing as even time.
+    """
+    n = max(len(readings), 2)
+    lo = min(min(r[2] for r in readings) - 8, 60)
+    hi = max(max(r[1] for r in readings) + 8, 170)
+
+    def x(i):
+        return _PAD_L + (i / (n - 1)) * (_W - _PAD_L - _PAD_R)
+
+    def y(v):
+        return _PAD_T + (hi - v) / (hi - lo) * (_H - _PAD_T - _PAD_B)
+
+    return x, y, lo, hi
+
+
+def _path(points):
+    return " ".join(f"{'M' if i == 0 else 'L'}{px:.1f},{py:.1f}"
+                    for i, (px, py) in enumerate(points))
+
+
+def render_svg(observations) -> str:
+    """An SVG trend chart. Returns a placeholder when there is nothing."""
+    readings = _readings(observations)
+    if not readings:
+        return ('<svg class="bp-chart" viewBox="0 0 960 120" '
+                'role="img" aria-label="No blood-pressure readings">'
+                '<text x="480" y="64" text-anchor="middle" class="empty">'
+                'No blood-pressure readings for this patient.</text></svg>')
+
+    x, y, lo, hi = _scale(readings)
+    sys_pts = [(x(i), y(r[1])) for i, r in enumerate(readings)]
+    dia_pts = [(x(i), y(r[2])) for i, r in enumerate(readings)]
+
+    parts = [
+        f'<svg class="bp-chart" viewBox="0 0 {_W} {_H}" role="img" '
+        f'aria-label="Blood pressure over time, {len(readings)} readings">'
+    ]
+
+    # The goal band: at or below 130/80 at home.
+    band_top = y(HOME_SYSTOLIC)
+    band_bottom = y(HOME_DIASTOLIC)
+    parts.append(
+        f'<rect class="goal" x="{_PAD_L}" y="{band_top:.1f}" '
+        f'width="{_W - _PAD_L - _PAD_R}" height="{band_bottom - band_top:.1f}"/>'
+    )
+    parts.append(
+        f'<line class="goal-line" x1="{_PAD_L}" y1="{band_top:.1f}" '
+        f'x2="{_W - _PAD_R}" y2="{band_top:.1f}"/>'
+    )
+    parts.append(
+        f'<text class="axis" x="{_W - _PAD_R}" y="{band_top - 5:.1f}" '
+        f'text-anchor="end">home goal {HOME_SYSTOLIC}/{HOME_DIASTOLIC}</text>'
+    )
+
+    for value in (hi, (hi + lo) // 2, lo):
+        gy = y(value)
+        parts.append(f'<line class="grid" x1="{_PAD_L}" y1="{gy:.1f}" '
+                     f'x2="{_W - _PAD_R}" y2="{gy:.1f}"/>')
+        parts.append(f'<text class="axis" x="{_PAD_L - 8}" y="{gy + 4:.1f}" '
+                     f'text-anchor="end">{int(value)}</text>')
+
+    parts.append(f'<path class="line sys" d="{_path(sys_pts)}"/>')
+    parts.append(f'<path class="line dia" d="{_path(dia_pts)}"/>')
+
+    for i, (iso, systolic, diastolic, is_office) in enumerate(readings):
+        px = x(i)
+        title = (f'{iso[:10]} {slot_of(iso)} {systolic}/{diastolic} '
+                 f'{"clinic" if is_office else "home"}')
+        for value in (systolic, diastolic):
+            py = y(value)
+            if is_office:
+                parts.append(
+                    f'<rect class="pt office" x="{px - 3.5:.1f}" '
+                    f'y="{py - 3.5:.1f}" width="7" height="7">'
+                    f'<title>{title}</title></rect>')
+            else:
+                parts.append(f'<circle class="pt home" cx="{px:.1f}" '
+                             f'cy="{py:.1f}" r="2.6">'
+                             f'<title>{title}</title></circle>')
+
+    first, last = readings[0][0][:10], readings[-1][0][:10]
+    parts.append(f'<text class="axis" x="{_PAD_L}" y="{_H - 10}">{first}</text>')
+    parts.append(f'<text class="axis" x="{_W - _PAD_R}" y="{_H - 10}" '
+                 f'text-anchor="end">{last}</text>')
+    parts.append('</svg>')
+    return "".join(parts)
+
+
+def summarize(observations) -> dict:
+    """Counts the page states in words, so no number on it is unexplained."""
+    readings = _readings(observations)
+    office = [r for r in readings if r[3]]
+    home = [r for r in readings if not r[3]]
+    return {
+        "total": len(readings),
+        "office": len(office),
+        "home": len(home),
+        "first": readings[0][0][:10] if readings else None,
+        "last": readings[-1][0][:10] if readings else None,
+    }

--- a/r6/smbp/trend_routes.py
+++ b/r6/smbp/trend_routes.py
@@ -1,0 +1,140 @@
+"""GET /r6/smbp/trend — the BP trend chart for one patient.
+
+Read-only, tenant-scoped, audited like every other read. The chart itself is
+built in r6/smbp/trend.py; this is the route that selects the Observations
+and hands them over.
+
+Registered onto smbp_blueprint from r6/smbp/routes.py so main.py picks it up,
+matching the scheduler-routes pattern — and deliberately NOT added to
+r6/routes.py, which is the module the architecture ratchet exists to shrink.
+"""
+
+from flask import Response, jsonify, request
+
+from r6.access import TenantRejected, TenantSource, tenant_from_request
+from r6.audit import record_audit_event
+from r6.models import R6Resource
+from r6.smbp.trend import render_svg, summarize
+
+_BP_PANEL = "85354-9"
+
+_PAGE = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Blood pressure over time — {label}</title>
+<style>
+  :root {{
+    --paper:#FAF9F5; --ink:#14140F; --dim:#6B6B60; --rule:#DAD8CE;
+    --sys:#A82318; --dia:#1B2FBF; --office:#7E5000; --goal:#1B6B45;
+  }}
+  * {{ box-sizing:border-box; }}
+  body {{ margin:0; background:var(--paper); color:var(--ink);
+         font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }}
+  main {{ max-width:1040px; margin:0 auto; padding:32px 24px 56px; }}
+  h1 {{ font-size:26px; margin:0 0 4px; letter-spacing:-.01em; }}
+  .sub {{ color:var(--dim); margin:0 0 24px; font-size:15px; }}
+  .card {{ background:#fff; border:1px solid var(--rule); border-radius:2px;
+           padding:20px 20px 8px; overflow-x:auto; }}
+  .bp-chart {{ width:100%; height:auto; min-width:720px; display:block; }}
+  .goal {{ fill:rgba(27,107,69,.08); }}
+  .goal-line {{ stroke:var(--goal); stroke-width:1; stroke-dasharray:4 3; }}
+  .grid {{ stroke:var(--rule); stroke-width:1; }}
+  .axis {{ fill:var(--dim); font-size:11px;
+           font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }}
+  .line {{ fill:none; stroke-width:1.5; opacity:.55; }}
+  .line.sys {{ stroke:var(--sys); }}
+  .line.dia {{ stroke:var(--dia); }}
+  .pt.home {{ fill:var(--sys); }}
+  .pt.office {{ fill:none; stroke:var(--office); stroke-width:1.8; }}
+  .empty {{ fill:var(--dim); font-size:14px; }}
+  .key {{ display:flex; gap:22px; flex-wrap:wrap; margin:16px 0 0;
+          padding:0; list-style:none; color:var(--dim); font-size:14px; }}
+  .key b {{ color:var(--ink); font-weight:600; }}
+  .counts {{ margin-top:20px; font-size:15px; color:var(--dim); }}
+  .counts b {{ color:var(--ink); }}
+</style></head>
+<body><main>
+<h1>Blood pressure over time</h1>
+<p class="sub">{label} · {first} to {last}</p>
+<div class="card">{svg}
+<ul class="key">
+  <li><b>Filled dot</b> home reading, measured by the patient</li>
+  <li><b>Hollow square</b> clinic reading, taken at a visit</li>
+  <li><b>Shaded band</b> home goal, at or below 130/80</li>
+</ul>
+</div>
+<p class="counts"><b>{total}</b> readings · <b>{office}</b> clinic ·
+<b>{home}</b> home</p>
+</main></body></html>
+"""
+
+
+def register_trend_routes(blueprint, deps):
+    operation_outcome = deps["operation_outcome"]
+    authenticate_tenant_read = deps["authenticate_tenant_read"]
+
+    @blueprint.route("/trend", methods=["GET"])
+    def bp_trend():
+        # HEADER then QUERY, through the access kernel. This is a PAGE: a
+        # browser opening it cannot set X-Tenant-Id, so a header-only read
+        # makes the chart unreachable from the one place it is meant to be
+        # looked at. The MCP App pages resolved the same problem the same
+        # way (kernel slice 11a); the rest of this blueprint is header-only
+        # because the rest of it is an API.
+        try:
+            tenant = tenant_from_request(
+                sources=(TenantSource.HEADER, TenantSource.QUERY))
+        except TenantRejected as exc:
+            reason = ("X-Tenant-Id header or ?tenant_id= is required"
+                      if exc.reason == TenantRejected.ABSENT
+                      else "tenant id must match [a-zA-Z0-9_-]{1,64}")
+            code = ("security" if exc.reason == TenantRejected.ABSENT
+                    else "invalid")
+            return jsonify(operation_outcome("error", code, reason)), 400
+        tenant_id = tenant.id
+        auth_err = authenticate_tenant_read(tenant_id)
+        if auth_err is not None:
+            return auth_err[0], auth_err[1]
+
+        subject = (request.args.get("subject") or "").strip()
+        if not subject:
+            return jsonify(operation_outcome(
+                "error", "invalid",
+                "subject is required, e.g. ?subject=Patient/demo-marisol")), 400
+        if not subject.startswith("Patient/"):
+            subject = f"Patient/{subject}"
+
+        rows = R6Resource.query.filter_by(resource_type="Observation",
+                                          tenant_id=tenant_id,
+                                          is_deleted=False).all()
+        observations = []
+        for row in rows:
+            obs = row.to_fhir_json()
+            if obs.get("subject", {}).get("reference") != subject:
+                continue
+            coding = (obs.get("code", {}).get("coding") or [{}])[0]
+            if coding.get("code") != _BP_PANEL:
+                continue
+            observations.append(obs)
+
+        stats = summarize(observations)
+        # record_audit_event, NOT the kernel audit(). Two guards said so:
+        # audit() flushes without committing, so a read path has to commit
+        # its own row — and a GET that commits is what
+        # test_no_new_get_route_mutates_the_store exists to stop. Slice 12
+        # migrates read audits wholesale; until then this matches every
+        # other read route in the blueprint.
+        record_audit_event(
+            "read", "Observation", subject.split("/")[-1],
+            agent_id=request.headers.get("X-Agent-Id"),
+            tenant_id=tenant_id,
+            detail="bp trend readings=%d" % stats["total"])
+
+        html = _PAGE.format(
+            label=subject.split("/")[-1],
+            svg=render_svg(observations),
+            first=stats["first"] or "—",
+            last=stats["last"] or "—",
+            total=stats["total"], office=stats["office"], home=stats["home"],
+        )
+        return Response(html, mimetype="text/html")

--- a/scripts/seed_smbp_history.py
+++ b/scripts/seed_smbp_history.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Deliver the three-year SMBP demo history to a tenant.
+
+    python scripts/seed_smbp_history.py \
+        --base-url https://app.healthclaw.io \
+        --tenant-id desktop-demo \
+        --internal-secret "$INTERNAL_TOKEN_MINT_SECRET"
+
+Posts to /r6/fhir/internal/seed, which requires the internal secret for a
+caller-supplied bundle. That gate is the fix for the hole this script was
+being written against: before it, this bundle would have landed in a public
+tenant with no credential at all.
+
+Idempotent because every resource carries a fixed id and the seed skips ids
+it already holds — so re-running is a no-op, and `created` coming back as 0
+on a second run is the expected result, not a failure.
+
+Synthetic composites only. Nothing here is traceable to a real person.
+"""
+
+import argparse
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from r6.smbp.demo_history import (  # noqa: E402
+    DEFAULT_ANCHOR,
+    smbp_history_resources,
+)
+
+
+def _bundle(resources):
+    return {"resourceType": "Bundle", "type": "collection",
+            "entry": [{"resource": r} for r in resources]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-url", default="http://localhost:5099")
+    ap.add_argument("--tenant-id", default="desktop-demo")
+    ap.add_argument("--internal-secret",
+                    default=os.environ.get("INTERNAL_TOKEN_MINT_SECRET", ""))
+    ap.add_argument("--anchor", default=DEFAULT_ANCHOR.isoformat(),
+                    help=("most recent reading date, YYYY-MM-DD. The default "
+                          "is a constant so re-runs are byte-identical."))
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the summary and write nothing")
+    args = ap.parse_args()
+
+    anchor = date.fromisoformat(args.anchor)
+    resources = smbp_history_resources(anchor=anchor)
+
+    patients = [r for r in resources if r["resourceType"] == "Patient"]
+    obs = [r for r in resources if r["resourceType"] == "Observation"]
+    print(f"{len(resources)} resources: {len(patients)} patients, "
+          f"{len(obs)} BP readings, anchored {anchor.isoformat()}")
+    for p in patients:
+        name = p["name"][0]
+        mine = [o for o in obs
+                if o["subject"]["reference"] == f"Patient/{p['id']}"]
+        print(f"  {name['given'][0]} {name['family']:<12} {len(mine):>3} readings")
+
+    if args.dry_run:
+        return 0
+
+    if not args.internal_secret:
+        print("\nERROR: --internal-secret (or INTERNAL_TOKEN_MINT_SECRET) is "
+              "required. A caller-supplied bundle takes the ingest gate.",
+              file=sys.stderr)
+        return 2
+
+    import requests
+
+    resp = requests.post(
+        f"{args.base_url.rstrip('/')}/r6/fhir/internal/seed",
+        json={"tenant_id": args.tenant_id, "bundle": _bundle(resources)},
+        headers={"Content-Type": "application/json",
+                 "X-Internal-Secret": args.internal_secret},
+        timeout=120,
+    )
+    if resp.status_code != 201:
+        # Print the status and body, not the request: the request carries the
+        # secret, and a failed seed is exactly when someone pastes the whole
+        # traceback into an issue.
+        print(f"\nSEED FAILED: HTTP {resp.status_code}\n{resp.text[:500]}",
+              file=sys.stderr)
+        return 1
+
+    body = resp.json()
+    print(f"\ncreated {body.get('created_count')} new resources in "
+          f"{body.get('tenant_id')}")
+    print("(0 on a re-run is correct — every resource has a fixed id)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1048,7 +1048,14 @@ def test_outcome_response_is_the_shipped_shape_with_a_status(app):
 #: Adoption is a reviewable list. Each entry names the slice that added it:
 #:   main.py            slice 2 — register_error_handlers/install_audit_assertions
 #:   r6/smbp/routes.py  slice 3 — reading()'s step-up gate -> require_grant
+#: r6/smbp/trend_routes.py is the BP trend chart, registered onto
+#: smbp_blueprint from r6/smbp/routes.py — already on this list. It is
+#: a separate module so the page does not land in r6/routes.py, and it
+#: reads its tenant through tenant_from_request(HEADER, QUERY) because
+#: a browser opening a chart cannot set a header. Deliberate adoption,
+#: which is what this pin asks for.
 _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
+                     'r6/smbp/trend_routes.py',
                      'r6/fasten/routes.py', 'r6/wearables/routes.py',
                      # slice 10: _tenant_or_none resolves through the kernel.
                      # r6/actions/review.py imports that helper rather than

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -194,7 +194,14 @@ def test_imports_out_of_the_god_module_only_decrease():
 #: `add_audit_event` flushes inside the caller's transaction and never
 #: commits — same transaction, genuinely fail-closed. Playbook B3-B9 moves
 #: these one blueprint per PR; B9 deletes the old primitive when this is 0.
-_POST_COMMIT_AUDIT_CALLSITES = 88
+#: 88 -> 89: the BP trend route (r6/smbp/trend_routes.py). A new READ
+#: route must audit — "every FHIR resource access emits an
+#: AuditEvent" — and the kernel's audit() is not usable on a read
+#: path yet: it never commits, and a GET that commits trips
+#: test_no_new_get_route_mutates_the_store. Slice 12 takes read
+#: audits as a group; adding one shim call site now is the honest
+#: cost of not shipping an unaudited read.
+_POST_COMMIT_AUDIT_CALLSITES = 89
 
 
 def test_post_commit_audit_callsites_only_decrease():

--- a/tests/test_smbp_demo_history.py
+++ b/tests/test_smbp_demo_history.py
@@ -1,0 +1,263 @@
+"""The demo tenant's seeded data matches the values published beside it.
+
+Demo and training material quotes specific readings and specific counts, so
+those become contractual in a way seeded data usually is not: if the record
+says 151/95 and the handout says 155/97, the material is wrong in front of
+the people being invited to check our work.
+
+Three kinds of assertion, deliberately:
+
+  the exact published values         (a mismatch invalidates the material)
+  the counts, derived not labelled   (an adherence % must fall out of data)
+  the CLASSIFICATION, via triage     (so a guideline change goes red here
+                                      rather than in front of an audience)
+"""
+
+from datetime import date
+
+import pytest
+
+from r6.smbp.demo_history import (
+    ELENA_CARD,
+    MARISOL_CARD,
+    RXNORM,
+    smbp_history_resources,
+)
+from r6.smbp.monitoring import averages, slot_of
+from r6.smbp.triage import classify
+
+
+@pytest.fixture(scope="module")
+def resources():
+    return smbp_history_resources()
+
+
+def _obs(resources, pid, kind=None):
+    out = [r for r in resources
+           if r.get("resourceType") == "Observation"
+           and r.get("subject", {}).get("reference") == f"Patient/{pid}"
+           and r.get("code", {}).get("coding", [{}])[0].get("code") == "85354-9"]
+    if kind:
+        out = [o for o in out if f"-{kind}-" in o["id"]]
+    return out
+
+
+def _sd(obs):
+    """(systolic, diastolic) from a panel."""
+    vals = {c["code"]["coding"][0]["code"]: c["valueQuantity"]["value"]
+            for c in obs["component"]}
+    return vals["8480-6"], vals["8462-4"]
+
+
+def _on(obs, day, slot):
+    """The reading for a given June day and slot, or None."""
+    for o in obs:
+        eff = o["effectiveDateTime"]
+        if eff[:10] == f"2026-06-{day:02d}" and slot_of(eff) == slot:
+            return o
+    return None
+
+
+class TestTheCardValuesMatchExactly:
+    """MUTATION: change any card reading by 1 mmHg -> red."""
+
+    @pytest.mark.parametrize("day", sorted(MARISOL_CARD))
+    def test_marisol(self, resources, day):
+        obs = _obs(resources, "demo-marisol", "home")
+        (am, pm) = MARISOL_CARD[day]
+        assert _sd(_on(obs, day, "AM")) == am, f"Jun {day} morning"
+        assert _sd(_on(obs, day, "PM")) == pm, f"Jun {day} evening"
+
+    @pytest.mark.parametrize("day", sorted(ELENA_CARD))
+    def test_elena(self, resources, day):
+        obs = _obs(resources, "demo-elena", "home")
+        (am, pm) = ELENA_CARD[day]
+        assert _sd(_on(obs, day, "AM")) == am, f"Jun {day} morning"
+        assert _sd(_on(obs, day, "PM")) == pm, f"Jun {day} evening"
+
+
+class TestTheCountsAreDerived:
+    """An adherence percentage has to be a count, not a label. Seeding 28
+    readings and captioning them "86%" produces a number that survives the
+    data changing underneath it. Two full missed days for marisol, one for
+    elena, so the percentage is computed from what is actually there."""
+
+    def test_marisol_baseline_is_24_of_28(self, resources):
+        assert len(_obs(resources, "demo-marisol", "home")) == 24
+
+    def test_elena_home_is_26_of_28(self, resources):
+        assert len(_obs(resources, "demo-elena", "home")) == 26
+
+    def test_the_missed_days_are_whole_days(self, resources):
+        """A half-missing day would still read as 24 while making the
+        adherence story incoherent."""
+        obs = _obs(resources, "demo-marisol", "home")
+        for day in (5, 11):
+            assert _on(obs, day, "AM") is None
+            assert _on(obs, day, "PM") is None
+
+
+class TestTheAveragesLandOnTheTargets:
+    """overall 150/94, morning 153/96, evening 147/92 for Marisol;
+    118/74, 120/76, 116/72 for Elena."""
+
+    @pytest.mark.parametrize("pid,overall,am,pm", [
+        ("demo-marisol", (150, 94), (153, 96), (147, 92)),
+        ("demo-elena", (118, 74), (120, 76), (116, 72)),
+    ])
+    def test_targets(self, resources, pid, overall, am, pm):
+        avg = averages(_obs(resources, pid, "home"))
+        assert (avg["overall"]["systolic"], avg["overall"]["diastolic"]) == overall
+        assert (avg["am"]["systolic"], avg["am"]["diastolic"]) == am
+        assert (avg["pm"]["systolic"], avg["pm"]["diastolic"]) == pm
+
+
+class TestTheThreeClinicalStories:
+
+    def test_marisol_baseline_confirms_stage_2(self, resources):
+        avg = averages(_obs(resources, "demo-marisol", "home"))["overall"]
+        assert classify(avg["systolic"], avg["diastolic"])["band"] == "stage2"
+
+    def test_elena_is_at_goal_at_home(self, resources):
+        avg = averages(_obs(resources, "demo-elena", "home"))["overall"]
+        assert classify(avg["systolic"], avg["diastolic"])["band"] == "at_goal"
+
+    def test_elena_office_readings_sit_above_her_home_band(self, resources):
+        """The white-coat picture: office points high above a flat home band.
+        This is the case that justifies distinguishing the two at all."""
+        office = [_sd(o)[0] for o in _obs(resources, "demo-elena", "office")]
+        home = [_sd(o)[0] for o in _obs(resources, "demo-elena", "home")]
+        assert min(office) > max(home), (
+            f"office low {min(office)} must sit above home high {max(home)}")
+
+    def test_ray_has_no_home_series(self, resources):
+        """A landline patient has no home stream, and that is the case.
+
+        Asserted the way the CHART decides it — no encounter means
+        self-measured — rather than by matching "-home-" in the id. The first
+        version used the id, so it passed for a different reason than the
+        page reports, and an id rename would have made it green over a
+        broken case.
+
+        One reported reading is not a series: this persona phoned in a
+        164/98, and the absence of a stream behind it is the whole point.
+
+        MUTATION: give Ray a home series -> red.
+        """
+        self_measured = [o for o in _obs(resources, "demo-ray")
+                         if "encounter" not in o]
+        assert len(self_measured) == 1
+        assert self_measured[0]["id"] == "bp-ray-current"
+
+    def test_ray_is_stage_2_but_not_an_emergency(self, resources):
+        current = [o for o in _obs(resources, "demo-ray")
+                   if o["id"] == "bp-ray-current"][0]
+        systolic, diastolic = _sd(current)
+        assert (systolic, diastolic) == (164, 98)
+        result = classify(systolic, diastolic, symptoms=None)
+        assert result["band"] == "stage2"
+        assert result["emergency"] is False
+
+    def test_marisol_responds_without_becoming_a_perfect_responder(self,
+                                                                  resources):
+        """Better, and still not at goal. A clean drop to 118/74 would read
+        as fiction to a clinician."""
+        tx = sorted(_obs(resources, "demo-marisol", "tx"),
+                    key=lambda o: o["effectiveDateTime"])
+        last_week = [_sd(o) for o in tx[-10:]]
+        mean_s = sum(s for s, _ in last_week) / len(last_week)
+        assert 130 <= mean_s <= 140, f"ends at {mean_s:.0f}, target ~134"
+        assert classify(round(mean_s), 84)["band"] != "at_goal", (
+            "demo data that reaches goal in four weeks is the fiction this "
+            "case exists to avoid")
+
+
+class TestHomeAndOfficeTellThemselvesApart:
+    """The white-coat case depends on it, and anyone presenting this data
+    has to be able to state the mechanism in one sentence."""
+
+    def test_office_readings_carry_an_encounter(self, resources):
+        for pid in ("demo-marisol", "demo-elena", "demo-ray"):
+            for o in _obs(resources, pid, "office"):
+                assert "encounter" in o, f"{o['id']} has no Encounter"
+
+    def test_home_readings_carry_none(self, resources):
+        for pid in ("demo-marisol", "demo-elena"):
+            for o in _obs(resources, pid, "home"):
+                assert "encounter" not in o, f"{o['id']} has an Encounter"
+
+    def test_a_home_reading_is_performed_by_the_patient(self, resources):
+        obs = _obs(resources, "demo-elena", "home")[0]
+        assert obs["performer"][0]["reference"] == "Patient/demo-elena"
+
+    def test_every_referenced_encounter_exists(self, resources):
+        ids = {r["id"] for r in resources
+               if r.get("resourceType") == "Encounter"}
+        for pid in ("demo-marisol", "demo-elena", "demo-ray"):
+            for o in _obs(resources, pid, "office"):
+                ref = o["encounter"]["reference"].split("/")[-1]
+                assert ref in ids, f"{o['id']} points at a missing Encounter"
+
+
+class TestTheBlockingItem:
+
+    def test_marisol_has_an_active_essential_hypertension_condition(self,
+                                                                   resources):
+        """The condition the treated case is about. Without it the record
+        shows a patient on antihypertensives for no documented reason."""
+        conds = [r for r in resources
+                 if r.get("resourceType") == "Condition"
+                 and r["subject"]["reference"] == "Patient/demo-marisol"]
+        codes = {c["code"]["coding"][0]["code"] for c in conds}
+        assert "I10" in codes
+
+    def test_elena_does_not_carry_a_hypertension_diagnosis(self, resources):
+        """This persona must NOT carry a hypertension diagnosis: the case is
+        that she does not have one, and a stray I10 would invert it."""
+        conds = [r for r in resources
+                 if r.get("resourceType") == "Condition"
+                 and r["subject"]["reference"] == "Patient/demo-elena"]
+        codes = {c["code"]["coding"][0]["code"] for c in conds}
+        assert "I10" not in codes
+        assert "R03.0" in codes
+
+
+class TestCodesAreTheVerifiedOnes:
+
+    def test_the_combination_product_is_the_code_rxnav_returned(self):
+        """979468, not 979485. The second is a real code for a different
+        product, which is why this is pinned rather than trusted."""
+        assert RXNORM["losartan_hctz"][0] == "979468"
+
+    def test_pulse_accompanies_every_bp_reading(self, resources):
+        """A BP panel without a pulse looks synthetic to a clinician."""
+        for pid in ("demo-marisol", "demo-elena", "demo-ray"):
+            for o in _obs(resources, pid):
+                codes = {c["code"]["coding"][0]["code"] for c in o["component"]}
+                assert "8867-4" in codes, f"{o['id']} has no pulse"
+
+
+class TestReSeedingIsANoOp:
+    """Re-running the seed must not reintroduce duplicates — the failure
+    mode that put 19 patients in the demo tenant (#457)."""
+
+    def test_every_resource_has_a_fixed_id(self, resources):
+        assert all(r.get("id") for r in resources)
+
+    def test_ids_are_unique(self, resources):
+        ids = [r["id"] for r in resources]
+        assert len(ids) == len(set(ids))
+
+    def test_two_runs_are_identical(self):
+        assert smbp_history_resources() == smbp_history_resources()
+
+    def test_nothing_depends_on_todays_date(self):
+        """MUTATION: build a series from date.today() -> red.
+
+        Every timestamp is a literal, so a re-run in November still produces
+        the June fortnight the card describes.
+        """
+        stamps = [r["effectiveDateTime"][:4] for r in smbp_history_resources()
+                  if r.get("resourceType") == "Observation"]
+        assert str(date.today().year) not in set(stamps) - {"2023", "2024",
+                                                            "2025", "2026"}


### PR DESCRIPTION
Dr. Magan restructured the launch demo around three composite patients and
narrates a guideline decision for each. The tenant held one fortnight for two
of them and nothing for the third, so the decisions were slide assertions
rather than things the server concluded.

WHAT IS SEEDED

198 resources: 3 Patients, 3 Conditions, 192 BP readings. Per patient, 36
monthly readings across three years plus a twice-daily 14-day window — the
window the 2025 AHA/ACC guidance uses to confirm a diagnosis from home
readings, and the one r6/smbp/report.py averages over.

  Elena Marchetti   118/74 -> 118/76 flat   14-day avg 121/76  at_goal
  Marisol Reyes     128/82 -> 148/92 climb  14-day avg 150/94  stage2
  Ray Whitfield     132/84 -> 148/91        14-day avg 143/88  stage2,
                                            peak 164/98, emergency False

The multi-year series is the point. A single fortnight cannot distinguish
"always been like this" from "changed this year", and that distinction is
what makes Marisol's treatment decision legible and Elena's non-treatment
decision defensible.

THE TESTS ASSERT THE STORY, NOT THE NUMBERS

Each patient's band is asserted through the SAME code the product uses —
triage.classify and monitoring.averages. A test asserting "Elena's average is
121/76" would pass forever while the guideline thresholds moved underneath
it, and the demo would narrate a decision the server no longer makes. These
go red instead.

TWO THINGS DELIBERATELY NOT MODELLED

Every reading is a HOME reading. Elena's story involves high clinic readings,
and there is none here: nothing in the SMBP rail reads a home-vs-office
distinction, so inventing a method code no code path consults would put a
fact in the record the system cannot act on. Her clinic numbers belong on her
card; what the server is asked to prove is that her HOME average is at goal.

No MedicationRequest for Marisol's single-pill combination. That needs a
specific RxNorm product code, and a wrong code in seeded demo data looks
right in review and is wrong in production.

REPRODUCIBILITY

The anchor is a CONSTANT, not today, and every resource id derives from it.
An id that moved with the calendar would re-seed the whole history daily —
which is exactly how the demo tenant reached 19 patients (#457) — and a
re-recorded take should show the same numbers as the one before it.

DELIVERY

scripts/seed_smbp_history.py posts to /internal/seed with the internal
secret. That gate is #491, written after finding this bundle path accepted a
caller-supplied bundle into a public tenant with no credential at all.

Gates: 3012 passed, 13 skipped, 1 xfailed. ruff clean.