### PR TITLE
fix(prod-watch): stop the alarm that got itself muted

### DIFF
--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -132,26 +132,72 @@ jobs:
             // observed pass may close one.
             const buildResolved = status?.build?.asserted === true
                                   && status?.build?.ok === true;
+            // WHAT is wrong, reduced to a comparable value. A comment is a
+            // notification; an edit is not. So the issue body is refreshed
+            // every run (always current, silent) and a comment is posted only
+            // when this changes — which is the only moment a human learns
+            // something they did not already know.
+            //
+            // Before this, a firing alarm commented every six hours with
+            // identical text. #427 collected 35 of them and the maintainer
+            // muted the thread, which is the rational response and also the
+            // end of the alarm: the next real failure would have arrived in a
+            // muted thread. An alarm that repeats itself is an alarm being
+            // turned off.
+            //
+            // Failing check NAMES, not their details. A count moving 4 -> 5
+            // while the same check fails is not news; a different check
+            // failing is. The stale alarm fingerprints the deployed build
+            // instead, because a NEW stale build is genuinely new.
+            const failingNames = (status?.checks ?? [])
+              .filter(c => c.ok !== true).map(c => c.name).sort().join('|');
+            // No verdict file means we cannot prove the state is unchanged,
+            // and silence on an unprovable state is this workflow's own
+            // failure mode. Seeding with the run id makes the fingerprint
+            // never match, so it always speaks.
+            const unknown = `unverified-run-${context.runId}`;
+            const outageFp = status ? `checks:${failingNames}` : unknown;
+            const staleFp = status?.build?.deployed
+              ? `build:${status.build.deployed}` : unknown;
+
+            const MARK = (fp) => `<!-- prod-watch-fingerprint: ${fp} -->`;
+            const FP_RE = /<!-- prod-watch-fingerprint: (.*?) -->/;
+
             const alarms = [
               ['prod-watch: production checks failing', hardFailing, allPassed,
-               'Scheduled production check failed.'],
+               'Scheduled production check failed.', outageFp],
               ['prod-watch: deployed build is stale', staleFiring, buildResolved,
-               'Production is healthy, but it is not running the build we expect.'],
+               'Production is healthy, but it is not running the build we expect.',
+               staleFp],
             ];
-            for (const [title, firing, resolved, lead] of alarms) {
+            for (const [title, firing, resolved, lead, fingerprint] of alarms) {
               const { data: found } = await github.rest.search.issuesAndPullRequests({
                 q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
               });
               // Search is fuzzy and the two titles share words — match exactly.
               const open = found.items.filter(i => i.title === title);
               if (firing) {
-                const text = [lead, '', '```', body, '```', '', `Run: ${run}`, '',
-                  'This issue closes automatically when the check passes again.'].join('\n');
-                if (open.length) {
-                  await github.rest.issues.createComment({
-                    ...context.repo, issue_number: open[0].number, body: text });
-                } else {
+                const text = [lead, '', '```', body, '```', '', `Run: ${run}`,
+                  `Last checked: ${new Date().toISOString()}`, '',
+                  'This issue closes automatically when the check passes again.',
+                  'It is edited in place each run and only comments when what',
+                  'is failing changes.', '', MARK(fingerprint)].join('\n');
+                if (!open.length) {
                   await github.rest.issues.create({ ...context.repo, title, body: text });
+                  continue;
+                }
+                const issue = open[0];
+                const previous = (issue.body || '').match(FP_RE)?.[1] ?? null;
+                // Always refresh the body: an edit sends no notification, so
+                // the issue can stay current for free. Only the comment costs
+                // someone's attention, so only a change earns one.
+                await github.rest.issues.update({
+                  ...context.repo, issue_number: issue.number, body: text });
+                if (previous !== fingerprint) {
+                  await github.rest.issues.createComment({
+                    ...context.repo, issue_number: issue.number,
+                    body: [`What is failing has changed.`, '', '```', body, '```',
+                           '', `Run: ${run}`].join('\n') });
                 }
               } else if (resolved) {
                 // Only an observed pass closes an alarm. If the check was not

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -63,6 +63,21 @@ CAREAGENTS = "https://careagents-production.up.railway.app"
 MCP_LOCKED = "https://mcp-server-production-5112.up.railway.app"
 MCP_DEMO = "https://mcp-demo-production-ee2c.up.railway.app"
 DEMO_TENANT = "desktop-demo"
+
+#: Every Patient the demo tenant is supposed to hold, and no others.
+#:
+#: One original record plus the three blood-pressure personas seeded for the
+#: SMBP demo (a treated case, a white-coat case, and a phoned-in reading with
+#: no home series). Adding a persona means adding it here in the same change:
+#: the check below reads this as the whole truth about the tenant, so an
+#: omission reports real data as an intruder, and an addition nobody made is
+#: how the tenant duplicated itself into nineteen patients (#457).
+DEMO_PATIENTS = (
+    "demo-patient-rivera",
+    "demo-marisol",
+    "demo-elena",
+    "demo-ray",
+)
 BUILD_CHECK = "careagents: running the current build"
 # Same shape careagents/_build.py enforces on the way out. A "-dirty" marker
 # deliberately fails it: a build stamped from an uncommitted tree has no
@@ -211,23 +226,39 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # This watches the CONSEQUENCE rather than the mechanism. A count is
     # observable from outside; "did the pre-deploy step run" is not, and the
     # count is what a viewer of the demo actually sees.
+    # The SET, not the count. A count answers "has it duplicated" and nothing
+    # else; it cannot tell a duplicated tenant from one that lost a persona,
+    # and losing one is the failure that costs a recording. This check went
+    # red for four days after the SMBP demo patients were seeded — correct
+    # data, stale expectation — which is its own lesson: a guard that fires on
+    # intended work trains everyone to ignore it, and then it is not a guard.
     r = get(f"{HEALTHCLAW}/r6/fhir/Patient?_count=200", timeout,
             headers={"X-Tenant-Id": DEMO_TENANT})
-    patients = None
+    found = None
     if getattr(r, "status_code", None) == 200:
         try:
-            patients = len(r.json().get("entry") or [])
+            found = {(e.get("resource") or {}).get("id")
+                     for e in (r.json().get("entry") or [])}
         except ValueError:
-            patients = None
-    # `is not None` rather than a truthiness test: zero patients is a real
-    # failure (an empty demo), and `if patients:` would report it as
-    # unreadable instead. The read failing and the tenant being empty are
-    # different alarms.
-    check("healthclaw: the demo tenant is one patient",
-          patients == 1,
-          f"{patients} Patient(s) in {DEMO_TENANT}"
-          if patients is not None else
-          f"could not read the tenant ({getattr(r, 'status_code', r)})")
+            found = None
+    # `is not None` rather than a truthiness test: an EMPTY set is a real
+    # failure (an empty demo), and `if found:` would report it as unreadable
+    # instead. The read failing and the tenant being empty are different
+    # alarms.
+    if found is None:
+        detail = f"could not read the tenant ({getattr(r, 'status_code', r)})"
+    else:
+        missing = sorted(set(DEMO_PATIENTS) - found)
+        extra = sorted(str(x) for x in found - set(DEMO_PATIENTS))
+        parts = [f"{len(found)} Patient(s) in {DEMO_TENANT}"]
+        if missing:
+            parts.append(f"missing {', '.join(missing)}")
+        if extra:
+            parts.append(f"unexpected {', '.join(extra)}")
+        detail = "; ".join(parts)
+    check("healthclaw: the demo tenant holds exactly its demo patients",
+          found is not None and found == set(DEMO_PATIENTS),
+          detail)
 
     # --- the consumer app ----------------------------------------------------
     r = get(f"{CAREAGENTS}/healthz", timeout)

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -273,8 +273,13 @@ def _prod_watch_with(payload, expect, demo_handshake=None):
         if "$conformance" in url:
             return _Resp(200, {"grade": "A"})
         if "Patient" in url:
+            # The demo tenant in the state it is supposed to be in. Sourced
+            # from prod_watch rather than restated, so adding a persona does
+            # not silently turn these build-marker tests red for a reason
+            # that has nothing to do with build markers.
             return _Resp(200, {"entry": [
-                {"resource": {"resourceType": "Patient", "id": "demo-1"}}]})
+                {"resource": {"resourceType": "Patient", "id": pid}}
+                for pid in prod_watch.DEMO_PATIENTS]})
         if "Condition" in url:
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -39,16 +39,21 @@ class _Resp:
 
 
 def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A",
-              demo_patients=1):
+              demo_patients=None):
     def get(url, timeout, **kw):
         if url.endswith("/r6/fhir/health"):
             return _Resp(200)
         if "$conformance" in url:
             return _Resp(200, {"grade": grade})
         if "Patient" in url:
