### PR TITLE
fix(qa): smoke_medplum reported 7/8 against a HealthClaw with no Medplum

### DIFF
--- a/scripts/smoke_medplum.py
+++ b/scripts/smoke_medplum.py
@@ -9,7 +9,25 @@ Usage:
     python scripts/smoke_medplum.py --base-url https://your-healthclaw \
         --tenant-id <tenant> --step-up-token <token>
 
-Exit code 0 = all guardrail checks passed.
+Exit code 0 = every check RAN and passed.
+
+WHY THAT SENTENCE IS PHRASED THAT WAY. This script reported "7/8 guardrail
+checks passed" against a HealthClaw with no Medplum behind it at all — every
+check but one describing local SQLite, and the one that would have caught it
+("Medplum-sourced") counted as a single lost point among seven wins.
+
+Worse, with read auth enabled the read-back returns 401, and two of the
+redaction checks are `"000-00-1234" not in blob`. An empty body contains no
+SSN either, so they PASSED on the body of a refusal. That is the same vacuous
+assertion as the Aidbox example's redaction demo (#499): a check that cannot
+distinguish "the value was removed" from "there was no response".
+
+So this file has GATES as well as checks. A gate is a precondition, and a
+failing one STOPS the run — the code after it does not execute, so there is
+no way to evaluate a check against a response that never arrived. The summary
+then names the gate that stopped it instead of printing a fraction, because
+the fraction would be over the checks that happened to run. That fraction is
+what made a HealthClaw with no Medplum behind it read as 7/8.
 """
 
 import argparse
@@ -24,6 +42,74 @@ SYNTHETIC_PATIENT = {
     "telecom": [{"system": "phone", "value": "555-000-1234"}],
     "birthDate": "1980-01-01",
 }
+
+
+class StoppedEarly(Exception):
+    """A gate failed. Raised so nothing downstream is even evaluated."""
+
+
+class Runner:
+    """Checks, gates, and a summary that cannot round a partial run up.
+
+    Importable and driven directly by tests/test_seed_scripts_still_run.py,
+    because CI cannot run this script for real — it needs a live Medplum
+    behind a live HealthClaw. The previous guard on this file was a grep for
+    the string "Content-Type", which is the best a procedural script allows
+    and is not much.
+    """
+
+    PASS, FAIL = "PASS", "FAIL"
+
+    def __init__(self):
+        self.results = []
+        self.stopped_by = None
+
+    def check(self, name, ok, detail=""):
+        """An observation. Failing one does not invalidate the others."""
+        if self.stopped_by is not None:
+            raise AssertionError(
+                f"check {name!r} ran after gate {self.stopped_by!r} failed")
+        self._record(name, self.PASS if ok else self.FAIL, detail)
+        return bool(ok)
+
+    def gate(self, name, ok, detail=""):
+        """A precondition. Failing one STOPS the run.
+
+        This is the whole point of the file. A check evaluated against a
+        response that never arrived is not a passing check — `"secret" not in
+        ""` is True — and a run that never reached Medplum has nothing to say
+        about Medplum. Raising means the code after it does not execute, so
+        there is no way to accidentally evaluate it anyway.
+        """
+        self._record(name, self.PASS if ok else self.FAIL, detail)
+        if ok:
+            return True
+        self.stopped_by = name
+        raise StoppedEarly(name)
+
+    def _record(self, name, verdict, detail):
+        self.results.append((name, verdict, detail))
+        print(f"  [{verdict}] {name}" + (f" — {detail}" if detail else ""))
+
+    def summary(self):
+        passed = sum(1 for _, v, _ in self.results if v == self.PASS)
+        line = f"{passed}/{len(self.results)} guardrail checks passed"
+        if self.stopped_by is not None:
+            # Never "7/8" for a run that stopped. The denominator would be the
+            # checks that HAPPENED to run, which is the number that made a
+            # HealthClaw with no Medplum behind it look 87% healthy.
+            line += (f" before the run STOPPED at the gate "
+                     f"'{self.stopped_by}'. The checks after it did not run, "
+                     "and none of them counts as passed")
+        return line + "."
+
+    def exit_code(self):
+        failed = any(v == self.FAIL for _, v, _ in self.results)
+        return 1 if failed or self.stopped_by is not None else 0
+
+    def finish(self):
+        print("\n" + self.summary())
+        sys.exit(self.exit_code())
 
 
 def main():
@@ -41,11 +127,16 @@ def main():
                  "X-Step-Up-Token": args.step_up_token,
                  "X-Human-Confirmed": "true"}
 
-    results = []
+    run = Runner()
+    try:
+        _run_checks(run, requests, base, read_hdr, write_hdr)
+    except StoppedEarly:
+        pass  # the gate already recorded and printed itself
+    run.finish()
 
-    def check(name, ok, detail=""):
-        results.append((name, ok, detail))
-        print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+
+def _run_checks(run, requests, base, read_hdr, write_hdr):
+    check, gate = run.check, run.gate
 
     # 1. Write is gated: create without step-up must be refused before Medplum.
     #
@@ -67,35 +158,34 @@ def main():
                       data=json.dumps(SYNTHETIC_PATIENT))
     ok_create = r.status_code in (200, 201)
     pid = (r.json() or {}).get("id") if ok_create else None
-    check("guardrailed create -> Medplum (201)", ok_create and bool(pid),
-          f"id={pid}" if pid else f"status {r.status_code}")
-    if not pid:
-        _finish(results)
+    gate("guardrailed create -> Medplum (201)", ok_create and bool(pid),
+         f"id={pid}" if pid else f"status {r.status_code}")
 
     # 3. Read back through HealthClaw is redacted.
     r = requests.get(f"{base}/r6/fhir/Patient/{pid}", headers=read_hdr)
+    # GATE, not check: a 401 body carries no SSN either, and the three
+    # redaction assertions below would pass on it while proving nothing.
+    gate("read returns 200", r.status_code == 200, f"status {r.status_code}")
     body = r.json() if r.status_code == 200 else {}
     blob = json.dumps(body)
     fam = (body.get("name", [{}])[0] or {}).get("family", "")
-    check("read returns 200", r.status_code == 200, f"status {r.status_code}")
+
+    # GATE: this script is named after Medplum. If the resource came from
+    # local storage, everything below describes SQLite, and reporting it as
+    # a score out of eight is how a run with no Medplum in existence read as
+    # 7/8.
+    gate("Medplum-sourced (not local storage)",
+         body.get("_source") == "upstream", f"_source={body.get('_source')!r}")
+
     check("name redacted (initial only)", fam == "T.", f"family={fam!r}")
     check("SSN masked in read", "000-00-1234" not in blob)
     check("phone redacted in read", "555-000-1234" not in blob)
-    check("Medplum-sourced", body.get("_source") == "upstream")
 
     # 4. Audit trail recorded.
     a = requests.get(f"{base}/r6/fhir/AuditEvent?_count=10", headers=read_hdr)
     audit_ok = a.status_code == 200 and (a.json().get("total", 0) or
                                          len(a.json().get("entry", []))) >= 1
     check("access audited (AuditEvent present)", audit_ok)
-
-    _finish(results)
-
-
-def _finish(results):
-    passed = sum(1 for _, ok, _ in results if ok)
-    print(f"\n{passed}/{len(results)} guardrail checks passed.")
-    sys.exit(0 if passed == len(results) else 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_seed_scripts_still_run.py
+++ b/tests/test_seed_scripts_still_run.py
@@ -79,3 +79,106 @@ def test_the_medplum_gate_check_sends_a_parseable_body():
     assert "Content-Type" in block, (
         "the no-step-up write must send a parseable body, or it is refused "
         "as malformed before the credential is ever considered")
+
+
+# ---------------------------------------------------------------------------
+# smoke_medplum: a partial run must not round itself up
+# ---------------------------------------------------------------------------
+#
+# The script reported "7/8 guardrail checks passed" against a HealthClaw with
+# no Medplum behind it at all — seven checks describing local SQLite, and the
+# single check that would have caught it counted as one lost point. Two of the
+# seven were `"000-00-1234" not in blob` evaluated on the body of a 401, which
+# is the #499 vacuous assertion: an empty body contains no SSN either.
+#
+# The guard on this file used to be a grep for the string "Content-Type",
+# which is what a procedural script allows. The check logic now lives in a
+# Runner that a test can drive, so these are behavioural.
+
+def _runner():
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import smoke_medplum
+    return smoke_medplum
+
+
+def test_a_failed_gate_stops_the_run_rather_than_scoring_it():
+    """MUTATION: make gate() record and return False instead of raising -> red.
+
+    The redaction checks live after the gates on purpose. If a failing gate
+    only returned False, they would still execute against an empty body and
+    pass.
+    """
+    m = _runner()
+    run = m.Runner()
+    run.check("write blocked without step-up (401)", True)
+    with pytest.raises(m.StoppedEarly):
+        run.gate("read returns 200", False, "status 401")
+
+    assert run.stopped_by == "read returns 200"
+    assert run.exit_code() == 1
+    assert "STOPPED at the gate" in run.summary()
+    assert "did not run" in run.summary()
+
+
+def test_the_summary_never_reports_a_bare_fraction_for_a_stopped_run():
+    """"7/8" is the number that made a run with no Medplum look healthy.
+
+    MUTATION: drop the stopped_by clause from summary() -> red.
+    """
+    m = _runner()
+    run = m.Runner()
+    for i in range(7):
+        run.check(f"check {i}", True)
+    with pytest.raises(m.StoppedEarly):
+        run.gate("Medplum-sourced (not local storage)", False, "_source=None")
+
+    summary = run.summary()
+    assert not summary.startswith("7/8 guardrail checks passed."), (
+        "a stopped run printed a plain fraction")
+    assert "Medplum-sourced" in summary, (
+        "the summary must name the gate that stopped it, or an operator "
+        "cannot tell a partial run from a failing one")
+
+
+def test_a_clean_run_still_exits_zero():
+    """The other side. A guard that can only fail is not a guard.
+
+    MUTATION: make exit_code() always return 1 -> red.
+    """
+    m = _runner()
+    run = m.Runner()
+    run.check("a", True)
+    run.gate("b", True)
+    run.check("c", True)
+    assert run.exit_code() == 0
+    assert run.summary() == "3/3 guardrail checks passed."
+
+
+def test_a_failing_check_is_not_a_stopped_run():
+    """A check and a gate are different things, and conflating them would
+    make any single failure hide every later result."""
+    m = _runner()
+    run = m.Runner()
+    run.check("a", False, "got 500")
+    run.check("b", True)
+    assert run.stopped_by is None
+    assert run.exit_code() == 1
+    assert run.summary() == "1/2 guardrail checks passed."
+
+
+def test_the_redaction_assertions_sit_after_both_gates():
+    """Order is the property; the Runner only enforces it if the source uses
+    it. Reading the source here is the cheap half, and the behavioural tests
+    above are the expensive half.
+
+    MUTATION: move the SSN/phone checks above the `read returns 200` gate
+    -> red, and they would evaluate on a refusal again.
+    """
+    src = (ROOT / "scripts" / "smoke_medplum.py").read_text()
+    body = src.split("def _run_checks")[1]
+    read_gate = body.index('gate("read returns 200')
+    source_gate = body.index('gate("Medplum-sourced')
+    for needle in ('check("SSN masked in read"', 'check("phone redacted in read"',
+                   'check("name redacted (initial only)"'):
+        assert body.index(needle) > read_gate, f"{needle} runs before the read gate"
+        assert body.index(needle) > source_gate, f"{needle} runs before the source gate"


### PR DESCRIPTION
Found by the set-2 evidence run. Two defects, one shape.

## What it scored

**A HealthClaw with no Medplum behind it at all: "7/8 guardrail checks passed."**

Seven of the eight describe local SQLite perfectly well. The one check that would have caught it — `Medplum-sourced` — counted as a single lost point among seven wins, and an operator reads 7/8 as a near-pass.

## And two of the seven passed on a refusal

With read auth enabled the read-back returns 401. At that point:

```python
check("SSN masked in read", "000-00-1234" not in blob)      # blob == "{}"
check("phone redacted in read", "555-000-1234" not in blob)  # passes
```

An empty body contains no SSN either. That is **#499 exactly** — an assertion that cannot tell *"the value was removed"* from *"there was no response"* — and the set-1 evidence pack flagged the same shape independently, in the same afternoon.

## Gates, not more checks

A **gate** is a precondition, and a failing one **stops the run by raising**, so the code after it never executes. There is no way to evaluate a check against a response that never arrived, rather than a rule saying you shouldn't.

Two gates now stand ahead of every redaction assertion:

| Gate | Why it is a gate |
|---|---|
| `read returns 200` | a 401 body carries no SSN either |
| `Medplum-sourced (not local storage)` | the script is named after Medplum; if the row came from SQLite, everything below describes SQLite |

The summary **names the gate that stopped it** instead of printing a fraction — the fraction would be over the checks that happened to run, which is precisely the number that made this look 87% healthy. Exit code is non-zero for a *stopped* run as well as a failing one.

## The property is now proven, not grepped

The check logic moved into an importable `Runner`. The previous guard on this file was a grep for the string `"Content-Type"` — the best a procedural script allows, and not much. Five tests drive it directly, including the two-sided ones that stop this from becoming a guard that can only fail:

- a clean run still exits **zero**
- a failing **check** is not a stopped run (conflating them would hide every later result behind the first failure)

## Evidence

Four mutations, each verified red:

| Mutation | Result |
|---|---|
| `gate()` returns False instead of raising | red — the redaction checks execute against an empty body again |
| summary drops its stopped clause | red |
| `exit_code()` always 1 | red |
| redaction checks moved back above the read gate | red |

`3138 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.