### PR TITLE
feat(kernel): four step-up sites are predicates, not gates — has_grant is the half that fits

### DIFF
--- a/docs/2026-08-03-access-kernel-spec.md
+++ b/docs/2026-08-03-access-kernel-spec.md
@@ -251,6 +251,98 @@ def register_error_handlers(app) -> None:
     """
 ```
 
+### 1.2b `has_grant` — the same decision, returned instead of raised
+
+**Added 2026-08-16, after reading all twelve remaining step-up call sites.**
+The original spec assumed every one of them was a gate that could become a
+`require_grant`. Four are not gates at all, and no amount of migration makes
+them into one:
+
+| Site | What it is | Why `require_grant` cannot go there |
+|---|---|---|
+| `r6/rate_limit.py:161` | picks a bucket key | wrapped in a `try/except` that must **never fail a request**; a raising gate here throttles or 500s on an auth question nobody asked |
+| `r6/read_auth.py:77` | one branch of a predicate | also accepts a session cookie and an OAuth bearer; the step-up branch is not allowed to decide the request |
+| `r6/agent_runs/routes.py:63` | the same shape, returning `bool` | caller composes it with two shared-secret checks |
+| `r6/command_center/routes.py:271` | session **or** token | refuses with `{"error": ...}`, not an OperationOutcome |
+
+The kernel offered only `require_grant`, which raises. So these four kept
+calling `validate_step_up_token` and destructuring its tuple — the exact idiom
+this module exists to delete — and the step-up ratchet could not reach zero by
+migration alone. `has_grant` is the missing half of the kernel, not a
+relaxation of it.
+
+```python
+def has_grant(
+    *,
+    scope: Scope,
+    tenant: Tenant,
+    audience: str | None = None,
+    operation: str | None = None,
+    also_bearer: bool = False,
+    also_body_field: str | None = None,
+) -> Grant | None:
+    """Ask whether this request holds a step-up grant. Answer, do not refuse.
+
+    THE ONE PROPERTY: identical to require_grant's, with the refusal returned
+    instead of raised — `has_grant(...) is None` is true in exactly the cases
+    `require_grant(...)` would raise StepUpDenied.
+    """
+```
+
+Four deliberate differences from `require_grant`, each one a design decision
+rather than an omission:
+
+- **Returns `Grant | None`, not `bool`.** The Grant carries the tenant it was
+  proved for, so a caller scopes its next query to `grant.tenant_id` rather
+  than re-reading the header it just checked. `None` is unambiguously falsy in
+  a way the 2-tuple never was.
+- **No `consume_nonce`.** Asking is not spending. A predicate that burned a
+  single-use token as a side effect of being consulted is the retro's defect
+  shape exactly — a control that looks like one thing and quietly does two.
+  The rate limiter consults this on every request; if it could consume, it
+  would eat the caller's token before the handler that needed it ever ran. A
+  caller that must consume wants `require_grant`.
+- **No status parameters.** This function makes no HTTP decision. That is the
+  entire reason it is not `require_grant`, and giving it `absent_status` would
+  blur the two back together.
+- **It does not catch the validator's exceptions.** A validator that cannot
+  reach its nonce store has decided *nothing*; answering "no grant" would file
+  an infrastructure outage as an authorization result, indistinguishable at
+  every call site from a caller with a bad token. `r6/rate_limit.py` catches
+  it itself, at the site that has a reason to, where a reviewer can see the
+  catch. This also keeps `r6/read_auth.py`'s current 500 a 500, so adopting it
+  there is not a behaviour change.
+
+Both entry points route through one private `_evaluate`, which is the only
+place in the repository that calls the validator or constructs a `Grant`. Two
+functions answering the same question differently would be worse than the
+tuple; `test_a_grant_is_constructed_in_exactly_one_place` holds that
+structurally, and the parametrized equivalence tests hold it behaviorally from
+both sides — every refusal, and every grant.
+
+#### The hazard it introduces, named
+
+`has_grant` where `require_grant` was meant **does not refuse**. It returns
+`None`, the handler falls through into the write, and the broad-except guard
+in §4.1 cannot see it because nothing was raised to swallow. It reads like a
+guard and is not one — which is the defect shape this project keeps finding.
+
+Two tests hold that line, and both must survive any future edit here:
+
+1. **The answer may never be discarded.** A bare `has_grant(...)` expression
+   statement gates nothing at all. Safe with `require_grant` (the refusal *is*
+   the raise); the whole bypass here. Detected by AST, and the detector is
+   proven against a synthetic file before the real scan is trusted.
+2. **Every production call site is an allowlist entry**
+   (`_HAS_GRANT_CALLSITES`), added by the PR that adopts it. It ships empty:
+   this slice is the pure addition, adopted by nothing, exactly as the kernel
+   itself landed.
+
+`has_grant` is deliberately **not** in `_GUARD_CALLS` (§4.1). That list is
+"names whose refusal must never be swallowed", and this one has no refusal to
+swallow; adding it would fail `r6/rate_limit.py`'s adoption, where the catch
+is correct.
+
 ### 1.3 Audit
 
 ```python
@@ -521,6 +613,41 @@ also turn a boolean helper into an exception, which changes control flow.
 They need a characterization test first. Their current pin is
 `test_no_write_path_indexes_the_step_up_tuple:1307`, which stops the idiom
 spreading but does not describe these two handlers' behavior.
+
+**Update, 2026-08-16.** "Turn a boolean helper into an exception" was the
+right diagnosis and the wrong prescription: those two do not need a
+characterization test so they can become gates, because they should not become
+gates. §1.2b adds `has_grant`, which is the same decision returned rather than
+raised, and they adopt *that*. Slices 15–18 below.
+
+### 2.5b Slices 15–18 — `has_grant`, the four predicates
+
+Landed first as a pure addition adopted by nothing (§1.2b). Then, one site per
+PR, each a characterization test followed by the swap:
+
+| # | Site | Notes |
+|---|---|---|
+| 15 | `r6/read_auth.py:77` → `Scope.TENANT_BOUND`, `also_bearer=True` | Widest blast radius of the four — it runs on every GET through the `before_request` hook. `require_scope=None` is load-bearing; `tests/test_patient_connect_token.py:126-130` goes red if a write scope replaces it. |
+| 16 | `r6/agent_runs/routes.py:63` | Keeps its own `logger.info`, or drops it because `_evaluate` now logs the same refusal. Decide in the PR; do not do both and double-log. |
+| 17 | `r6/command_center/routes.py:271` | Session-**or**-token. The JSON error body is unchanged; only the token branch moves. |
+| 18 | `r6/rate_limit.py:161` | **Last.** The only site that keeps a broad `except` around a kernel call, and the only one where that is correct. Its `_tenant_claim_is_authenticated` takes a raw `str`, so this PR also needs a non-raising tenant read or a `Tenant` built from the id the limiter already holds — settle that in the PR, not here. |
+
+Not in this group, and not for the reason the others were:
+`r6/command_center/routes.py:321` and `:609` interpolate the validator's raw
+reason into the response body — `{"error": f"step-up token rejected: {err}"}`.
+That is the **#478 leak**, which was closed after slice 6 fixed the three
+`r6/routes.py` write gates; these two were never in that diff and still carry
+it. `has_grant` returns no reason, so adopting it here silently changes a wire
+contract *and* fixes a disclosure in the same PR. Two things, one diff. The
+leak gets its own issue and its own fix; the migration follows it.
+
+`r6/sdc/routes.py:104` is the twelfth site and belongs to neither group. It is
+a real gate, so it wants `require_grant` — but its absent-token refusal names
+`dryRun=true`, and the kernel's uniform OperationOutcome cannot say that.
+Either the message becomes generic (a wire change, and a worse one: that
+sentence is the only place a caller learns the preview mode exists) or
+`require_grant` grows a caller-supplied absent message. The second is a spec
+change and belongs to a CTO gate, not a migration PR.
 
 ### 2.6 Slices 9–11 — `tenant_from_request`
 

--- a/r6/access.py
+++ b/r6/access.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     'TenantSource', 'Tenant', 'TenantRejected', 'tenant_from_request',
-    'Scope', 'Grant', 'StepUpDenied', 'require_grant',
+    'Scope', 'Grant', 'StepUpDenied', 'require_grant', 'has_grant',
     'register_error_handlers',
     'audit', 'AuditAssertionError',
     'install_audit_assertions', 'install_read_audit_assertion',
@@ -358,6 +358,89 @@ def _step_up_token(*, also_bearer: bool, also_body_field: str | None) -> str:
     return ''
 
 
+@dataclass(frozen=True)
+class _Outcome:
+    """What ONE step-up evaluation decided. Private on purpose.
+
+    The public surface is a Grant or a refusal. This type is the shared
+    middle so that `require_grant` and `has_grant` cannot drift into two
+    different answers to the same question — which is the whole reason the
+    kernel exists. It never leaves this module, so there is no two-field
+    result for a caller to mis-destructure.
+    """
+
+    grant: Grant | None
+    reason: str      # public-safe; '' when granted
+    absent: bool     # the request presented no token at all
+
+
+def _evaluate(
+    *,
+    scope: Scope,
+    tenant: Tenant,
+    audience: str | None,
+    operation: str | None,
+    consume_nonce: bool,
+    also_bearer: bool,
+    also_body_field: str | None,
+    caller: str,
+) -> _Outcome:
+    """The single step-up decision. Both public entry points route here.
+
+    THE ONE PROPERTY: a Grant is constructed on exactly one line in this
+    repository, and only after validate_step_up_token returned True for this
+    tenant, scope, audience and operation.
+
+    Does NOT catch exceptions from the validator. A validator that cannot
+    reach its nonce store has not decided anything, and answering "no grant"
+    would file an infrastructure outage as an authorization result — which
+    reads, at every call site, exactly like a caller who presented a bad
+    token. Callers that must survive that (r6/rate_limit.py) catch it
+    themselves, visibly, at the site that has a reason to.
+    """
+    if not isinstance(tenant, Tenant):
+        # A raw string here would mean the caller skipped format validation.
+        raise TypeError(
+            f'{caller} needs a Tenant from tenant_from_request, '
+            f'not {type(tenant).__name__}')
+
+    token = _step_up_token(also_bearer=also_bearer,
+                           also_body_field=also_body_field)
+    if not token:
+        return _Outcome(grant=None, reason=_DENIED_ABSENT, absent=True)
+
+    # Destructure both halves. A truthiness test on the tuple is a silent
+    # auth bypass — this module exists so that idiom has one home.
+    valid, error = _stepup_mod.validate_step_up_token(
+        token,
+        tenant.id,
+        consume_nonce=consume_nonce,
+        require_scope=_SCOPE_REQUIREMENT[scope],
+        require_audience=audience,
+        require_operation=operation,
+    )
+    if valid:
+        return _Outcome(
+            grant=Grant(
+                tenant_id=tenant.id,
+                scope=scope,
+                audience=audience,
+                operation=operation,
+                nonce_consumed=consume_nonce,
+            ),
+            reason='',
+            absent=False,
+        )
+
+    # The log keeps the full reason whatever the caller is told, so a withheld
+    # cause is still diagnosable from this side. It fires for a REJECTED token
+    # only, never for an absent one: an anonymous request is not an event, and
+    # a predicate on a hot path (the rate limiter) would otherwise log once per
+    # request.
+    logger.info('step-up refused for tenant %s: %s', tenant.id, error)
+    return _Outcome(grant=None, reason=_public_reason(error), absent=False)
+
+
 def require_grant(
     *,
     scope: Scope,
@@ -390,43 +473,80 @@ def require_grant(
     Raises StepUpDenied with the checked flag set. Never returns None, never
     returns False, never returns a tuple.
     """
