### PR TITLE
fix(step-up): the #478 leak is at five sites, not two, and now has a guard (#508)

### DIFF
--- a/r6/access.py
+++ b/r6/access.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'TenantSource', 'Tenant', 'TenantRejected', 'tenant_from_request',
     'Scope', 'Grant', 'StepUpDenied', 'require_grant', 'has_grant',
+    'public_step_up_reason',
     'register_error_handlers',
     'audit', 'AuditAssertionError',
     'install_audit_assertions', 'install_read_audit_assertion',
@@ -319,12 +320,23 @@ _WITHHELD_REASONS = {
 }
 
 
-def _public_reason(error: str) -> str:
+def public_step_up_reason(error: str) -> str:
     """The sentence the caller gets for a validator refusal.
 
     Default-deny: anything not explicitly published collapses to the generic
     text. The failure mode of the opposite default is a new reason leaking on
     the day it is written, when nobody is looking at this file.
+
+    PUBLIC (was `_public_reason`), because the owner's ruling is not a
+    property of `require_grant`. Two sites cannot use the kernel's gate and
+    still have to obey the ruling: `r6/command_center/routes.py` answers a
+    refusal in its own JSON shape, so it built the sentence itself and shipped
+    the raw reason — #478's leak, in a place #478's fix never reached (#508).
+
+    A site that publishes a refusal reason without going through this function
+    is publishing an unclassified string. That is the whole hazard, and it is
+    why this is a named export rather than something each caller can
+    reimplement with a set literal.
     """
     return error if error in _PUBLIC_REASONS else _DENIED_REJECTED
 
@@ -438,7 +450,7 @@ def _evaluate(
     # a predicate on a hot path (the rate limiter) would otherwise log once per
     # request.
     logger.info('step-up refused for tenant %s: %s', tenant.id, error)
-    return _Outcome(grant=None, reason=_public_reason(error), absent=False)
+    return _Outcome(grant=None, reason=public_step_up_reason(error), absent=False)
 
 
 def require_grant(

--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -44,6 +44,7 @@ from r6.command_center.models import (
     default_conversation_id,
 )
 from r6.command_center.agents import load_agents, load_agent_templates, get_agent
+from r6.access import public_step_up_reason
 from r6.read_auth import TENANT_SESSION_KEY, authorize_tenant_read
 from r6.stepup import validate_step_up_token
 
@@ -321,7 +322,15 @@ def _authz_write(tenant_id: str) -> tuple | None:
         valid, err = validate_step_up_token(step_up, tenant_id)
         if valid:
             return None
-        return jsonify({"error": f"step-up token rejected: {err}"}), 401
+        # `public_step_up_reason`, never `err` (#508). One of the eleven
+        # values err can take is 'Token tenant mismatch', which tells a caller
+        # holding a token they should not have that it is VALID and merely
+        # issued elsewhere — the distinction a prober is trying to draw. The
+        # other ten describe the caller's own token and are published
+        # verbatim, per the owner's 2026-08-10 ruling.
+        return jsonify({
+            "error": f"step-up token rejected: {public_step_up_reason(err)}"
+        }), 401
     if session.get(SESSION_KEY) == tenant_id:
         return None
     return jsonify({
@@ -608,7 +617,10 @@ def api_generate_link():
             }), 401
         valid, err = validate_step_up_token(step_up, tenant_id)
         if not valid:
-            return jsonify({"error": f"step-up token rejected: {err}"}), 401
+            # Classified, not raw (#508). See _authz_write above.
+            return jsonify({
+                "error": f"step-up token rejected: {public_step_up_reason(err)}"
+            }), 401
 
     import os
     base_url = (

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -38,7 +38,7 @@ from r6.audit import add_audit_event, record_audit_event
 from r6.redaction import apply_patient_controlled_redaction
 from r6.redaction import apply_redaction
 from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
-                       tenant_from_request)
+                       public_step_up_reason, tenant_from_request)
 from r6.stepup import validate_step_up_token, generate_step_up_token
 from r6.oauth import register_oauth_routes
 from r6.read_auth import (
@@ -2186,7 +2186,7 @@ def bind_telegram_chat():
         return jsonify({'error': 'valid step-up token required'}), 401
     valid, err = validate_step_up_token(token, tenant_id)
     if not valid:
-        return jsonify({'error': err or 'invalid step-up token'}), 401
+        return jsonify({'error': public_step_up_reason(err)}), 401
 
     from r6.telegram_push import bind as bind_chat
     try:
@@ -3107,7 +3107,7 @@ def curatr_apply_fix(resource_type, resource_id):
     if not valid:
         return _operation_outcome(
             'error', 'security',
-            f'Step-up token rejected: {err}'
+            f'Step-up token rejected: {public_step_up_reason(err)}'
         ), 403
 
     body = request.get_json(silent=True)
@@ -3136,8 +3136,8 @@ def curatr_apply_fix(resource_type, resource_id):
         )
         if not valid:
             return _operation_outcome(
-                'error', 'security', f'Step-up token rejected: {err}'
-            ), 403
+                'error', 'security',
+                f'Step-up token rejected: {public_step_up_reason(err)}'), 403
 
     try:
         result = _curatr_apply_fix(

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1363,7 +1363,16 @@ _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
                      # kernel. This is the god module's FIRST kernel import
                      # and the remaining 20 raw reads in it are pinned by
                      # tests/test_ratchets.py::_RAW_TENANT_READS.
-                     'r6/routes.py'}
+                     'r6/routes.py',
+                     # #508, and NOT a migration slice. This blueprint imports
+                     # `public_step_up_reason` and nothing else: its two
+                     # step-up checks still call the validator directly and
+                     # are still counted by _STEP_UP_CALLSITES. What moved is
+                     # only which sentence a refusal is allowed to say, which
+                     # is a ruling rather than a gate. Migrating these two is
+                     # slice 17, and it stays blocked on their JSON wire
+                     # shape.
+                     'r6/command_center/routes.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():

