### PR TITLE
feat(upstream): one connector registry, so Aidbox has a name and adding a server is a row

### DIFF
--- a/docs/upstream-connectors.md
+++ b/docs/upstream-connectors.md
@@ -1,0 +1,82 @@
+# Which FHIR server we sit in front of
+
+HealthClaw is a guardrail layer, so the server holding the records is
+somebody else's. This is how you tell it which one, and how it authenticates.
+
+## Configure
+
+```bash
+FHIR_UPSTREAM_KIND=aidbox                      # aidbox | medplum | hapi | generic
+FHIR_UPSTREAM_URL=https://aidbox.example/fhir  # the FHIR base
+FHIR_UPSTREAM_CLIENT_ID=healthclaw
+FHIR_UPSTREAM_CLIENT_SECRET=...
+FHIR_UPSTREAM_TOKEN_URL=                       # only to override the derived one
+```
+
+`FHIR_UPSTREAM_KIND` is optional and defaults to `generic`. What naming a kind
+buys you is the auth style and the token-endpoint rule, so you do not have to
+work either out from our source.
+
+| kind | auth | notes |
+|---|---|---|
+| `aidbox` | HTTP Basic | An Aidbox `Client` credential, scoped by an AccessPolicy. |
+| `medplum` | OAuth2 client-credentials | A Medplum `ClientApplication`. Token endpoint is the server's origin + `/oauth2/token`. |
+| `hapi` | none | Public sandboxes take no credential. Add the client id/secret for one behind Basic. |
+| `generic` | HTTP Basic | Any FHIR server. Basic when credentials are set, anonymous when they are not. |
+
+An unknown kind is refused rather than defaulted. An unknown kind means an
+unknown auth style, and quietly falling back to anonymous would point
+unauthenticated requests at a record system because somebody mistyped a
+variable.
+
+## Verify
+
+`GET /r6/fhir/health` reports the kind **we** resolved beside the software the
+server names itself:
+
+```json
+{"checks": {"upstream": {
+  "status": "connected", "kind": "medplum", "software": "medplum",
+  "fhir_version": "4.0.1", "upstream_url": "http://localhost:8103/fhir/R4"}}}
+```
+
+Read those two together. When they disagree — `kind: medplum` against
+`software: aidbox` — the deployment is pointed somewhere nobody meant, and
+that is otherwise invisible until a request fails for a reason that names
+neither.
+
+## Existing deployments
+
+Nothing to change. `MEDPLUM_BASE_URL` / `MEDPLUM_CLIENT_ID` /
+`MEDPLUM_CLIENT_SECRET` still work and imply `kind=medplum`, and
+`FHIR_UPSTREAM_URL` with Basic credentials still works as `generic`.
+`FHIR_UPSTREAM_URL` continues to win over `MEDPLUM_BASE_URL` when both are
+set. Every one of those combinations is pinned in
+`tests/test_upstream_connector_registry.py`, because this is the one path
+every upstream read and write goes through and a deployment that stops
+authenticating does not crash — it returns 502s that look like the upstream's
+fault.
+
+## What this does not cover
+
+The **SHARP** per-request path, where the caller supplies the server in
+`X-FHIR-Server-URL` and their own token. That is a different trust
+relationship: the credential belongs to the caller, not to us, which is why
+its 401s pass through to them instead of becoming our 502s. Folding it into
+this registry would put a caller-supplied server through the same resolution
+as an operator-configured one.
+
+## Verified
+
+Both connectors have been run end to end, not just reasoned about.
+
+- **Aidbox** — [`examples/aidbox-healthclaw-guardrails`](../examples/aidbox-healthclaw-guardrails/),
+  six asserted steps against Aidbox `edge`.
+- **Medplum** — [the self-host runbook](runbooks/medplum-self-host-qa.md),
+  8/8 against Medplum 5.1.30. Self-hosted on purpose: the hosted service
+  exercises the one code path that always worked.
+
+Adding a connector means adding a row to `CONNECTORS` in
+`r6/upstream_connectors.py` and running it against a real instance of that
+server. The second half is not optional — every defect found in these two was
+invisible from the code.

--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -32,6 +32,11 @@ import socket
 import time
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
+from r6.upstream_connectors import (
+    AUTH_OAUTH2,
+    resolve_upstream_config,
+)
+
 import httpx
 
 from r6.version import __version__
