### PR TITLE
fix(startup): a typo in FHIR_UPSTREAM_KIND started the app and 500'd everything

### DIFF
--- a/r6/fhir_proxy.py
+++ b/r6/fhir_proxy.py
@@ -814,7 +814,14 @@ def upstream_status() -> dict:
     Returns a dict rather than a pair: a 2-tuple is always truthy, and this
     codebase has a documented bypass built on exactly that shape.
     """
-    proxy = get_proxy()
+    try:
+        proxy = get_proxy()
+    except ValueError as exc:
+        # An unknown connector kind. Startup validation refuses to boot on
+        # this, so reaching here means something bypassed it — and /health
+        # answering a 500 HTML page is the worst way to say so. Report it.
+        logger.error('upstream misconfigured: %s', exc)
+        return {'check': 'misconfigured', 'degraded': True}
     if proxy:
         payload = proxy.healthy()
         return {'check': payload,

--- a/r6/runtime_config.py
+++ b/r6/runtime_config.py
@@ -84,6 +84,21 @@ def validate_runtime_environment(
     """Validate fail-closed production settings and return the app env."""
     env = os.environ if environ is None else environ
     app_env = resolve_app_env(env)
+
+    # EVERY environment, not just production: an unknown FHIR_UPSTREAM_KIND is
+    # a typo, and a typo here produced a deployment that STARTED, reported
+    # itself started, and then answered 500 to every request including
+    # /health — an opaque HTML error page, while the registry's own excellent
+    # explanation went to a log nobody reads during a deploy.
+    #
+    # resolve_upstream_config raises with that explanation. Calling it here
+    # moves the failure to boot, where an orchestrator keeps the previous
+    # version running instead of rolling out a broken one. It reads the
+    # environment and returns a dataclass: no client is built and no network
+    # call is made, so this costs nothing when the config is right.
+    from r6.upstream_connectors import resolve_upstream_config
+    resolve_upstream_config(environ=env)
+
     if app_env != "production":
         return app_env
 

--- a/tests/test_fhir_proxy.py
+++ b/tests/test_fhir_proxy.py
@@ -870,3 +870,62 @@ class TestMedplumProxy:
         assert not isinstance(proxy, MedplumProxy)
         proxy.close()
         os.environ.pop('FHIR_UPSTREAM_URL', None)
+
+
+class TestAnUnknownConnectorKindFailsAtBootNotPerRequest:
+    """A typo in FHIR_UPSTREAM_KIND used to produce a RUNNING deployment.
+
+    Measured before the fix: the app booted and reported itself booted,
+    `/health` answered **500 with an HTML error page**, and every read 500'd.
+    The registry's own explanation — naming the variable, the bad value and
+    the four valid kinds — went to a log nobody reads during a deploy.
+
+    An orchestrator handles "did not start" correctly: it keeps the previous
+    version serving. It handles "started and 500s" by rolling the broken one
+    out.
+    """
+
+    def test_the_environment_validator_refuses_an_unknown_kind(self):
+        """MUTATION: delete the resolve_upstream_config call from
+        validate_runtime_environment -> red."""
+        from r6.runtime_config import validate_runtime_environment
+
+        with pytest.raises(ValueError, match="not one of"):
+            validate_runtime_environment(environ={
+                "FHIR_UPSTREAM_KIND": "bogus",
+                "FHIR_UPSTREAM_URL": "https://x.example/fhir",
+            })
+
+    @pytest.mark.parametrize("kind", ["aidbox", "medplum", "hapi", "generic"])
+    def test_every_real_kind_still_boots(self, kind):
+        """The other side. A validator that refuses everything is not a
+        validator, and this one runs on every start in every environment."""
+        from r6.runtime_config import validate_runtime_environment
+
+        assert validate_runtime_environment(environ={
+            "FHIR_UPSTREAM_KIND": kind,
+            "FHIR_UPSTREAM_URL": "https://x.example/fhir",
+            "FHIR_UPSTREAM_CLIENT_ID": "cid",
+            "FHIR_UPSTREAM_CLIENT_SECRET": "csec",
+        }) != "production"
+
+    def test_no_upstream_at_all_still_boots(self):
+        """Local mode is the common case and must not need any of this."""
+        from r6.runtime_config import validate_runtime_environment
+
+        assert validate_runtime_environment(environ={}) != "production"
+
+    def test_health_reports_it_rather_than_raising_an_html_500(self, monkeypatch):
+        """Belt and braces: startup refuses, so reaching here means something
+        bypassed it. A 500 HTML page is the worst available way to say
+        "your connector kind is misspelt".
+
+        monkeypatch, not os.environ: a bogus kind left in the environment now
+        fails every LATER test at app construction, because the validator
+        this PR adds runs on every start. Found the hard way — 884 errors.
+
+        MUTATION: drop the ValueError catch in upstream_status -> red.
+        """
+        monkeypatch.setenv("FHIR_UPSTREAM_KIND", "bogus")
+        monkeypatch.setenv("FHIR_UPSTREAM_URL", "https://x.example/fhir")
+        assert upstream_status() == {'check': 'misconfigured', 'degraded': True}


### PR DESCRIPTION
Found by the set-2 evidence run, then measured directly.

## What a typo did

With `FHIR_UPSTREAM_KIND=bogus`, the app **booted and reported itself booted**:

| Endpoint | Result |
|---|---|
| `/r6/fhir/health` | **500**, an HTML error page |
| every read | **500** |

`resolve_upstream_config` raises with a genuinely good message — it names the variable, the bad value, the four valid kinds, and why guessing is refused:

> `FHIR_UPSTREAM_KIND='bogus' is not one of ['aidbox', 'generic', 'hapi', 'medplum']. Refusing to guess: an unknown kind means an unknown auth style, and defaulting to anonymous would send unauthenticated requests at a record system.`

That message went to a log nobody reads during a deploy. The operator got *"Internal Server Error"*.

## Fail at boot, in every environment

An orchestrator handles **"did not start"** correctly: it keeps the previous version serving. It handles **"started, then 500s"** by rolling the broken one out over a working one.

So the check moves into `validate_runtime_environment`, and deliberately runs **before** the `if app_env != "production"` early return. An unknown kind is a typo, and a typo produces a broken deployment wherever it happens — not only in production.

It reads the environment and returns a dataclass. No client is built and no network call is made, so a correct config pays nothing for this.

Belt and braces: `upstream_status()` catches the `ValueError` and reports `misconfigured` + degraded, so anything that reaches `/health` gets a **503 with a JSON body** instead of a 500 with an HTML one.

## Found the hard way, and it is the best evidence the fix works

My first version of the last test set `os.environ` directly, as the neighbouring tests do. The suite went to **884 errors** — because a bad kind now stops the app starting, everywhere, immediately. `monkeypatch` instead, and the note is in the test so the next person does not repeat it.

## Evidence

Both sides pinned, because a validator that refuses everything is not a validator and this one runs on every start:

- all four real kinds boot
- no upstream at all boots

Three mutations, each verified red:

| Mutation | Result |
|---|---|
| boot validation removed | red |
| validation moved behind the production early-return | red |
| the `/health` catch removed | red |

`3142 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean.