### PR TITLE
fix(care-gaps): a tombstone is not a patient, and not evidence (#422)

### DIFF
--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -65,12 +65,28 @@ def register_caregaps_routes(blueprint, deps):
         engine itself cannot tell the difference afterwards, because an
         unidentifiable patient produces exactly the rule results a healthy
         one does.
+
+        `is_deleted=False` is #422, and the honest version of it: this count
+        decides whether the operation may pick a subject at all, and a count
+        that includes tombstones decides on a set nobody can see. A tenant
+        that deleted its duplicate Patient would still read as ambiguous, the
+        symptom would not move, and the only apparent next move would be a
+        hard delete against production.
+
+        WOULD, not did. Verified 2026-08-16: `is_deleted = True` is written on
+        one line in this repository (r6/routes.py:2824, the demo walkthrough,
+        on Permission rows) and no route accepts DELETE, so no Patient row can
+        carry a tombstone today. This is a reader fixed ahead of its writer —
+        which is the only order in which it can be fixed quietly. Every read
+        path in r6/routes.py has filtered since the column existed; the
+        feature modules added later did not.
         """
         if supplied:
             return supplied, "supplied"
         # Two rows is all it takes to know the match is ambiguous.
         rows = R6Resource.query.filter_by(
-            resource_type="Patient", tenant_id=tenant_id).limit(2).all()
+            resource_type="Patient", tenant_id=tenant_id,
+            is_deleted=False).limit(2).all()
         if not rows:
             return None, "no-patient"
         if len(rows) > 1:
@@ -78,16 +94,33 @@ def register_caregaps_routes(blueprint, deps):
         return f"Patient/{rows[0].id}", "tenant-default"
 
     def _patient_for(subject, tenant_id):
+        """The demographics the rules read age and sex from.
+
+        Filtered for the same reason, and it is the half `_resolve_subject`
+        cannot cover: a caller may SUPPLY `?subject=Patient/<deleted-id>`,
+        which never passes through the resolver above. Without this, a deleted
+        patient's date of birth still selects which preventive rules fire.
+        """
         if not subject or not subject.startswith("Patient/"):
             return None
         row = R6Resource.query.filter_by(
             resource_type="Patient", id=subject.split("/", 1)[1],
-            tenant_id=tenant_id).first()
+            tenant_id=tenant_id, is_deleted=False).first()
         return row.to_fhir_json() if row else None
 
     def _resources_for(resource_type, subject, tenant_id):
+        """The clinical evidence a gap is evaluated against.
+
+        The most consequential of the three. These rows are what CLOSES a
+        gap — a Procedure closes a screening, an Immunization closes a
+        vaccine, an Observation closes A1c monitoring. Counting a
+        soft-deleted row here tells a patient they are covered by a record
+        the system considers deleted, which is the failure direction that
+        matters: it withholds a due item rather than repeating one.
+        """
         rows = R6Resource.query.filter_by(
-            resource_type=resource_type, tenant_id=tenant_id).all()
+            resource_type=resource_type, tenant_id=tenant_id,
+            is_deleted=False).all()
         out = []
         for row in rows:
             res = row.to_fhir_json()

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -176,6 +176,179 @@ def test_care_gaps_with_a_supplied_subject_reports_that_state(
 
 
 # ─────────────────────────────────────────────
+# A tombstone is not a patient, and not evidence (#422)
+#
+# Every query in this module counted soft-deleted rows. Three consequences,
+# each worse than the last: a tenant that deleted its duplicate Patient still
+# reads as ambiguous and is told nothing (so the only apparent next move is a
+# hard delete against production); a supplied `?subject=` naming a deleted
+# Patient still hands its date of birth to the rules; and a deleted clinical
+# record still CLOSES a gap, which withholds a due screening rather than
+# repeating one.
+#
+# None of that is reachable TODAY, and the tests say so by writing the
+# tombstone themselves rather than through a product path. Verified while
+# fixing this: `is_deleted = True` appears on one line in the repository
+# (r6/routes.py:2824, the demo walkthrough, on Permission rows) and no route
+# accepts DELETE. #422's own text cites a `delete-my-records` flow; no such
+# flow exists yet.
+#
+# That is the argument for fixing the readers now rather than the argument
+# against. The day a delete path ships, every one of these three is live at
+# once, silently, in a clinical surface — and nothing in the diff that ships
+# it would look wrong.
+
+def _soft_delete(app, tenant_id, resource_type, resource_id):
+    """Tombstone one row, exactly as the delete paths do."""
+    with app.app_context():
+        row = db.session.get(R6Resource, (tenant_id, resource_type, resource_id))
+        assert row is not None, "nothing to soft-delete — check the seed"
+        row.is_deleted = True
+        db.session.commit()
+
+
+def test_a_soft_deleted_patient_no_longer_makes_the_match_ambiguous(
+        client, app, tenant_id, tenant_headers):
+    """#422, stated as the operator's experience: they deleted the duplicate,
+    and the symptom must move.
+
+    MUTATION: drop `is_deleted=False` from _resolve_subject -> red, and the
+    answer goes back to "ambiguous-patient" for a tenant with one live
+    Patient.
+    """
+    _seed_patient(app, tenant_id, pid="p-live")
+    _seed_patient(app, tenant_id, pid="p-gone")
+    _soft_delete(app, tenant_id, "Patient", "p-gone")
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    resolution = json.loads(
+        _resp_param(r.get_json(), "subjectResolution")["valueString"])
+    assert resolution == {"state": "tenant-default", "subject": "Patient/p-live"}
+
+
+def test_the_last_patient_being_deleted_reads_as_no_patient_not_a_default(
+        client, app, tenant_id, tenant_headers):
+    """The other side of the same filter. A tombstone must not be RESOLVED as
+    the tenant's own Patient either — that would evaluate a deleted person and
+    report a confident state while doing it.
+
+    MUTATION: filter `is_deleted=True` (an easy inversion to typo) -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-only")
+    _soft_delete(app, tenant_id, "Patient", "p-only")
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    body = r.get_json()
+    resolution = json.loads(_resp_param(body, "subjectResolution")["valueString"])
+    assert resolution == {"state": "no-patient", "subject": None}
+    consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
+    assert consumer["unevaluated"] == "no-patient"
+
+
+def test_a_supplied_subject_naming_a_deleted_patient_gets_no_demographics(
+        client, app, tenant_id, tenant_headers):
+    """The half `_resolve_subject` cannot cover: a supplied subject never
+    passes through the resolver, so `_patient_for` needs its own filter.
+
+    The route already knows what to do with a subject it cannot read — #417
+    made that `check-incomplete`, which tells the caller the answer is partial
+    instead of presenting it as a clean sheet. A deleted Patient must land
+    there, identically to one that was never stored.
+
+    Asserted against a live control of the same age and sex, so the test
+    cannot pass by the endpoint being broken for everyone.
+
+    MUTATION: drop `is_deleted=False` from _patient_for -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-erased", gender="female",
+                  birth=_birth_date_for_age(58))
+    _soft_delete(app, tenant_id, "Patient", "p-erased")
+    _seed_patient(app, tenant_id, pid="p-alive", gender="female",
+                  birth=_birth_date_for_age(58))
+
+    def _unevaluated(pid):
+        body = client.get(f"/r6/fhir/Patient/$care-gaps?subject=Patient/{pid}",
+                          headers=tenant_headers).get_json()
+        return json.loads(
+            _resp_param(body, "consumerSummary")["valueString"]).get(
+                "unevaluated")
+
+    # Not `is None`: a live patient with partial evidence reports
+    # 'evidence-not-read', which is a different sentence about a different
+    # gap. The property is that only the deleted one is unreadable.
+    assert _unevaluated("p-alive") != "check-incomplete", (
+        "the live control is already check-incomplete — this test would pass "
+        "for the wrong reason")
+    assert _unevaluated("p-erased") == "check-incomplete", (
+        "a deleted Patient was read as demographics and evaluated as though "
+        "the record were still there")
+
+
+def test_a_soft_deleted_observation_no_longer_closes_a_gap(
+        client, app, tenant_id, tenant_headers):
+    """The most consequential of the three, and the one that reaches a person.
+
+    `_seed_patient` stores a blood-pressure Observation, which is what closes
+    `bp-screening`. Delete it and the gap must REOPEN. If a tombstone still
+    counts as evidence, a patient who deleted a record is told they are up to
+    date on a screening the system no longer has.
+
+    MUTATION: drop `is_deleted=False` from _resources_for -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-bp")
+
+    before = client.post("/r6/fhir/Patient/$care-gaps?subject=Patient/p-bp",
+                         headers=tenant_headers).get_json()
+    open_before = [g["rule_id"] for g in
+                   json.loads(_resp_param(before, "summary")["valueString"])["gaps"]]
+    assert "bp-screening" not in open_before, (
+        "the seeded Observation should close bp-screening — if it does not, "
+        "this test is not exercising what it claims")
+
+    _soft_delete(app, tenant_id, "Observation", "o-p-bp")
+
+    after = client.post("/r6/fhir/Patient/$care-gaps?subject=Patient/p-bp",
+                        headers=tenant_headers).get_json()
+    open_after = [g["rule_id"] for g in
+                  json.loads(_resp_param(after, "summary")["valueString"])["gaps"]]
+    assert "bp-screening" in open_after, (
+        "a soft-deleted Observation still closed the gap")
+
+
+def test_a_resource_row_is_born_live_rather_than_null(app, tenant_id):
+    """The trap under every `is_deleted=False` filter in this repository.
+
+    The column is nullable with a PYTHON-side default. `is_deleted = 0` does
+    not match NULL in SQL, so a row written without that default would be
+    invisible to this module's three filters and to all 18 in r6/routes.py —
+    live data, silently unreadable, with no error anywhere.
+
+    Verified rather than assumed: the model's custom __init__ does not set the
+    field, and the row still lands as False because SQLAlchemy applies the
+    column default at INSERT.
+
+    MUTATION: remove `default=False` from R6Resource.is_deleted -> red, and
+    every newly written resource disappears from every read path.
+    """
+    with app.app_context():
+        db.session.add(R6Resource(
+            resource_type="Patient",
+            resource_json=json.dumps({"resourceType": "Patient", "id": "p-new"}),
+            resource_id="p-new", tenant_id=tenant_id))
+        db.session.commit()
+        stored = db.session.get(R6Resource, (tenant_id, "Patient", "p-new"))
+        assert stored.is_deleted is False, (
+            f"a new row was written with is_deleted={stored.is_deleted!r}; "
+            "NULL is invisible to every read filter in the codebase")
+        assert R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type="Patient",
+            is_deleted=False).count() == 1
+
+
+# ─────────────────────────────────────────────
 # What we say when we did not look (#417)
 # ─────────────────────────────────────────────
 

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -267,7 +267,20 @@ def test_no_new_package_mutates_without_auditing():
 #: at none of theirs. Nothing has detonated because no DELETE route exists and
 #: only Permission-revoke sets the flag — it is a loaded gun, not a fire.
 #: Playbook F5 introduces one shared live-resource selector and takes this to 0.
-_FILES_QUERYING_WITHOUT_SOFT_DELETE = 12
+#:
+#: Re-verified 2026-08-16 while fixing #422, and the gun is even less loaded
+#: than this said: `is_deleted = True` is written on exactly ONE line in the
+#: repository (r6/routes.py:2824), inside the demo walkthrough, clearing
+#: Permission rows. No route accepts DELETE. So no Patient, Observation or
+#: Procedure row can carry a tombstone today by any path — which is why the
+#: #422 class has never been seen in production and is also why it will land
+#: silently the day a delete path ships. Fix the readers before the writer.
+#:
+#: 12 -> 11: #422 filtered all three queries in r6/caregaps/routes.py — the
+#: ambiguity count that decides whether $care-gaps may pick a subject, the
+#: demographics a supplied subject resolves to, and the clinical rows that
+#: CLOSE a gap.
+_FILES_QUERYING_WITHOUT_SOFT_DELETE = 11
 
 #: r6/purge.py hard-deletes a tenant's rows. It must NOT filter is_deleted —
 #: a purge that skipped soft-deleted rows would leave exactly the records the


### PR DESCRIPTION
Closes #422.

## What was wrong

All three `R6Resource` queries in `r6/caregaps/routes.py` counted soft-deleted rows.

| Query | What it decides | With a tombstone |
|---|---|---|
| `_resolve_subject` | whether `$care-gaps` may pick a subject at all | a tenant that deleted its duplicate Patient still reads `ambiguous-patient` and is told nothing |
| `_patient_for` | the demographics the rules read age and sex from | a supplied `?subject=` never passes through the resolver, so a deleted Patient still selects which rules fire |
| `_resources_for` | the clinical rows that **close** a gap | a deleted Procedure still closed a screening — the direction that withholds a due item rather than repeating one |