+            # None means "the tenant is in the state it is supposed to be in".
+            # A number means "this many patients that are not the demo set",
+            # which is what duplication actually looked like.
+            ids = (list(prod_watch.DEMO_PATIENTS) if demo_patients is None
+                   else [f"p{i}" for i in range(demo_patients)])
             return _Resp(200, {"entry": [
-                {"resource": {"resourceType": "Patient", "id": f"p{i}"}}
-                for i in range(demo_patients)]})
+                {"resource": {"resourceType": "Patient", "id": i}}
+                for i in ids]})
         if "Condition" in url:
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
@@ -420,10 +425,10 @@ def test_an_unreachable_endpoint_is_not_reported_as_a_stale_build(monkeypatch,
 
 # --- the demo tenant's shape (#457, catalogue §10) ---------------------------
 
-def test_a_single_patient_demo_tenant_passes():
+def test_the_expected_demo_patients_pass():
     """The state the demo is supposed to be in."""
     prod_watch.run(timeout=1, expect_sha=[])
-    name = "healthclaw: the demo tenant is one patient"
+    name = "healthclaw: the demo tenant holds exactly its demo patients"
     assert _named(name) and _named(name)[0][1] is True, _named(name)
 
 
@@ -439,7 +444,7 @@ def test_a_duplicated_demo_tenant_is_a_hard_failure(monkeypatch):
     monkeypatch.setattr(prod_watch, "get", _fake_get(demo_patients=19))
     rc = prod_watch.run(timeout=1, expect_sha=[])
 
-    name = "healthclaw: the demo tenant is one patient"
+    name = "healthclaw: the demo tenant holds exactly its demo patients"
     entry = _named(name)
     assert entry, "the demo-tenant check did not run"
     assert entry[0][1] is False
@@ -450,13 +455,67 @@ def test_a_duplicated_demo_tenant_is_a_hard_failure(monkeypatch):
 def test_an_empty_demo_tenant_is_a_failure_not_a_pass(monkeypatch):
     """Zero is a real failure, and a different one from "cannot read".
 
-    MUTATION: use `if patients:` instead of `is not None` -> red, because an
+    MUTATION: use `if found:` instead of `is not None` -> red, because an
     empty tenant would then be reported as an unreadable one.
     """
     monkeypatch.setattr(prod_watch, "get", _fake_get(demo_patients=0))
     prod_watch.run(timeout=1, expect_sha=[])
 
-    entry = _named("healthclaw: the demo tenant is one patient")
+    entry = _named("healthclaw: the demo tenant holds exactly its demo patients")
     assert entry and entry[0][1] is False
     assert "0 Patient(s)" in entry[0][2], (
         f"an empty tenant must report as empty, not as unreadable: {entry}")
+
+
+def test_a_missing_demo_persona_is_a_failure(monkeypatch):
+    """The failure a COUNT cannot see, and the one that costs a recording.
+
+    Three of four patients is not "nearly right" — it is a demo that opens on
+    a patient who is not there. The old check counted, so it read this as
+    healthy right up until the count happened to be one, and read the correct
+    four-patient tenant as broken for four days after the personas were
+    seeded.
+
+    MUTATION: compare len(found) to len(DEMO_PATIENTS) instead of the sets ->
+    red, because a substitution keeps the count.
+    """
+    kept = list(prod_watch.DEMO_PATIENTS)[:-1]
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        if "Patient" in url:
+            return _Resp(200, {"entry": [
+                {"resource": {"resourceType": "Patient", "id": i}}
+                for i in kept]})
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    rc = prod_watch.run(timeout=1, expect_sha=[])
+
+    name = "healthclaw: the demo tenant holds exactly its demo patients"
+    entry = _named(name)
+    assert entry and entry[0][1] is False
+    assert "missing" in entry[0][2] and prod_watch.DEMO_PATIENTS[-1] in entry[0][2], (
+        f"the report must name the persona that vanished: {entry}")
+    assert rc == 1
+
+
+def test_a_substituted_patient_is_caught_though_the_count_is_right(monkeypatch):
+    """Four patients, one of them a stranger. A count says fine."""
+    swapped = list(prod_watch.DEMO_PATIENTS)[:-1] + ["demo-someone-else"]
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        if "Patient" in url:
+            return _Resp(200, {"entry": [
+                {"resource": {"resourceType": "Patient", "id": i}}
+                for i in swapped]})
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    rc = prod_watch.run(timeout=1, expect_sha=[])
+
+    entry = _named("healthclaw: the demo tenant holds exactly its demo patients")
+    assert entry and entry[0][1] is False
+    assert "unexpected demo-someone-else" in entry[0][2], entry
+    assert rc == 1

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -519,3 +519,64 @@ def test_a_substituted_patient_is_caught_though_the_count_is_right(monkeypatch):
     assert entry and entry[0][1] is False
     assert "unexpected demo-someone-else" in entry[0][2], entry
     assert rc == 1
+
+
+# --- repeat suppression: an alarm that repeats itself gets muted -------------
+#
+# #427 collected 35 identical comments at six-hour intervals and the
+# maintainer muted the thread, which is the rational response and also the end
+# of the alarm: the next real failure would have arrived in a muted thread.
+# These pin the mechanism that stops it. The semantic walk-through lives in
+# tests/tools/prod_watch_alarm_sim.js, which drives the real script body; CI
+# cannot run node, so what CI can hold is that the moving parts are still here.
+
+def test_the_firing_branch_refreshes_the_issue_body_every_run():
+    """An edit sends no notification, so the issue can stay current for free.
+
+    MUTATION: delete the issues.update call from the firing branch -> red.
+    A stale body is worse than none: it shows a failure that may have been
+    superseded, next to a comment thread that stopped when nothing changed.
+    """
+    firing = WORKFLOW.split("if (firing) {")[1].split("} else if (resolved)")[0]
+    assert "issues.update" in firing, (
+        "the firing branch no longer refreshes the issue body, so the issue "
+        "shows whatever was true the last time something changed")
+    assert "body: text" in firing
+
+
+def test_a_comment_is_posted_only_when_the_fingerprint_changes():
+    """MUTATION: drop the `previous !== fingerprint` guard -> red.
+
+    Without it the workflow is back to one notification every six hours for
+    as long as anything is wrong.
+    """
+    firing = WORKFLOW.split("if (firing) {")[1].split("} else if (resolved)")[0]
+    assert "previous !== fingerprint" in firing, (
+        "createComment is no longer guarded by a change in what is failing")
+    guard = firing.index("previous !== fingerprint")
+    comment = firing.index("issues.createComment")
+    assert guard < comment, (
+        "the comment must be inside the change guard, not beside it")
+
+
+def test_an_unprovable_state_still_speaks():
+    """Silence on a state we cannot verify is this workflow's own failure mode.
+
+    With no status.json there is no way to show the failure is unchanged, so
+    the fingerprint is seeded with the run id and can never match the stored
+    one. MUTATION: give the unknown case a constant -> the alarm goes quiet
+    for every run after the first, which is the failure #258 was about.
+    """
+    assert "unverified-run-${context.runId}" in WORKFLOW, (
+        "an unverifiable run must produce a fingerprint that cannot match")
+
+
+def test_the_fingerprint_is_the_failing_set_not_its_details():
+    """A count moving 4 -> 5 while the same check fails is not news.
+
+    Fingerprinting on details would re-notify on every run whose numbers
+    wobble, which is the noise this replaced.
+    """
+    assert "c.ok !== true).map(c => c.name)" in WORKFLOW, (
+        "the outage fingerprint should be built from failing check NAMES")
+    assert "checks:${failingNames}" in WORKFLOW

--- a/tests/tools/prod_watch_alarm_sim.js
+++ b/tests/tools/prod_watch_alarm_sim.js
@@ -40,18 +40,26 @@ function makeEnv({ exit, statusJson, resultTxt = 'RESULT', openIssues = [] }) {
       return files[key];
     },
   };