-    if not isinstance(tenant, Tenant):
-        # A raw string here would mean the caller skipped format validation.
-        raise TypeError(
-            'require_grant needs a Tenant from tenant_from_request, '
-            f'not {type(tenant).__name__}')
+    outcome = _evaluate(
+        scope=scope, tenant=tenant, audience=audience, operation=operation,
+        consume_nonce=consume_nonce, also_bearer=also_bearer,
+        also_body_field=also_body_field, caller='require_grant',
+    )
+    if outcome.grant is not None:
+        return outcome.grant
 
-    token = _step_up_token(also_bearer=also_bearer,
-                           also_body_field=also_body_field)
-    if not token:
-        reason, status = _DENIED_ABSENT, absent_status
-    else:
-        # Destructure both halves. A truthiness test on the tuple is a silent
-        # auth bypass — this module exists so that idiom has one home.
-        valid, error = _stepup_mod.validate_step_up_token(
-            token,
-            tenant.id,
-            consume_nonce=consume_nonce,
-            require_scope=_SCOPE_REQUIREMENT[scope],
-            require_audience=audience,
-            require_operation=operation,
-        )
-        if valid:
-            return Grant(
-                tenant_id=tenant.id,
-                scope=scope,
-                audience=audience,
-                operation=operation,
-                nonce_consumed=consume_nonce,
-            )
-        # The log keeps the full reason whatever the caller is told, so a
-        # withheld cause is still diagnosable from this side.
-        logger.info('step-up refused for tenant %s: %s', tenant.id, error)
-        reason, status = _public_reason(error), rejected_status
-
+    status = absent_status if outcome.absent else rejected_status
     # The ONLY place in the repository that sets the checked flag. Pinned by
     # test_the_checked_flag_is_set_in_exactly_one_place.
