### PR TITLE
fix(example): the MCP server had never started, and nothing asked whether it had

### DIFF
--- a/examples/aidbox-healthclaw-guardrails/.env.example
+++ b/examples/aidbox-healthclaw-guardrails/.env.example
@@ -27,6 +27,12 @@
 #   openssl rand -hex 32
 STEP_UP_SECRET=dev-only-change-me
 
+# Authenticates callers to the MCP server. It REFUSES TO START without one
+# rather than serving an unauthenticated tool endpoint, so this is required,
+# not optional. Generate one with:
+#   openssl rand -hex 32
+MCP_AUTH_TOKEN=dev-only-change-me
+
 # The credential the guardrail proxy presents to Aidbox. Must match the
 # Client secret in init-bundle/bundle.json. Change both together.
 FHIR_UPSTREAM_CLIENT_SECRET=healthclaw-secret

--- a/examples/aidbox-healthclaw-guardrails/README.md
+++ b/examples/aidbox-healthclaw-guardrails/README.md
@@ -41,7 +41,8 @@ cd HealthClawGuardrails/examples/aidbox-healthclaw-guardrails
 ## Run it
 
 ```bash
-cp .env.example .env      # set STEP_UP_SECRET; BOX_LICENSE stays commented out
+cp .env.example .env      # set STEP_UP_SECRET and MCP_AUTH_TOKEN;
+                          # BOX_LICENSE stays commented out
 docker compose up -d
 ```
 
@@ -236,6 +237,32 @@ references; Aidbox refuses it, every clinical-write probe returned 422, and
 the report concluded *"the gate blocks confirmed writes too, so its 428s
 prove nothing"* — a true measurement with the wrong cause attached. The gate
 was fine. The probes now create a subject first.
+
+### 5. What the agent actually connects to
+
+```bash
+curl -X POST http://localhost:3001/mcp/rpc -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 401
+
+curl -X POST http://localhost:3001/mcp/rpc -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 27 tools
+```
+
+The MCP server refuses to start at all without `MCP_AUTH_TOKEN` rather than
+serving an unauthenticated tool endpoint. `MCP_PUBLIC_DEMO=true` is the
+documented alternative and is deliberately not used here: an example about
+what an agent may do with health data should not open with an
+unauthenticated tool server.
+
+This step exists because for a long time the service never ran. The proxy's
+health check called `curl`, which is not in that image, so it exited 127 on
+every probe and reported unhealthy forever — and `mcp`, which waits on
+`condition: service_healthy`, never started. The diagram at the top of this
+file opens with the MCP server, and nothing had ever asked whether it was
+there. Both checks now run in `walkthrough.sh`.
 
 ## How the two servers are wired
 

--- a/examples/aidbox-healthclaw-guardrails/docker-compose.yaml
+++ b/examples/aidbox-healthclaw-guardrails/docker-compose.yaml
@@ -128,7 +128,17 @@ services:
       APP_ENV: development
       DATABASE_URL: sqlite:////tmp/healthclaw.db
     healthcheck:
-      test: curl -f http://localhost:5000/r6/fhir/health || exit 1
+      # python, NOT curl — the guardrails image does not ship curl, so
+      # `curl -f ...` exited 127 ("not found") on every probe. The proxy was
+      # healthy the whole time and reported unhealthy forever, which meant
+      # the mcp service below — `condition: service_healthy` — never started
+      # at all. The example's own diagram opens with the MCP server, and it
+      # had never once come up.
+      #
+      # urlopen raises on any non-2xx, so a degraded 503 fails the probe the
+      # same way a refused connection does.
+      test: ["CMD-SHELL",
+             "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/r6/fhir/health', timeout=4)\""]
       interval: 5s
       timeout: 5s
       retries: 40
@@ -146,3 +156,14 @@ services:
       PORT: "3001"
       FHIR_BASE_URL: http://healthclaw:5000/r6/fhir
       TENANT_ID: demo
