### PR TITLE
fix(validator): a FHIR validator is configured, not found on port 8080

### DIFF
--- a/examples/aidbox-healthclaw-guardrails/README.md
+++ b/examples/aidbox-healthclaw-guardrails/README.md
@@ -93,14 +93,13 @@ Two more things that will bite you:
   variables this example depends on, and the wiring below was configured
   correctly and did nothing. A pin turns that into a pull failure instead.
 
-One more, if you also develop HealthClaw itself: **running this example makes
-120 of HealthClaw's own tests fail.** `FHIR_VALIDATOR_URL` defaults to
-`http://localhost:8080`, and the availability probe treats anything answering
-`/health` as a FHIR validator — which Aidbox, on that port, is not. The
-failures present as `assert 422 == 201` on ordinary writes and point nowhere
-near the cause. `docker compose stop aidbox` before running the suite, or set
-`FHIR_VALIDATOR_URL` to something unreachable. Tracked as
-[#488](https://github.com/aks129/HealthClawGuardrails/issues/488).
+Previously, running this example broke HealthClaw's own test suite: about 120
+tests failed with `assert 422 == 201` on ordinary writes, because
+`FHIR_VALIDATOR_URL` defaulted to `http://localhost:8080` and anything
+answering `/health` there was treated as a FHIR validator — which Aidbox, on
+that port, is not. That default is gone
+([#488](https://github.com/aks129/HealthClawGuardrails/issues/488)), and the
+suite now passes with this example running. No need to stop Aidbox first.
 
 From a HealthClaw checkout you can build the two images instead of pulling
 them:

--- a/r6/validator.py
+++ b/r6/validator.py
@@ -13,8 +13,30 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-# Validator service URL (HL7 validator-wrapper)
-VALIDATOR_URL = os.environ.get('FHIR_VALIDATOR_URL', 'http://localhost:8080')
+
+class ValidatorUnavailable(RuntimeError):
+    """The external validator did not answer as a validator.
+
+    Distinct from a resource being invalid, and handled the same way as
+    an unreachable one: fall back to structural validation.
+    """
+
+# Validator service URL (HL7 validator-wrapper). NO DEFAULT, on purpose.
+#
+# This used to default to http://localhost:8080, which asserts that a FHIR
+# validator is listening on one of the most contended ports on a developer's
+# machine. Anything answering /health there was treated as a validator: the
+# Aidbox example in this repo binds exactly that port, and running it turned
+# every write in the suite into a 422 reading "Validator returned HTTP 404".
+#
+# That cost an hour three separate times in one day, and each time it looked
+# like the change under test. Twice it was nearly diagnosed as a guardrail
+# regression; once a correct fix was nearly reverted because of it. Issue #488.
+#
+# Unset now means "no external validator", which is the honest reading of an
+# unset variable and leaves structural validation doing the work it already
+# did. A deployment that wants the validator-wrapper says so.
+VALIDATOR_URL = os.environ.get('FHIR_VALIDATOR_URL', '').strip()
 
 # Supported FHIR resource types (R4 stable + R6 experimental ballot3)
 R6_RESOURCE_TYPES = [
@@ -171,6 +193,13 @@ class R6Validator:
                 and (now - self._last_availability_check) < _AVAILABILITY_TTL):
             return self._validator_available
 
+        # No URL configured is not a failure to reach one — it is a
+        # deployment that has not asked for an external validator.
+        if not self.validator_url:
+            self._validator_available = False
+            self._last_availability_check = now
+            return False
+
         try:
             resp = requests.get(f'{self.validator_url}/health', timeout=2)
             self._validator_available = resp.status_code < 400
@@ -203,18 +232,22 @@ class R6Validator:
                 'operation_outcome': outcome
             }
 
-        # Non-200 response from validator
-        return {
-            'valid': False,
-            'operation_outcome': {
-                'resourceType': 'OperationOutcome',
-                'issue': [{
-                    'severity': 'error',
-                    'code': 'exception',
-                    'diagnostics': f'Validator returned HTTP {resp.status_code}'
-                }]
-            }
-        }
+        # A non-200 is the VALIDATOR failing, not the resource being invalid.
+        # A real validator-wrapper answers 200 and puts the problems in an
+        # OperationOutcome; anything else means we asked something that does
+        # not validate, or one that is broken. Rejecting the caller's resource
+        # on that basis rejects valid data and blames it on validation, which
+        # is what a 404 from a mis-identified service did to every write in
+        # this repo's own suite (#488).
+        #
+        # So it raises, and validate_resource's existing handler marks the
+        # validator unavailable and falls back to structural validation —
+        # exactly what it already does when the request throws. Consistency
+        # with that path is the point: "the validator is unreachable" and
+        # "the validator answered something that is not a validation" are the
+        # same situation from the caller's side.
+        raise ValidatorUnavailable(
+            f'Validator returned HTTP {resp.status_code} from {url}')
 
     def _validate_structural(self, resource):
         """

--- a/tests/test_validator_is_not_whatever_answers_8080.py
+++ b/tests/test_validator_is_not_whatever_answers_8080.py
@@ -1,0 +1,146 @@
+"""A FHIR validator is a thing you configure, not a thing you find on 8080.
+
+`FHIR_VALIDATOR_URL` defaulted to `http://localhost:8080`, and availability
+was "GET /health answered under 400". Anything listening there was therefore
+a validator — including the Aidbox instance this repo's own example starts on
+exactly that port. Running the example turned every write in the suite into a
+422 reading "Validator returned HTTP 404", because Aidbox has no /validate.
+
+It cost an hour three separate times in one day. Each time it presented as
+the change under test: twice as a guardrail regression, once nearly causing a
+correct fix to be reverted. Issue #488.
+
+Two things were wrong, and both are needed:
+
+  the DEFAULT   asserted a validator exists at a very contended local port
+  the FAILURE   treated a non-200 from that service as "your resource is
+                invalid" rather than "this is not a validator"
+
+The second is what turned a misconfiguration into a rejection of valid data,
+with a diagnostic naming the wrong party.
+"""
+
+import pytest
+import requests
+
+from r6.validator import R6Validator, ValidatorUnavailable
+
+VALID = {
+    "resourceType": "Observation",
+    "status": "final",
+    "code": {"coding": [{"system": "http://loinc.org", "code": "2823-3"}]},
+    "subject": {"reference": "Patient/x"},
+}
+
+
+class TestAnUnsetUrlMeansNoExternalValidator:
+    """MUTATION: restore the http://localhost:8080 default -> red."""
+
+    def test_the_module_default_is_empty(self):
+        from r6 import validator as mod
+        assert mod.VALIDATOR_URL == "" or mod.VALIDATOR_URL, (
+            "VALIDATOR_URL should come from the environment")
+        # The important half: no hardcoded localhost anywhere in the module.
+        src = (__import__("pathlib").Path(mod.__file__)).read_text()
+        assert "'http://localhost:8080'" not in src, (
+            "a default validator URL is an assertion that a validator is "
+            "listening there, and on 8080 that is usually something else")
+
+    def test_no_url_means_unavailable_without_a_network_call(self, monkeypatch):
+        def explode(*a, **kw):
+            raise AssertionError("probed the network with no URL configured")
+        monkeypatch.setattr(requests, "get", explode)
+        assert R6Validator(validator_url="")._is_validator_available() is False
+
+    def test_validation_still_happens_structurally(self):
+        """Unset must not mean unvalidated."""
+        v = R6Validator(validator_url="")
+        assert v.validate_resource(VALID)["valid"] is True
+        bad = v.validate_resource({"resourceType": "Observation"})
+        assert bad["valid"] is False, (
+            "structural validation must still reject a resource missing "
+            "required elements")
+
+
+class TestSomethingThatIsNotAValidatorDoesNotRejectValidData:
+
+    def _validator_where(self, health_status, validate_status, monkeypatch):
+        v = R6Validator(validator_url="http://localhost:8080")
+
+        class _R:
+            def __init__(self, code):
+                self.status_code = code
+
+            def json(self):
+                return {}
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: _R(health_status))
+        monkeypatch.setattr(requests, "post", lambda *a, **kw: _R(validate_status))
+        return v
+
+    def test_a_404_on_validate_falls_back_instead_of_failing_the_write(
+            self, monkeypatch):
+        """MUTATION: return {'valid': False} on a non-200 -> red.
+
+        This is the exact shape of Aidbox on 8080: healthy, and with no
+        /validate. Every write in the suite 422'd on it.
+        """
+        v = self._validator_where(200, 404, monkeypatch)
+        result = v.validate_resource(VALID)
+        assert result["valid"] is True, (
+            "a service that is not a validator made a valid resource "
+            "invalid, and the diagnostic blamed the resource")
+
+    def test_the_non_200_is_raised_as_unavailability_not_invalidity(
+            self, monkeypatch):
+        v = self._validator_where(200, 503, monkeypatch)
+        with pytest.raises(ValidatorUnavailable):
+            v._validate_external(VALID)
+
+    def test_the_validator_is_marked_unavailable_so_it_is_rechecked(
+            self, monkeypatch):
+        v = self._validator_where(200, 404, monkeypatch)
+        v.validate_resource(VALID)
+        assert v._validator_available is None, (
+            "a failed external validation should invalidate the availability "
+            "cache, so recovery is picked up rather than waiting out a TTL")
+
+
+class TestARealValidatorStillRejectsInvalidResources:
+    """Two-sided (#213). A fix that made every resource valid would satisfy
+    everything above while removing profile validation entirely."""
+
+    def test_errors_in_a_200_outcome_still_fail(self, monkeypatch):
+        v = R6Validator(validator_url="http://validator.example")
+
+        class _Health:
+            status_code = 200
+
+        class _Outcome:
+            status_code = 200
+
+            def json(self):
+                return {"resourceType": "OperationOutcome",
+                        "issue": [{"severity": "error",
+                                   "code": "structure",
+                                   "diagnostics": "nope"}]}
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: _Health())
+        monkeypatch.setattr(requests, "post", lambda *a, **kw: _Outcome())
+        result = v.validate_resource(VALID)
+        assert result["valid"] is False, (
+            "a real validator reporting errors must still reject — otherwise "
+            "this change quietly turned validation off")
+
+    def test_a_clean_200_outcome_passes(self, monkeypatch):
+        v = R6Validator(validator_url="http://validator.example")
+
+        class _R:
+            status_code = 200
+
+            def json(self):
+                return {"resourceType": "OperationOutcome", "issue": []}
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: _R())
+        monkeypatch.setattr(requests, "post", lambda *a, **kw: _R())
+        assert v.validate_resource(VALID)["valid"] is True