--- a/tests/test_no_raw_step_up_reason_reaches_a_caller.py
+++ b/tests/test_no_raw_step_up_reason_reaches_a_caller.py
@@ -1,0 +1,184 @@
+"""The validator's raw refusal reason goes to a log or to the classifier.
+
+Nowhere else. #478 found three write gates in r6/routes.py interpolating it
+straight into the response:
+
+    valid, err = validate_step_up_token(step_up_token, tenant_id)
+    if not valid:
+        return _operation_outcome(..., f'Step-up token rejected: {err}'), 401
+
+One of the eleven values `err` can take is 'Token tenant mismatch', which
+tells a caller presenting a token they should not have that the token is
+VALID and merely issued to a different tenant. That separates "a real
+credential I stole or guessed" from "junk" — the distinction a prober is
+trying to draw, and the one carve-out in the owner's 2026-08-10 ruling that a
+refusal states its reason.
+
+#478 was closed after kernel slice 6 migrated those three gates. Two sites in
+r6/command_center/routes.py were never in that diff and still carried it
+(#508). A leak that comes back after its issue is closed is a leak with no
+guard on it, so this file is the guard rather than another fix.
+
+THE RULE, in one sentence: the name bound to the error half of
+`validate_step_up_token`'s tuple may be passed to a logger or to
+`r6.access.public_step_up_reason`, and to nothing else.
+
+MUTATION: interpolate the raw reason into any response anywhere -> red.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from r6.access import _DENIED_REJECTED, public_step_up_reason
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_PRODUCTION_DIRS = ('r6', 'careagents', 'adapters', 'api', 'services',
+                    'scripts', 'openclaw', 'hermes', 'migrations')
+_PRODUCTION_ROOT_FILES = ('main.py', 'app.py', 'models.py')
+
+#: The two destinations a raw reason may reach. A logger keeps it on our side
+#: of the wire; the classifier is what decides whether the caller may see it.
+_ALLOWED_SINKS = ('public_step_up_reason', 'debug', 'info', 'warning',
+                  'error', 'exception', 'critical', 'log')
+
+
+def _production_python_files():
+    for name in _PRODUCTION_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            yield path
+    for folder in _PRODUCTION_DIRS:
+        base = REPO_ROOT / folder
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob('*.py')):
+            if '__pycache__' not in path.parts:
+                yield path
+
+
+def _reason_names(func):
+    """Names bound to the error half of a validate_step_up_token tuple."""
+    names = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target, value = node.targets[0], node.value
+        if not isinstance(target, ast.Tuple) or len(target.elts) != 2:
+            continue
+        if not isinstance(value, ast.Call):
+            continue
+        called = (getattr(value.func, 'id', None)
+                  or getattr(value.func, 'attr', None))
+        if called != 'validate_step_up_token':
+            continue
+        second = target.elts[1]
+        if isinstance(second, ast.Name):
+            names.add(second.id)
+    return names
+
+
+def _guarded_uses(func, name):
+    """Line numbers where `name` is read somewhere other than an allowed sink.
+
+    A read is allowed when its nearest enclosing Call is a logger method or
+    the classifier. Everything else — an f-string in a response, a dict value,
+    a `.format` argument, a bare return — is a use that can reach a caller.
+    """
+    allowed_lines = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        called = (getattr(node.func, 'id', None)
+                  or getattr(node.func, 'attr', None))
+        if called not in _ALLOWED_SINKS:
+            continue
+        for arg in ast.walk(node):
+            if isinstance(arg, ast.Name) and arg.id == name:
+                allowed_lines.add((arg.lineno, arg.col_offset))
+
+    bad = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Name) and node.id == name \
+                and isinstance(node.ctx, ast.Load) \
+                and (node.lineno, node.col_offset) not in allowed_lines:
+            bad.append(node.lineno)
+    return bad
+
+
+def _leaks():
+    scanned = 0
+    for path in _production_python_files():
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        scanned += 1
+        for func in ast.walk(tree):
+            if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for name in _reason_names(func):
+                for lineno in _guarded_uses(func, name):
+                    yield (f'{path.relative_to(REPO_ROOT)}:{lineno}',
+                           f'{func.name}() reads `{name}` outside a logger '
+                           'or public_step_up_reason')
+    assert scanned > 100, f'the leak scan only walked {scanned} files'
+
+
+def test_no_production_site_uses_the_raw_validator_reason():
+    """MUTATION: drop public_step_up_reason() from either command_center site
+    -> red. That is #508 going back in."""
+    leaks = list(_leaks())
+    assert not leaks, (
+        "the validator's raw reason may only reach a logger or the "
+        "classifier; one of its eleven values names another tenant's "
+        'credential:\n  ' + '\n  '.join(f'{w} — {why}' for w, why in leaks))
+
+
+def test_the_leak_detector_actually_detects_the_leak():
+    """A guard that cannot fail is the defect it was written to catch.
+
+    Proven on synthetic sources before the real scan above is trusted —
+    this suite has shipped a check whose subject never ran.
+    """
+    leaking = ast.parse(
+        'def handler():\n'
+        '    valid, err = validate_step_up_token(t, tid)\n'
+        '    if not valid:\n'
+        '        return jsonify({"error": f"rejected: {err}"}), 401\n')
+    func = next(n for n in ast.walk(leaking)
+                if isinstance(n, ast.FunctionDef))
+    assert _reason_names(func) == {'err'}
+    assert _guarded_uses(func, 'err') == [4]
+
+    classified = ast.parse(
+        'def handler():\n'
+        '    valid, err = validate_step_up_token(t, tid)\n'
+        '    if not valid:\n'
+        '        logger.info("refused: %s", err)\n'
+        '        return jsonify({"error": public_step_up_reason(err)}), 401\n')
+    func = next(n for n in ast.walk(classified)
+                if isinstance(n, ast.FunctionDef))
+    assert _guarded_uses(func, 'err') == []
+
+
+# --- the wire behaviour, both sides of the ruling -------------------------
+
+@pytest.mark.parametrize('reason', [
+    'Step-up token expired',
+    'Read-scoped token cannot authorize this operation',
+    'Token audience mismatch',
+    'Token operation mismatch',
+])
+def test_a_reason_about_the_callers_own_token_still_reaches_them(reason):
+    """The other half, and the reason this is a classifier rather than a
+    blanket redaction. Collapsing all eleven was the previous behaviour and
+    the owner overruled it: a refusal nobody can name cannot be acted on.
+
+    MUTATION: make public_step_up_reason return _DENIED_REJECTED always
+    -> red.
+    """
+    assert public_step_up_reason(reason) == reason
+
+
+def test_the_one_reason_about_someone_elses_credential_does_not():
+    assert public_step_up_reason('Token tenant mismatch') == _DENIED_REJECTED

