### PR TITLE
fix(proxy): health said upstream, healthy, 200 — and the writes were in SQLite

### DIFF
--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -758,12 +758,70 @@ def reset_proxy():
     _medplum_cache['expires_at'] = 0.0
 
 
-def is_proxy_enabled() -> bool:
-    """Check if any upstream proxy mode is configured."""
+def upstream_intended() -> bool:
+    """True when the environment NAMES an upstream, working or not.
+
+    This is the old `is_proxy_enabled` — an env-var presence check — under a
+    name that says what it actually measures. It answers "did the operator
+    mean to proxy", which is only useful next to the answer to "are we
+    proxying". Never use it alone to describe the running system.
+    """
     return bool(
         os.environ.get('FHIR_UPSTREAM_URL', '').strip()
         or os.environ.get('MEDPLUM_BASE_URL', '').strip()
     )
+
+
+def is_proxy_enabled() -> bool:
+    """True when a proxy EXISTS, not when one was asked for.
+
+    These were the same question until an upstream could refuse to be built.
+    Since #503 an OAuth2 upstream with no credentials returns None from
+    get_proxy() rather than making anonymous requests at a record system —
+    correct, and it split the question in two while this function kept
+    answering the old one.
+
+    The consequence, measured: with FHIR_UPSTREAM_URL set and the secret
+    missing, /r6/fhir/health reported mode 'upstream', status 'healthy',
+    HTTP 200 — and every write landed in the container's own SQLite. An
+    operator reading that page has no way to see it, and the data is in the
+    wrong store by the time anyone looks.
+
+    `upstream_intended()` is the other half. Health reports both, because
+    "local because nobody configured an upstream" and "local because the
+    upstream we configured could not be built" are different situations and
+    only one of them is fine.
+    """
+    return get_proxy() is not None
+
+
+def upstream_status() -> dict:
+    """What /health should say about the upstream, and whether it is degraded.
+
+    Three states, and the middle one is the reason this function exists:
+
+      not_configured   nobody asked for an upstream. Local mode by design.
+      misconfigured    one was NAMED and no client could be built for it.
+                       Writes are landing in local storage while the operator
+                       believes they are going to their FHIR server.
+      <health payload> a proxy exists; the proxy reports on itself.
+
+    'misconfigured' is degraded rather than a quiet 200, which is consistent
+    with an upstream that is configured and unreachable — that already
+    answers 503. The failure it makes loud is the one where a deploy succeeds
+    and the data goes somewhere nobody looks.
+
+    Returns a dict rather than a pair: a 2-tuple is always truthy, and this
+    codebase has a documented bypass built on exactly that shape.
+    """
+    proxy = get_proxy()
+    if proxy:
+        payload = proxy.healthy()
+        return {'check': payload,
+                'degraded': payload.get('status') != 'connected'}
+    if upstream_intended():
+        return {'check': 'misconfigured', 'degraded': True}
+    return {'check': 'not_configured', 'degraded': False}
 
 
 # ---------------------------------------------------------------------------

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -57,9 +57,9 @@ from r6.health_compliance import (
     export_audit_trail, MEDICAL_DISCLAIMER
 )
 from r6.fhir_proxy import (
-    get_proxy,
     get_proxy_for_request,
     is_proxy_enabled,
+    upstream_status,
     is_sharp_context_active,
     close_request_proxy,
     sanitize_operation_outcome_resource,
@@ -1990,15 +1990,12 @@ def health_check():
         health['checks']['database'] = 'error'
         logger.warning(f'Health check: database failed: {e}')
 
-    # Check upstream FHIR server connectivity
-    proxy = get_proxy()
-    if proxy:
-        upstream_health = proxy.healthy()
-        health['checks']['upstream'] = upstream_health
-        if upstream_health.get('status') != 'connected':
-            health['status'] = 'degraded'
-    else:
-        health['checks']['upstream'] = 'not_configured'
+    # Check upstream FHIR server connectivity. Three states, incl. an upstream
+    # that was named and could not be built — see r6.fhir_proxy.upstream_status.
+    upstream = upstream_status()
+    health['checks']['upstream'] = upstream['check']
+    if upstream['degraded']:
+        health['status'] = 'degraded'
 
     status_code = 200 if health['status'] == 'healthy' else 503
     return jsonify(health), status_code

--- a/tests/test_fhir_proxy.py
+++ b/tests/test_fhir_proxy.py
@@ -12,6 +12,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from r6.fhir_proxy import (
+    upstream_intended,
+    upstream_status,
     FHIRUpstreamProxy, MedplumProxy, get_proxy, reset_proxy, is_proxy_enabled,
     _fetch_medplum_token, _medplum_cache,
     sanitize_upstream_error, upstream_unreachable_outcome,
@@ -601,7 +603,10 @@ class TestProxyRouteIntegration:
         """Health endpoint reports upstream connection status."""
         os.environ['FHIR_UPSTREAM_URL'] = 'https://hapi.fhir.org/baseR4'
 
-        with patch('r6.routes.get_proxy') as mock_get:
+        # Patched where it is LOOKED UP: /health now asks
+        # r6.fhir_proxy.upstream_status, which calls get_proxy itself, so
+        # r6.routes no longer holds that name.
+        with patch('r6.fhir_proxy.get_proxy') as mock_get:
             mock_proxy = MagicMock()
             mock_proxy.healthy.return_value = {
                 'status': 'connected',
@@ -807,10 +812,51 @@ class TestMedplumProxy:
         proxy = get_proxy()
         assert proxy is None
 
-    def test_is_proxy_enabled_with_medplum(self):
-        """is_proxy_enabled() returns True when MEDPLUM_BASE_URL is set."""
+    def test_a_base_url_alone_is_an_intention_not_a_proxy(self):
+        """THIS TEST ASSERTED THE DEFECT, and it is worth saying how.
+
+        It read "is_proxy_enabled() returns True when MEDPLUM_BASE_URL is
+        set", which was a true description of the code and stopped being a
+        true description of the system at #503 — after which an OAuth2
+        upstream with no credentials refuses to build rather than making
+        anonymous requests at a record system.
+
+        So the URL alone meant: /health says mode 'upstream', status
+        'healthy', HTTP 200, and every write lands in local SQLite. Measured,
+        not theorised.
+
+        MUTATION: revert is_proxy_enabled to the env-var check -> red.
+        """
         os.environ['MEDPLUM_BASE_URL'] = 'https://api.medplum.com/fhir/R4'
+        assert upstream_intended() is True, (
+            'the environment names an upstream, which is the question this '
+            'half answers')
+        assert is_proxy_enabled() is False, (
+            'no client can be built without credentials, so nothing is being '
+            'proxied and the system must not say it is')
+
+    def test_credentials_turn_the_intention_into_a_proxy(self):
+        """The other side: this must stay True, or the fix has just disabled
+        every working Medplum deployment."""
+        os.environ['MEDPLUM_BASE_URL'] = 'https://api.medplum.com/fhir/R4'
+        os.environ['MEDPLUM_CLIENT_ID'] = 'cid'
+        os.environ['MEDPLUM_CLIENT_SECRET'] = 'csec'
         assert is_proxy_enabled() is True
+
+    def test_health_calls_a_misconfigured_upstream_degraded(self):
+        """The operator-visible half. 'not_configured' and 'misconfigured'
+        are different situations and only one of them is fine.
+
+        MUTATION: report 'not_configured' for a named-but-unbuildable
+        upstream, or drop the degraded flag -> red.
+        """
+        os.environ['MEDPLUM_BASE_URL'] = 'https://api.medplum.com/fhir/R4'
+        status = upstream_status()
+        assert status == {'check': 'misconfigured', 'degraded': True}
+
+        os.environ.pop('MEDPLUM_BASE_URL', None)
+        assert upstream_status() == {'check': 'not_configured',
+                                     'degraded': False}
 
     def test_fhir_upstream_takes_priority_over_medplum(self):
         """FHIR_UPSTREAM_URL takes priority; MedplumProxy is NOT created."""


### PR DESCRIPTION
Found by the set-2 evidence run, verified with a real create and read.

## The failure

With `FHIR_UPSTREAM_URL` (or `MEDPLUM_BASE_URL`) set and the client secret missing:

| `/r6/fhir/health` said | reality |
|---|---|
| `"mode": "upstream"` | `get_proxy()` is `None` |
| `"status": "healthy"`, HTTP 200 | every write landing in the container's own SQLite |

An operator reading that page has no way to see it, and the data is in the wrong store by the time anyone looks.

## Two functions answering different questions under one name

They were the same question until **#503**, which made an OAuth2 upstream with no credentials *refuse to build* rather than make anonymous requests at a record system. That fix was right, and it split the question in two. `is_proxy_enabled` kept answering the old one — *is an upstream named* — while everything reading it means *are we proxying*.

```python
upstream_intended()   # the environment names an upstream, working or not
is_proxy_enabled()    # a proxy EXISTS — get_proxy() is not None
```

## /health gets a third state, and the middle one is the point

| state | meaning | HTTP |
|---|---|---|
| `not_configured` | nobody asked for an upstream; local by design | 200 |
| `misconfigured` | one was **named** and no client could be built | **503** |
| *(payload)* | a proxy exists and reports on itself | 200 / 503 |

`misconfigured` is degraded rather than a quiet 200 for two reasons: the data is going somewhere nobody watches, and it is **consistent with what already happens** — an upstream that is configured and *unreachable* answers 503 two lines above. A deploy with half its upstream config now fails at the health check instead of succeeding quietly.

That is a deliberate behaviour change for a misconfigured deployment. A correctly configured one is unaffected, and `test_credentials_turn_the_intention_into_a_proxy` exists specifically so this cannot have disabled every working Medplum deployment.

## One of the two failing tests was asserting the defect

`test_is_proxy_enabled_with_medplum` read *"returns True when `MEDPLUM_BASE_URL` is set"* — a true description of the code, and a false description of the system since #503. Same shape as the `hapi` pin in #512: a specification written from the implementation.

Rewritten to the honest property, both sides: a base URL alone is an **intention**; credentials turn it into a **proxy**. The second failure was a mock patching `r6.routes.get_proxy`, a name `routes.py` no longer holds.

## Ratchet

The branch moved **out** of the god module into `r6.fhir_proxy.upstream_status`. `r6/routes.py` is **3924 lines — three fewer than the pin at 3927.**

`upstream_status` returns a dict, not a pair: a 2-tuple is always truthy, and this codebase has a documented auth bypass built on exactly that shape.

## Evidence

Three mutations, each verified red:

| Mutation | Result |
|---|---|
| `is_proxy_enabled` reverted to the env check | red |
| `misconfigured` reported as `not_configured` | red |
| the `degraded` flag dropped | red |

`3129 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.