### PR TITLE
fix(connectors): the hapi connector read credentials, accepted them, and dropped them

### DIFF
--- a/r6/upstream_connectors.py
+++ b/r6/upstream_connectors.py
@@ -88,7 +88,20 @@ CONNECTORS: dict[str, Connector] = {
     ),
     "hapi": Connector(
         name="hapi",
-        auth=AUTH_NONE,
+        # AUTH_BASIC, not AUTH_NONE. This entry shipped saying one thing and
+        # doing another: the summary tells an operator to set
+        # FHIR_UPSTREAM_CLIENT_ID/_SECRET for a secured HAPI, and AUTH_NONE
+        # made `basic_auth` return None, so those credentials were read,
+        # accepted, and dropped. Against a secured server that is an anonymous
+        # request, a 401, and a sanitized 502 that reads as the upstream's
+        # fault — the exact failure this module's own docstring says must not
+        # happen quietly.
+        #
+        # AUTH_BASIC does not make a credential mandatory. `basic_auth`
+        # returns None when either half is unset, so a public sandbox stays
+        # anonymous, which is why this is the same auth style as `generic`.
+        # What separates the two entries is the summary, not the behaviour.
+        auth=AUTH_BASIC,
         summary="HAPI FHIR. Public sandboxes take no credential; add "
                 "FHIR_UPSTREAM_CLIENT_ID/_SECRET for one behind HTTP Basic.",
     ),

--- a/tests/test_upstream_connector_registry.py
+++ b/tests/test_upstream_connector_registry.py
@@ -80,12 +80,65 @@ class TestTheRegistryNamesWhatWeAreInFrontOf:
     @pytest.mark.parametrize("kind,auth", [
         ("aidbox", AUTH_BASIC),
         ("medplum", AUTH_OAUTH2),
-        ("hapi", AUTH_NONE),
+        # hapi was AUTH_NONE, and this row PINNED the defect. Its summary
+        # tells an operator to set FHIR_UPSTREAM_CLIENT_ID/_SECRET for a
+        # secured server, and AUTH_NONE made `basic_auth` drop them. Changing
+        # this row is changing a specification deliberately, with the reason
+        # recorded — not raising a ratchet to go green.
+        ("hapi", AUTH_BASIC),
         ("generic", AUTH_BASIC),
     ])
     def test_each_kind_declares_its_auth_style(self, kind, auth):
         c = _resolve(FHIR_UPSTREAM_KIND=kind, FHIR_UPSTREAM_URL=AIDBOX)
         assert c.kind == kind and c.auth == auth
+
+    def test_a_connector_that_offers_credentials_actually_sends_them(self):
+        """THE RULE, and the general form of the hapi defect: a summary that
+        names a credential must belong to an auth style that carries one.
+
+        The registry summary is not decoration — `supported_connectors()`
+        publishes it as the answer to "what does this build support and how do
+        I authenticate to it". A connector whose prose and whose behaviour
+        disagree is the retro's shape with an operator manual attached, and
+        the failure is silent: credentials accepted, dropped, 401 upstream,
+        502 that reads as the upstream's fault.
+
+        MUTATION: set hapi back to AUTH_NONE -> red.
+        """
+        offenders = []
+        for connector in CONNECTORS.values():
+            mentions_credential = (
+                "CLIENT_ID" in connector.summary
+                or "Basic" in connector.summary
+                or "credential" in connector.summary.lower())
+            if mentions_credential and connector.auth == AUTH_NONE:
+                offenders.append(f"{connector.name}: {connector.summary}")
+        assert not offenders, (
+            "a connector offers a credential its auth style cannot send:\n  "
+            + "\n  ".join(offenders))
+
+    def test_hapi_sends_a_credential_when_one_is_configured(self):
+        """The behaviour, measured rather than inferred from the enum.
+
+        MUTATION: set hapi back to AUTH_NONE -> red.
+        """
+        c = _resolve(FHIR_UPSTREAM_KIND="hapi", FHIR_UPSTREAM_URL=AIDBOX,
+                     FHIR_UPSTREAM_CLIENT_ID="hapi-user",
+                     FHIR_UPSTREAM_CLIENT_SECRET="hapi-pass")
+        assert c.basic_auth == ("hapi-user", "hapi-pass")
+
+    def test_hapi_stays_anonymous_when_none_is(self):
+        """The other side, and why this is not a breaking change: a public
+        sandbox takes no credential and must keep taking none.
+
+        MUTATION: make basic_auth return a pair when only one half is set,
+        or make AUTH_BASIC demand credentials -> red.
+        """
+        c = _resolve(FHIR_UPSTREAM_KIND="hapi", FHIR_UPSTREAM_URL=AIDBOX)
+        assert c.basic_auth is None
+        half = _resolve(FHIR_UPSTREAM_KIND="hapi", FHIR_UPSTREAM_URL=AIDBOX,
+                        FHIR_UPSTREAM_CLIENT_ID="hapi-user")
+        assert half.basic_auth is None
 
     def test_aidbox_is_first_class_now(self):
         """It was the better-verified connector and the one with no name."""


### PR DESCRIPTION
Found by the set-2 evidence run — measured **on the wire** against a recording upstream: identical environment, `kind=hapi` sends no `Authorization` header, `kind=generic` sends `Basic`. This is my defect, from #504.

## The control says one thing and does another

The registry entry — the summary an operator reads out of `supported_connectors()`:

> "HAPI FHIR. Public sandboxes take no credential; **add `FHIR_UPSTREAM_CLIENT_ID`/`_SECRET` for one behind HTTP Basic**."

and it carried `auth=AUTH_NONE`, so `basic_auth` returns `None` whatever is configured:

```python
@property
def basic_auth(self):
    if self.auth == AUTH_BASIC and self.client_id and self.client_secret:
        return (self.client_id, self.client_secret)
    return None
```

An operator following that sentence against a secured HAPI gets anonymous requests → 401 → a sanitized 502 that reads as the upstream's fault. That is the exact quiet failure `r6/upstream_connectors.py`'s own docstring opens by warning about:

> *"a deployment that stops authenticating does not fail loudly — it fails as a 502 that looks like the upstream's fault."*

## Not a breaking change

`AUTH_BASIC` does not make a credential mandatory — `basic_auth` returns `None` when either half is unset, so a public sandbox stays anonymous and no working deployment moves. What separates `hapi` from `generic` is the summary, not the behaviour. Both sides are now measured rather than inferred from the enum.

## The pin was the defect

`tests/test_upstream_connector_registry.py:83` asserted `("hapi", AUTH_NONE)` — a specification written from the code rather than from the promise, which is why the suite was green over it.

Changing that row is changing a specification **deliberately, with the reason recorded at the row**. It is not raising a ratchet to go green. The two edits look identical in a diff, which is why it is worth saying out loud.

## The durable half

hapi was one instance of a general rule, and the rule is what stops the fifth connector repeating it:

> **A connector whose summary names a credential must belong to an auth style that can send one.**

Checked across every entry in `CONNECTORS`, so a server added next month cannot ship prose its behaviour does not honour.

## Evidence

Mutation — `hapi` back to `AUTH_NONE` → **3 tests red** (the auth-style row, the general rule, and the behavioural check).

`3130 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.