### PR TITLE
fix(example): the redaction demo was asserting on a refusal, and the harness could not run against a real FHIR server

### DIFF
--- a/examples/aidbox-healthclaw-guardrails/README.md
+++ b/examples/aidbox-healthclaw-guardrails/README.md
@@ -109,14 +109,37 @@ curl -u "$AIDBOX_CLIENT:$AIDBOX_SECRET" http://localhost:8080/fhir/Patient/pt-de
   "address": [{"line": ["221 Baker St"], "city": "Pittsburgh"}] }
 ```
 
-Through the proxy, same resource, same Aidbox:
+Through the proxy, same resource, same Aidbox. Reads are authenticated too —
+`READ_AUTH_ENABLED` is on, so a tenant header alone gets a 401, and the same
+step-up token that authorises a write is what proves the tenant claim on a
+read:
 
 ```bash
-curl -H "X-Tenant-Id: demo" http://localhost:5000/r6/fhir/Patient/pt-demo
+TOKEN=$(curl -s -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: demo" -d '{"tenant_id":"demo"}' \
+  http://localhost:5000/r6/fhir/internal/step-up-token | jq -r .token)
+
+curl -H "X-Tenant-Id: demo" -H "X-Step-Up-Token: $TOKEN" \
+  http://localhost:5000/r6/fhir/Patient/pt-demo
+```
+
+```json
+{ "resourceType": "Patient", "id": "pt-demo",
+  "name": [{"given": ["M."], "family": "A."}],
+  "identifier": [{"system": "urn:mrn", "value": "***8214"}],
+  "birthDate": "1974",
+  "address": [{"state": "PA"}] }
 ```
 
 The name is reduced to initials, the MRN is masked, the address and phone are
 gone, and the birth date is truncated to a year.
+
+Forget the token and you get an OperationOutcome — which is worth knowing
+because an OperationOutcome contains no PHI, so a redaction check written as
+"none of the identifiers appear in the response" passes on a refusal without
+testing redaction at all. `walkthrough.sh` shipped with exactly that hole; it
+now asserts it received `Patient/pt-demo` before it asserts anything about
+what the Patient contains.
 
 Aidbox still holds the complete record. Redaction is a property of the path
 the agent uses, not a modification of the data. `walkthrough.sh` asserts this
@@ -127,7 +150,8 @@ would satisfy the lazier check.
 ### 2. The read left a record
 
 ```bash
-curl -H "X-Tenant-Id: demo" "http://localhost:5000/r6/fhir/AuditEvent?_count=1"
+curl -H "X-Tenant-Id: demo" -H "X-Step-Up-Token: $TOKEN" \
+  "http://localhost:5000/r6/fhir/AuditEvent?_count=5"
 ```
 
 An AuditEvent naming the tenant, the agent, the resource and the time, with no
@@ -175,9 +199,30 @@ control, not proof. See *What this example does not show* below.
 curl "http://localhost:5000/r6/fhir/\$conformance?format=text"
 ```
 
-Seven properties, 35 checks, run against the deployment that is actually
-running. The same harness runs in HealthClaw's CI as a merge gate, so a
-regression shows up as a grade change rather than an incident.
+Seven properties, run against the deployment that is actually running. The
+same harness runs in HealthClaw's CI as a merge gate, so a regression shows
+up as a grade change rather than an incident.
+
+**Against Aidbox this scores B (6/7), not A.** The example says so rather
+than quietly asserting a softer threshold, because the failure is worth
+knowing: in upstream mode a search carrying an unknown parameter is forwarded
+to Aidbox, which answers 404 or 502, instead of being refused by the
+guardrail with an OperationOutcome naming the parameter. Error fidelity is
+graded on what the caller is told when something goes wrong, and in proxy
+mode part of that answer is currently Aidbox's, not ours. Tracked as
+[#498](https://github.com/aks129/HealthClawGuardrails/issues/498).
+
+The other six hold. `walkthrough.sh` asserts exactly that — every property
+except error fidelity must pass, so any other regression goes red, and the
+day the gap closes the same assertion passes at 7/7 unchanged.
+
+Two of those six only started holding here recently. The harness builds a
+clinical Observation referencing `Patient/conformance-subject`, a patient
+nothing creates. The local SQLite store accepts it because it validates no
+references; Aidbox refuses it, every clinical-write probe returned 422, and
+the report concluded *"the gate blocks confirmed writes too, so its 428s
+prove nothing"* — a true measurement with the wrong cause attached. The gate
+was fine. The probes now create a subject first.
 
 ## How the two servers are wired
 

--- a/examples/aidbox-healthclaw-guardrails/README.md
+++ b/examples/aidbox-healthclaw-guardrails/README.md
@@ -64,6 +64,19 @@ empty licence harder than a missing one, and refuses to boot.
 activated" from "the proxy image is too old to authenticate", because both
 otherwise surface as the same unexplained failure several steps later.
 
+There is a second harness in [`qa/`](qa/) that asserts the same properties
+from a browser and records the run as a video:
+
+```bash
+cd qa && npm install && npx playwright install chromium
+HEALTHCLAW_PORT=5099 npx playwright test      # artifacts/**/video.webm
+```
+
+It exists because a recording made separately from the assertions is a
+re-enactment, and re-enactments drift from the system they depict. Here the
+assertions and the frames come from the same requests, so a video showing a
+pass cannot exist unless the pass happened.
+
 Two more things that will bite you:
 
 - **macOS holds port 5000.** AirPlay Receiver (ControlCenter) listens there,

--- a/examples/aidbox-healthclaw-guardrails/qa/.gitignore
+++ b/examples/aidbox-healthclaw-guardrails/qa/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+artifacts/

--- a/examples/aidbox-healthclaw-guardrails/qa/demo.spec.ts
+++ b/examples/aidbox-healthclaw-guardrails/qa/demo.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+
+/**
+ * The example, asserted against the running stack — and filmed while it runs.
+ *
+ * Every number on screen is a live response. Nothing here is a re-enactment:
+ * the assertions and the recording come from the same requests, so a video
+ * that shows a pass cannot exist unless the pass happened. That property is
+ * the reason this is a test rather than a screen capture with narration.
+ *
+ * Requires the stack to be up and seeded:
+ *   docker compose up -d && ./scripts/seed-aidbox.sh
+ */
+
+const PROXY = `http://localhost:${process.env.HEALTHCLAW_PORT || '5000'}`;
+const AIDBOX = process.env.AIDBOX_URL || 'http://localhost:8080';
+const AIDBOX_AUTH = 'Basic ' + Buffer.from(
+  `${process.env.AIDBOX_CLIENT || 'root'}:${process.env.AIDBOX_SECRET || 'qNbQS6sw82'}`
+).toString('base64');
+const TENANT = process.env.TENANT || 'demo';
+
+/** Values that must never appear on the agent's side of the proxy. */
+const IDENTIFIERS = ['Alvarez', 'Maria', 'MRN-88214', '221 Baker St',
+                     '555-867-5309', '1974-03-11'];
+
+const OBSERVATION = {
+  resourceType: 'Observation',
+  status: 'final',
+  subject: { reference: 'Patient/pt-demo' },
+  effectiveDateTime: '2026-08-11',
+  code: { coding: [{ system: 'http://loinc.org', code: '85354-9' }] },
+  valueQuantity: { value: 128, unit: 'mmHg' },
+};
+
+const SHELL = `
+<style>
+  :root{
+    --ground:#0f1620; --panel:#16202c; --edge:#243244;
+    --ink:#e3eaf2; --muted:#8598ad;
+    --guard:#e0a33e;      /* the guardrail acting: held, refused, masked */
+    --pass:#57c795;       /* an assertion that held */
+    --raw:#7fb2e5;        /* the record as the system of record holds it */
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:var(--ground); color:var(--ink);
+    font:15px/1.5 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
+    padding:22px 30px;
+  }
+  header{display:flex; align-items:baseline; gap:14px; margin-bottom:6px}
+  h1{font-size:19px; font-weight:600; margin:0; letter-spacing:-0.01em}
+  .sub{color:var(--muted); font-size:13px}
+  .flow{
+    color:var(--muted); font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;
+    margin:2px 0 16px; letter-spacing:0.02em;
+  }
+  .step{
+    background:var(--panel); border:1px solid var(--edge); border-radius:9px;
+    padding:13px 16px; margin-bottom:11px;
+    opacity:0; transform:translateY(6px);
+    animation:in .28s ease-out forwards;
+  }
+  @keyframes in{to{opacity:1; transform:none}}
+  .head{display:flex; align-items:center; gap:10px; margin-bottom:9px}
+  .n{
+    color:var(--muted); font:11px ui-monospace,monospace; letter-spacing:.1em;
+    text-transform:uppercase;
+  }
+  .t{font-weight:600; font-size:14px}
+  .chip{
+    margin-left:auto; font:11px/1 ui-monospace,monospace; padding:5px 9px;
+    border-radius:20px; letter-spacing:.04em;
+  }
+  .chip.pass{background:rgba(87,199,149,.14); color:var(--pass);
+             border:1px solid rgba(87,199,149,.32)}
+  .cols{display:grid; grid-template-columns:1fr 1fr; gap:11px}
+  .cols.three{grid-template-columns:1fr 1fr 1fr}
+  .box{border:1px solid var(--edge); border-radius:7px; padding:9px 11px;
+       background:rgba(0,0,0,.18)}
+  .lbl{font:10px ui-monospace,monospace; letter-spacing:.09em;
+       text-transform:uppercase; color:var(--muted); margin-bottom:6px}
+  .box.raw .lbl{color:var(--raw)}
+  .box.guard .lbl{color:var(--guard)}
+  pre{margin:0; font:12px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace;
+      white-space:pre-wrap; word-break:break-word}
+  .raw pre{color:var(--raw)}
+  .guard pre{color:var(--guard)}
+  table{width:100%; border-collapse:collapse; font:12px ui-monospace,monospace}
+  td,th{padding:5px 8px; text-align:left; border-bottom:1px solid var(--edge)}
+  th{color:var(--muted); font-weight:400; font-size:10px; letter-spacing:.08em;
+     text-transform:uppercase}
+  tr:last-child td{border-bottom:none}
+  .code{color:var(--guard); font-weight:600}
+  .code.ok{color:var(--pass)}
+  .note{color:var(--muted); font-size:12px; margin-top:8px; line-height:1.5}
+  .yes{color:var(--pass)} .no{color:var(--muted)}
+</style>
+<header>
+  <h1>HealthClaw Guardrails in front of Aidbox</h1>
+  <span class="sub">live stack &middot; every value below is a real response</span>
+</header>
+<div class="flow">AI agent &rarr; MCP server &rarr; guardrail proxy &rarr; Aidbox &nbsp;|&nbsp; redact &middot; audit &middot; step-up &middot; human-in-the-loop</div>
+<main id="out"></main>
+`;
+
+/** Append one finished step to the page. */
+async function render(page, html: string) {
+  await page.evaluate((h) => {
+    const d = document.createElement('div');
+    d.className = 'step';
+    d.innerHTML = h;
+    document.getElementById('out')!.appendChild(d);
+    d.scrollIntoView({ block: 'end' });
+  }, html);
+  // Pacing is for the recording, not the assertions. A step that
+  // appears and scrolls away in under a second is a test that also
+  // happens to produce an unwatchable file.
+  await page.waitForTimeout(1500);
+}
+
+const head = (n: string, t: string) =>
+  `<div class="head"><span class="n">${n}</span><span class="t">${t}</span>` +
+  `<span class="chip pass">PASS</span></div>`;
+
+const esc = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+async function stepUpToken(request: APIRequestContext): Promise<string> {
+  const r = await request.post(`${PROXY}/r6/fhir/internal/step-up-token`, {
+    headers: { 'X-Tenant-Id': TENANT, 'Content-Type': 'application/json' },
+    data: { tenant_id: TENANT },
+  });
+  expect(r.status(), 'minting a step-up token').toBe(200);
+  const token = (await r.json()).token;
+  expect(token, 'the mint returned a token').toBeTruthy();
+  return token;
+}
+
+test('the guardrails hold, in front of a real FHIR server', async ({ page, request }) => {
+  await page.setContent(SHELL);
+  await page.waitForTimeout(1200);
+
+  // ---- 0. The stack is what we think it is -------------------------------
+  // Asserted first because every step below is meaningless if the proxy is
+  // serving its own SQLite store instead of Aidbox — and it would still pass
+  // most of them.
+  const health = await (await request.get(`${PROXY}/r6/fhir/health`)).json();
+  expect(health.mode, 'proxy must be in upstream mode, not local').toBe('upstream');
+  expect(health.checks.upstream.status, 'proxy must reach Aidbox').toBe('connected');
+
+  const anon = await request.get(`${AIDBOX}/fhir/Patient/pt-demo`);
+  expect(anon.status(), 'Aidbox must refuse anonymous callers').not.toBe(200);
+
+  await render(page, head('00', 'The proxy is talking to Aidbox, with its own credential') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">proxy /health</div><pre>mode      ${health.mode}
+upstream  ${health.checks.upstream.status}
+version   ${health.version}</pre></div>
+      <div class="box"><div class="lbl">Aidbox, no credential</div><pre>GET /fhir/Patient/pt-demo
+&rarr; HTTP ${anon.status()}</pre></div>
+    </div>
+    <div class="note">The agent never holds an Aidbox credential. The proxy does, and
+    Aidbox refuses callers who do not &mdash; so &ldquo;the proxy authenticates&rdquo; is a
+    fact here, not a diagram.</div>`);
+
+  // ---- 1. The same record, both ways -------------------------------------
+  const token = await stepUpToken(request);
+  const authed = { 'X-Tenant-Id': TENANT, 'X-Step-Up-Token': token };
+
+  const direct = await (await request.get(`${AIDBOX}/fhir/Patient/pt-demo`,
+    { headers: { Authorization: AIDBOX_AUTH } })).json();
+  const noToken = await request.get(`${PROXY}/r6/fhir/Patient/pt-demo`,
+    { headers: { 'X-Tenant-Id': TENANT } });
+  const proxiedRes = await request.get(`${PROXY}/r6/fhir/Patient/pt-demo`,
+    { headers: authed });
+  const proxied = await proxiedRes.json();
+
+  // Reads are authenticated: a tenant header alone is not a credential.
+  expect(noToken.status(), 'a read without a token must be refused').toBe(401);
+
+  // The shape check comes FIRST and is the load-bearing one. A refusal
+  // contains none of the identifiers either, so "nothing leaked" is true of
+  // an error body — which is exactly how this demo passed while testing
+  // nothing at all.
+  expect(proxied.resourceType, 'the proxy must return the record itself').toBe('Patient');
+  expect(proxied.id).toBe('pt-demo');
+  expect(JSON.stringify(direct), 'Aidbox holds the identified record').toContain('Alvarez');
+  for (const id of IDENTIFIERS) {
+    expect(JSON.stringify(proxied), `identifier survived redaction: ${id}`).not.toContain(id);
+  }
+
+  const pick = (o: any) => JSON.stringify(
+    { name: o.name, identifier: o.identifier, birthDate: o.birthDate, address: o.address },
+    null, 1).replace(/\n\s*/g, ' ').replace(/([,{])\s/g, '$1\n  ');
+
+  await render(page, head('01', 'The same record, with and without governance') + `
+    <div class="cols three">
+      <div class="box raw"><div class="lbl">Aidbox &middot; system of record</div><pre>${esc(pick(direct))}</pre></div>
+      <div class="box"><div class="lbl">proxy &middot; tenant header only</div><pre>HTTP ${noToken.status()}
+a tenant claim is not
+a credential</pre></div>
+      <div class="box guard"><div class="lbl">proxy &middot; authenticated agent</div><pre>${esc(pick(proxied))}</pre></div>
+    </div>
+    <div class="note">Initials, a masked MRN, the year only, and the street gone &mdash; while
+    Aidbox still holds every character. Redaction is a property of the path the agent
+    takes, not an edit to the data.</div>`);
+
+  // ---- 2. The read left a record -----------------------------------------
+  const audit = await (await request.get(
+    `${PROXY}/r6/fhir/AuditEvent?_count=5`, { headers: authed })).json();
+  expect(audit.resourceType, 'expected a Bundle of AuditEvents').toBe('Bundle');
+  expect(audit.entry?.length, 'the read emitted no AuditEvent').toBeGreaterThan(0);
+  for (const id of IDENTIFIERS) {
+    expect(JSON.stringify(audit), `PHI in the audit trail: ${id}`).not.toContain(id);
+  }
+
+  const first = audit.entry[0].resource;
+  await render(page, head('02', 'The read left a record, and the record is safe to hand over') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">AuditEvent &middot; ${audit.entry.length} of ${audit.total ?? audit.entry.length}</div><pre>action    ${first.action ?? '-'}
+recorded  ${(first.recorded ?? '').slice(0, 19)}
+type      ${first.type?.code ?? first.type?.coding?.[0]?.code ?? '-'}</pre></div>
+      <div class="box guard"><div class="lbl">checked for PHI</div><pre>${IDENTIFIERS.map(i => '&check; ' + i + ' absent').join('\n')}</pre></div>
+    </div>
+    <div class="note">Every access is written down, and the detail carries no PHI &mdash; so the
+    trail you hand a reviewer is safe to hand over.</div>`);
+
+  // ---- 3. Two gates, neither substituting for the other -------------------
+  const write = (headers: Record<string, string>) =>
+    request.post(`${PROXY}/r6/fhir/Observation`, {
+      headers: { 'X-Tenant-Id': TENANT, 'Content-Type': 'application/fhir+json', ...headers },
+      data: OBSERVATION,
+    });
+
+  const neither = await write({});
+  const humanOnly = await write({ 'X-Human-Confirmed': 'true' });
+  const tokenOnly = await write({ 'X-Step-Up-Token': token });
+  const both = await write({ 'X-Step-Up-Token': token, 'X-Human-Confirmed': 'true' });
+
+  expect(neither.status(), 'no gate satisfied').toBe(428);
+  expect(humanOnly.status(), 'a confirmation is not a credential').toBe(401);
+  expect(tokenOnly.status(), 'a credential is not a confirmation').toBe(428);
+  expect(both.status(), 'both gates satisfied must succeed').toBe(201);
+
+  // The proxy reporting its own 201 says nothing about storage. Ask Aidbox.
+  const landed = await (await request.get(
+    `${AIDBOX}/fhir/Observation?subject=Patient/pt-demo&code=85354-9`,
+    { headers: { Authorization: AIDBOX_AUTH } })).json();
+  expect(landed.total, 'the write returned 201 but Aidbox has no such Observation')
+    .toBeGreaterThan(0);
+
+  const row = (h: boolean, t: boolean, s: number, why: string) =>
+    `<tr><td>${h ? '<span class="yes">&check;</span>' : '<span class="no">&mdash;</span>'}</td>` +
+    `<td>${t ? '<span class="yes">&check;</span>' : '<span class="no">&mdash;</span>'}</td>` +
+    `<td class="code${s < 400 ? ' ok' : ''}">${s}</td><td style="color:var(--muted)">${why}</td></tr>`;
+
+  await render(page, head('03', 'A write, and two gates that do not substitute for each other') + `
+    <table>
+      <tr><th>human</th><th>step-up</th><th>status</th><th></th></tr>
+      ${row(false, false, neither.status(), 'human confirmation is missing')}
+      ${row(true, false, humanOnly.status(), 'a confirmation is not a credential')}
+      ${row(false, true, tokenOnly.status(), 'a credential is not a confirmation')}
+      ${row(true, true, both.status(), 'and only then')}
+    </table>
+    <div class="note">Confirmed in Aidbox, not taken from the proxy&rsquo;s own answer:
+    <strong>${landed.total}</strong> matching Observation(s) on Patient/pt-demo.
+    The agent did useful work. It could not finish alone.</div>`);
+
+  // ---- 4. Grade it -------------------------------------------------------
+  const conf = await (await request.get(`${PROXY}/r6/fhir/$conformance`)).json();
+  const failed = (conf.properties || []).filter((p: any) => !p.passed).map((p: any) => p.key);
+
+  // Not "the grade is A". Every property except the known proxy-mode gap
+  // must hold; the day #498 closes, this same assertion passes at 7/7.
+  expect(failed.filter((k: string) => k !== 'error_fidelity'),
+    'a property that should hold did not').toEqual([]);
+
+  const props = (conf.properties || []).map((p: any) =>
+    `<tr><td>${p.passed ? '<span class="yes">&check;</span>' : '<span style="color:var(--guard)">&mdash;</span>'}</td>` +
+    `<td>${p.key.replace(/_/g, ' ')}</td></tr>`).join('');
+
+  await render(page, head('04', 'Graded against the deployment that is actually running') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">conformance</div><table>${props}</table></div>
+      <div class="box guard"><div class="lbl">grade ${conf.grade} &middot; ${conf.score.passed}/${conf.score.total}</div><pre>The one failure is error
+fidelity, and in upstream
+mode it measures how AIDBOX
+answers an unknown search
+parameter &mdash; not how the
+guardrail does.
+
+Stated, not graded away.
+Tracked as #498.</pre></div>
+    </div>
+    <div class="note">The same harness runs in CI as a merge gate, so a regression shows up
+    as a grade change rather than as an incident.</div>`);
+
+  await page.waitForTimeout(3000);
+});

--- a/examples/aidbox-healthclaw-guardrails/qa/package.json
+++ b/examples/aidbox-healthclaw-guardrails/qa/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aidbox-healthclaw-guardrails-qa",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Asserts the Aidbox example against the running stack, and records the run",
+  "scripts": {
+    "test": "playwright test",
+    "install:browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
+  }
+}

--- a/examples/aidbox-healthclaw-guardrails/qa/playwright.config.ts
+++ b/examples/aidbox-healthclaw-guardrails/qa/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+// QA for the Aidbox example, and the recording of it — the same run.
+//
+// No `webServer`: this suite tests a stack that is ALREADY up
+// (`docker compose up -d` + `./scripts/seed-aidbox.sh`), because what is
+// under test is the composition, not the Flask app. A config that started
+// its own server would pass with Aidbox absent, which is the one outcome
+// this suite exists to rule out. It fails fast with a named reason instead.
+//
+// Video is on for every test rather than on failure: the artifact IS the
+// deliverable here, and a recording that only exists when something breaks
+// is not one you can send anybody.
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 120_000,
+  reporter: [['list']],
+  use: {
+    // 720p, and the page is laid out for it. Anything narrower turns the
+    // side-by-side comparison — the whole point of step 1 — into a stack.
+    viewport: { width: 1280, height: 720 },
+    video: { mode: 'on', size: { width: 1280, height: 720 } },
+    trace: 'retain-on-failure',
+  },
+  outputDir: './artifacts',
+});

--- a/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
+++ b/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
@@ -81,6 +81,24 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# READS are authenticated too, because READ_AUTH_ENABLED is on. A tenant
+# header alone gets a 401, not a redacted record — the same token that
+# authorises a write is what proves the tenant claim on a read.
+#
+# This is minted here, before step 1, rather than in step 3 where it used to
+# live. Without it every read below returns an OperationOutcome, and an
+# OperationOutcome contains no PHI: the redaction assertions passed
+# VACUOUSLY, on a refusal rather than on a record. That is why step 1 now
+# checks it received a Patient before it checks what the Patient contains.
+token=$(curl -sS -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: ${TENANT}" -d "{\"tenant_id\":\"${TENANT}\"}" \
+  "${HC}/r6/fhir/internal/step-up-token" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+[ -z "$token" ] && die "Could not mint a step-up token on ${HC}.
+Every read and write below needs one. Is STEP_UP_SECRET set in .env?"
+READ_AUTH=(-H "X-Tenant-Id: ${TENANT}" -H "X-Step-Up-Token: ${token}")
+
+# ---------------------------------------------------------------------------
 step "1. The same resource, both ways"
 
 direct=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
@@ -88,26 +106,40 @@ direct=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
 echo "  direct from Aidbox:"
 echo "$direct" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('name','identifier','birthDate','address')})[:300])"
 
-proxied=$(curl -sS -H "X-Tenant-Id: ${TENANT}" \
-  "${HC}/r6/fhir/Patient/pt-demo")
+proxied=$(curl -sS "${READ_AUTH[@]}" "${HC}/r6/fhir/Patient/pt-demo")
 echo "  through the guardrail proxy:"
-echo "$proxied" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('name','identifier','birthDate','address','meta')})[:300])"
+echo "$proxied" | python3 -c "import json,sys; r=json.load(sys.stdin); print('   ', json.dumps({k:r.get(k) for k in ('resourceType','id','name','identifier','birthDate','address')})[:300])"
 
-# The assertion is on the distinctive values, not on the shape of the mask:
-# checking for '***masked***' would pass if redaction were replaced by a
-# function that returned that string and nothing else.
+# Three assertions, in this order. The first exists because the other two
+# are satisfied by ANY response that lacks the identifiers — including a
+# refusal, which is what this step was actually receiving.
 python3 - "$direct" "$proxied" <<'PY'
 import json, sys
 direct, proxied = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+
+# 1. We are looking at the record, not at an error about the record.
+if proxied.get("resourceType") != "Patient" or proxied.get("id") != "pt-demo":
+    print("  \033[31mFAIL\033[0m the proxy did not return Patient/pt-demo. "
+          "Nothing below would be testing redaction:")
+    print("        " + json.dumps(proxied)[:300])
+    sys.exit(1)
+
+# 2. Aidbox really does hold the identified record, so the comparison means
+#    something.
+if "Alvarez" not in json.dumps(direct):
+    print("  \033[31mFAIL\033[0m Aidbox did not return the identified record; "
+          "is the seed loaded?")
+    sys.exit(1)
+
+# 3. The distinctive values are gone. Asserted on the values themselves, not
+#    on the shape of the mask: checking for '***masked***' would pass if
+#    redaction were replaced by a function returning that string and nothing
+#    else.
 raw = json.dumps(proxied)
 leaked = [tok for tok in ("Alvarez", "Maria", "MRN-88214", "221 Baker St",
                           "555-867-5309", "1974-03-11") if tok in raw]
 if leaked:
     print(f"  \033[31mFAIL\033[0m identifiers survived redaction: {leaked}")
-    sys.exit(1)
-if "Alvarez" not in json.dumps(direct):
-    print("  \033[31mFAIL\033[0m Aidbox did not return the identified record; "
-          "is the seed loaded?")
     sys.exit(1)
 print("  \033[32mPASS\033[0m Aidbox holds the full record; the agent's path does not")
 PY
@@ -116,18 +148,23 @@ PY
 # ---------------------------------------------------------------------------
 step "2. The read left a record"
 
-audit=$(curl -sS -H "X-Tenant-Id: ${TENANT}" "${HC}/r6/fhir/AuditEvent?_count=1")
+audit=$(curl -sS "${READ_AUTH[@]}" "${HC}/r6/fhir/AuditEvent?_count=5")
 echo "$audit" | python3 -c "
 import json,sys
 b=json.load(sys.stdin)
+# Same trap as step 1: a refusal is a JSON object with no entries, and 'no
+# PHI in it' is trivially true of a refusal. Check the shape first.
+if b.get('resourceType') != 'Bundle':
+    print('  \033[31mFAIL\033[0m expected a Bundle of AuditEvents, got:')
+    print('        ' + json.dumps(b)[:300]); sys.exit(1)
 n=b.get('total', len(b.get('entry',[])))
 print(f'    AuditEvent entries: {n}')
-raw=json.dumps(b)
-for tok in ('Alvarez','MRN-88214','221 Baker St'):
-    if tok in raw:
-        print(f'  \033[31mFAIL\033[0m PHI in the audit trail: {tok}'); sys.exit(1)
 if not b.get('entry'):
     print('  \033[31mFAIL\033[0m the read emitted no AuditEvent'); sys.exit(1)
+raw=json.dumps(b)
+for tok in ('Alvarez','MRN-88214','221 Baker St','555-867-5309'):
+    if tok in raw:
+        print(f'  \033[31mFAIL\033[0m PHI in the audit trail: {tok}'); sys.exit(1)
 print('  \033[32mPASS\033[0m audit written, and PHI-free')
 "
 [ $? -ne 0 ] && fail=1
@@ -170,41 +207,60 @@ write() {  # write <expected> <label> [extra curl args...]
                             || bad "$label: expected ${expected}, got ${code}"
 }
 
+# $token was minted before step 1 — reads need it too.
 write 428 "neither gate"
 write 401 "confirmed, no credential" -H 'X-Human-Confirmed: true'
+write 428 "credential, no human" -H "X-Step-Up-Token: ${token}"
+write 201 "both gates satisfied" -H "X-Step-Up-Token: ${token}" \
+                                 -H 'X-Human-Confirmed: true'
 
-token=$(curl -sS -X POST -H 'Content-Type: application/json' \
-  -H "X-Tenant-Id: ${TENANT}" -d "{\"tenant_id\":\"${TENANT}\"}" \
-  "${HC}/r6/fhir/internal/step-up-token" \
-  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
-
-if [ -z "$token" ]; then
-  bad "could not mint a step-up token"
-else
-  write 428 "credential, no human" -H "X-Step-Up-Token: ${token}"
-  write 201 "both gates satisfied" -H "X-Step-Up-Token: ${token}" \
-                                   -H 'X-Human-Confirmed: true'
-
-  # The write is only real if Aidbox holds it. Ask Aidbox, going around the
-  # proxy — the proxy reporting its own 201 says nothing about storage.
-  landed=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
-    "${AIDBOX_URL}/fhir/Observation?subject=Patient/pt-demo&code=85354-9" \
-    | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
-  [ "${landed:-0}" -ge 1 ] && ok "the Observation reached Aidbox (${landed} found)" \
-                           || bad "the write returned 201 but Aidbox has no such Observation"
-fi
+# The write is only real if Aidbox holds it. Ask Aidbox, going around the
+# proxy — the proxy reporting its own 201 says nothing about storage.
+landed=$(curl -sS -u "${AIDBOX_CLIENT}:${AIDBOX_SECRET}" \
+  "${AIDBOX_URL}/fhir/Observation?subject=Patient/pt-demo&code=85354-9" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
+[ "${landed:-0}" -ge 1 ] && ok "the Observation reached Aidbox (${landed} found)" \
+                         || bad "the write returned 201 but Aidbox has no such Observation"
 
 # ---------------------------------------------------------------------------
 step "4. Grade the deployment"
 
-curl -sS "${HC}/r6/fhir/\$conformance?format=text" | sed -n '1,4p' | sed 's/^/    /'
-grade=$(curl -sS "${HC}/r6/fhir/\$conformance" \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('grade',''), d['score']['passed'], d['score']['total'])" 2>/dev/null)
-echo "    grade: ${grade}"
-case "$grade" in
-  "A 7 7") ok "Grade A, 7/7" ;;
-  *)       bad "expected 'A 7 7', got '${grade}'" ;;
-esac
+curl -sS "${HC}/r6/fhir/\$conformance?format=text" | sed -n '1,2p' | sed 's/^/    /'
+
+# NOT an assertion that the grade is A. In upstream mode it is B, and the one
+# property that fails — error fidelity — fails for a reason worth stating
+# rather than hiding behind a softer threshold: a search carrying an unknown
+# parameter is forwarded to Aidbox, which answers 404/502, instead of being
+# refused by the guardrail with an OperationOutcome naming the parameter.
+# That is a real gap in proxy mode, tracked as #498.
+#
+# So the assertion is: every OTHER property holds, and error fidelity is the
+# only failure. Anything else regressing goes red, and the day the gap is
+# closed this still passes at 7/7 without an edit.
+curl -sS "${HC}/r6/fhir/\$conformance" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+score = d['score']
+failed = [p['key'] for p in d.get('properties', []) if not p.get('passed')]
+print(f\"    grade {d.get('grade')} ({score['passed']}/{score['total']})\")
+KNOWN = {'error_fidelity'}
+unexpected = set(failed) - KNOWN
+if unexpected:
+    print('  \033[31mFAIL\033[0m properties that should hold did not: '
+          + ', '.join(sorted(unexpected)))
+    sys.exit(1)
+if failed:
+    print('  \033[32mPASS\033[0m ' + str(score['passed']) + '/'
+          + str(score['total']) + ' — the only failure is error fidelity,')
+    print('       which in upstream mode measures how Aidbox answers an '
+          'unknown search')
+    print('       parameter, not how the guardrail does. Known, and stated '
+          'rather than')
+    print('       graded away.')
+else:
+    print('  \033[32mPASS\033[0m Grade A, 7/7')
+"
+[ $? -ne 0 ] && fail=1
 
 # ---------------------------------------------------------------------------
 if [ "$fail" -ne 0 ]; then

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -133,6 +133,14 @@ def _synthetic_patient():
 def _synthetic_observation(subject_ref: str = "Patient/conformance-subject"):
     # A CLINICAL resource — human-in-the-loop and medical disclaimers apply to
     # clinical types (Observation/Condition/...), not to demographic Patient.
+    #
+    # PASS A REAL SUBJECT when one can be made. The default references a
+    # patient nobody creates, which the local SQLite store accepts because it
+    # validates no references — and a real FHIR server refuses. Against Aidbox
+    # every clinical-write probe returned 422 and the harness reported it as
+    # "the gate blocks confirmed writes too, so its 428s prove nothing": a
+    # true observation with the wrong cause attached. The gate was fine; the
+    # reference was dangling.
     return {
         "resourceType": "Observation",
         "status": "final",
@@ -522,6 +530,19 @@ def _create_synthetic(client, ctx) -> tuple[Optional[str], object]:
     return pid, status
 
 
+def _subject_ref(client, ctx) -> str:
+    """A subject reference for a clinical probe, real where one can be made.
+
+    Falls back to the placeholder when the Patient create fails, rather than
+    adding a check and returning early: a deployment that refuses writes
+    should still reach the clinical-write checks and fail THEM, which is the
+    report that names the actual property. A gate here would only change
+    which check reports the same failure.
+    """
+    pid, _ = _create_synthetic(client, ctx)
+    return f"Patient/{pid}" if pid else "Patient/conformance-subject"
+
+
 def _is_resource(body, resource_type: str, rid: str) -> bool:
     """The response IS the resource that was asked for."""
     return (isinstance(body, dict)
@@ -720,10 +741,11 @@ def probe_human_in_the_loop(client, ctx) -> ProbeResult:
     r = ProbeResult("human_in_the_loop", "Human-in-the-Loop")
     # A CLINICAL write with step-up present but human confirmation absent must
     # yield 428. (Demographic Patient writes are not gated by human-in-the-loop.)
+    subject = _subject_ref(client, ctx)
     headers = {"X-Tenant-Id": ctx.tenant, "X-Step-Up-Token": ctx.step_up_token,
                "Content-Type": "application/fhir+json"}
     status, _, _ = client.request("POST", "/Observation", headers,
-                                  _synthetic_observation())
+                                  _synthetic_observation(subject))
     r.checks.append(Check("clinical write without human confirmation is blocked (428)",
                           status == 428, f"status {status}"))
 
@@ -736,7 +758,7 @@ def probe_human_in_the_loop(client, ctx) -> ProbeResult:
     # mechanism. This grades the gate's behavior, not the attestation behind
     # it, and the report says so in the note.
     status, body, _ = client.request("POST", "/Observation", ctx.write_headers(),
-                                     _synthetic_observation())
+                                     _synthetic_observation(subject))
     oid = body.get("id") if isinstance(body, dict) else None
     r.checks.append(Check("confirmed clinical write is accepted",
                           bool(oid) and status in (200, 201),
@@ -780,7 +802,8 @@ def probe_medical_disclaimer(client, ctx) -> ProbeResult:
     r = ProbeResult("medical_disclaimer", "Medical Disclaimers")
     # Disclaimers attach to CLINICAL reads — create + read back an Observation.
     status, body, _ = client.request(
-        "POST", "/Observation", ctx.write_headers(), _synthetic_observation())
+        "POST", "/Observation", ctx.write_headers(),
+        _synthetic_observation(_subject_ref(client, ctx)))
     oid = body.get("id") if isinstance(body, dict) else None
     if not oid:
         r.checks.append(Check("synthetic observation created", False,


### PR DESCRIPTION
Follow-up to #496. That PR made the example correct on paper; this one is what running it against a live Aidbox found. **The walkthrough now passes end to end against a real Aidbox** — the first time it has ever been executed.

## 1. The headline demonstration was asserting nothing

`READ_AUTH_ENABLED` is on, so reads need a tenant-bound step-up token. The walkthrough sent only `X-Tenant-Id`, so **every read returned an OperationOutcome** — and an OperationOutcome contains no PHI, so the check "none of the identifiers appear in the response" was **true of a refusal**.

Redact-on-read is the example's whole argument, and it was passing on an error body:

```
through the guardrail proxy:
  {"name": null, "identifier": null, "birthDate": null, "address": null}
```

Those nulls are `.get()` on an error, not a redacted patient. With the token, the actual demonstration finally appears:

```
{"resourceType": "Patient", "id": "pt-demo",
 "name": [{"family": "A.", "given": ["M."]}],
 "identifier": [{"system": "urn:mrn", "value": "***8214"}],
 "birthDate": "1974", "address": [{"state": "PA"}]}
```

The durable fix is ordering: step 1 now asserts it received `Patient/pt-demo` **before** asserting anything about what it contains, so an error body can never satisfy it again. Step 2 gained the same shape check. The README's two read examples also sent no token and would have returned 401 verbatim.

## 2. The conformance harness could not run against a real FHIR server

Clinical probes build an Observation referencing `Patient/conformance-subject` — a patient nothing creates. SQLite validates no references so it passed locally; Aidbox refuses it, and all three clinical-write probes returned 422. The harness then reported:

> ✗ confirmed clinical write is accepted — status 422; **the gate blocks confirmed writes too, so its 428s prove nothing**

A true measurement with the wrong cause attached, accusing a gate that was working perfectly. Probes now create a subject first.

**Live grade against Aidbox: D (4/7) → B (6/7).** Local mode unchanged at A 7/7, pinned by the suite.

## 3. The remaining failure is stated, not graded away

Error fidelity still fails in upstream mode, legitimately: an unknown search parameter is forwarded to Aidbox, which answers 404/502, instead of being refused by the guardrail with an OperationOutcome naming the parameter. Filed as **#498**.

Step 4 does not assert a softer grade. It asserts **every property except error fidelity passes** — so any other regression goes red, and the day #498 closes the same assertion passes at 7/7 untouched. The README says B, not A, and says why.

## Method note

I nearly reverted the probe fix on a misdiagnosis. The conformance suite went red and I read it as my change breaking the Grade A gate. It was **#488**: Aidbox on `:8080` is mistaken for the FHIR validator, which 422s every write. Rerunning with Aidbox stopped showed *the same five failures on an unmodified tree*. The environment was the variable, not the diff — worth recording because the wrong conclusion was one command away, and it would have thrown out a correct fix.

## Verification

```
0. Preflight            PASS  upstream mode, connected; Aidbox refuses anonymous callers (401)
1. Both ways            PASS  Aidbox holds the full record; the agent's path does not
2. Audit                PASS  2 AuditEvents, PHI-free
3. Write matrix         PASS  428 / 401 / 428 / 201, and the Observation reached Aidbox
4. Grade                PASS  B (6/7); only error fidelity fails, and it is #498
```

- Full suite green with Aidbox stopped: 3046 passed
- `uv run ruff check .` clean, table stakes clean
- Conformance suite 35/35 — Grade A preserved in local mode