### PR TITLE
fix(medplum): the connector only ever worked against hosted Medplum, and failed open

### DIFF
--- a/docs/2026-08-14-platform-and-connector-review.md
+++ b/docs/2026-08-14-platform-and-connector-review.md
@@ -1,0 +1,134 @@
+# Platform and connector review — 2026-08-14
+
+What we run, where, and what is not earning its keep. Written from the live
+platforms rather than from memory: `railway list --json`, the Vercel API, and
+the repo's own config files.
+
+Findings are ordered by what they cost if left alone, not by how easy they are
+to fix. Two are already fixed in the PR that carries this document; the rest
+need a decision that is not mine to make.
+
+## What is actually deployed
+
+**Railway — `awake-serenity`** is production. One project, thirteen services:
+
+| | |
+|---|---|
+| app | `HealthClawGuardrails`, `careagents`, `careagents-worker`, `mcp-server`, `mcp-demo`, `openclaw-bot`, `shl-server` |
+| data | `Postgres`, `Postgres-_BFS` |
+| cache | `Redis`, `Redis-3Yfx`, `Redis-CS4j`, `Redis-u_QV` |
+
+Four other Railway projects exist (`castage`, `generous-radiance`,
+`shl-deploy`, `melodious-truth`) and none of them is HealthClaw.
+
+**Vercel** holds ten projects under `aks129s-projects`; `healthclaw` and
+`careagents` are the two that relate to this repo. Since the 2026-08-06
+incident, `app.healthclaw.io` is served by Railway, and Vercel's role is the
+marketing site and demos.
+
+## Findings
+
+### 1. The Medplum connector only worked against hosted Medplum — FIXED
+
+`_MEDPLUM_TOKEN_ENDPOINT` was the constant `https://api.medplum.com/oauth2/token`
+with no override. Self-hosting is Medplum's central proposition, so pointing
+`MEDPLUM_BASE_URL` at your own server was the expected case, and it sent your
+self-hosted client credentials to a service that has never heard of them.
+
+The endpoint is now derived from the base URL that the proxy was built with,
+with `MEDPLUM_TOKEN_URL` as an explicit override.
+
+### 2. A Medplum token failure became an anonymous request — FIXED
+
+`_inject_bearer` caught every exception, logged it, and returned — after which
+the request went out **with no `Authorization` header at all**. A token failure
+was silently downgraded to an anonymous request against the record system.
+
+This is what made finding 1 dangerous rather than merely broken: wrong
+endpoint, swallowed failure, unauthenticated read. It now raises, so a caller
+sees a failed request instead of a successful one nobody intended.
+
+Both defects survived because every Medplum test mocks `_fetch_medplum_token`.
+The guardrails wrapped around the connector were thoroughly covered; the
+connector's authentication had never run.
+
+### 3. Four Redis instances and two Postgres, for seven services
+
+Nobody set out to run four caches. This is what a year of "add a plugin to
+unblock the thing" looks like, and each one is a monthly line item, a backup
+surface, and a credential.
+
+Not a change to make from a service list: the mapping from service to
+datastore has to come from each service's environment. Worth an hour with the
+Railway dashboard before the next invoice, and a decision recorded here.
+
+### 4. `vercel.json` uses the legacy `builds` array
+
+```json
+"builds": [{ "src": "api/index.py", "use": "@vercel/python" }]
+```
+
+A `builds` array opts the project out of zero-config, which means out of Fluid
+Compute defaults, the current Python runtimes, and build-output optimisations.
+Vercel's current guidance is `vercel.ts` with a typed config.
+
+The reason to be careful rather than quick: `api/index.py` is a **second entry
+point into the same Flask app**, and the 2026-08-06 outage was two generators
+disagreeing about which was authoritative. Modernising the config without
+first settling what Vercel is *for* would repeat that. My recommendation is to
+settle the question first: if Vercel is marketing plus demos, it should not be
+building the Flask app at all.
+
+### 5. The prod stack is single-instance
+
+`railway.toml` sets a healthcheck and `restartPolicyType = "ON_FAILURE"` with
+three retries, which is the right shape. What it does not set is replicas or a
+region, so every service is one container in one place. A restart is a cold
+start with downtime, and Railway supports replicas per service.
+
+Worth doing for `HealthClawGuardrails` and `mcp-server` specifically — the two
+things a partner or a demo audience talks to. `careagents-worker` should stay
+single-instance unless its job claiming is idempotent, which is a separate
+question from this review.
+
+### 6. `preDeployCommand` seeds the demo tenant on every deploy
+
+```
+flask --app main init-db && flask --app main seed-demo --tenant-id desktop-demo
+```
+
+This is the mechanism behind #457, where the demo tenant duplicated itself into
+nineteen patients. Seeding is idempotent now and the drift guard checks the
+exact patient set, so the arrangement is safe today — but a deploy-time write
+to a tenant that a demo depends on is a standing risk, and it is worth asking
+whether the seed belongs in a deploy hook at all rather than in a command
+somebody runs deliberately.
+
+## The connector question
+
+The request was for "standard connectors to Medplum and Health Samurai". Both
+exist, by different routes, and that is the actual problem:
+
+| | Medplum | Aidbox |
+|---|---|---|
+| how | `MEDPLUM_BASE_URL` + client credentials | `FHIR_UPSTREAM_URL` + HTTP Basic |
+| code | `MedplumProxy` subclass | base `FHIRUpstreamProxy` |
+| auth | OAuth2 client-credentials | HTTP Basic |
+| verified against a live server | no | yes (`examples/aidbox-healthclaw-guardrails`) |
+
+Two code paths, two naming conventions, no way for an operator to ask what is
+supported. Aidbox is the better-verified of the two and is the one with no
+name of its own.
+
+**Recommendation, not done here:** one connector registry keyed by a
+`FHIR_UPSTREAM_KIND` of `aidbox` / `medplum` / `hapi` / `generic`, each
+declaring its auth style and its token endpoint rule, with the env names
+unified under `FHIR_UPSTREAM_*`. `MEDPLUM_*` stays as an alias so nothing
+breaks. That is a focused change, but it is a change to the one path every
+upstream read and write goes through, and it deserves its own PR rather than a
+ride along with a bug fix.
+
+The prerequisite is a live Medplum to verify against. Aidbox took a licence
+and a browser click, and it found five defects that reading the code had not.
+Nothing in this section should be believed about Medplum until the same thing
+has been done to it.

