### PR TITLE
fix(scripts): the SMBP seed script imports a constant that no longer exists

### DIFF
--- a/scripts/seed_smbp_history.py
+++ b/scripts/seed_smbp_history.py
@@ -21,14 +21,10 @@ Synthetic composites only. Nothing here is traceable to a real person.
 import argparse
 import os
 import sys
-from datetime import date
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from r6.smbp.demo_history import (  # noqa: E402
-    DEFAULT_ANCHOR,
-    smbp_history_resources,
-)
+from r6.smbp.demo_history import smbp_history_resources  # noqa: E402
 
 
 def _bundle(resources):
@@ -42,20 +38,16 @@ def main() -> int:
     ap.add_argument("--tenant-id", default="desktop-demo")
     ap.add_argument("--internal-secret",
                     default=os.environ.get("INTERNAL_TOKEN_MINT_SECRET", ""))
-    ap.add_argument("--anchor", default=DEFAULT_ANCHOR.isoformat(),
-                    help=("most recent reading date, YYYY-MM-DD. The default "
-                          "is a constant so re-runs are byte-identical."))
     ap.add_argument("--dry-run", action="store_true",
                     help="print the summary and write nothing")
     args = ap.parse_args()
 
-    anchor = date.fromisoformat(args.anchor)
-    resources = smbp_history_resources(anchor=anchor)
+    resources = smbp_history_resources()
 
     patients = [r for r in resources if r["resourceType"] == "Patient"]
     obs = [r for r in resources if r["resourceType"] == "Observation"]
     print(f"{len(resources)} resources: {len(patients)} patients, "
-          f"{len(obs)} BP readings, anchored {anchor.isoformat()}")
+          f"{len(obs)} observations")
     for p in patients:
         name = p["name"][0]
         mine = [o for o in obs

--- a/tests/test_seed_scripts_still_run.py
+++ b/tests/test_seed_scripts_still_run.py
@@ -1,0 +1,60 @@
+"""The operator scripts still import and run.
+
+scripts/seed_smbp_history.py shipped broken. It imported `DEFAULT_ANCHOR`
+from r6.smbp.demo_history, that module was rewritten, the constant went
+away, and nothing noticed — because the test suite exercises the LIBRARY the
+script calls and the e2e harness seeds through the Flask CLI. The script
+itself was the one path with no caller in CI.
+
+It broke where it hurts most: the operator reaches for a seed script when
+they are setting up a demo, usually against a remote deployment, usually
+against the clock. An ImportError at that moment costs the demo, and the
+traceback points at the module rather than at the script that failed to keep
+up with it.
+
+`--dry-run` exists partly for this. It builds every resource and prints the
+summary without needing a server, so a subprocess can prove the whole
+import-and-build path works for the price of one process.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: Scripts an operator runs by hand, with an argument set that does no I/O.
+_DRY_RUNNABLE = [
+    ("scripts/seed_smbp_history.py", ["--dry-run"]),
+]
+
+
+@pytest.mark.parametrize("script,args", _DRY_RUNNABLE)
+def test_the_script_runs_end_to_end(script, args):
+    """MUTATION: import a name from demo_history that does not exist -> red."""
+    result = subprocess.run(
+        [sys.executable, str(ROOT / script), *args],
+        capture_output=True, text=True, cwd=ROOT, timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"{script} exited {result.returncode}. An operator hits this while "
+        f"setting up a demo, against the clock.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+    assert result.stdout.strip(), f"{script} printed nothing"
+
+
+def test_the_dry_run_refuses_to_write_without_a_credential():
+    """A dry run that silently became a real run would be worse than a
+    broken one. Without --dry-run and without a secret it must refuse rather
+    than post."""
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/seed_smbp_history.py"),
+         "--base-url", "http://127.0.0.1:1", "--internal-secret", ""],
+        capture_output=True, text=True, cwd=ROOT, timeout=120,
+    )
+    assert result.returncode == 2, (
+        "expected a refusal for a missing internal secret, got "
+        f"{result.returncode}")
+    assert "internal-secret" in result.stderr


### PR DESCRIPTION
scripts/seed_smbp_history.py shipped broken in #492. It imports
DEFAULT_ANCHOR from r6.smbp.demo_history; that module was rewritten in the
same PR, the anchor concept went away because every timestamp became a
literal, and the script kept the import.

Nothing caught it. The suite exercises the LIBRARY the script calls, and the
e2e harness seeds through the Flask CLI, so the script was the one path with
no caller anywhere in CI. I found it by running it against production.

It breaks where it hurts: an operator reaches for a seed script while
setting up a demo, usually against a remote deployment, usually against the
clock. An ImportError there costs the demo, and the traceback names the
module rather than the script that failed to keep up with it.

THE FIX IS TWO LINES; THE TEST IS THE POINT

tests/test_seed_scripts_still_run.py runs the script as a subprocess with
--dry-run, which builds every resource and prints a summary without needing
a server. Verified red against the broken script before the fix.

It also pins that a run WITHOUT --dry-run and without a credential refuses
rather than posting — a dry run that silently became a real run would be
worse than a broken one.

Gates: 3039 passed, 13 skipped, 1 xfailed. ruff clean.