+
+      # REQUIRED, and the server refuses to start without it — it fail-closes
+      # rather than serving an unauthenticated MCP endpoint, which is the
+      # behaviour you want and also the reason this service crash-looped
+      # unnoticed for as long as the proxy's health check was broken: nothing
+      # depending on it ever got far enough to start it.
+      #
+      # MCP_PUBLIC_DEMO=true is the documented alternative and is deliberately
+      # not used here. An example about what an agent may do with health data
+      # should not open with an unauthenticated tool server.
+      MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:?set MCP_AUTH_TOKEN in .env}

--- a/examples/aidbox-healthclaw-guardrails/qa/.gitignore
+++ b/examples/aidbox-healthclaw-guardrails/qa/.gitignore
@@ -1,2 +1,3 @@
+node_modules
 node_modules/
 artifacts/

--- a/examples/aidbox-healthclaw-guardrails/qa/demo.spec.ts
+++ b/examples/aidbox-healthclaw-guardrails/qa/demo.spec.ts
@@ -18,6 +18,8 @@ const AIDBOX_AUTH = 'Basic ' + Buffer.from(
   `${process.env.AIDBOX_CLIENT || 'root'}:${process.env.AIDBOX_SECRET || 'qNbQS6sw82'}`
 ).toString('base64');
 const TENANT = process.env.TENANT || 'demo';
