### PR TITLE
fix(action-rail): form-fill said it fails loud on a deleted record, and rendered it

### DIFF
--- a/r6/actions/rails/form_fill.py
+++ b/r6/actions/rails/form_fill.py
@@ -59,9 +59,17 @@ class FormFillExecutor:
         # (3) Load the reviewed QR, tenant-scoped. If it vanished (deleted or
         # stale), the reviewed answers are gone: fail loud, never render a
         # blank/guessed form.
+        #
+        # `is_deleted=False` is what makes that comment true (#509). It named
+        # deletion as the case it handled and the query did not filter, so a
+        # soft-deleted QuestionnaireResponse was loaded and RENDERED into a
+        # form submitted on a patient's behalf — the exact "blank/guessed
+        # form" outcome the sentence above promises to prevent. A control
+        # that reads as one thing and does another, with a comment supplying
+        # the misreading.
         row = R6Resource.query.filter_by(
             resource_type='QuestionnaireResponse', id=reviewed_qr_id,
-            tenant_id=action.tenant_id).first()
+            tenant_id=action.tenant_id, is_deleted=False).first()
         if row is None:
             return ExecutionResult(status='failed',
                                    error=errors.STALE_SOURCE_DATA)
@@ -124,7 +132,7 @@ class FormFillExecutor:
                 q_id = q_id.rstrip('/').split('/')[-1]
                 row = R6Resource.query.filter_by(
                     resource_type='Questionnaire', id=q_id,
-                    tenant_id=tenant_id).first()
+                    tenant_id=tenant_id, is_deleted=False).first()
                 if row is not None:
                     return row.to_fhir_json()
         except Exception:  # noqa: BLE001 — non-fatal; fall through to canonical
@@ -145,9 +153,12 @@ class FormFillExecutor:
             return None
         try:
             patient_id = str(subject_ref).split('/', 1)[1]
+            # A deleted Patient's NAME would otherwise be printed on the
+            # title of a form that gets submitted. The renderer treats a
+            # missing label as "no name", which is the right answer here.
             row = R6Resource.query.filter_by(
                 resource_type='Patient', id=patient_id,
-                tenant_id=tenant_id).first()
+                tenant_id=tenant_id, is_deleted=False).first()
             if row is None:
                 return None
             names = (row.to_fhir_json().get('name') or [])

--- a/tests/actions/test_form_fill_execute.py
+++ b/tests/actions/test_form_fill_execute.py
@@ -94,6 +94,46 @@ def test_execute_missing_qr_row_is_stale_source_data(app, tenant_id, monkeypatch
     assert result.error == errors.STALE_SOURCE_DATA
 
 
+def test_a_soft_deleted_reviewed_qr_fails_loud_like_a_missing_one(
+        app, tenant_id, monkeypatch):
+    """#509. The comment above this query names deletion as the case it
+    handles; the query did not filter `is_deleted`, so a tombstoned
+    QuestionnaireResponse was loaded and RENDERED into a form submitted on a
+    patient's behalf.
+
+    Asserted against a live control in the same test, because "it failed" is
+    only meaningful next to "and the identical live one succeeds". Without
+    that half this passes if execute() is broken for everyone.
+
+    MUTATION: drop `is_deleted=False` from the reviewed-QR query -> red, and
+    the deleted answers are rendered as a completed form.
+    """
+    monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)
+    _seed(app, tenant_id, [PATIENT, MED_A, ALLERGY_A])
+    with app.app_context():
+        live_id = _persist_qr(tenant_id, _reviewed_qr())
+        live = FormFillExecutor().execute(_action(
+            tenant_id, {'questionnaire': 'healthclaw-intake', 'body': 'x',
+                        'reviewed_qr_id': live_id}))
+        assert live.status == 'completed', (
+            f'the live control did not complete ({live.error}); this test '
+            'would pass for the wrong reason')
+
+        gone_id = _persist_qr(tenant_id, _reviewed_qr())
+        row = db.session.get(
+            R6Resource, (tenant_id, 'QuestionnaireResponse', gone_id))
+        row.is_deleted = True
+        db.session.commit()
+
+        result = FormFillExecutor().execute(_action(
+            tenant_id, {'questionnaire': 'healthclaw-intake', 'body': 'x',
+                        'reviewed_qr_id': gone_id}))
+
+    assert result.status == 'failed', (
+        'a deleted QuestionnaireResponse was rendered into a form')
+    assert result.error == errors.STALE_SOURCE_DATA
+
+
 def test_execute_happy_path_renders_persists_and_links(app, tenant_id,
                                                        monkeypatch):
     monkeypatch.setenv('PUBLIC_BASE_URL', BASE_URL)

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -280,7 +280,11 @@ def test_no_new_package_mutates_without_auditing():
 #: ambiguity count that decides whether $care-gaps may pick a subject, the
 #: demographics a supplied subject resolves to, and the clinical rows that
 #: CLOSE a gap.
