### PR TITLE
fix(evidence): the packs said "no real identity" and carried the operator account name

### DIFF
--- a/docs/evidence/2026-08-16-set1-guardrail-core.md
+++ b/docs/evidence/2026-08-16-set1-guardrail-core.md
@@ -4,6 +4,9 @@
 - **Owner:** owner-guardrail-core
 - **Repo HEAD:** `2b7872d` (`feat(kernel): four step-up sites are predicates, not gates — has_grant is the half that fits (#506)`)
 - **Working tree:** clean at start of run; this document is the only file added.
+- **One redaction:** the operator's home-directory name in pasted shell output
+  reads `<user>`. Nothing else in any transcript below is altered — the
+  redaction is incidental to every claim the output supports.
 - **Verdict: EVIDENCE PARTIAL.** Local half complete. Live-proxy half **BLOCKED** —
   the stack described in the task was not running when the run began, and
   starting it was outside the granted scope.
@@ -32,14 +35,14 @@ Confirmed three independent ways rather than trusting one failed `curl`:
 
 ```
 $ docker ps
-failed to connect to the docker API at unix:///Users/eugenevestel/.docker/run/docker.sock;
+failed to connect to the docker API at unix:///Users/<user>/.docker/run/docker.sock;
 check if the path is correct and if the daemon is running: dial unix
-/Users/eugenevestel/.docker/run/docker.sock: connect: no such file or directory
+/Users/<user>/.docker/run/docker.sock: connect: no such file or directory
 
 $ ls -la ~/.docker/run/
 total 0
-drwxr-xr-x@  2 eugenevestel  staff   64 Aug 16 17:16 .
-drwxr-xr-x@ 22 eugenevestel  staff  704 Aug 16 17:06 ..
+drwxr-xr-x@  2 <user>  staff   64 Aug 16 17:16 .
+drwxr-xr-x@ 22 <user>  staff  704 Aug 16 17:06 ..
         # the socket file is gone; the directory mtime is 17:16 today
 
 $ lsof -nP -iTCP -sTCP:LISTEN | grep -E ':(5099|8080|3001)\b'

--- a/docs/evidence/2026-08-16-set2-connectors.md
+++ b/docs/evidence/2026-08-16-set2-connectors.md
@@ -2,6 +2,10 @@
 
 **Owner:** owner-connectors · **Date:** 2026-08-16 · **Verdict: EVIDENCE PARTIAL**
 
+**One redaction:** the operator's home-directory name in pasted shell output
+reads `<user>`. Nothing else in any transcript below is altered — the redaction
+is incidental to every claim the output supports.
+
 Two of the four connector kinds ran a full live walkthrough against a real
 server of that kind. Two did not run at all, because the servers they need
 were not running on this machine and starting them was out of scope for this
@@ -23,16 +27,16 @@ them was running when this pass started, and the Docker daemon itself was down.
 $ docker context ls
 NAME              DOCKER ENDPOINT                                      ERROR
 default           unix:///var/run/docker.sock
-desktop-linux *   unix:///Users/eugenevestel/.docker/run/docker.sock
+desktop-linux *   unix:///Users/<user>/.docker/run/docker.sock
 
 $ docker info --format '{{.ServerVersion}}'
-failed to connect to the docker API at unix:///Users/eugenevestel/.docker/run/docker.sock;
+failed to connect to the docker API at unix:///Users/<user>/.docker/run/docker.sock;
 check if the path is correct and if the daemon is running:
-dial unix /Users/eugenevestel/.docker/run/docker.sock: connect: no such file or directory
+dial unix /Users/<user>/.docker/run/docker.sock: connect: no such file or directory
 
 $ ls -la ~/.docker/run          # the socket file itself is gone
 total 0
-drwxr-xr-x@  2 eugenevestel  staff   64 Aug 16 17:16 .
+drwxr-xr-x@  2 <user>  staff   64 Aug 16 17:16 .
 
 $ pgrep -fl 'com.docker.backend|Docker Desktop|dockerd'
 (no output)

--- a/tests/test_no_operator_home_path_in_docs.py
+++ b/tests/test_no_operator_home_path_in_docs.py
@@ -1,0 +1,88 @@
+"""A pasted shell transcript must not carry the operator's account name.
+
+Evidence packs are the most quoted artifacts this repo produces, and they are
+built by pasting real terminal output — which is the point. Real terminal
+output contains `/Users/<account>/...` and `ls -l` owner columns, and this
+repository is public.
+
+The two Wave-1 packs shipped with eight such lines while the PR that added
+them stated they had been scanned and contained no real identity. That is the
+defect shape the packs themselves are about: a self-assessment substituted for
+a check. So the check exists now.
+
+The needle is the *shape* — an absolute home path with a concrete account name
+— rather than any particular name. A guard keyed to one person's username
+would not fire for the next contributor, and would have to write that username
+into a public file to work at all.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Directories whose contents are published or quoted outward.
+_SCANNED_DIRS = ('docs',)
+
+# `/Users/name/` (macOS) and `/home/name/` (Linux). The placeholder forms a
+# redaction should use are allowed through, and so is the literal `~`.
+_HOME_PATH = re.compile(r'/(?:Users|home)/(?!<)([A-Za-z0-9._-]+)/')
+
+# The other half of the same leak: an `ls -l` owner column. Four of the eight
+# shipped lines were this shape, and a home-path regex does not see it.
+#   drwxr-xr-x@  2 someone  staff   64 Aug 16 17:16 .
+_LS_OWNER = re.compile(
+    r'^[-dlbcps][rwxsStT-]{9}[@+.]?\s+\d+\s+(?!<)([A-Za-z0-9._-]+)\s+\S+\s+\d')
+
+# Redaction placeholders and the shared-runner accounts that appear in pasted
+# CI output. `runner` and `ubuntu` are GitHub Actions; they name no person.
+_ALLOWED_ACCOUNTS = frozenset({
+    'user', 'username', 'you', 'me', 'youruser', 'your-user',
+    'runner', 'ubuntu', 'root', 'home',
+})
+
+
+def _published_markdown() -> list[Path]:
+    paths: list[Path] = []
+    for directory in _SCANNED_DIRS:
+        paths.extend(sorted((REPO_ROOT / directory).rglob('*.md')))
+    return paths
+
+
+def test_the_scan_reaches_the_evidence_packs():
+    """Guard the guard: a scan that silently covers nothing passes forever."""
+    scanned = _published_markdown()
+    assert len(scanned) >= 20, (
+        'the docs scan collapsed to %d file(s) — check _SCANNED_DIRS'
+        % len(scanned))
+
+    packs = [p for p in scanned if p.parent.name == 'evidence']
+    assert packs, (
+        'docs/evidence/ is not being scanned, and it is the directory this '
+        'guard exists for')
+
+
+def test_no_published_doc_carries_an_operator_home_path():
+    offenders = []
+    for path in _published_markdown():
+        text = path.read_text(encoding='utf-8')
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for account in _HOME_PATH.findall(line):
+                if account.lower() in _ALLOWED_ACCOUNTS:
+                    continue
+                offenders.append(
+                    '%s:%d names the account %r in a home path'
+                    % (path.relative_to(REPO_ROOT), line_no, account))
+
+            owner = _LS_OWNER.match(line.strip())
+            if owner and owner.group(1).lower() not in _ALLOWED_ACCOUNTS:
+                offenders.append(
+                    '%s:%d names the account %r in an ls -l owner column'
+                    % (path.relative_to(REPO_ROOT), line_no, owner.group(1)))
+
+    assert not offenders, (
+        'A published document carries a real account name in an absolute home '
+        'path. Replace the account with `<user>`; the path is incidental to '
+        'whatever the transcript is evidence for.\n\n' + '\n'.join(offenders))


### PR DESCRIPTION
**Landing on top of #519, which merged before this was caught.** Auto-merge was armed on that PR; my lint fix turned the checks green and it merged at 02:49:20Z. The content below is live on public `main` right now.

## What was wrong

Both Wave-1 evidence packs paste real terminal output — which is the point of an evidence pack. Real terminal output contains `/Users/<account>/` paths and `ls -l` owner columns, and this repository is public.

Eight lines across the two packs named the operator's account. #519's body said the packs were *"Scanned before committing: no emails, no tokens, no keys, **no real identity**."*

**Not PHI and not a secret.** The paths are incidental to every claim the transcripts support. But it breaks the standing rule against real identities in public writing, and the false sentence in the PR body is what makes it worth a commit rather than a shrug.

It is also, precisely, the defect the packs are *about*: a self-assessment substituted for a check. So the check exists now.

## The guard

`tests/test_no_operator_home_path_in_docs.py` keys on the **shape**, not on any name:

- an absolute home path (`/Users/x/`, `/home/x/`) with a concrete account
- an `ls -l` owner column — four of the eight lines were this shape, and a home-path regex does not see it

A guard keyed to one username would not fire for the next contributor, and would have to write that username into a public file to work at all. Redaction placeholders and CI runner accounts (`runner`, `ubuntu`, `root`) pass.

## Proven both ways

Against the content this replaces:

```
docs/evidence/2026-08-16-set1-guardrail-core.md:35 ... in a home path
docs/evidence/2026-08-16-set1-guardrail-core.md:41 ... in an ls -l owner column
docs/evidence/2026-08-16-set2-connectors.md:26 ... in a home path
docs/evidence/2026-08-16-set2-connectors.md:35 ... in an ls -l owner column
   (8 total, four of each shape)
1 failed, 1 passed
```

After: `2 passed`.

The scan's own width is pinned too — a docs scan that silently matches nothing passes forever, which is the failure mode of every guard of this kind.

## Candidate for feature set 1

**What this is not:** it does not remove the account name from git history, only from the working tree. History rewriting on a public repo is the owner's call and is almost certainly not worth it here — the name is already public through commit authorship, which is why this is graded hygiene rather than a leak.

**Not run:** nothing else in either pack was re-verified. The redaction is textual and every surrounding claim is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)