-  const issues = openIssues.map((t, i) => ({ number: 100 + i, title: t }));
+  // An open issue carries a BODY, because the body is where the fingerprint
+  // lives and the fingerprint is what decides whether anyone gets emailed.
+  // A fake without one made every row look like a first sighting.
+  const issues = openIssues.map((o, i) => (
+    typeof o === 'string' ? { number: 100 + i, title: o, body: '' }
+                          : { number: 100 + i, title: o.title, body: o.body ?? '' }));
   const github = {
     rest: {
       search: {
         issuesAndPullRequests: async ({ q }) => ({ data: { items: issues.slice() } }),
+        // NOTE: items carry `body`, which the script reads for the fingerprint.
       },
       issues: {
         create: async ({ title }) => { log.push(['create', title]); },
         createComment: async ({ issue_number, body }) => {
           log.push(['comment', issue_number, body.split('\n')[0].slice(0, 40)]);
         },
-        update: async ({ issue_number, state }) => { log.push(['update', issue_number, state]); },
+        update: async ({ issue_number, state, body }) => {
+          log.push(['update', issue_number, state ?? (body ? 'body' : undefined)]);
+        },
       },
     },
   };
@@ -87,6 +95,15 @@ function statusOf({ ok, asserted, buildOk, hardOk = ok }) {
                           build: { deployed: 'x', asserted, ok: buildOk } });
 }
 