--- a/docs/2026-08-14-platform-and-connector-review.md
+++ b/docs/2026-08-14-platform-and-connector-review.md
@@ -114,11 +114,10 @@ exist, by different routes, and that is the actual problem:
 | how | `MEDPLUM_BASE_URL` + client credentials | `FHIR_UPSTREAM_URL` + HTTP Basic |
 | code | `MedplumProxy` subclass | base `FHIRUpstreamProxy` |
 | auth | OAuth2 client-credentials | HTTP Basic |
-| verified against a live server | no | yes (`examples/aidbox-healthclaw-guardrails`) |
+| verified against a live server | yes, self-hosted 5.1.30 ([runbook](runbooks/medplum-self-host-qa.md)) | yes ([example](../examples/aidbox-healthclaw-guardrails/)) |
 
 Two code paths, two naming conventions, no way for an operator to ask what is
-supported. Aidbox is the better-verified of the two and is the one with no
-name of its own.
+supported. Both are verified now. Aidbox is still the one with no name of its own.
 
 **Recommendation, not done here:** one connector registry keyed by a
 `FHIR_UPSTREAM_KIND` of `aidbox` / `medplum` / `hapi` / `generic`, each
@@ -128,7 +127,16 @@ breaks. That is a focused change, but it is a change to the one path every
 upstream read and write goes through, and it deserves its own PR rather than a
 ride along with a bug fix.
 