### PR DESCRIPTION
Closes #488.

This cost an hour three separate times **in a single day**, and each time it presented as the change under test. Twice it was nearly diagnosed as a guardrail regression; once it nearly caused a correct fix to be reverted. That is the argument for fixing it rather than documenting it again.

## Two defects, and the second is what made the first expensive

**1. The default asserted a validator exists on 8080.**

```python
VALIDATOR_URL = os.environ.get('FHIR_VALIDATOR_URL', 'http://localhost:8080')
```

Availability was "GET `/health` answered under 400", so *anything* listening there qualified. This repo's own Aidbox example binds exactly that port. Running the example made ~120 tests fail.

The default is gone. Unset now means "no external validator" — the honest reading of an unset variable — and structural validation keeps doing the work it already did.

**2. A non-200 from that service meant "your resource is invalid".**

```python
# Non-200 response from validator
return {'valid': False, ... 'diagnostics': f'Validator returned HTTP {resp.status_code}'}
```

A real validator-wrapper answers **200** and puts problems in an OperationOutcome. Anything else means we asked something that does not validate. So a 404 from Aidbox rejected perfectly valid data and blamed it on validation — the failure named the wrong party, which is why it read as a guardrail regression every time.

It now raises `ValidatorUnavailable`, which `validate_resource`'s existing handler already treats as a fallback to structural validation — the same path an unreachable validator takes. "Unreachable" and "answered something that is not a validation" are the same situation from the caller's side, and they should never have had different outcomes.

## Not a way to turn validation off

Two-sided (#213): a real validator reporting errors in a 200 outcome **still rejects**. Without that test, this change would satisfy everything else here by quietly disabling profile validation.

Both halves mutation-verified:

- restore the `localhost:8080` default → 1 red
- restore non-200-means-invalid → 3 red

## Proven under the hostile condition, not argued

Full suite run **with Aidbox bound to 8080** — the exact configuration that has broken it three times:

```
3095 passed, 13 skipped, 1 xfailed
```

Previously the same condition produced ~120 failures with `assert 422 == 201` on ordinary writes.

## Docs

`examples/aidbox-healthclaw-guardrails/README.md` told readers to `docker compose stop aidbox` before running the suite. It now records that the collision is fixed and no longer needs working around.