--- a/tests/test_step_up_states_why.py
+++ b/tests/test_step_up_states_why.py
@@ -88,20 +88,20 @@ class TestTheCallerIsTold:
     ])
     def test_a_reason_about_the_callers_own_token_is_published(
             self, error, expected):
-        assert access._public_reason(error) == expected
+        assert access.public_step_up_reason(error) == expected
 
     def test_the_cross_tenant_reason_is_never_published(self):
         """The one carve-out. This is the oracle: it separates a valid token
         issued elsewhere from junk."""
-        assert access._public_reason('Token tenant mismatch') == \
+        assert access.public_step_up_reason('Token tenant mismatch') == \
             access._DENIED_REJECTED
 
     def test_an_unknown_reason_defaults_to_silence(self):
         """Default-deny. A reason nobody classified must not leak on the day
         it is written."""
-        assert access._public_reason('Token issuer is evil.example') == \
+        assert access.public_step_up_reason('Token issuer is evil.example') == \
             access._DENIED_REJECTED
-        assert access._public_reason('') == access._DENIED_REJECTED
+        assert access.public_step_up_reason('') == access._DENIED_REJECTED
 
     def test_the_absent_case_is_unchanged(self):
         """No token at all is not a validator refusal and has no reason to


### PR DESCRIPTION
Closes #508.

## The count went up while I was writing the fix

#478 closed on 2026-08-11 after kernel slice 6 migrated the three `r6/routes.py` write gates. Its own text said the leak lived at *"the direct `validate_step_up_token` call sites still counted by `_STEP_UP_CALLSITES`"*. Nothing checked that claim after the fix, so the issue closed on three of them.

I filed #508 for the two in `command_center`. Writing the guard found **three more**:

| Site | What it is |
|---|---|
| `r6/command_center/routes.py:324` | `_authz_write`, session-or-token |
| `r6/command_center/routes.py:611` | dashboard-url minting |
| `r6/routes.py:2189` | `bind_telegram_chat` |
| `r6/routes.py:3110` | curatr apply-fix, the gate |
| `r6/routes.py:3140` | curatr apply-fix, the nonce consume |

Each interpolated the validator's raw reason into the response. One of the eleven values is `Token tenant mismatch`, which tells a caller presenting a token they should not have that it is **valid** and merely issued elsewhere — separating a real stolen credential from junk. That is the single carve-out in the owner's 2026-08-10 ruling.

## The guard is the point, not the five one-line fixes

A leak that comes back after its issue is closed is a leak nobody pinned.

> **The rule:** the name bound to the error half of `validate_step_up_token`'s tuple may be passed to a logger or to `r6.access.public_step_up_reason`, and to nothing else.

One sentence, AST-checkable across every production module. The detector is proven against synthetic leaking *and* non-leaking sources before the real scan is trusted — this suite has shipped a check whose subject never ran, and that is not happening in the file whose whole job is catching a recurrence.

## `_public_reason` → `public_step_up_reason`

The owner's ruling is not a property of `require_grant`. Two of these sites answer in their own JSON shape and cannot use the kernel's gate, so they built the sentence themselves and got it wrong. One name for the classification, exported, and a site that publishes a reason without going through it is publishing an unclassified string.

## Both sides of the ruling are pinned

A blanket redaction would pass every leak test above and quietly restore the four-words-and-no-recourse behaviour the owner overruled in #475. So:

- the nine reasons that describe **the caller's own token** still reach them verbatim (parametrized)
- the one that describes **someone else's** does not

## Evidence

Seven mutations, each verified red:

| Mutation | Result |
|---|---|
| each of the five sites reverted, individually | leak scan red |
| classifier collapsed to always-generic | ruling tests red |
| `Token tenant mismatch` added to the public set | carve-out test red |

`3122 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.

## Ratchets

- `r6/routes.py` is **exactly 3927 lines**, unchanged. The god-module pin is not raised; the import rides in the existing `from r6.access import (...)` tuple.
- `_STEP_UP_CALLSITES` unchanged at 12 — these sites still call the validator directly. What moved is only which sentence a refusal may say.
- `r6/command_center/routes.py` joins `_ADOPTION_ALLOWED` with the reason recorded: it imports the classifier and nothing else, and migrating its two gates is slice 17, still blocked on their JSON wire shape.