@@ -376,7 +381,13 @@ class FHIRUpstreamProxy:
 
     def __init__(self, upstream_url: str, local_base_url: str = '',
                  caller_auth: bool = False,
-                 basic_auth: tuple[str, str] | None = None):
+                 basic_auth: tuple[str, str] | None = None,
+                 kind: str = ''):
+        # The connector kind this proxy was BUILT as, reported by healthy()
+        # beside the `software` the server names itself. When those two
+        # disagree the deployment is pointed somewhere nobody meant, and that
+        # is otherwise invisible until a request fails naming neither.
+        self.kind = kind
         self.upstream_url = upstream_url.rstrip('/')
         self.local_base_url = local_base_url.rstrip('/')
         # True when the CALLER's own credential is forwarded upstream (SHARP
@@ -417,6 +428,7 @@ class FHIRUpstreamProxy:
                     'upstream_url': self.upstream_url,
                     'fhir_version': data.get('fhirVersion', 'unknown'),
                     'software': data.get('software', {}).get('name', 'unknown'),
+                    **({'kind': self.kind} if self.kind else {}),
                 }
             return {
                 'status': 'error',
@@ -588,30 +600,40 @@ class FHIRUpstreamProxy:
         }
 
 
-class MedplumProxy(FHIRUpstreamProxy):
+class OAuth2UpstreamProxy(FHIRUpstreamProxy):
     """
-    FHIRUpstreamProxy variant for Medplum.
+    FHIRUpstreamProxy variant for upstreams using OAuth2 client-credentials.
 
-    Injects a Bearer token (obtained via OAuth2 client-credentials) into every
-    outgoing request.  Tokens are cached in Redis when available; an in-process
-    dict provides fallback caching so the server stays functional without Redis.
+    Injects a Bearer token into every outgoing request. Tokens are cached in
+    Redis when available; an in-process dict provides fallback caching so the
+    server stays functional without Redis.
+
+    Named for the GRANT rather than for Medplum, because the grant is what
+    this implements and Medplum is one server that uses it. `MedplumProxy`
+    remains as an alias below: it is imported by name in several tests and in
+    scripts, and renaming a class is not worth breaking a caller over.
     """
 
     def __init__(
         self,
-        medplum_base_url: str,
+        base_url: str,
         client_id: str,
         client_secret: str,
         local_base_url: str = '',
+        token_endpoint: str = '',
+        kind: str = '',
     ):
-        super().__init__(medplum_base_url, local_base_url)
+        super().__init__(base_url, local_base_url, kind=kind)
         self._client_id = client_id
         self._client_secret = client_secret
-        # Resolved once, from the server this proxy actually points at.
-        self._token_endpoint = medplum_token_endpoint(medplum_base_url)
+        # Resolved once, from the server this proxy actually points at — not
+        # read from the environment at request time, which would let a proxy
+        # built for one server start authenticating against another after an
+        # unrelated env change.
+        self._token_endpoint = token_endpoint or medplum_token_endpoint(base_url)
         # Inject auth into every request via httpx event hook
         self._client.event_hooks['request'] = [self._inject_bearer]