-    raise StepUpDenied(reason, http_status=status, checked=True)
+    raise StepUpDenied(outcome.reason, http_status=status, checked=True)
+
+
+def has_grant(
+    *,
+    scope: Scope,
+    tenant: Tenant,
+    audience: str | None = None,
+    operation: str | None = None,
+    also_bearer: bool = False,
+    also_body_field: str | None = None,
+) -> Grant | None:
+    """Ask whether this request holds a step-up grant. Answer, do not refuse.
+
+    THE ONE PROPERTY: identical to require_grant's, with the refusal returned
+    instead of raised — `has_grant(...) is None` is true in exactly the cases
+    `require_grant(...)` would raise StepUpDenied.
+
+    WHY THIS EXISTS. Four step-up call sites are not authorization gates and
+    cannot become one:
+
+      r6/rate_limit.py:161      picks a bucket key, inside a try/except that
+                                must never fail a request
+      r6/read_auth.py:77        one branch of a predicate that also accepts a
+                                session cookie and an OAuth bearer
+      r6/agent_runs/routes.py:63  the same shape, returning bool
+      r6/sdc/routes.py:104      refuses with a message naming `dryRun=true`,
+                                which the kernel's uniform outcome cannot say
+
+    Migrating them to require_grant would make a rate limiter fail requests
+    and would rewrite three wire contracts. They kept calling
+    validate_step_up_token directly instead, which is the tuple this module
+    exists to delete. This is the missing half of the kernel, not a relaxation
+    of it.
+
+    Returns the Grant, or None. Not a bool: the Grant carries the tenant it
+    was proved for, so a caller scopes its next query to grant.tenant_id
+    rather than re-reading a header, and None is unambiguously falsy in a way
+    a 2-tuple never was.
+
+    NO ``consume_nonce``, deliberately. Asking is not spending. A predicate
+    that burned a single-use token as a side effect of being consulted is the
+    retro's defect shape exactly — a control that looks like one thing and
+    quietly does two. A caller that must consume wants require_grant.
+
+    NO status parameters, deliberately. This function makes no HTTP decision;
+    the caller does, which is the entire reason it is not require_grant.
+
+    Raises nothing this kernel defines. It DOES propagate an exception from
+    the validator — see _evaluate.
+
+    THE HAZARD, named so it is reviewable: `has_grant` where `require_grant`
+    was meant does not refuse. It returns None and the handler falls through
+    into the write, and the broad-except guard in
+    tests/test_access_kernel.py cannot see it because nothing was raised to
+    swallow. Two tests hold that line: the result may never be discarded, and
+    every call site is an allowlist entry added by the PR that adopts it.
+    """
+    return _evaluate(
+        scope=scope, tenant=tenant, audience=audience, operation=operation,
+        consume_nonce=False, also_bearer=also_bearer,
+        also_body_field=also_body_field, caller='has_grant',
+    ).grant
 
 
 def register_error_handlers(app) -> None:

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -17,6 +17,7 @@ because they cannot honestly ship later:
 import ast
 import dataclasses
 import json