## What #422 gets wrong

Stated up front because it changes the **priority**, not the fix.

The issue cites a `delete-my-records` flow. There is no such flow. I grepped for the writer: `is_deleted = True` appears on **exactly one line in the repository** — `r6/routes.py:2824`, inside the demo walkthrough, clearing `Permission` rows — and **no route accepts DELETE**. So no Patient, Observation or Procedure row can carry a tombstone today by any path.

This is a reader fixed ahead of its writer. That is the argument for landing it now: the day a delete path ships, all three are live at once, silently, in a clinical surface, and nothing in the diff that ships it would look wrong. The tests write the tombstone themselves and say so, rather than implying a product path that does not exist.

I have corrected the ratchet comment, which was directionally right and imprecise about the same fact.

## A second thing, found on the way

`is_deleted` is **nullable with a Python-side default**. `is_deleted = 0` does not match `NULL` in SQL, so a row written without that default is invisible to these three filters *and* to all 18 in `r6/routes.py` — live data, unreadable, no error anywhere.

Verified empirically rather than assumed (the model has a custom `__init__` that never sets the field; the row still lands `False` because SQLAlchemy applies the column default at INSERT). Now pinned: removing `default=False` goes red.

## Evidence

Five mutations, each verified red:

| Mutation | Result |
|---|---|
| drop the filter in `_resolve_subject` | ambiguous again with one live Patient |
| invert it to `is_deleted=True` | a tombstone resolves as the tenant default |
| drop the filter in `_patient_for` | a deleted patient is evaluated as present |
| drop the filter in `_resources_for` | a deleted Observation closes the gap |
| remove `default=False` on the column | every newly written row disappears |