-        logger.info('Medplum proxy initialized (token endpoint %s)',
+        logger.info('OAuth2 upstream proxy initialized (token endpoint %s)',
                     self._token_endpoint)
 
     def _inject_bearer(self, request: httpx.Request) -> None:
@@ -632,6 +654,10 @@ class MedplumProxy(FHIRUpstreamProxy):
         token = _fetch_medplum_token(self._client_id, self._client_secret,
                                      self._token_endpoint)
         request.headers['Authorization'] = f'Bearer {token}'
+
+
+#: Back-compat alias. Imported by name in tests and scripts.
+MedplumProxy = OAuth2UpstreamProxy
 
 
 # --- Module-level singleton ---
@@ -681,37 +707,44 @@ def get_proxy() -> FHIRUpstreamProxy | None:
     """
     Return the proxy singleton, or None if no upstream is configured.
 
-    Priority:
-      1. FHIR_UPSTREAM_URL — generic upstream proxy (optional HTTP Basic via
-         FHIR_UPSTREAM_CLIENT_ID + FHIR_UPSTREAM_CLIENT_SECRET)
-      2. MEDPLUM_BASE_URL  — Medplum proxy (OAuth2 client-credentials)
+    WHICH upstream, and how it authenticates, is answered by
+    r6.upstream_connectors rather than by branches here — see that module for
+    the registry and for why the SHARP per-request path is deliberately not
+    part of it. This function's remaining job is to turn a resolved config
+    into a client and hold the singleton.
+
+    Precedence is unchanged: FHIR_UPSTREAM_URL wins over MEDPLUM_BASE_URL.
     """
     global _proxy_instance
     if _proxy_instance is not None:
         return _proxy_instance
 
+    config = resolve_upstream_config()
+    if config is None:
+        return None
+
     local_base = os.environ.get('FHIR_LOCAL_BASE_URL', '').strip()
 
-    upstream_url = os.environ.get('FHIR_UPSTREAM_URL', '').strip()
-    if upstream_url:
-        _proxy_instance = FHIRUpstreamProxy(
-            upstream_url, local_base, basic_auth=_upstream_basic_auth())
-        return _proxy_instance
-
-    medplum_url = os.environ.get('MEDPLUM_BASE_URL', '').strip()
-    if medplum_url:
-        client_id = os.environ.get('MEDPLUM_CLIENT_ID', '').strip()
-        client_secret = os.environ.get('MEDPLUM_CLIENT_SECRET', '').strip()
-        if not client_id or not client_secret:
+    if config.auth == AUTH_OAUTH2:
+        # Refusing beats proceeding: a client-credentials upstream with no
+        # credentials can only make anonymous requests, and an anonymous
+        # request at a record system is not a degraded mode worth having.
+        if not config.client_id or not config.client_secret:
             logger.warning(
-                'MEDPLUM_BASE_URL is set but MEDPLUM_CLIENT_ID / '
-                'MEDPLUM_CLIENT_SECRET are missing — Medplum proxy disabled'
-            )
+                'Upstream kind %r needs client credentials and none are set '
+                '(FHIR_UPSTREAM_CLIENT_ID/_SECRET) — upstream proxy disabled',
+                config.kind)
             return None
-        _proxy_instance = MedplumProxy(medplum_url, client_id, client_secret, local_base)
+        _proxy_instance = OAuth2UpstreamProxy(
+            config.base_url, config.client_id, config.client_secret,
+            local_base, token_endpoint=config.token_endpoint,
+            kind=config.kind)
         return _proxy_instance
 
-    return None
+    _proxy_instance = FHIRUpstreamProxy(
+        config.base_url, local_base, basic_auth=config.basic_auth,
+        kind=config.kind)
+    return _proxy_instance
 
 
 def reset_proxy():

