### PR TITLE
chore(privacy): describe collaborators by role, not by name

### DIFF
--- a/docs/2026-08-01-alignment-review.md
+++ b/docs/2026-08-01-alignment-review.md
@@ -166,7 +166,7 @@ HMCP becoming the standard while we remain a project. The third makes the Bo Hol
 agent-identity thread and HL7/CARIN engagement **existential, not optional**.
 
 **First-1000 playbook** (from Solace, Guava, PicnicHealth, Ada): pick one population
-(Medicare + small practices like Dr. Magan's), make it free where a practice or sponsor
+(Medicare + small independent practices), make it free where a practice or sponsor
 pays, and publish the trust artifact — **"X actions completed, 100% human-approved, 0
 safety incidents."** That counter is the consumer analogue of the "115M interactions"
 stat that raised Hippocratic $126M. It also converges exactly with item 19: the approve

--- a/docs/2026-08-01-alignment-review.md
+++ b/docs/2026-08-01-alignment-review.md
@@ -162,7 +162,7 @@ Not a moat: "agent in a minute" (incumbents do record-grounded chat for 300M wee
 health users) and raw connectivity (b.well's 1.7M providers dwarfs ours).
 
 Threats, in order: OpenAI/Anthropic adding actions; Amazon widening past its clinic;
-HMCP becoming the standard while we remain a project. The third makes the Bo Holland
+HMCP becoming the standard while we remain a project. The third makes the Health Bank One
 agent-identity thread and HL7/CARIN engagement **existential, not optional**.
 
 **First-1000 playbook** (from Solace, Guava, PicnicHealth, Ada): pick one population
@@ -201,7 +201,7 @@ Wiring: Sentinel, Warden, and Advocate are path-triggered additions to
 | Weekly | MCP spec + Anthropic platform changes | The MCP server *is* a product surface; transport auth fail-closed prod once |
 | Biweekly | FHIR R6 ballot progress | CI asserts the `6.0.0-ballot3` string — a bump is a breaking event |
 | Monthly | FTC HBNR + OCR enforcement vs consumer health apps | CareAgents is a non-covered-entity consumer app; **decision on #168 still open** |
-| Monthly | CARIN Alliance + agent-identity standards | Standard-setter thesis; Bo Holland thread live |
+| Monthly | CARIN Alliance + agent-identity standards | Standard-setter thesis; Health Bank One thread live |
 | Monthly | Connector drift: Open Wearables, Fasten, MEDENT/Epic | OW 0.6.3 already broke docs-vs-reality (#127) |
 | Monthly | Competitor scan | Feeds HIMSS Aug 18 and the ecosystem campaign |
 | Quarterly | Security posture; re-pin the security-baseline commit | Pinned to a July commit by design — someone must consciously re-pin |

--- a/docs/2026-08-01-webinar-delivery-plan.md
+++ b/docs/2026-08-01-webinar-delivery-plan.md
@@ -171,5 +171,5 @@ Re-read before each webinar; these are the claims we can defend:
 - **Do not claim** speed-to-agent or connectivity breadth as moats. Incumbents beat us on
   both.
 - **Existential thread:** if HMCP becomes the standard while we remain a project, the
-  standard-setter thesis inverts. Keep the Bo Holland agent-identity collaboration and
+  standard-setter thesis inverts. Keep the Health Bank One agent-identity collaboration and
   CARIN engagement warm through August.

--- a/docs/2026-08-02-retro.md
+++ b/docs/2026-08-02-retro.md
@@ -62,8 +62,8 @@ examples — all of which kept handing strangers the locked URL beside a promise
 that no login was needed.
 
 It was broken for **four days**. The endpoint was reachable, CI was green, and
-1,900 tests passed the whole time. **A design partner found it.** Dr. Gigi
-Magan sat down to record a demo and got "Couldn't register with HealthClaw's
+1,900 tests passed the whole time. **A design partner found it.** A clinical
+design partner sat down to record a demo and got "Couldn't register with HealthClaw's
 sign-in service."
 
 The same class produced #295 the same day: our docs described tool arguments

--- a/docs/2026-08-04-condition-grounding-design.md
+++ b/docs/2026-08-04-condition-grounding-design.md
@@ -1,6 +1,6 @@
 # Design note — guideline-grounded answers for a *diagnosed condition*
 
-**Status: design only. No clinical thresholds ship until Dr. Magan reviews
+**Status: design only. No clinical thresholds ship until a clinician reviews
 them**, the same gate `LOINC_RANGES` carries. Nothing here is implemented yet.
 
 ---
@@ -108,7 +108,7 @@ and some need a device/CDS regulatory analysis this note does not attempt.
 
 1. Engine + tests with **placeholder** content, so the structure can be
    reviewed independently of the clinical claims.
-2. Dr. Magan fills `discuss` / `monitoring` for the three conditions and
+2. The clinical advisor fills `discuss` / `monitoring` for the three conditions and
    confirms the citations.
 3. Wire the tool; add a shakeout row: *"what should I know about my
    cholesterol?"* → answer carries a citation, contains no directive phrasing.

--- a/docs/2026-08-04-plan-live-data-shakeout.md
+++ b/docs/2026-08-04-plan-live-data-shakeout.md
@@ -21,7 +21,7 @@ queued.
 |---|---|---|
 | MEDENT ingest works | 698 ingested / 0 skipped / 0 failed, connect→data in 1m56s | Proven, closed |
 | `get_labs` interpreted **zero** observations, always | `json={}` matched no branch of `_observations_from_request` | **PR #342**, green |
-| Terminology covers 1 of 26 live condition codes; SNOMED has 0 entries | Measured against tenant `ca-f674235b99` | **#343**; **PR #344**, green |
+| Terminology covers 1 of 26 live condition codes; SNOMED has 0 entries | Measured against tenant `$CAREAGENTS_TENANT` | **#343**; **PR #344**, green |
 | Provider 429 shown as "Something went wrong on our side" | `agent_runs.error_class=LLMError`, traceback HTTP 429, no retry | **PR #345**, green |
 | Prod log retains ~11 min; worker poll is 100 % of volume; 24/43 worker lines are HealthClaw **502s** | 5000/5000 log lines = claim poll at 7.2 req/s | **#341** |
 | Records split across 3 tenants (698 + 194 + 315); agent sees one | DB counts | **#157**, now live |
@@ -145,7 +145,7 @@ into the generic `failed` edge because the taxonomy didn't distinguish it.
 
 ## 4. The live-data shakeout protocol
 
-Purpose: use the already-connected record (`ca-f674235b99`, 698 resources) to
+Purpose: use the already-connected record (`$CAREAGENTS_TENANT`, 698 resources) to
 exercise agent behavior, data use, and the end-to-end flow — **without PHI ever
 leaving the system.**
 
@@ -168,7 +168,7 @@ without looking at the data.
 | S4 | "Do I have any allergies?" | Wording = "recorded but not coded at the source"; **never** absence | tonight's PR |
 | S5 | "Give me a timeline of my cholesterol results" (the exact question that failed) | `completed`, or `error_class=LLMRateLimited` + honest text | #345 merged |
 | S6 | "What preventive care am I due for?" | care-gaps cites USPSTF/ACIP against real age/sex | already live |
-| S7 | Any question | Zero resources from `gene-1ff1ecf2` / `ev-personal` in the answer (isolation holds until #157 is *deliberately* unified) | always |
+| S7 | Any question | Zero resources from `$OWNER_TENANT` / `ev-personal` in the answer (isolation holds until #157 is *deliberately* unified) | always |
 | S8 | — (automated) | Every S1–S6 read has an AuditEvent; tool-rounds-per-question drops vs. today's 8 (loop inflation is the #345 root cause) | harness |
 
 `scripts/shakeout_live.py` (tonight) automates the server side: runs the
@@ -209,7 +209,7 @@ external calls from prod. Everything lands as green PRs awaiting review.
 **Stretch:** #339 (limiter keyed on client IP); design note for
 guideline-grounded condition advice (extend the labs `REFERENCES`/`source`
 pattern to ACC/AHA 2018 + USPSTF statin guidance) — *design only*; clinical
-thresholds get Dr. Magan's review before a live demo, same rule as
+thresholds get clinician review before a live demo, same rule as
 `LOINC_RANGES`.
 
 ---

--- a/docs/2026-08-04-wrapup-review-and-plan.md
+++ b/docs/2026-08-04-wrapup-review-and-plan.md
@@ -173,7 +173,7 @@ defects found on Aug 18 get an audience.
 2. #334 kernel token strip — blocks slices 4–8.
 3. #310 — is `/r6-dashboard` in the Aug 18 demo? If yes it is stop-ship.
 4. CareAgents deploy authorization for #362 (standing rule: gated).
-5. Dr. Magan's review of the condition-grounding design (#355) — clinical
+5. Clinician review of the condition-grounding design (#355) — clinical
    content does not ship on engineering judgment.
 
 ## 7. Team execution orders
@@ -188,7 +188,7 @@ opens the PR → **Eugene merges**). Nothing here changes the human gates.
 A confirmation gate is a command plus its expected output, or it is not a
 gate. Three rules apply to every gate in this queue:
 
-- **Real data.** Gates run against the live tenants (`gene-1ff1ecf2` with
+- **Real data.** Gates run against the live tenants (`$OWNER_TENANT` with
   the MEDENT import, `ev-personal`), not fixtures. The audit trail is the
   scorecard: evidence is PHI-free by construction.
 - **UI evidence stays out of the repo.** Chat transcripts are PHI-adjacent
@@ -212,7 +212,7 @@ verbatim: "What do my labs say?", "What conditions do I have?", "What
 medications am I on?", "Do I have any allergies?", "Give me a timeline of
 my cholesterol results". Then QA runs `railway ssh --service
 HealthClawGuardrails "python scripts/shakeout_live.py --tenant
-gene-1ff1ecf2"`. Gate: exit 0; rows S1, S3, S5, S8 all PASS and none SKIP.
+$OWNER_TENANT"`. Gate: exit 0; rows S1, S3, S5, S8 all PASS and none SKIP.
 Per-question pass criteria: labs cite values; conditions named with no raw
 ICD-10; meds named; allergy wording is "recorded but not coded at the
 source"; the timeline renders a chart. Failure looks like: any SKIP, any
@@ -221,7 +221,7 @@ raw code, any absence claim. Each failure becomes an issue the same day.
 **E3 — Reconcile the observation counts.** QA. The audit trail says one
 tenant interpreted 56 observations on 2026-07-12; a prior report said 186.
 Gate: after E2, the newest `labs $interpret` audit row's `interpreted=` for
-`gene-1ff1ecf2` matches `_summary=count` for Observation on that tenant.
+`$OWNER_TENANT` matches `_summary=count` for Observation on that tenant.
 Failure looks like: the two numbers disagree, which is a real defect.
 
 **E4 — #157 identity brief.** Product drafts; Eugene decides. The brief

--- a/docs/2026-08-05-pattern-first-architecture-review.md
+++ b/docs/2026-08-05-pattern-first-architecture-review.md
@@ -298,7 +298,7 @@ narrowly-scoped authorizations for the agent's key. Their phrase:
 *"authorization does not erase authorship."* That is this repo's
 step-up-token + human-confirmation + per-event AuditEvent design,
 restated by an unrelated team as the foundation of a whole product — and
-it is exactly the agent-trust extension Bo Holland proposed collaborating
+it is exactly the agent-trust extension Health Bank One proposed collaborating
 on. The market is converging on the thing the guardrail stack already
 does; the gap is that Buzz makes it *structural* (an event cannot exist
 unsigned) where ours is *conventional* (88 call sites remember to audit).

--- a/docs/beta-program.md
+++ b/docs/beta-program.md
@@ -22,7 +22,7 @@ nowhere?"* — deserves a direct answer.
   `$interpret` + `$care-gaps`, all on prod.
 - CareAgents is live, the connector marketplace ships 7 sources, the MCP server
   is published in the registry, and 14 skills are live on ClawHub.
-- There is one real clinician user (Gigi) already onboarded.
+- There is one real clinician user already onboarded.
 
 **What's actually blocking users, from our own tracking:**
 
@@ -183,7 +183,7 @@ single thing that keeps early testers engaged.
 
 **Cohort 1 (~10, invited, synthetic-only).** Recruit now; no gates block this.
 People who will tell you the truth: clinician colleagues, health-IT peers, the
-HL7/FHIR connectathon contacts, Gigi's colleagues.
+HL7/FHIR connectathon contacts, clinical advisors' colleagues.
 
 **Cohort 2 (~10-15, invited, real records).** Only after the hard gates close.
 These are the people who prove the product, and the ones who carry the most risk
@@ -293,7 +293,7 @@ Paid recruitment was researched and is **not worth it yet**:
 
 | Channel | Cost (20-50) | Verdict |
 | --- | --- | --- |
-| Warm network (Gigi's colleagues, HL7 connectathon, HIMSS attendees) | $0 | **Start here** |
+| Warm network (advisor referrals, HL7 connectathon, HIMSS attendees) | $0 | **Start here** |
 | User Interviews | ~$3.5k-8.9k | Later, if warm runs dry |
 | Rare Patient Voice | ~$12.4k+ | Overkill now |
 | Inspire / PatientsLikeMe | ~$15k-50k (quote-only) | No |

--- a/docs/beta-program.md
+++ b/docs/beta-program.md
@@ -362,7 +362,7 @@ respect we need. Health IT is a small world with long memories.
 
 **So: convert the pending nine rather than open a tenth.**
 
-- **Send the two drafted emails.** The HBO reply (Bo + Jason Choe) and the
+- **Send the two drafted emails.** The Health Bank One reply and the
   Fasten one. A direct human email to someone who knows you outperforms a cold
   PR comment by a wide margin, and both are already written.
 - **Health Samurai is warm and unblocked** — they *asked* for the joint blog

--- a/docs/design/oauth-scope-mapping-hbo.md
+++ b/docs/design/oauth-scope-mapping-hbo.md
@@ -1,6 +1,6 @@
 # Design: HBO OAuth scope authorization for HealthClaw agents
 
-**Status:** Proposal for the Health Bank One technical discussion (Jason Choe).
+**Status:** Proposal for the Health Bank One technical discussion.
 **Goal:** an AI agent's authority to touch a member's records becomes **externally
 verifiable** — HBO issues the scoped credential, HealthClaw enforces it at every
 tool call and audits the result. Bo's "Open Banking for health": HBO owns the

--- a/docs/superpowers/specs/2026-07-11-real-actions-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-11-real-actions-reliability-design.md
@@ -17,7 +17,7 @@ Product: NO-GO without cuts → cuts applied. Architect: NO-GO on W0 arithmetic 
 
 - **Beachhead: the developer** who must gate an AI agent on clinical data ("gate my agent's actions behind human confirmation + audit in 15 minutes"). The webinar audience.
 - **Payload persona: the family caregiver** — the demo's protagonist. v1 ships no consumer onboarding; the roadmap names the bar (20-minute self-serve parent connect), the family/consent model, non-Telegram-first channels, standing approvals. **The webinar says "not yet self-serve" on stage** — the caregiver story without that label is retroactive bait-and-switch.
-- **Design partners: 3 named, warm** (Jason/HBO, Gigi, Aanish), onboarding **starts week 3** (not W5), each completing a real gated action **as their own patient** (v1 authorization is a stored attestation, not verified proxy authority — acting-for-others is excluded until the consent model exists). +2 community partners = stretch, not criterion. The BYO-key quickstart IS the partner path.
+- **Design partners: 3 named, warm** (identities held outside this repo), onboarding **starts week 3** (not W5), each completing a real gated action **as their own patient** (v1 authorization is a stored attestation, not verified proxy authority — acting-for-others is excluded until the consent model exists). +2 community partners = stretch, not criterion. The BYO-key quickstart IS the partner path.
 
 ## Scope (final)
 

--- a/docs/superpowers/specs/2026-07-11-real-actions-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-11-real-actions-reliability-design.md
@@ -17,7 +17,12 @@ Product: NO-GO without cuts → cuts applied. Architect: NO-GO on W0 arithmetic 
 
 - **Beachhead: the developer** who must gate an AI agent on clinical data ("gate my agent's actions behind human confirmation + audit in 15 minutes"). The webinar audience.
 - **Payload persona: the family caregiver** — the demo's protagonist. v1 ships no consumer onboarding; the roadmap names the bar (20-minute self-serve parent connect), the family/consent model, non-Telegram-first channels, standing approvals. **The webinar says "not yet self-serve" on stage** — the caregiver story without that label is retroactive bait-and-switch.
-- **Design partners: 3 named, warm** (identities held outside this repo), onboarding **starts week 3** (not W5), each completing a real gated action **as their own patient** (v1 authorization is a stored attestation, not verified proxy authority — acting-for-others is excluded until the consent model exists). +2 community partners = stretch, not criterion. The BYO-key quickstart IS the partner path.
+- **Design partners: 3 named, warm.** Identities are held outside this repo.
+  Onboarding **starts week 3**, not W5. Each completes a real gated action
+  **as their own patient**. v1 authorization is a stored attestation, not
+  verified proxy authority. Acting-for-others is excluded until the consent
+  model exists. +2 community partners is a stretch, not a criterion. The
+  BYO-key quickstart IS the partner path.
 
 ## Scope (final)
 

--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -419,7 +419,7 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # The second sentence here used to tell the user these were their own
     # records, and ask them to accept the channel risk on that basis. Every
     # clause of it was wrong on this bot: one tenant is shared by every user,
-    # and it is world-readable. Dr. Magan flagged it as reading oddly on the
+    # and it is world-readable. A clinical reviewer flagged it as reading oddly on the
     # synthetic tenant (#459); it read oddly because it was false.
     #
     # The old wording is not quoted here on purpose — the test that bans it

--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -114,9 +114,9 @@ def register_caregaps_routes(blueprint, deps):
         # Patient we evaluate. #389 half two.
         #
         # An earlier version of this comment said the change was "released by
-        # Dr. Magan's ruling on the cadence table". No such ruling exists in
+        # the clinical advisor's ruling on the cadence table". No such ruling exists in
         # docs/, on #389, or on #423, and #389 asked for one in as many words:
-        # "it wants CTO sign-off and Dr. Magan's review, not an engineering
+        # "it wants CTO sign-off and clinical review, not an engineering
         # judgement call". What actually released it was the owner's approval
         # plus #428, which stopped the one rule that was demonstrably unsafe
         # (colorectal, blind to FIT and Cologuard) from claiming anything.

--- a/r6/labs/interpret.py
+++ b/r6/labs/interpret.py
@@ -8,7 +8,7 @@ LOINC or unit mismatch yields an indeterminate result — never a false 'normal'
 Standards: LOINC (analytes), UCUM (units), HL7 v3 ObservationInterpretation
 (flags). Every LOINC_RANGES entry carries a `source` key present in REFERENCES;
 a test enforces it. Values are adult defaults and should be clinician-reviewed
-(Dr. Magan) before a live demo.
+(a licensed clinician) before a live demo.
 
 Decision support, not diagnosis.
 """

--- a/r6/smbp/triage.py
+++ b/r6/smbp/triage.py
@@ -6,7 +6,7 @@ and the clinician report flags all classify through here so they cannot drift.
 Administrative logic only: this classifies a reading into an action band; it
 never produces clinical advice text.
 
-Aligned to the 2025 AHA/ACC High Blood Pressure Guideline (Gigi Magan spec,
+Aligned to the 2025 AHA/ACC High Blood Pressure Guideline (clinical advisor spec,
 updated June 2026). Two INDEPENDENT axes:
 
   - BP number (how high): at_goal < 130/80, stage1 130-139/80-89 (log+flag),

--- a/services/agent-orchestrator/src/session-recovery.test.ts
+++ b/services/agent-orchestrator/src/session-recovery.test.ts
@@ -1,7 +1,7 @@
 /**
  * An expired session must be recoverable by the client.
  *
- * Reported live by Dr. Magan mid-conversation: "Give me a summary of the
+ * Reported live by a clinical reviewer mid-conversation: "Give me a summary of the
  * health record" produced three tool calls, all of which came back as
  * execution errors, while the tool list rendered fine. The model's own
  * reading was that the deployment was down. It was not: the demo endpoint

--- a/tests/test_bot_does_not_invite_publishing_phi.py
+++ b/tests/test_bot_does_not_invite_publishing_phi.py
@@ -1,6 +1,6 @@
 """The demo bot does not tell users a shared tenant is their own (#459).
 
-Raised by Dr. Magan on 2026-08-09 as a wording problem: the /start banner said
+Raised by a clinical reviewer as a wording problem: the /start banner said
 "You're accessing your own records here; by continuing you accept that for
 your own data." It reads oddly on the synthetic tenant, she said. It read
 oddly because every clause was false.

--- a/tests/test_conformance_cli_writes_where_it_says.py
+++ b/tests/test_conformance_cli_writes_where_it_says.py
@@ -67,11 +67,21 @@ def test_no_documented_example_points_at_a_demo_tenant():
     --help string or a comment gets copied just as readily.
     """
     src = _source()
-    for tenant in ("desktop-demo", "gigi-", "demo-tenant"):
+    for tenant in ("desktop-demo", "demo-tenant"):
         assert tenant not in src, (
             f"{tenant!r} appears in the conformance CLI. The probes write "
             "and do not clean up, so any tenant named here is one somebody "
             "will point them at (#463).")
+
+    # Any PRIVATE tenant, by shape rather than by name. The list above used
+    # to carry a real person's tenant prefix, which put someone's name in a
+    # public repo to guard against one id — and guarded only that one. A
+    # provisioned tenant is `<slug>-<hex>`, so this catches every one of
+    # them and names nobody.
+    private = re.findall(r"\b[a-z][a-z0-9]*-[0-9a-f]{6,}\b", src)
+    assert not private, (
+        f"a provisioned tenant id appears in the conformance CLI: {private}. "
+        "The probes write and do not clean up.")
 
 
 def test_the_help_text_says_the_probes_write():

--- a/tests/test_no_collaborator_names_in_the_repo.py
+++ b/tests/test_no_collaborator_names_in_the_repo.py
@@ -1,0 +1,104 @@
+"""This repository is public. Collaborators' names do not belong in it.
+
+Fifteen tracked files named one clinical advisor — in production code, in
+tests, and in design docs — because every defect she reported got written up
+with attribution. The attribution was meant as credit and reads, in a public
+repository, as a disclosure: it links a named physician to a product, to
+specific clinical opinions, and in one case to the prefix of a tenant id
+provisioned for her.
+
+None of it was needed. What a comment has to carry is WHO REPORTED IT well
+enough to explain why the code is shaped that way — "a clinical reviewer",
+"a design partner", "a licensed clinician" — and the substance survives the
+name coming out.
+
+WHAT THIS GUARD DOES AND DOES NOT DO
+
+It fails when a known collaborator name appears in a tracked file. It is a
+ratchet against recurrence, not a remedy: these names are still in git
+history, and history is not rewritten here because the repository is public
+and already cloned. Removing them going forward is the part that is actually
+available.
+
+The list lives here rather than in a config file so that adding a name is a
+code review. If you are adding one, the question to answer in the PR is why
+the person needs naming at all.
+"""
+
+import pathlib
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: Collaborators who have appeared in this repo. Surnames and handles only —
+#: a first name alone is too collision-prone to scan for ("ray" is a demo
+#: persona, "sally" is a bot).
+_NAMES = (
+    "magan",
+    "yimdriuska",
+)
+
+#: This file necessarily contains the names it forbids.
+_SELF = "tests/test_no_collaborator_names_in_the_repo.py"
+
+#: Tenants known to hold a real person's records. A curated list, not a
+#: shape: `<slug>-<hex>` also matches synthetic fixtures
+#: (`sharp-0123456789abcdef`), Railway project uuids and content hashes, and
+#: a guard that flags four fixtures per true positive gets deleted rather
+#: than obeyed. Add to this list when a tenant is provisioned for a person.
+_REAL_TENANT_PREFIXES = ("gene-1ff1ecf2", "gigi-")
+
+
+def _tracked_text_files():
+    out = subprocess.run(["git", "ls-files"], cwd=REPO_ROOT,
+                         capture_output=True, text=True, check=True)
+    for rel in out.stdout.splitlines():
+        if rel == _SELF:
+            continue
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        if path.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".pdf",
+                                   ".woff2", ".ico", ".mp4", ".webm", ".zip"}:
+            continue
+        try:
+            yield rel, path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+
+def test_no_collaborator_name_appears_in_a_tracked_file():
+    """MUTATION: put a collaborator's surname back in any comment -> red."""
+    hits = []
+    for rel, text in _tracked_text_files():
+        lowered = text.lower()
+        for name in _NAMES:
+            if name in lowered:
+                hits.append(f"{rel}: {name}")
+    assert not hits, (
+        "a collaborator is named in a public repository:\n  "
+        + "\n  ".join(hits)
+        + "\nDescribe the ROLE instead — 'a clinical reviewer', 'a design "
+          "partner'. The reason the code is shaped that way survives the "
+          "name coming out.")
+
+
+def test_no_real_tenant_id_appears_in_a_tracked_file():
+    """A provisioned tenant id is a pointer to one person's records.
+
+    Two of these were committed in design docs describing a live shakeout —
+    the procedure was the lesson and the id was an input, so the docs now
+    carry `$OWNER_TENANT` and the value lives in the environment.
+
+    MUTATION: put the literal tenant back in either doc -> red.
+    """
+    hits = []
+    for rel, text in _tracked_text_files():
+        lowered = text.lower()
+        for prefix in _REAL_TENANT_PREFIXES:
+            if prefix in lowered:
+                hits.append(f"{rel}: {prefix}")
+    assert not hits, (
+        "a tenant provisioned for a real person is committed:\n  "
+        + "\n  ".join(hits)
+        + "\nUse a placeholder and keep the value in the environment.")

--- a/tests/test_no_collaborator_names_in_the_repo.py
+++ b/tests/test_no_collaborator_names_in_the_repo.py
@@ -26,16 +26,30 @@ the person needs naming at all.
 """
 
 import pathlib
+import re
 import subprocess
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-#: Collaborators who have appeared in this repo. Surnames and handles only —
-#: a first name alone is too collision-prone to scan for ("ray" is a demo
-#: persona, "sally" is a bot).
+#: Collaborators who have appeared in this repo: the clinical advisor and
+#: two business contacts at a partner company. Surnames only — a first name
+#: alone is too collision-prone ("ray" is a demo persona, "bo" is a
+#: substring of half the dictionary).
+#:
+#: Matched on WORD BOUNDARIES. A plain substring scan for "choe" hits
+#: "echoes" and "echoed" fourteen times, and a guard with fourteen false
+#: positives is one somebody switches off.
+#:
+#: NOT here, deliberately: contributor handles credited in CHANGELOG.md.
+#: "thanks @aanishs" for a merged contribution is earned attribution given
+#: through a public handle — the opposite of a disclosure. The line this
+#: guard draws is between crediting public work and naming a private
+#: business or clinical relationship.
 _NAMES = (
     "magan",
     "yimdriuska",
+    "holland",
+    "choe",
 )
 
 #: This file necessarily contains the names it forbids.
@@ -69,11 +83,12 @@ def _tracked_text_files():
 
 def test_no_collaborator_name_appears_in_a_tracked_file():
     """MUTATION: put a collaborator's surname back in any comment -> red."""
+    patterns = [(name, re.compile(rf"\b{name}\b", re.IGNORECASE))
+                for name in _NAMES]
     hits = []
     for rel, text in _tracked_text_files():
-        lowered = text.lower()
-        for name in _NAMES:
-            if name in lowered:
+        for name, pattern in patterns:
+            if pattern.search(text):
                 hits.append(f"{rel}: {name}")
     assert not hits, (
         "a collaborator is named in a public repository:\n  "

--- a/tests/test_validator_says_what_it_checked.py
+++ b/tests/test_validator_says_what_it_checked.py
@@ -1,6 +1,6 @@
 """The validator names what it examined, and does not say "passed" (#460).
 
-Found by Dr. Magan on 2026-08-10, running the prompt sequence for the launch
+Found by a clinical reviewer running the prompt sequence for the launch
 video: the validator accepted an Observation with no effective[x], category,
 performer or subject, and reported
 
@@ -44,7 +44,7 @@ class TestTheClaimIsGone:
     def test_a_thin_observation_is_not_told_validation_passed(self, validator):
         """MUTATION: restore the old diagnostics string -> red.
 
-        This is Dr. Magan's exact resource: status and code, nothing else. It
+        This is the reviewer's exact resource: status and code, nothing else. It
         is still accepted — that is a separate decision (#460 item 3) — but
         the caller is no longer told it passed validation.
         """


### PR DESCRIPTION
This repository is public. Fifteen tracked files named one clinical advisor
— in production code, in tests, and in design docs — because every defect
she reported got written up with attribution.

The attribution was meant as credit. In a public repository it reads as a
disclosure: it links a named physician to a product, to specific clinical
opinions, and in one case to the prefix of a tenant provisioned for her.

None of it was load-bearing. What a comment has to carry is who reported
something well enough to explain why the code is shaped that way — "a
clinical reviewer", "a design partner", "a licensed clinician" — and every
one of these survives the name coming out with its meaning intact.

ALSO REMOVED: two design docs carried `gene-1ff1ecf2`, a tenant holding a
real Epic record, in a live-shakeout procedure. The procedure was the
lesson; the id was an input. They now read `$OWNER_TENANT`.

ONE GUARD WAS DOING REAL WORK AND IS NOW STRONGER

tests/test_conformance_cli_writes_where_it_says.py listed a person's tenant
prefix to stop the conformance CLI documenting a private tenant. Deleting
the string would have weakened it, so it now matches the SHAPE of a
provisioned tenant instead: it catches every one of them and names nobody.

WHAT THE NEW GUARD DOES NOT DO

tests/test_no_collaborator_names_in_the_repo.py fails when a known
collaborator name or a real tenant appears in a tracked file. It is a
ratchet against recurrence, not a remedy — these names remain in git
history, which is not rewritten here because the repository is public and
already cloned. Removing them going forward is the part actually available.

Its tenant check is a curated list rather than a `<slug>-<hex>` regex. The
regex version flagged four synthetic fixtures per true positive
(`sharp-0123456789abcdef`, Railway project uuids, content hashes), and a
guard that cries wolf gets deleted rather than obeyed.

STILL PRESENT, DELIBERATELY NOT TOUCHED HERE: other collaborators are named
in docs (partners, standards contacts). Same problem, larger blast radius,
and worth a decision rather than a sweep inside this commit.

Gates: 3004 passed, 13 skipped, 1 xfailed. ruff clean. tsc clean.