+import logging
 import pathlib
 import re
 
@@ -35,6 +36,7 @@ from r6.access import (
     TenantSource,
     audit,
     fhir_response,
+    has_grant,
     install_audit_assertions,
     install_read_audit_assertion,
     outcome_response,
@@ -466,6 +468,295 @@ def test_step_up_denied_is_catchable_as_exception(app):
     """
     assert issubclass(StepUpDenied, Exception)
     assert StepUpDenied.__bases__ == (Exception,)
+
+
+# ---------------------------------------------------------------------------
+# §1.2b has_grant — the same decision, returned instead of raised
+# ---------------------------------------------------------------------------
+#
+# Four step-up call sites are predicates, not gates: a rate limiter that must
+# never fail a request, two boolean helpers that also accept a session cookie,
+# and one refusal whose wire contract names `dryRun=true`. They cannot call
+# require_grant, so they kept calling validate_step_up_token and its tuple.
+#
+# The property that makes has_grant safe to add is EQUIVALENCE, and it is the
+# only thing worth testing hard: `has_grant(...) is None` in exactly the cases
+# `require_grant(...)` raises. Two functions that answer the same question
+# differently would be worse than the tuple.
+
+#: (label, headers, kwargs) — every way the kernel refuses.
+_REFUSALS = [
+    ('no token at all', {}, {}),
+    ('junk', {'X-Step-Up-Token': 'not-a-token'}, {}),
+    ('a token for another tenant', 'other-tenant-token', {}),
+    ('an expired token', 'expired-token', {}),
+    ('a read-scoped token asked for write', 'read-token', {}),
+    ('a bearer the endpoint did not opt into', 'bearer-only', {}),
+    ('the wrong audience', 'valid-token', {'audience': 'someone-else'}),
+    ('the wrong operation', 'valid-token', {'operation': 'not-this-one'}),
+]
+
+
+def _refusal_headers(marker, tenant_id):
+    """Build the headers for one row of _REFUSALS."""
+    if isinstance(marker, dict):
+        return marker
+    if marker == 'other-tenant-token':
+        return _headers(generate_step_up_token('some-other-tenant'))
+    if marker == 'expired-token':
+        return _headers(generate_step_up_token(tenant_id, ttl_seconds=-10))
+    if marker == 'read-token':
+        return _headers(generate_step_up_token(tenant_id, scope='read'))
+    if marker == 'bearer-only':
+        # Valid, but presented on a header neither call opted into reading.
+        return {'Authorization': f'Bearer {generate_step_up_token(tenant_id)}'}
+    if marker == 'valid-token':
+        return _headers(generate_step_up_token(tenant_id))
+    raise AssertionError(f'unknown refusal marker {marker!r}')
+
+
+@pytest.mark.parametrize('label,marker,kwargs', _REFUSALS,
+                         ids=[row[0] for row in _REFUSALS])
+def test_has_grant_answers_none_wherever_require_grant_refuses(
+        app, tenant_id, label, marker, kwargs):
+    """THE ONE PROPERTY, both sides in one request context.
+
+    MUTATION: make has_grant skip any check require_grant makes — drop the
+    audience binding, accept a read token for write, read the bearer without
+    being asked — and the row for it goes red on the has_grant half while
+    require_grant still refuses.
+    """
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    headers = _refusal_headers(marker, tenant_id)
+
+    with app.test_request_context(headers=headers):
+        assert has_grant(scope=Scope.WRITE, tenant=tenant, **kwargs) is None
+        with pytest.raises(StepUpDenied):
+            require_grant(scope=Scope.WRITE, tenant=tenant, **kwargs)
+
+
+@pytest.mark.parametrize('scope', [Scope.WRITE, Scope.TENANT_BOUND])
+def test_has_grant_returns_the_same_grant_require_grant_returns(
+        app, tenant_id, scope):
+    """Equivalence on the other side: where one grants, so does the other.
+
+    A predicate that were merely stricter would pass every refusal test above
+    and quietly deny real callers. This is the half that catches it.
+    """
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        assert has_grant(scope=scope, tenant=tenant) == require_grant(
+            scope=scope, tenant=tenant)
+
+
+def test_has_grant_reads_the_opted_in_sources_the_same_way(app, tenant_id):
+    """also_bearer / also_body_field mean the same thing in both.
+
+    MUTATION: hardcode also_bearer=False in has_grant's delegation -> red.
+    """
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers={'Authorization': f'Bearer {token}'}):
+        assert has_grant(scope=Scope.WRITE, tenant=tenant) is None
+        grant = has_grant(scope=Scope.WRITE, tenant=tenant, also_bearer=True)
+    assert grant is not None and grant.tenant_id == tenant_id
+
+
+def test_the_grant_it_returns_names_the_tenant_it_proved(app, tenant_id):
+    """Why it is not a bool. A caller scopes its next query to
+    grant.tenant_id rather than re-reading the header it just checked."""
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        grant = has_grant(scope=Scope.WRITE, tenant=tenant)
+    assert grant.tenant_id == tenant_id
+    assert grant.nonce_consumed is False
+
+
+def test_has_grant_cannot_be_asked_to_consume_a_nonce(app, tenant_id):
+    """Asking is not spending.
+
+    A predicate that burned a single-use token as a side effect of being
+    consulted is the retro's defect shape — a control that looks like one
+    thing and quietly does two. The rate limiter consults this on every
+    request; if it could consume, it would eat the caller's token before the
+    handler that needed it ever ran.
+
+    MUTATION: add consume_nonce to the signature -> red.
+    """
+    import inspect
+    from r6 import access as access_mod
+
+    params = inspect.signature(access_mod.has_grant).parameters
+    assert 'consume_nonce' not in params
+    assert 'absent_status' not in params and 'rejected_status' not in params, (
+        'has_grant makes no HTTP decision — that is why it is not '
+        'require_grant')
+
+    # And behaviorally: consulting it twice does not spend the token.
+    token = generate_step_up_token(tenant_id)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers(token)):
+        assert has_grant(scope=Scope.WRITE, tenant=tenant) is not None
+        assert has_grant(scope=Scope.WRITE, tenant=tenant) is not None
+
+
+def test_has_grant_refuses_a_raw_string_tenant_and_says_which_call(
+        app, tenant_id):
+    """Same type check as require_grant, and the message names the caller
+    rather than the shared helper the traceback actually died in."""
+    with app.test_request_context(headers=_headers(
+            generate_step_up_token(tenant_id))):
+        with pytest.raises(TypeError, match='has_grant'):
+            has_grant(scope=Scope.WRITE, tenant=tenant_id)
+
+
+def test_a_validator_failure_propagates_rather_than_reading_as_a_denial(
+        app, tenant_id, monkeypatch):
+    """An outage is not an authorization answer.
+
+    If the nonce store is unreachable the validator has decided NOTHING.
+    Returning None there would file the outage as "this caller has no grant",
+    which is indistinguishable at every call site from a bad token — and on
+    r6/read_auth.py's path it would turn a 500 into a silent denial, changing
+    behaviour in the slice that adopts it.
+
+    r6/rate_limit.py catches this itself, at the site that has a reason to,
+    where the catch is visible to a reviewer.
+
+    MUTATION: wrap the validator call in try/except and return None -> red.
+    """
+    from r6 import access as access_mod
+
+    def _explode(*_args, **_kwargs):
+        raise RuntimeError('nonce store unreachable')
+
+    monkeypatch.setattr(access_mod._stepup_mod, 'validate_step_up_token',
+                        _explode)
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with app.test_request_context(headers=_headers('any-token')):
+        with pytest.raises(RuntimeError):
+            has_grant(scope=Scope.WRITE, tenant=tenant)
+        with pytest.raises(RuntimeError):
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+
+
+def test_an_absent_token_is_not_logged_but_a_rejected_one_is(
+        app, tenant_id, caplog):
+    """The limiter consults this on every request. An anonymous request is
+    not an event; a presented-and-invalid token is.
+
+    MUTATION: log unconditionally -> red, and the rate limiter emits one INFO
+    line per unauthenticated request on the internet.
+    """
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    with caplog.at_level(logging.INFO, logger='r6.access'):
+        with app.test_request_context():
+            assert has_grant(scope=Scope.WRITE, tenant=tenant) is None
+        assert caplog.records == []
+
+        with app.test_request_context(headers=_headers('not-a-token')):
+            assert has_grant(scope=Scope.WRITE, tenant=tenant) is None
+        assert [r for r in caplog.records if 'step-up refused' in r.message]
+
+
+def test_a_grant_is_constructed_in_exactly_one_place():
+    """Two entry points, one decision. The equivalence tests above check the
+    behaviour; this checks it stays structural rather than duplicated, which
+    is what would let the two drift later.
+
+    MUTATION: give has_grant its own Grant(...) -> red.
+    """
+    source = (REPO_ROOT / 'r6' / 'access.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    built = [node.lineno for node in ast.walk(tree)
+             if isinstance(node, ast.Call)
+             and getattr(node.func, 'id', None) == 'Grant']
+    assert len(built) == 1, f'Grant is constructed on lines {built}'
+    enclosing = [node.name for node in ast.walk(tree)
+                 if isinstance(node, ast.FunctionDef)
+                 and node.lineno <= built[0] <= (node.end_lineno or 0)]
+    assert enclosing == ['_evaluate']
+
+
+# --- the hazard has_grant introduces, and the two tests that hold it -------
+#
+# `has_grant` where `require_grant` was meant does not refuse. It returns None
+# and the handler falls through into the write. The broad-except guard cannot
+# see it, because nothing was raised to swallow.
+
+#: Production call sites of has_grant. EMPTY: this slice is the pure addition,
+#: adopted by nothing, exactly as the kernel itself landed. A migration slice
+#: adds its site here in the same PR that writes it — adoption is a reviewable
+#: list, not a thing that happens quietly.
+_HAS_GRANT_CALLSITES: frozenset[str] = frozenset()
+
+
+def _has_grant_calls():
+    """(path:lineno, is_discarded) for every production call to has_grant."""
+    for path in _production_python_files():
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        discarded = {node.value.lineno for node in ast.walk(tree)
+                     if isinstance(node, ast.Expr)
+                     and isinstance(node.value, ast.Call)}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = (getattr(node.func, 'id', None)
+                    or getattr(node.func, 'attr', None))
+            if name == 'has_grant':
+                yield (f'{path.relative_to(REPO_ROOT)}:{node.lineno}',
+                       node.lineno in discarded)
+
+
+def test_has_grant_is_adopted_by_nothing_yet():
+    """MUTATION: call has_grant from any production module -> red."""
+    sites = sorted(site for site, _ in _has_grant_calls())
+    unexpected = [s for s in sites if s not in _HAS_GRANT_CALLSITES]
+    assert not unexpected, (
+        'has_grant is a non-raising check: a call site that forgets to act on '
+        'the answer is a silent bypass, so each one is listed deliberately in '
+        '_HAS_GRANT_CALLSITES by the PR that adopts it. Unlisted: '
+        + ', '.join(unexpected))
+
+
+def test_a_has_grant_call_may_never_have_its_answer_thrown_away():
+    """`has_grant(...)` on a line by itself gates nothing at all.
+
+    With require_grant that shape is safe — the refusal is the raise. Here it
+    is the whole bypass, and it looks exactly like a guard to a reader.
+
+    MUTATION: write a bare `has_grant(...)` statement anywhere -> red.
+    """
+    thrown_away = [site for site, discarded in _has_grant_calls() if discarded]
+    assert not thrown_away, (
+        'the answer is the only thing has_grant does; discarding it is a '
+        'guard that checks nothing: ' + ', '.join(thrown_away))
+
+
+def test_the_discarded_answer_guard_actually_detects_the_shape(tmp_path):
+    """A guard that cannot fail is the defect it was written to catch.
+
+    This suite has shipped a check whose subject never ran; this one proves
+    its own detector on a synthetic file before trusting the real scan.
+    """
+    tree = ast.parse(
+        'def handler():\n'
+        '    has_grant(scope=1, tenant=2)\n'          # thrown away
+        '    grant = has_grant(scope=1, tenant=2)\n'  # kept
+        '    if has_grant(scope=1, tenant=2):\n'      # kept
+        '        pass\n'
+        '    return grant\n')
+    discarded = {node.value.lineno for node in ast.walk(tree)
+                 if isinstance(node, ast.Expr)
+                 and isinstance(node.value, ast.Call)}
+    calls = [node.lineno for node in ast.walk(tree)
+             if isinstance(node, ast.Call)
+             and getattr(node.func, 'id', None) == 'has_grant']
+    assert sorted(calls) == [2, 3, 4]
+    assert [lineno in discarded for lineno in sorted(calls)] == [
+        True, False, False]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The step-up ratchet (`_STEP_UP_CALLSITES`) has sat at 12 because the kernel could only *refuse*. I read all twelve. Four are not authorization gates and cannot become one:

| Site | What it is | Why `require_grant` cannot go there |
|---|---|---|
| `r6/rate_limit.py:161` | picks a bucket key | inside a `try/except` that must **never fail a request** |
| `r6/read_auth.py:77` | one branch of a predicate | also accepts a session cookie and an OAuth bearer |
| `r6/agent_runs/routes.py:63` | the same shape, returning `bool` | composed with two shared-secret checks |
| `r6/command_center/routes.py:271` | session **or** token | refuses in JSON, not an OperationOutcome |

So they kept destructuring `validate_step_up_token`'s tuple — the exact idiom this module exists to delete. `has_grant` is the missing half of the kernel, not a relaxation of it.

## What

`has_grant(...) -> Grant | None`. Both entry points now route through one private `_evaluate`, which is the **only place in the repository** that calls the validator or constructs a `Grant`.

Four deliberate differences from `require_grant`:

- **`Grant | None`, not `bool`** — the Grant names the tenant it proved, so a caller scopes its next query to `grant.tenant_id` rather than re-reading the header it just checked.
- **No `consume_nonce`** — asking is not spending. A predicate that burned a single-use token as a side effect of being consulted is the retro's defect shape; the limiter would eat the token before the handler that needed it ran.
- **No status parameters** — it makes no HTTP decision. That is why it is not `require_grant`.
- **It does not catch the validator's exceptions** — a validator that cannot reach its nonce store has decided *nothing*. Returning `None` there files an outage as an authorization result, indistinguishable at every call site from a bad token. It also keeps `read_auth`'s current 500 a 500, so adopting it there is not a behaviour change.

## The hazard, named

`has_grant` where `require_grant` was meant **does not refuse**. It returns `None`, the handler falls through into the write, and the §4.1 broad-except guard cannot see it because nothing was raised to swallow. Two tests hold that line:

1. **The answer may never be discarded** — a bare `has_grant(...)` statement gates nothing. AST-detected, and the detector is proven against a synthetic file before the real scan is trusted.
2. **Every production call site is an allowlist entry** (`_HAS_GRANT_CALLSITES`), ships **empty** — adopted by nothing, exactly as the kernel itself landed.

`has_grant` is deliberately **not** in `_GUARD_CALLS`: that list is "names whose refusal must never be swallowed", and this one has no refusal to swallow.

## Evidence

Seven mutations, each verified red:

| Mutation | Result |
|---|---|
| `has_grant` always grants | equivalence rows red |
| `has_grant` builds its own `Grant` | one-place test red |
| `consume_nonce` added to the signature | red |
| validator exception swallowed | red |
| refusal logged unconditionally | absent-not-logged red |
| a bare `has_grant(...)` statement in production | discarded-answer red |
| any production module calls it | adopted-by-nothing red |

Equivalence is tested from **both** sides — 8 parametrized refusal rows assert `has_grant(...) is None` *and* `require_grant(...)` raises in the same request context, plus a grant-side test, because a predicate that were merely stricter would pass every refusal row and quietly deny real callers.

`3115 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean. No behaviour change: adopted by nothing.

## Two findings recorded, not fixed here

- **`command_center/routes.py:321` and `:609` still carry the #478 leak** — they interpolate the validator's raw reason into the response body (`{"error": f"step-up token rejected: {err}"}`), and one of the eleven values is `Token tenant mismatch`. #478 was closed after slice 6 fixed the three `r6/routes.py` write gates; these two were never in that diff. Adopting `has_grant` there would change a wire contract *and* fix a disclosure in one PR. The leak needs its own issue first.
- **`sdc/routes.py:104` belongs to neither group** — it is a real gate, but its absent-token message names `dryRun=true`, which the kernel's uniform OperationOutcome cannot say. Either that sentence is lost (and it is the only place a caller learns the preview mode exists) or `require_grant` grows a caller-supplied absent message. That is a spec change for the CTO gate.

Spec: §1.2b (interface + hazard), §2.5b (slices 15–18, one site per PR, `rate_limit` last).