-_FILES_QUERYING_WITHOUT_SOFT_DELETE = 11
+#: 11 -> 10: #509 filtered r6/actions/rails/form_fill.py. Its own comment
+#: named deletion as the case it handled and the query did not, so a
+#: tombstoned QuestionnaireResponse was rendered into a form submitted on a
+#: patient's behalf.
+_FILES_QUERYING_WITHOUT_SOFT_DELETE = 10
 
 #: r6/purge.py hard-deletes a tenant's rows. It must NOT filter is_deleted —
 #: a purge that skipped soft-deleted rows would leave exactly the records the


### PR DESCRIPTION
Refs #509.

## The comment is the defect

`r6/actions/rails/form_fill.py`, step (3), unchanged for its whole life:

```python
# (3) Load the reviewed QR, tenant-scoped. If it vanished (deleted or
# stale), the reviewed answers are gone: fail loud, never render a
# blank/guessed form.
row = R6Resource.query.filter_by(
    resource_type='QuestionnaireResponse', id=reviewed_qr_id,
    tenant_id=action.tenant_id).first()
```

The query does not filter `is_deleted`. A soft-deleted QuestionnaireResponse is loaded and **rendered into a form submitted on a patient's behalf** — the exact "blank/guessed form" outcome the sentence promises to prevent.

The comment is what makes the code read as safe. Without it a reviewer might have looked at the query.

## Two more in the same file

| Site | What a tombstone does |
|---|---|
| the Questionnaire loaded for nicer labels | deleted labels on a live form |
| the Patient whose **name** goes on the title of the submitted form | a deleted patient's name printed on a form that gets filed |

The third is the one a *person* would notice, and the least likely to be noticed by us.

This is the **action rail**, which is where "nothing executes without a human" has to be demonstrable. An execution that consumed a record the system considers deleted is not that.

## The test has a live control

The identical non-deleted QuestionnaireResponse must reach `completed` in the same test:

```python
assert live.status == 'completed', (
    f'the live control did not complete ({live.error}); this test '
    'would pass for the wrong reason')
```

Without that half, this passes whenever `execute()` is broken for everyone — which is how a check ends up describing nothing.

## Reachability, stated as in #422

`is_deleted = True` is written on one line in this repository — the demo walkthrough, on `Permission` rows — and no route accepts DELETE. So this is a reader fixed ahead of its writer. That is the argument for doing it now: the day a delete path ships, this executes on deleted data silently, and nothing in that diff would look wrong.

## Evidence

Mutation — drop `is_deleted=False` from the reviewed-QR query → **red**.

Ratchet `_FILES_QUERYING_WITHOUT_SOFT_DELETE` **11 → 10**.

`3136 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.

## Not in this PR

#509's other half — `context_builder` writing into a tombstoned row without clearing the flag, unlike the ingester on the same operation — is a **product question**: does re-ingesting resurrect a record a patient deleted? That is not an engineering judgement call, so it stays open.