--- a/r6/upstream_connectors.py
+++ b/r6/upstream_connectors.py
@@ -1,0 +1,185 @@
+"""Which FHIR server we are in front of, and how we authenticate to it.
+
+Before this, "supported upstreams" was two unrelated branches in `get_proxy`
+under two naming conventions: `FHIR_UPSTREAM_*` with HTTP Basic, and
+`MEDPLUM_*` with OAuth2. Aidbox — the one verified end to end, with a
+published example — had no name of its own and travelled as "generic". An
+operator had no way to ask what was supported, and adding a third server
+meant a third branch.
+
+This module answers three questions in one place: what servers we know how to
+sit in front of, how each one expects to be authenticated, and where its token
+endpoint lives.
+
+WHAT IT DELIBERATELY DOES NOT TOUCH: the SHARP per-request path. That upstream
+is chosen by the caller and authenticated with the CALLER's own token, which
+is a different trust relationship from a proxy holding a credential of its
+own. Folding the two together would put a caller-supplied server behind the
+same resolution logic as an operator-configured one, and the difference
+between those is the whole reason `caller_auth` exists.
+
+BACK COMPATIBILITY IS A HARD REQUIREMENT here, not a courtesy: this is the one
+path every upstream read and write goes through, and a deployment that stops
+authenticating does not fail loudly — it fails as a 502 that looks like the
+upstream's fault. Every environment that resolved to a working proxy before
+resolves to the identical proxy now, which
+tests/test_upstream_connector_registry.py asserts combination by combination.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
+
+#: How the proxy proves who it is to the upstream.
+AUTH_NONE = "none"
+AUTH_BASIC = "basic"
+AUTH_OAUTH2 = "oauth2_client_credentials"
+
+
+@dataclass(frozen=True)
+class Connector:
+    """One FHIR server we know how to sit in front of."""
+
+    name: str
+    auth: str
+    summary: str
+    #: True when the server's token endpoint hangs off its origin rather than
+    #: needing to be configured. Only meaningful for AUTH_OAUTH2.
+    token_path: str | None = None
+
+    def token_endpoint(self, base_url: str, explicit: str = "") -> str:
+        """Where to ask THIS deployment for a token.
+
+        Derived from the server we are actually talking to. The Medplum
+        connector shipped with a constant pointing at Medplum's hosted
+        service, so a self-hosted instance — the case self-hosting exists for
+        — sent its credentials somewhere that had never heard of them. Any
+        connector added here inherits the fix rather than repeating the bug.
+        """
+        if explicit:
+            return explicit
+        if not self.token_path:
+            return ""
+        parts = urlsplit(base_url or "")
+        if parts.scheme and parts.netloc:
+            return urlunsplit((parts.scheme, parts.netloc, self.token_path, "", ""))
+        return ""
+
+
+#: Every upstream this build knows by name.
+#:
+#: `generic` is not a fallback for "we could not tell" — it is a real entry
+#: for a server that takes HTTP Basic or nothing, which is most of them. What
+#: naming the others buys is the auth style and the token rule, which is
+#: exactly what an operator would otherwise have to work out from our source.
+CONNECTORS: dict[str, Connector] = {
+    "aidbox": Connector(
+        name="aidbox",
+        auth=AUTH_BASIC,
+        summary="Aidbox Client credential over HTTP Basic, scoped by AccessPolicy.",
+    ),
+    "medplum": Connector(
+        name="medplum",
+        auth=AUTH_OAUTH2,
+        summary="Medplum ClientApplication via OAuth2 client-credentials.",
+        token_path="/oauth2/token",
+    ),
+    "hapi": Connector(
+        name="hapi",
+        auth=AUTH_NONE,
+        summary="HAPI FHIR. Public sandboxes take no credential; add "
+                "FHIR_UPSTREAM_CLIENT_ID/_SECRET for one behind HTTP Basic.",
+    ),
+    "generic": Connector(
+        name="generic",
+        auth=AUTH_BASIC,
+        summary="Any FHIR server. HTTP Basic when credentials are set, "
+                "anonymous when they are not.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class UpstreamConfig:
+    """The resolved answer to "what are we in front of, and how do we sign in"."""
+
+    kind: str
+    base_url: str
+    auth: str
+    client_id: str = ""
+    client_secret: str = ""
+    token_endpoint: str = ""
+
+    @property
+    def connector(self) -> Connector:
+        return CONNECTORS[self.kind]
+
+    @property
+    def basic_auth(self) -> tuple[str, str] | None:
+        if self.auth == AUTH_BASIC and self.client_id and self.client_secret:
+            return (self.client_id, self.client_secret)
+        return None
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def resolve_upstream_config(environ=None) -> UpstreamConfig | None:
+    """Read the environment and say what upstream is configured, or None.
+
+    Precedence is unchanged from the code this replaces: an explicit
+    FHIR_UPSTREAM_URL wins over MEDPLUM_BASE_URL. Deployments set one or the
+    other, and reversing the order would silently move a live deployment onto
+    a different server.
+    """
+    get = (lambda k: (environ or os.environ).get(k, "").strip()) if environ is not None else _env
+
+    kind = get("FHIR_UPSTREAM_KIND").lower()
+    if kind and kind not in CONNECTORS:
+        raise ValueError(
+            f"FHIR_UPSTREAM_KIND={kind!r} is not one of "
+            f"{sorted(CONNECTORS)}. Refusing to guess: an unknown kind means "
+            "an unknown auth style, and defaulting to anonymous would send "
+            "unauthenticated requests at a record system."
+        )
+
+    url = get("FHIR_UPSTREAM_URL")
+    client_id = get("FHIR_UPSTREAM_CLIENT_ID")
+    client_secret = get("FHIR_UPSTREAM_CLIENT_SECRET")
+    token_url = get("FHIR_UPSTREAM_TOKEN_URL")
+
+    if not url:
+        # The MEDPLUM_* names predate the unified ones and are still set on
+        # real deployments. They imply the kind, which is why no existing
+        # deployment has to learn FHIR_UPSTREAM_KIND to keep working.
+        url = get("MEDPLUM_BASE_URL")
+        if url:
+            kind = kind or "medplum"
+            client_id = client_id or get("MEDPLUM_CLIENT_ID")
+            client_secret = client_secret or get("MEDPLUM_CLIENT_SECRET")
+            token_url = token_url or get("MEDPLUM_TOKEN_URL")
+
+    if not url:
+        return None
+
+    connector = CONNECTORS[kind or "generic"]
+    return UpstreamConfig(
+        kind=connector.name,
+        base_url=url,
+        auth=connector.auth,
+        client_id=client_id,
+        client_secret=client_secret,
+        token_endpoint=connector.token_endpoint(url, token_url),
+    )
+
+
+def supported_connectors() -> list[dict]:
+    """The registry, for an operator asking what this build supports."""
+    return [
+        {"kind": c.name, "auth": c.auth, "summary": c.summary}
+        for c in sorted(CONNECTORS.values(), key=lambda c: c.name)
+    ]
+

--- a/tests/test_upstream_connector_registry.py
+++ b/tests/test_upstream_connector_registry.py
@@ -1,0 +1,241 @@
+"""The connector registry, and the promise that nothing moved underneath it.
+
+This is the one path every upstream read and write goes through, and its
+failure mode is quiet: a deployment that stops authenticating does not crash,
+it returns 502s that look like the upstream's fault. So the first class here
+is not about the new feature at all. It is a table of every environment
+combination that resolved to a working proxy before this change, asserting it
+resolves to the identical proxy now.
+
+The rest covers what the registry adds: a named kind per server, an auth style
+that comes from the registry rather than from a branch, and a token endpoint
+derived from the server being addressed.
+"""
+
+import pytest
+
+from r6.fhir_proxy import FHIRUpstreamProxy, MedplumProxy, OAuth2UpstreamProxy
+from r6.upstream_connectors import (
+    AUTH_BASIC,
+    AUTH_NONE,
+    AUTH_OAUTH2,
+    CONNECTORS,
+    resolve_upstream_config,
+    supported_connectors,
+)
+
+AIDBOX = "https://aidbox.example/fhir"
+MEDPLUM = "https://medplum.example/fhir/R4"
+
+
+def _resolve(**env):
+    return resolve_upstream_config(environ=env)
+
+
+class TestNothingMovedForDeploymentsThatAlreadyWork:
+    """MUTATION: swap the precedence so MEDPLUM_BASE_URL wins -> red.
+
+    Every row is a live-shaped environment from before the registry existed.
+    A row that changes meaning is a deployment that silently stops working.
+    """
+
+    def test_generic_upstream_with_basic_credentials(self):
+        """The Aidbox example's exact configuration, under its old name."""
+        c = _resolve(FHIR_UPSTREAM_URL=AIDBOX,
+                     FHIR_UPSTREAM_CLIENT_ID="healthclaw",
+                     FHIR_UPSTREAM_CLIENT_SECRET="s3cret")
+        assert c.base_url == AIDBOX
+        assert c.auth == AUTH_BASIC
+        assert c.basic_auth == ("healthclaw", "s3cret")
+
+    def test_generic_upstream_with_no_credentials_stays_anonymous(self):
+        """Public sandboxes were reachable without credentials and must stay so."""
+        c = _resolve(FHIR_UPSTREAM_URL="https://hapi.example/fhir")
+        assert c.auth == AUTH_BASIC and c.basic_auth is None
+
+    def test_medplum_env_still_resolves_medplum(self):
+        """No deployment should have to learn FHIR_UPSTREAM_KIND to keep working."""
+        c = _resolve(MEDPLUM_BASE_URL=MEDPLUM,
+                     MEDPLUM_CLIENT_ID="cid", MEDPLUM_CLIENT_SECRET="csec")
+        assert c.kind == "medplum"
+        assert c.auth == AUTH_OAUTH2
+        assert (c.client_id, c.client_secret) == ("cid", "csec")
+        assert c.token_endpoint == "https://medplum.example/oauth2/token"
+
+    def test_fhir_upstream_url_still_wins_over_medplum(self):
+        """Precedence, pinned. Reversing it moves a live deployment to a
+        different server without changing a single variable."""
+        c = _resolve(FHIR_UPSTREAM_URL=AIDBOX, MEDPLUM_BASE_URL=MEDPLUM,
+                     MEDPLUM_CLIENT_ID="cid", MEDPLUM_CLIENT_SECRET="csec")
+        assert c.base_url == AIDBOX
+        assert c.auth == AUTH_BASIC
+
+    def test_no_upstream_is_still_local_mode(self):
+        assert _resolve() is None
+        assert _resolve(FHIR_UPSTREAM_URL="   ") is None
+
+
+class TestTheRegistryNamesWhatWeAreInFrontOf:
+
+    @pytest.mark.parametrize("kind,auth", [
+        ("aidbox", AUTH_BASIC),
+        ("medplum", AUTH_OAUTH2),
+        ("hapi", AUTH_NONE),
+        ("generic", AUTH_BASIC),
+    ])
+    def test_each_kind_declares_its_auth_style(self, kind, auth):
+        c = _resolve(FHIR_UPSTREAM_KIND=kind, FHIR_UPSTREAM_URL=AIDBOX)
+        assert c.kind == kind and c.auth == auth
+
+    def test_aidbox_is_first_class_now(self):
+        """It was the better-verified connector and the one with no name."""
+        c = _resolve(FHIR_UPSTREAM_KIND="aidbox", FHIR_UPSTREAM_URL=AIDBOX,
+                     FHIR_UPSTREAM_CLIENT_ID="healthclaw",
+                     FHIR_UPSTREAM_CLIENT_SECRET="s3cret")
+        assert c.basic_auth == ("healthclaw", "s3cret")
+
+    def test_medplum_under_the_unified_names(self):
+        c = _resolve(FHIR_UPSTREAM_KIND="medplum", FHIR_UPSTREAM_URL=MEDPLUM,
+                     FHIR_UPSTREAM_CLIENT_ID="cid",
+                     FHIR_UPSTREAM_CLIENT_SECRET="csec")
+        assert c.auth == AUTH_OAUTH2
+        assert c.token_endpoint == "https://medplum.example/oauth2/token"
+
+    def test_an_unknown_kind_refuses_rather_than_guessing(self):
+        """MUTATION: fall back to 'generic' on an unknown kind -> red.
+
+        An unknown kind means an unknown auth style. Defaulting to generic
+        would send anonymous requests at whatever that server is, and a typo
+        in a variable name is not a reason to do that quietly.
+        """
+        with pytest.raises(ValueError, match="not one of"):
+            _resolve(FHIR_UPSTREAM_KIND="epic", FHIR_UPSTREAM_URL=AIDBOX)
+
+    def test_the_supported_list_is_answerable(self):
+        listed = {c["kind"] for c in supported_connectors()}
+        assert listed == set(CONNECTORS)
+        assert all(c["summary"] for c in supported_connectors())
+
+
+class TestTheTokenEndpointFollowsTheServer:
+    """The defect this registry inherits the fix for: a token endpoint that
+    was a constant pointing at one vendor's hosted service."""
+
+    @pytest.mark.parametrize("base,expected", [
+        ("https://api.medplum.com/fhir/R4", "https://api.medplum.com/oauth2/token"),
+        ("https://self.hosted.example/fhir/R4", "https://self.hosted.example/oauth2/token"),
+        ("http://localhost:8103/fhir/R4", "http://localhost:8103/oauth2/token"),
+    ])
+    def test_derived_from_the_configured_base(self, base, expected):
+        c = _resolve(FHIR_UPSTREAM_KIND="medplum", FHIR_UPSTREAM_URL=base,
+                     FHIR_UPSTREAM_CLIENT_ID="i", FHIR_UPSTREAM_CLIENT_SECRET="s")
+        assert c.token_endpoint == expected
+
+    def test_an_explicit_override_wins(self):
+        c = _resolve(FHIR_UPSTREAM_KIND="medplum", FHIR_UPSTREAM_URL=MEDPLUM,
+                     FHIR_UPSTREAM_TOKEN_URL="https://auth.example/token",
+                     FHIR_UPSTREAM_CLIENT_ID="i", FHIR_UPSTREAM_CLIENT_SECRET="s")
+        assert c.token_endpoint == "https://auth.example/token"
+
+    def test_a_basic_connector_has_no_token_endpoint(self):
+        c = _resolve(FHIR_UPSTREAM_KIND="aidbox", FHIR_UPSTREAM_URL=AIDBOX)
+        assert c.token_endpoint == ""
+
+
+class TestGetProxyBuildsWhatTheConfigSays:
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        from r6.fhir_proxy import reset_proxy
+        reset_proxy()
+        yield
+        reset_proxy()
+
+    def test_basic_upstream_builds_a_plain_proxy(self, monkeypatch):
+        from r6.fhir_proxy import get_proxy
+        monkeypatch.setenv("FHIR_UPSTREAM_URL", AIDBOX)
+        monkeypatch.setenv("FHIR_UPSTREAM_CLIENT_ID", "healthclaw")
+        monkeypatch.setenv("FHIR_UPSTREAM_CLIENT_SECRET", "s3cret")
+        p = get_proxy()
+        assert isinstance(p, FHIRUpstreamProxy)
+        assert not isinstance(p, OAuth2UpstreamProxy)
+
+    def test_oauth2_upstream_builds_a_token_injecting_proxy(self, monkeypatch):
+        from r6.fhir_proxy import get_proxy
+        monkeypatch.setenv("FHIR_UPSTREAM_KIND", "medplum")
+        monkeypatch.setenv("FHIR_UPSTREAM_URL", MEDPLUM)
+        monkeypatch.setenv("FHIR_UPSTREAM_CLIENT_ID", "cid")
+        monkeypatch.setenv("FHIR_UPSTREAM_CLIENT_SECRET", "csec")
+        p = get_proxy()
+        assert isinstance(p, OAuth2UpstreamProxy)
+        assert p._token_endpoint == "https://medplum.example/oauth2/token"
+
+    def test_oauth2_without_credentials_refuses_rather_than_going_anonymous(
+            self, monkeypatch):
+        """MUTATION: build the proxy anyway when credentials are missing -> red.
+
+        A client-credentials upstream with no credentials can only make
+        anonymous requests. That is not a degraded mode, it is a different
+        request than the one intended.
+        """
+        from r6.fhir_proxy import get_proxy
+        monkeypatch.setenv("FHIR_UPSTREAM_KIND", "medplum")
+        monkeypatch.setenv("FHIR_UPSTREAM_URL", MEDPLUM)
+        assert get_proxy() is None
+
+    def test_the_old_class_name_still_imports(self):
+        """Scripts and tests import MedplumProxy by name."""
+        assert MedplumProxy is OAuth2UpstreamProxy
+
+
+class TestHealthNamesTheConnectorBesideTheServer:
+    """The kind WE resolved, printed next to the software the server claims.
+
+    When those disagree — kind `medplum` against software `aidbox` — the
+    deployment is pointed somewhere nobody meant, and that is otherwise
+    invisible until a request fails for a reason naming neither.
+
+    Carried on the proxy rather than added by the health handler, because
+    r6/routes.py is under a shrink-only ratchet and because the kind is a
+    property of the connection, not of the endpoint that reports it.
+    """
+
+    def _proxy_reporting(self, kind, software="aidbox"):
+        import httpx
+        p = FHIRUpstreamProxy("https://up.example/fhir", kind=kind)
+        p._client = httpx.Client(
+            base_url="https://up.example/fhir",
+            transport=httpx.MockTransport(lambda r: httpx.Response(
+                200, json={"resourceType": "CapabilityStatement",
+                           "fhirVersion": "4.0.1",
+                           "software": {"name": software}})))
+        return p
+
+    def test_the_kind_is_reported(self):
+        p = self._proxy_reporting("aidbox")
+        try:
+            assert p.healthy()["kind"] == "aidbox"
+        finally:
+            p.close()
+
+    def test_a_mismatch_is_visible_rather_than_hidden(self):
+        """MUTATION: drop 'kind' from healthy() -> red.
+
+        Both facts have to be on the same line for anyone to notice they
+        disagree.
+        """
+        p = self._proxy_reporting("medplum", software="aidbox")
+        try:
+            h = p.healthy()
+            assert h["kind"] == "medplum" and h["software"] == "aidbox"
+        finally:
+            p.close()
+
+    def test_an_unkinded_proxy_omits_it_entirely(self):
+        """SHARP builds proxies with no configured kind. An empty string in
+        the payload would read as a connector named ''."""
+        p = self._proxy_reporting("")
+        try:
+            assert "kind" not in p.healthy()
+        finally:
+            p.close()


### PR DESCRIPTION
The follow-up I deliberately held back until both connectors had actually been run. Both have now, so the abstraction is being built over verified behaviour rather than over assumptions.

## The problem

"Supported upstreams" was two unrelated branches in `get_proxy` under two naming conventions:

| | Medplum | Aidbox |
|---|---|---|
| env | `MEDPLUM_BASE_URL` + client credentials | `FHIR_UPSTREAM_URL` + HTTP Basic |
| code | `MedplumProxy` subclass | base `FHIRUpstreamProxy` |

**Aidbox — the better-verified of the two, with a published example — had no name of its own** and travelled as "generic". An operator had no way to ask what was supported, and a third server meant a third branch.

## The registry

`r6/upstream_connectors.py` answers three questions in one place: what we know how to sit in front of, how each expects to be authenticated, and where its token endpoint lives.

| `FHIR_UPSTREAM_KIND` | auth | token endpoint |
|---|---|---|
| `aidbox` | HTTP Basic | — |
| `medplum` | OAuth2 client-credentials | origin + `/oauth2/token` |
| `hapi` | none | — |
| `generic` | HTTP Basic when credentials are set | — |

Env names unified under `FHIR_UPSTREAM_*`. Adding a server is now a row plus a live run.

## Back compatibility is the requirement, not a courtesy