The `_patient_for` test asserts against a **live control** of the same age and sex, so it cannot pass by the endpoint being broken for everyone. The `_resources_for` test asserts the gap is closed *before* the delete, so it cannot pass against a fixture that was never exercising the rule.

`3100 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.

Ratchet `_FILES_QUERYING_WITHOUT_SOFT_DELETE` **12 → 11**.

## The sweep #422 asked for, and what it found

The issue asked for a sweep of resource reads that feed a *decision* rather than a display, and for a statement of which were checked. All 11 remaining soft-delete-blind files, read:

**Same shape as this bug — a decision on a set that includes tombstones. Not fixed here; this is playbook F5's shared selector, and doing them piecemeal is how you get five idioms.**

- `r6/quality/routes.py:45` — loads every resource of a type for a **quality measure**. A deleted row counts toward numerator and denominator.
- `r6/actions/routes.py:253` — the MedicationRequest list an **rx-transfer proposal** is built from. Arguably the most consequential of the remainder: a deleted medication would be proposed for transfer.
- `r6/labs/routes.py:117` — `_patient_for` again, for lab interpretation.
- `r6/smbp/routes.py:142`, `r6/smbp/scheduler_routes.py:66` — Observation counts feeding a session summary and per-patient reading counts.
- `r6/sdc/routes.py:211`, `r6/sdc/documents.py:82` — load a specific resource by id for `$populate` / `$extract`.

**Checked and deliberately correct as they are:**

- `main.py:119` — "does this tenant have any data" before auto-seeding. Counting tombstones is **right**: a tenant with soft-deleted rows is not empty, and re-seeding would resurrect a set the operator deleted. Same reasoning as `r6/purge.py`'s exemption.
- `r6/context_builder.py:86` — an upsert lookup. It must see tombstones or it inserts a duplicate composite PK.

**Two things worth their own issue, filed separately rather than folded in here:**

- `r6/actions/rails/form_fill.py:62` — the comment says *"If it vanished (deleted or stale) … fail loud, never render a blank/guessed form"*, and the query does not filter `is_deleted`. The code does not do what the comment says it does.
- `r6/context_builder.py:86` — on hitting an existing row it calls `update_resource` but never clears `is_deleted`, unlike `r6/fasten/ingester.py:422` which does. Re-ingesting a tombstoned id would leave it invisible. The opposite failure, same column.