-The prerequisite is a live Medplum to verify against. Aidbox took a licence
-and a browser click, and it found five defects that reading the code had not.
-Nothing in this section should be believed about Medplum until the same thing
-has been done to it.
+The prerequisite was a live Medplum to verify against. That has since been
+done — see [the runbook](runbooks/medplum-self-host-qa.md). A self-hosted
+Medplum needs no credentials from anybody, and it is the configuration that
+matters: the hosted service exercises the one code path that already worked.
+
+The run confirmed the two fixes above against a real server and found a third
+defect, in the QA script rather than the product. `smoke_medplum.py`'s first
+check is named `write blocked without step-up (401)` and was asserting on a
+400: it sent no `Content-Type`, so the body never parsed and the request was
+refused as malformed before the credential was considered. It failed rather
+than passed, which is the only reason it was noticed.
+
+Final state: 8/8 guardrail checks against self-hosted Medplum 5.1.30.

--- a/docs/runbooks/medplum-self-host-qa.md
+++ b/docs/runbooks/medplum-self-host-qa.md
@@ -1,0 +1,117 @@
+# Running the Medplum QA against a self-hosted Medplum
+
+The connector's authentication had never run against a real Medplum. Every
+test mocked `_fetch_medplum_token`, so the guardrails wrapped around it were
+covered while the connector itself was not, and two defects lived there:
+a token endpoint hardcoded to Medplum's hosted service, and a token failure
+that fell through to an unauthenticated request.
+
+Self-hosted, not hosted, is the configuration that matters here. The hosted
+service exercises the one code path that already worked; the endpoint bug
+only appears when the server is somewhere else. This runbook is the loop that
+found it, so it can be run again.
+
+No Medplum credentials are needed. A self-hosted instance issues its own.
+
+## 1. Start Medplum
+
+```bash
+curl -O https://raw.githubusercontent.com/medplum/medplum/main/docker-compose.full-stack.yml
+```
+
+Two settings have to be overridden for a headless bootstrap. Put this beside
+it as `docker-compose.override.yml`:
+
+```yaml
+services:
+  medplum-server:
+    environment:
+      # The upstream compose enables signup captcha with Medplum's public test
+      # keys. Those validate against Google, and a script has no browser.
+      MEDPLUM_RECAPTCHA_SITE_KEY: ''
+      MEDPLUM_RECAPTCHA_SECRET_KEY: ''
+      # Bootstrapping takes several /auth calls in a row and the default
+      # limiter returns 429 partway through.
+      MEDPLUM_DEFAULT_AUTH_RATE_LIMIT: '600'
+```
+
+```bash
+docker compose -f docker-compose.full-stack.yml -f docker-compose.override.yml \
+  -p medplum-selfhost up -d
+```
+
+Wait for `http://localhost:8103/healthcheck` to return 200. Roughly a minute
+on a cold pull.
+
+**The rate limiter lives in Redis**, so restarting the server does not reset
+it. If a bootstrap run gets throttled, clear the counters:
+
+```bash
+docker compose -p medplum-selfhost exec redis redis-cli -a medplum FLUSHALL
+```
+
+## 2. Bootstrap a project and a client
+
+Three steps, and the third needs PKCE — Medplum refuses the code exchange with
+"Missing verification context" otherwise, and the error does not say PKCE.
+
+1. `POST /auth/newuser` with `codeChallenge` (S256) and `codeChallengeMethod`
+2. `POST /auth/newproject` with the returned `login`
+3. `POST /oauth2/token` with `grant_type=authorization_code`, the returned
+   `code`, and `code_verifier`
+
+A new project is created with a `ClientApplication` already in it, so read it
+rather than creating one:
+
+```
+GET /fhir/R4/ClientApplication      (Bearer, the token from step 3)
+```
+
+Its `id` and `secret` are `MEDPLUM_CLIENT_ID` and `MEDPLUM_CLIENT_SECRET`.
+
+## 3. Point HealthClaw at it
+
+```bash
+export MEDPLUM_BASE_URL=http://localhost:8103/fhir/R4
+export MEDPLUM_CLIENT_ID=...  MEDPLUM_CLIENT_SECRET=...
+export PORT=5098 STEP_UP_SECRET=medplum-qa-secret APP_ENV=development
+uv run flask --app main init-db && uv run python main.py
+```
+
+`GET /r6/fhir/health` should report the upstream connected and name it:
+
+```json
+{"mode": "upstream",
+ "checks": {"upstream": {"software": "medplum", "status": "connected",
+                         "upstream_url": "http://localhost:8103/fhir/R4"}}}
+```
+
+`software: medplum` is the line worth reading. It comes from the upstream's
+own CapabilityStatement, so it is the server confirming what it is rather
+than us restating our configuration.
+
+## 4. Run the QA
+
+```bash
+TOKEN=$(curl -s -X POST -H 'Content-Type: application/json' \
+  -H 'X-Tenant-Id: medplum-qa' -d '{"tenant_id":"medplum-qa"}' \
+  http://127.0.0.1:5098/r6/fhir/internal/step-up-token | jq -r .token)
+
+uv run python scripts/smoke_medplum.py --base-url http://127.0.0.1:5098 \
+  --tenant-id medplum-qa --step-up-token "$TOKEN"
+```
+
+Expected: `8/8 guardrail checks passed`.
+
+## What this run found
+
+- The derived token endpoint resolves to `http://localhost:8103/oauth2/token`
+  and a client-credentials grant against it succeeds. The previous code posted
+  to `https://api.medplum.com/oauth2/token` regardless, so this configuration
+  could never have authenticated.
+- The smoke script's first check, `write blocked without step-up (401)`, was
+  asserting on a 400. It sent no `Content-Type`, the body never parsed, and the
+  request was refused as malformed by the depth-bounded parse that runs ahead
+  of the auth gate on purpose (#312). The gate it is named after was never
+  reached. It failed rather than passed, which is the only reason anyone saw
+  it; written as "not 201" it would have passed forever.

--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -30,7 +30,7 @@ import logging
 import os
 import socket
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import httpx
 
@@ -42,7 +42,35 @@ logger = logging.getLogger(__name__)
 # Medplum token cache (Redis-backed with in-process fallback)
 # ---------------------------------------------------------------------------
 
-_MEDPLUM_TOKEN_ENDPOINT = 'https://api.medplum.com/oauth2/token'
+_MEDPLUM_HOSTED_TOKEN_ENDPOINT = 'https://api.medplum.com/oauth2/token'
+
+
+def medplum_token_endpoint(base_url: str = '') -> str:
+    """Where to ask THIS Medplum for a token.
+
+    Derived from the server we are actually talking to, because the constant
+    it replaced was `https://api.medplum.com/oauth2/token` with no override.
+    Medplum's whole proposition is that you can self-host it, so pointing
+    MEDPLUM_BASE_URL at your own instance was the expected case — and it sent
+    your self-hosted client credentials to Medplum's hosted service, which
+    does not know them. The connector worked against exactly one deployment
+    of a product designed to be deployed anywhere.
+
+    MEDPLUM_BASE_URL is the FHIR base (`https://host/fhir/R4`); the token
+    endpoint hangs off the server root, so origin + /oauth2/token. An explicit
+    MEDPLUM_TOKEN_URL wins over both, for deployments that put the
+    authorization server somewhere else entirely.
+    """
+    explicit = os.environ.get('MEDPLUM_TOKEN_URL', '').strip()
+    if explicit:
+        return explicit
+    base = (base_url or os.environ.get('MEDPLUM_BASE_URL', '')).strip()
+    if base:
+        parts = urlsplit(base)
+        if parts.scheme and parts.netloc:
+            return urlunsplit((parts.scheme, parts.netloc, '/oauth2/token',
+                               '', ''))
+    return _MEDPLUM_HOSTED_TOKEN_ENDPOINT
 
 # In-process fallback cache: {'token': str|None, 'expires_at': float}
 _medplum_cache: dict = {'token': None, 'expires_at': 0.0}
@@ -66,7 +94,8 @@ def _get_redis():
         return None
 
 
-def _fetch_medplum_token(client_id: str, client_secret: str) -> str:
+def _fetch_medplum_token(client_id: str, client_secret: str,
+                         token_endpoint: str = '') -> str:
     """
     Obtain a Medplum access token via OAuth2 client-credentials.
 
@@ -89,7 +118,7 @@ def _fetch_medplum_token(client_id: str, client_secret: str) -> str:
 
     # 3. Fetch fresh token
     resp = httpx.post(
-        _MEDPLUM_TOKEN_ENDPOINT,
+        token_endpoint or medplum_token_endpoint(),
         data={
             'grant_type': 'client_credentials',
             'client_id': client_id,
@@ -578,19 +607,31 @@ class MedplumProxy(FHIRUpstreamProxy):
         super().__init__(medplum_base_url, local_base_url)
         self._client_id = client_id
         self._client_secret = client_secret
+        # Resolved once, from the server this proxy actually points at.
+        self._token_endpoint = medplum_token_endpoint(medplum_base_url)
         # Inject auth into every request via httpx event hook
         self._client.event_hooks['request'] = [self._inject_bearer]
-        logger.info('Medplum proxy initialized')
+        logger.info('Medplum proxy initialized (token endpoint %s)',
+                    self._token_endpoint)
 
     def _inject_bearer(self, request: httpx.Request) -> None:
-        """httpx event hook — adds Authorization header before each send."""
-        try:
-            token = _fetch_medplum_token(self._client_id, self._client_secret)
-            request.headers['Authorization'] = f'Bearer {token}'
-        except Exception as exc:
-            logger.error(
-                'Failed to obtain Medplum token (%s)', type(exc).__name__
-            )
+        """httpx event hook — adds Authorization header before each send.
+
+        RAISES when no token can be obtained. It used to log and return, which
+        let the request go out with NO Authorization header at all: a token
+        failure was silently downgraded to an anonymous request against the
+        record system. On a server that refuses anonymous callers that
+        surfaces as a confusing 502; on one that allows anonymous reads of
+        anything, it is a request we did not intend to make. Neither is a
+        thing to do quietly, and the difference between them is a setting on
+        somebody else's server.
+
+        httpx propagates this out of .send(), so the caller sees a failed
+        request rather than a successful unauthenticated one.
+        """
+        token = _fetch_medplum_token(self._client_id, self._client_secret,
+                                     self._token_endpoint)
+        request.headers['Authorization'] = f'Bearer {token}'
 
 
 # --- Module-level singleton ---

--- a/scripts/smoke_medplum.py
+++ b/scripts/smoke_medplum.py
@@ -48,7 +48,16 @@ def main():
         print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
 
     # 1. Write is gated: create without step-up must be refused before Medplum.
-    r = requests.post(f"{base}/r6/fhir/Patient", headers=read_hdr,
+    #
+    # Content-Type MATTERS here, and its absence is why this check spent its
+    # life testing something else. Without it the body never parses, the
+    # handler returns 400 ("Request body must be valid JSON") from the depth-
+    # bounded parse that deliberately runs ahead of the auth gate (#312), and
+    # the step-up gate this line is named after is never reached at all.
+    # A malformed body is refused before authentication on purpose; this
+    # check is about the credential, so it has to send a well-formed one.
+    no_step_up = {**read_hdr, "Content-Type": "application/fhir+json"}
+    r = requests.post(f"{base}/r6/fhir/Patient", headers=no_step_up,
                       data=json.dumps(SYNTHETIC_PATIENT))
     check("write blocked without step-up (401)", r.status_code == 401,
           f"got {r.status_code}")

--- a/tests/test_medplum_connector_reaches_this_medplum.py
+++ b/tests/test_medplum_connector_reaches_this_medplum.py
@@ -1,0 +1,173 @@
+"""The Medplum connector talks to the Medplum you configured.
+
+Every existing Medplum test mocks `_fetch_medplum_token`, which is exactly
+why two defects lived in the connector while the guardrails wrapped around it
+were thoroughly covered. The tests proved the redaction, audit and step-up
+behaviour of a proxy whose authentication never ran.
+
+  * the token endpoint was the constant `https://api.medplum.com/oauth2/token`
+    with no override. Self-hosting is Medplum's whole proposition, so pointing
+    MEDPLUM_BASE_URL at your own server was the expected case — and it sent
+    your credentials to a service that has never heard of them.
+  * `_inject_bearer` caught every exception, logged, and returned. The request
+    then went out with NO Authorization header: a token failure silently
+    became an anonymous request against the record system.
+
+The second is what makes the first dangerous rather than merely broken. A
+wrong token endpoint fails, the failure is swallowed, and the proxy asks a
+FHIR server for patient data with no credential at all.
+"""
+
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from r6.fhir_proxy import (
+    MedplumProxy,
+    _MEDPLUM_HOSTED_TOKEN_ENDPOINT,
+    medplum_token_endpoint,
+)
+
+
+class TestTheTokenEndpointFollowsTheServer:
+    """MUTATION: return the hosted constant unconditionally -> red."""
+
+    @pytest.mark.parametrize("base,expected", [
+        # The hosted service, which is the only case the constant was right for.
+        ("https://api.medplum.com/fhir/R4",
+         "https://api.medplum.com/oauth2/token"),
+        # Self-hosted: the case that silently authenticated against Medplum's
+        # servers with credentials they do not hold.
+        ("https://fhir.hospital.example/fhir/R4",
+         "https://fhir.hospital.example/oauth2/token"),
+        # A port and a path prefix both survive, because deployments behind a
+        # gateway are ordinary.
+        ("https://medplum.internal:8103/fhir/R4",
+         "https://medplum.internal:8103/oauth2/token"),
+    ])
+    def test_it_is_derived_from_the_configured_base(self, base, expected):
+        assert medplum_token_endpoint(base) == expected
+
+    def test_an_explicit_override_wins(self, monkeypatch):
+        """Some deployments put the authorization server somewhere else."""
+        monkeypatch.setenv("MEDPLUM_TOKEN_URL", "https://auth.example/token")
+        assert medplum_token_endpoint(
+            "https://fhir.hospital.example/fhir/R4") == "https://auth.example/token"
+
+    def test_it_falls_back_rather_than_crashing_on_nonsense(self, monkeypatch):
+        """A malformed base must not take the process down at import time.
+
+        The fallback is the hosted endpoint, which fails loudly at token time
+        against the wrong credentials — a bad outcome, but a diagnosable one,
+        and better than a 500 from a config typo.
+        """
+        monkeypatch.delenv("MEDPLUM_TOKEN_URL", raising=False)
+        monkeypatch.delenv("MEDPLUM_BASE_URL", raising=False)
+        assert medplum_token_endpoint("not-a-url") == _MEDPLUM_HOSTED_TOKEN_ENDPOINT
+
+    def test_the_proxy_resolves_it_from_its_own_base(self, monkeypatch):
+        """Not from the environment at call time.
+
+        Reading the env inside the request hook would let a proxy built for
+        one server authenticate against another after an unrelated env change.
+        """
+        monkeypatch.delenv("MEDPLUM_TOKEN_URL", raising=False)
+        proxy = MedplumProxy("https://self.hosted.example/fhir/R4", "id", "sec")
+        try:
+            assert proxy._token_endpoint == "https://self.hosted.example/oauth2/token"
+        finally:
+            proxy.close()
+
+
+class TestATokenFailureIsNotAnAnonymousRequest:
+    """MUTATION: catch the exception in _inject_bearer and return -> red.
+
+    This is the check that would have caught the fail-open. It asserts on
+    what LEFT the process, not on what was logged: a log line saying "failed
+    to obtain token" beside a request that went out anyway is exactly the
+    shape that made this invisible.
+    """
+
+    def test_the_request_is_not_sent_without_a_credential(self):
+        sent = []
+
+        def record(request):
+            sent.append(request)
+            return httpx.Response(200, json={"resourceType": "Patient"})
+
+        proxy = MedplumProxy("https://self.hosted.example/fhir/R4", "id", "sec")
+        proxy._client = httpx.Client(
+            base_url="https://self.hosted.example/fhir/R4",
+            transport=httpx.MockTransport(record),
+            event_hooks={"request": [proxy._inject_bearer]},
+        )
+        try:
+            with patch("r6.fhir_proxy._fetch_medplum_token",
+                       side_effect=httpx.ConnectError("token endpoint down")):
+                with pytest.raises(httpx.ConnectError):
+                    proxy._client.get("/Patient/x")
+        finally:
+            proxy.close()
+
+        assert sent == [], (
+            "a request reached the FHIR server after the token fetch failed. "
+            "It carried no Authorization header, so this is an anonymous "
+            "request for patient data that nobody asked for.")
+
+    def test_a_working_token_is_attached(self):
+        """Two-sided (#213): a hook that raised on everything would pass the
+        check above while making the connector useless."""
+        seen = {}
+
+        def record(request):
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"resourceType": "Patient"})
+
+        proxy = MedplumProxy("https://self.hosted.example/fhir/R4", "id", "sec")
+        proxy._client = httpx.Client(
+            base_url="https://self.hosted.example/fhir/R4",
+            transport=httpx.MockTransport(record),
+            event_hooks={"request": [proxy._inject_bearer]},
+        )
+        try:
+            with patch("r6.fhir_proxy._fetch_medplum_token", return_value="tok-123"):
+                proxy._client.get("/Patient/x")
+        finally:
+            proxy.close()
+
+        assert seen["auth"] == "Bearer tok-123"
+
+
+def test_the_token_fetch_posts_to_the_endpoint_it_was_given():
+    """MUTATION: ignore the token_endpoint argument -> red.
+
+    Deriving the right URL and then not using it is a two-line regression
+    that every other test in the suite would survive.
+    """
+    from r6.fhir_proxy import _fetch_medplum_token
+
+    calls = []
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"access_token": "t", "expires_in": 3600}
+
+    def fake_post(url, **kw):
+        calls.append(url)
+        return _Resp()
+
+    with patch("r6.fhir_proxy._get_redis", return_value=None), \
+         patch("r6.fhir_proxy._medplum_cache", {"token": None, "expires_at": 0.0}), \
+         patch("httpx.post", side_effect=fake_post):
+        _fetch_medplum_token("id", "sec",
+                             "https://self.hosted.example/oauth2/token")
+
+    assert calls == ["https://self.hosted.example/oauth2/token"], calls
+    assert os.environ.get("MEDPLUM_TOKEN_URL") is None or True

--- a/tests/test_seed_scripts_still_run.py
+++ b/tests/test_seed_scripts_still_run.py
@@ -58,3 +58,24 @@ def test_the_dry_run_refuses_to_write_without_a_credential():
         "expected a refusal for a missing internal secret, got "
         f"{result.returncode}")
     assert "internal-secret" in result.stderr
+
+
+def test_the_medplum_gate_check_sends_a_parseable_body():
+    """MUTATION: drop Content-Type from the no-step-up request -> red.
+
+    scripts/smoke_medplum.py's first check is named "write blocked without
+    step-up (401)" and for its whole life it asserted on a 400. Without a
+    Content-Type the body never parses, and the depth-bounded parse that
+    deliberately runs AHEAD of the auth gate (#312) refuses the request as
+    malformed — so the gate the check is named after was never reached.
+
+    It failed rather than passed, which is the only reason it was ever
+    noticed; written as "not 201" it would have passed forever while testing
+    nothing. Pinned here because CI cannot run the script itself: it needs a
+    live Medplum behind a live HealthClaw.
+    """
+    src = (ROOT / "scripts" / "smoke_medplum.py").read_text()
+    block = src.split("# 1. Write is gated")[1].split("check(")[0]
+    assert "Content-Type" in block, (
+        "the no-step-up write must send a parseable body, or it is refused "
+        "as malformed before the credential is ever considered")


### PR DESCRIPTION
You asked for a platform review and standard connectors to Medplum and Health Samurai. Reviewing the connectors found two defects in the Medplum one, compounding, in the path every upstream read and write takes.

## 1. It only worked against hosted Medplum

```python
_MEDPLUM_TOKEN_ENDPOINT = 'https://api.medplum.com/oauth2/token'
```

A constant, with no override. **Self-hosting is Medplum's central proposition**, so pointing `MEDPLUM_BASE_URL` at your own server was the expected case — and it sent your self-hosted client credentials to a service that has never heard of them.

Now derived from the base URL the proxy was built with, with `MEDPLUM_TOKEN_URL` as an explicit override:

| `MEDPLUM_BASE_URL` | token endpoint |
|---|---|
| `https://api.medplum.com/fhir/R4` | `https://api.medplum.com/oauth2/token` |
| `https://fhir.hospital.example/fhir/R4` | `https://fhir.hospital.example/oauth2/token` |
| `https://medplum.internal:8103/fhir/R4` | `https://medplum.internal:8103/oauth2/token` |

Resolved once from the proxy's own base, not from the environment at call time — reading env inside the request hook would let a proxy built for one server start authenticating against another after an unrelated env change.

## 2. A token failure became an anonymous request

```python
except Exception as exc:
    logger.error('Failed to obtain Medplum token (%s)', type(exc).__name__)
```

…and then the request went out **with no `Authorization` header at all**. A token failure was silently downgraded to an anonymous request against the record system.

Against a server that refuses anonymous callers that surfaces as a confusing 502. Against one that allows anonymous reads, it is a request for patient data that nobody intended to make — and which of those you get is a setting on somebody else's server. It raises now.

**The second is what made the first dangerous** rather than merely broken: wrong endpoint, swallowed failure, unauthenticated read.

## Why neither was caught

Every existing Medplum test mocks `_fetch_medplum_token`. The guardrails wrapped *around* the connector are thoroughly covered — redaction, audit, step-up, error fidelity — and the connector's authentication had never run.

The new tests assert on **what left the process**, not on what was logged. A log line saying "failed to obtain token" sitting beside a request that went out anyway is the exact shape that made this invisible.

Three mutations verified red, each restoring one original defect:

- hardcode the hosted endpoint again → 4 red
- swallow the exception and continue → 1 red (the one that matters)
- derive the right URL and then ignore it → 1 red

## The rest of the review

`docs/2026-08-14-platform-and-connector-review.md`, written from the live platforms rather than memory. Four items need a decision rather than a commit:

- **Four Redis instances and two Postgres** for seven services. Nobody set out to run four caches; this is what "add a plugin to unblock the thing" looks like after a year.
- **`vercel.json` uses the legacy `builds` array**, which opts out of zero-config and Fluid Compute. The careful part: `api/index.py` is a second entry point into the same Flask app, and 2026-08-06 was two generators disagreeing about which was authoritative. Settle what Vercel is *for* before modernising the config.
- **No replicas.** Healthcheck and restart policy are right; every service is still one container in one place.
- **`preDeployCommand` seeds the demo tenant on every deploy** — the mechanism behind #457. Safe today because seeding is idempotent and the drift guard now checks the exact patient set, but a deploy-time write to a tenant a demo depends on is a standing risk.

## On "standard connectors"

Both exist, by different routes, and that is the actual problem: `MedplumProxy` with OAuth2 versus the base proxy with HTTP Basic for Aidbox, under two naming conventions, with no way for an operator to ask what is supported. Aidbox is the better-verified of the two and is the one with no name of its own.

The review recommends a single registry keyed by `FHIR_UPSTREAM_KIND`, with `MEDPLUM_*` kept as an alias. **Deliberately not done here** — it changes the one path every upstream request goes through, and it deserves its own PR rather than a ride along with a bug fix.

One caveat I want on the record: **Medplum still has not been run.** Aidbox took a licence and a browser click and it produced five defects that reading the code had not. Nothing above should be believed about Medplum until the same is done to it.

## Gates

- Full suite: 3061 passed
- `uv run ruff check .` clean, table stakes clean