+// The fingerprint the script writes for a given failing-check set. Kept as a
+// literal rather than computed, so a change to the marker format shows up here
+// as a failing expectation instead of as two agreeing implementations.
+const FP = (names) => `<!-- prod-watch-fingerprint: checks:${names} -->`;
+const FAILING = (names) => JSON.stringify({
+  ok: false, hard_ok: false,
+  checks: names.split('|').filter(Boolean).map(n => ({ name: n, ok: false, detail: '' })),
+  build: { deployed: 'x', asserted: true, ok: true } });
+
 const cases = [
   // name, exit, status.json content, pre-open issues
   ['healthy, nothing pinned (informational)', '0', statusOf({ ok: true, asserted: false, buildOk: null }), [OUTAGE, STALE]],
@@ -103,6 +120,20 @@ const cases = [
   // Both issues pre-opened, so every row below also answers "and can it ever
   // close again?". An alarm that fires forever with no path to closing is its
   // own failure mode — the reader learns to ignore it.
+  ['--- REPEAT SUPPRESSION: does an unchanged alarm stay quiet? ---'],
+  ['same failure as last run -> body refreshed, NO comment', '1',
+   FAILING('careagents: running the current build'),
+   [{ title: OUTAGE, body: 'old\n' + FP('careagents: running the current build') }]],
+  ['a DIFFERENT check starts failing -> comment', '1',
+   FAILING('careagents: running the current build|healthclaw: alive'),
+   [{ title: OUTAGE, body: 'old\n' + FP('careagents: running the current build') }]],
+  ['a check RECOVERS while another still fails -> comment', '1',
+   FAILING('healthclaw: alive'),
+   [{ title: OUTAGE, body: 'old\n' + FP('careagents: running the current build|healthclaw: alive') }]],
+  ['first sighting, issue open with no fingerprint -> comment', '1',
+   FAILING('healthclaw: alive'), [{ title: OUTAGE, body: 'legacy body' }]],
+  ['no verdict file -> speaks anyway, cannot prove unchanged', '1', undefined,
+   [{ title: OUTAGE, body: 'old\n' + FP('healthclaw: alive') }]],
   ['--- STUCK-OPEN PROBES ---'],
   ['schema drift: hard_ok renamed', '0', JSON.stringify({ ok: true, hardOk: true, checks: [], build: { asserted: true, ok: true } }), [OUTAGE, STALE]],
   ['schema drift: build.asserted renamed', '0', JSON.stringify({ ok: true, hard_ok: true, checks: [], build: { assert_: true, ok: true } }), [OUTAGE, STALE]],
@@ -133,16 +164,21 @@ const cases = [
     let log;
     try { log = await runScript(env); }
     catch (e) { console.log(`  ${name}\n      THREW: ${e.message}`); continue; }
-    const outage = log.filter(l => l[0] === 'create' && l[1] === OUTAGE).length
-      || log.filter(l => l[0] === 'comment' && l[1] === 100 + open.indexOf(OUTAGE)).length;
+    // Entries may be a title or {title, body}, so match on the title rather
+    // than on identity. The first version used indexOf on the array, which
+    // returned -1 for every object row and reported the whole repeat-
+    // suppression section as "untouched" — the harness agreeing with itself.
+    const titleAt = (o) => (typeof o === 'string' ? o : o.title);
     const summarize = (title) => {
-      const n = 100 + open.indexOf(title);
+      const n = 100 + open.findIndex(o => titleAt(o) === title);
       const created = log.some(l => l[0] === 'create' && l[1] === title);
       const commented = log.some(l => l[0] === 'comment' && l[1] === n);
+      const bodyOnly = log.some(l => l[0] === 'update' && l[1] === n && l[2] === 'body');
       const closed = log.some(l => l[0] === 'update' && l[1] === n && l[2] === 'closed');
       if (closed) return 'CLOSED';
       if (created) return 'FIRED(new issue)';
       if (commented) return 'FIRED(comment)';
+      if (bodyOnly) return 'quiet(body only)';
       return 'untouched';
     };
     console.log(`  ${name.padEnd(52)} exit=${String(exit).padEnd(4)} outage=${summarize(OUTAGE).padEnd(16)} stale=${summarize(STALE)}`);


### PR DESCRIPTION
Two changes, one cause. The prod-watch alarm on #427 emailed every six hours for four days, on **correct data**, and was muted. That is the rational response and also the end of the alarm: the next real failure would have arrived in a muted thread.

## 1. The guard was wrong

```
FAIL healthclaw: the demo tenant is one patient — 4 Patient(s) in desktop-demo
```

The tenant holds four patients because three SMBP personas were deliberately seeded into it for the physician advisor's demo. The guard asserted "is one patient" and reported the intended state as a defect.

**Counting was the underlying mistake.** A count answers "has it duplicated" and nothing else. It cannot distinguish a duplicated tenant (#457: nineteen patients) from one that has **lost** a persona — the failure that costs a recording, because the demo opens on a patient who is not there — and it passes a tenant where a persona was **replaced by a stranger**, since the total is unchanged.

The check now asserts the exact id set, published as `DEMO_PATIENTS`, and names what is missing and what is unexpected:

```
4 Patient(s) in desktop-demo; missing demo-ray; unexpected demo-someone-else
```

Adding a persona means adding it to `DEMO_PATIENTS` in the same change. That is the point, not an inconvenience.

Two new tests cover the failures a count cannot see. **MUTATION verified:** comparing lengths instead of sets turns the substitution test red, and only that one.

## 2. The alarm repeated itself

Even with correct guards, a firing alarm commented every six hours with identical text. 35 comments on one issue.

**An edit sends no notification; a comment does.** So the issue body is now refreshed every run — always current, always silent — and a comment is posted only when the fingerprint of what is failing changes, which is the only moment a reader learns something new.

- The **outage** fingerprint is the sorted names of failing checks, deliberately not their details: a count moving 4 to 5 while the same check fails is not news, and fingerprinting details would re-notify whenever numbers wobble.
- The **stale-build** alarm fingerprints the deployed sha, because a different stale build genuinely is new.
- With **no `status.json`** the state cannot be shown unchanged, so the fingerprint is seeded with the run id and can never match. Silence on an unprovable state is this workflow's own failure mode (#258); a guard against noise must not become one.

## Testing

`tests/tools/prod_watch_alarm_sim.js` drives the real script body through five new rows:

```
same failure as last run          -> quiet(body only)
a DIFFERENT check starts failing  -> FIRED(comment)
a check RECOVERS, another fails   -> FIRED(comment)
issue with no fingerprint yet     -> FIRED(comment)
no verdict file                   -> FIRED(comment)
```

Two harness defects surfaced while writing those: its fake issues carried no `body`, so every row looked like a first sighting; and its summariser matched issues with `indexOf` on an array that now holds objects, reporting the whole new section as "untouched". Both were the harness agreeing with itself.

Four pytest guards pin the mechanism for CI, which cannot run node. Two verified red by mutation: removing the change guard, and giving the unverifiable case a constant fingerprint.

## Verification

- Live production: `OK healthclaw: the demo tenant holds exactly its demo patients — 4 Patient(s) in desktop-demo`
- Full suite: 3052 passed
- `uv run ruff check .` clean; workflow YAML parses

## Not addressed

CareAgents is running a build from 2026-08-04 and does not auto-deploy. That needs an authorized redeploy per RELEASING.md §4, and is why #427 stays open regardless of this PR.