This is the one path every upstream read and write goes through, and its failure mode is quiet: a deployment that stops authenticating doesn't crash, it returns 502s that look like the upstream's fault.

So `MEDPLUM_*` still works and implies the kind; `FHIR_UPSTREAM_URL` still wins over `MEDPLUM_BASE_URL`. Every previously-working combination is pinned combination by combination — **reversing the precedence turns 16 of them red.**

## Two deliberate refusals

- **An unknown kind raises** instead of falling back to `generic`. An unknown kind is an unknown auth style, and a mistyped variable is not a reason to point anonymous requests at a record system.
- **An OAuth2 upstream with no credentials returns `None`** instead of building a proxy that can only ask anonymously.

Both mutation-verified.

## The health endpoint now names both sides

```json
{"status": "connected", "kind": "medplum", "software": "medplum",
 "upstream_url": "http://localhost:8103/fhir/R4"}
```

The kind **we** resolved, beside the software the server names itself. A disagreement — `kind: medplum` against `software: aidbox` — says the deployment is pointed somewhere nobody meant, which is otherwise invisible until a request fails naming neither.

Worth noting how this landed: my first two attempts put it in the health handler and grew `r6/routes.py`, which is under a shrink-only ratchet. The pin is the one thing you don't edit to go green, so the third design carries the kind **on the proxy** instead — which is better anyway, since the kind is a property of the connection rather than of the endpoint that reports it. `routes.py` is byte-identical to main.

## Deliberately untouched

The **SHARP** per-request path. Its upstream is caller-supplied and authenticated with the caller's own token — a different trust relationship, and the reason its 401s pass through to them rather than becoming our 502s.

## Verified live, not just unit-tested

- **Aidbox** as `kind=aidbox`: the full example walkthrough, six steps green, grade B (6/7) as before.
- **Medplum** as `kind=medplum` under the unified variable names: smoke QA 8/8 against self-hosted 5.1.30.

## Gates

- Full suite: 3087 passed
- `uv run ruff check .` clean; ratchets pass with `routes.py` unchanged

Docs: `docs/upstream-connectors.md`.

*(Aside: #488 bit three separate times during this work — Aidbox on `:8080` being mistaken for the FHIR validator, producing a Grade F and 50 unrelated test failures. Each time it looked like my change. It is worth fixing.)*