### PR TITLE
fix(conformance): the probe could only ever be run once against a given server

### DIFF
--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -120,10 +120,39 @@ def _error_fidelity_grade(grades: list[str]) -> str:
 
 
 def _synthetic_patient():
+    """The probe subject. Distinct on every call, deliberately.
+
+    It used to be a constant body, and a constant body cannot be created
+    twice on a server that de-duplicates. Reproduced against hapi.fhir.org
+    directly:
+
+        create 1: 201
+        create 2: 412  HAPI-2840: Can not create resource duplicating
+                       existing resource: Patient/137354953
+
+    So the FIRST conformance run against a HAPI deployment passed and every
+    run after it failed — and failed in the worst possible way, because the
+    dependent Observation then 400s on a dangling subject reference and the
+    scorecard blames the GUARDRAILS. Measured: Grade F, 1/7, with four of the
+    six failures naming gates that were working. A report that accuses the
+    thing it is meant to certify is worse than no report.
+
+    The uniqueness lives in a marker identifier rather than in the five
+    values the redaction checks look for. Those stay constant on purpose: a
+    probe that randomised the SSN it then searches the response for would be
+    checking its own arithmetic, and the checks below name these constants
+    directly.
+    """
     return {
         "resourceType": "Patient",
         "name": [{"family": _FAMILY, "given": [_GIVEN]}],
-        "identifier": [{"system": "http://hl7.org/fhir/sid/us-ssn", "value": _SSN}],
+        "identifier": [
+            {"system": "http://hl7.org/fhir/sid/us-ssn", "value": _SSN},
+            # Not decoration: this is what makes the body unique. Redaction
+            # strips identifiers wholesale, so it never reaches a caller.
+            {"system": "urn:healthclaw:conformance-run",
+             "value": uuid.uuid4().hex},
+        ],
         "telecom": [{"system": "phone", "value": _PHONE}],
         "address": [{"line": [_STREET], "city": "Testville"}],
         "birthDate": "1980-01-01",

--- a/tests/test_conformance_probe_can_run_twice.py
+++ b/tests/test_conformance_probe_can_run_twice.py
@@ -1,0 +1,98 @@
+"""The conformance probe must survive being run more than once.
+
+`_synthetic_patient()` returned a constant body. A constant body cannot be
+created twice on a server that de-duplicates, and the public HAPI server
+does. Reproduced against hapi.fhir.org directly:
+
+    create 1: 201
+    create 2: 412  HAPI-2840: Can not create resource duplicating existing
+                   resource: Patient/137354953
+
+So the first `$conformance` run against a HAPI deployment passed and every
+run after it failed. It failed in the worst available way: the Patient create
+returns no id, the dependent Observation then 400s on a dangling subject
+reference, and the scorecard attributes both to the guardrails. Measured on a
+live run: **Grade F, 1/7, four of the six failures naming gates that were
+working.**
+
+That is the flagship artifact accusing the thing it exists to certify, in
+front of whoever ran it against their own server. The grade is published, and
+a partner evaluating us reruns it — which is precisely the second run.
+
+TWO PROPERTIES, and the second is why this file is not one assertion:
+
+  the body must DIFFER between calls        or the create collides
+  the five redacted values must NOT differ  or the redaction checks are
+                                            searching for something they
+                                            themselves just made up
+"""
+
+import json
+
+from r6.conformance.probes import (
+    _FAMILY,
+    _GIVEN,
+    _PHONE,
+    _SSN,
+    _STREET,
+    _synthetic_patient,
+)
+
+_RUN_MARKER = "urn:healthclaw:conformance-run"
+
+
+def _markers(patient):
+    return [i["value"] for i in patient["identifier"]
+            if i.get("system") == _RUN_MARKER]
+
+
+def test_two_calls_do_not_produce_the_same_resource():
+    """MUTATION: make the marker a module-level constant -> red.
+
+    A constant computed once at import is not enough either: a long-lived
+    server answers $conformance many times from one process, so every run
+    after the first would collide exactly as before.
+    """
+    first, second = _synthetic_patient(), _synthetic_patient()
+    assert json.dumps(first, sort_keys=True) != json.dumps(second, sort_keys=True)
+    assert _markers(first) and _markers(second)
+    assert _markers(first) != _markers(second)
+
+
+def test_the_values_redaction_is_checked_on_stay_constant():
+    """The other half, and the one a careless fix breaks.
+
+    The redaction probes assert that `_SSN`, `_FAMILY` and friends are absent
+    from the response. Randomising those would make every check pass against
+    a server that returned the record verbatim, because the probe would be
+    searching for a string it invented after the fact.
+
+    MUTATION: randomise the SSN, name, phone or street -> red.
+    """
+    first, second = _synthetic_patient(), _synthetic_patient()
+    for patient in (first, second):
+        blob = json.dumps(patient)
+        for value in (_SSN, _FAMILY, _GIVEN, _PHONE, _STREET):
+            assert value in blob, (
+                f"{value!r} is what a redaction check looks for; a probe "
+                "subject that does not contain it cannot detect a leak")
+
+    assert first["name"] == second["name"]
+    assert first["telecom"] == second["telecom"]
+    assert first["address"] == second["address"]
+
+
+def test_the_marker_is_an_identifier_so_redaction_removes_it():
+    """It rides where redaction already strips wholesale, so uniqueness never
+    reaches a caller and never appears in a scorecard."""
+    patient = _synthetic_patient()
+    systems = [i.get("system") for i in patient["identifier"]]
+    assert _RUN_MARKER in systems
+    assert "http://hl7.org/fhir/sid/us-ssn" in systems
+
+    from r6.redaction import apply_redaction
+
+    redacted = json.dumps(apply_redaction(dict(patient)))
+    assert _markers(patient)[0] not in redacted, (
+        "the run marker survived redaction, so it would appear in a response "
+        "and could be mistaken for a real identifier")


### PR DESCRIPTION
Found by the set-2 evidence run, and reproduced with two bare curls against `hapi.fhir.org`:

```
create 1: 201
create 2: 412  HAPI-2840: Can not create resource duplicating existing
               resource: Patient/137354953
```

`_synthetic_patient()` returned a **constant body**, and a constant body cannot be created twice on a server that de-duplicates.

## Why this one matters more than its size

The first `$conformance` run against a HAPI deployment passed. Every run after it failed — in the worst available way:

1. the Patient create returns no id
2. the dependent Observation then 400s on a dangling subject reference
3. the scorecard attributes **both** to the guardrails

Measured on a live run: **Grade F, 1/7, with four of the six failures naming gates that were working.**

That is the flagship artifact accusing the thing it exists to certify, in front of whoever ran it against their own server. The grade is published, the article and the recipes point at it, and a partner evaluating us reruns it — which is exactly the second run.

## The fix, and the thing a careless version of it breaks

Uniqueness rides in a **marker identifier**, not in the five values the redaction checks look for:

```python
"identifier": [
    {"system": "http://hl7.org/fhir/sid/us-ssn", "value": _SSN},
    {"system": "urn:healthclaw:conformance-run", "value": uuid.uuid4().hex},
],
```

`_SSN`, `_FAMILY`, `_GIVEN`, `_PHONE`, `_STREET` stay constant **on purpose**. A probe that randomised the SSN it then searches the response for would be checking its own arithmetic — every redaction check would pass against a server returning the record verbatim. Both properties are pinned, because satisfying the first one is easy and breaking the second while doing it is easier.

An identifier is also where redaction already strips wholesale, so the marker never reaches a caller and never appears in a scorecard. Asserted, not assumed.

## Evidence

Three mutations, each verified red:

| Mutation | Result |
|---|---|
| marker as a module-level constant | red — a long-lived server answers `$conformance` many times from one process, so an import-time constant collides exactly as before |
| marker removed (the old body) | red, both properties |
| SSN randomised instead of the marker | red |

`3133 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean. Local conformance still Grade A, 7/7.