+const MCP = `http://localhost:${process.env.MCP_PORT || '3001'}`;
+const MCP_TOKEN = process.env.MCP_AUTH_TOKEN || '';
 
 /** Values that must never appear on the agent's side of the proxy. */
 const IDENTIFIERS = ['Alvarez', 'Maria', 'MRN-88214', '221 Baker St',
@@ -294,6 +296,36 @@ Tracked as #498.</pre></div>
     </div>
     <div class="note">The same harness runs in CI as a merge gate, so a regression shows up
     as a grade change rather than as an incident.</div>`);
+
+  // ---- 5. The tool surface the agent actually connects to ---------------
+  // The service this example's diagram opens with had never started: the
+  // proxy health check called curl, which is absent from that image, so mcp
+  // waited on a `service_healthy` that never arrived. Nothing asked.
+  const listBody = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+  const mcpAnon = await request.post(`${MCP}/mcp/rpc`, { data: listBody });
+  expect(mcpAnon.status(), 'the MCP server must refuse unauthenticated callers').toBe(401);
+
+  const mcpAuthed = await request.post(`${MCP}/mcp/rpc`, {
+    headers: { Authorization: `Bearer ${MCP_TOKEN}` }, data: listBody,
+  });
+  expect(mcpAuthed.status()).toBe(200);
+  const tools = (await mcpAuthed.json()).result?.tools ?? [];
+  expect(tools.length, 'the authenticated tool surface must be served').toBeGreaterThan(0);
+
+  await render(page, head('05', 'What the agent actually connects to') + `
+    <div class="cols">
+      <div class="box"><div class="lbl">tools/list &middot; no credential</div><pre>HTTP ${mcpAnon.status()}
+
+the MCP server refuses to
+start without a token at all,
+rather than serve an
+unauthenticated tool surface</pre></div>
+      <div class="box guard"><div class="lbl">tools/list &middot; authenticated &middot; ${tools.length} tools</div><pre>${tools.slice(0, 7).map((t: any) => '&middot; ' + t.name).join('\n')}
+&hellip; and ${tools.length - 7} more</pre></div>
+    </div>
+    <div class="note">Every one of those tools reaches Aidbox only through the guardrail
+    proxy above &mdash; so the four properties hold for the agent's whole surface, not
+    just for the requests in this demo.</div>`);
 
   await page.waitForTimeout(3000);
 });

--- a/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
+++ b/examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh
@@ -263,6 +263,30 @@ else:
 [ $? -ne 0 ] && fail=1
 
 # ---------------------------------------------------------------------------
+step "5. What the agent actually connects to"
+
+# The diagram at the top of the README opens with the MCP server, and for a
+# long time this example never started it: the proxy's health check called
+# curl, which is not in that image, so it reported unhealthy forever and the
+# mcp service — depends_on: service_healthy — never came up. Nothing noticed,
+# because nothing asked. This step asks.
+MCP="http://localhost:${MCP_PORT:-3001}"
+mcp_code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "${MCP}/mcp/rpc" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
+echo "    tools/list, no token      -> HTTP ${mcp_code}"
+[ "$mcp_code" = "401" ] && ok "the MCP server refuses unauthenticated callers" \
+                        || bad "expected 401 from an unauthenticated tools/list, got ${mcp_code}"
+
+tools=$(curl -sS -X POST "${MCP}/mcp/rpc" -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${MCP_AUTH_TOKEN}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('result',{}).get('tools',[])))" 2>/dev/null)
+echo "    tools/list, with token    -> ${tools:-0} tools"
+[ "${tools:-0}" -gt 0 ] && ok "the agent's tool surface is served, and gated" \
+                        || bad "authenticated tools/list returned no tools"
+
+# ---------------------------------------------------------------------------
 if [ "$fail" -ne 0 ]; then
   printf '\n\033[31mWalkthrough FAILED.\033[0m A guardrail this example claims did not hold.\n'
   exit 1


### PR DESCRIPTION
Found while running the **standalone** copy of the example — the exact artifact intended for `Aidbox/examples` — rather than the in-repo one.

## The MCP server has never come up

The README's diagram opens with it:

```
AI agent ──▶ MCP server ──▶ Guardrail proxy ──▶ Aidbox
  :3001                        :5000              :8080
```

The proxy's health check ran `curl -f http://localhost:5000/r6/fhir/health`, and **curl is not in the guardrails image**. Every probe exited 127:

```
exit=1 out=/bin/sh: 1: curl: not found
```

So the container reported `unhealthy` forever *while serving perfectly*, and `mcp` — which waits on `condition: service_healthy` — was never started by compose at all. Silent in both directions: the proxy looked broken and worked; the MCP server looked absent and was.

Health check is now a `python urlopen`, which the image does have. A degraded 503 still fails it, because urlopen raises on any non-2xx.

## And then it crash-looped

With `mcp` finally starting:

```
Error: MCP_AUTH_TOKEN is required when NODE_ENV=production
       (or set MCP_PUBLIC_DEMO=true to run an unauthenticated, demo-tenant-only server)
```

Fail-closed, which is the behaviour we want — the example just never set one. `MCP_AUTH_TOKEN` is now required alongside `STEP_UP_SECRET`. **`MCP_PUBLIC_DEMO=true` is deliberately not used**: an example about what an agent may do with health data should not open with an unauthenticated tool server.

## Step 5 asks the question nothing was asking

| request | result |
|---|---|
| `tools/list`, no credential | **401** |
| `tools/list`, authenticated | **27 tools** |

Both in `walkthrough.sh` and in the browser harness, so the recording shows it too.

## Why this went unnoticed

Two shapes, one lesson:

- a health check that cannot fail for the right reason is not a health check
- a dependency nobody exercises is a dependency nobody has

Both stayed invisible because the only thing that would have caught them was a step that did not exist. The walkthrough asserted redaction, audit, the write gates and the grade — and never once asked whether the service at the front of its own diagram was running.

## Verification

Six steps, live against a real Aidbox:

```
0. Preflight        PASS  upstream mode, connected; Aidbox refuses anonymous callers
1. Both ways        PASS  Aidbox holds the full record; the agent's path does not
2. Audit            PASS  written, PHI-free
3. Write matrix     PASS  428 / 401 / 428 / 201, confirmed in Aidbox
4. Grade            PASS  B (6/7); only error fidelity, which is #498
5. MCP              PASS  401 unauthenticated, 27 tools authenticated
```

- Full suite green with Aidbox stopped: 3046 passed
- `uv run ruff check .` clean, table stakes clean

## Next

With this merged, the standalone copy is ready to submit to [Aidbox/examples](https://github.com/Aidbox/examples). That submission also needs the `1.10.0` images published, since it pulls rather than builds.