### PR TITLE
docs: five claims in the merged process documents were not true

### DIFF
--- a/docs/2026-08-16-delivery-process.md
+++ b/docs/2026-08-16-delivery-process.md
@@ -28,7 +28,7 @@ fourth overlapping protocol *is* the illegibility being complained about.
 | Document | Owns | Unchanged by this |
 |---|---|---|
 | `docs/2026-08-05-healthclaw-2.0-playbook.md` | the **architecture** half of 2.0 — eight ratchets to zero, by strangler | yes |
-| the 2.0 verification plan (artifact) + `.claude/agents/owner-*.md` | the **QA** half — six feature sets, four artifacts, two sign-offs | yes |
+| the 2.0 verification plan (artifact) + the owner briefs (local only) | the **QA** half — six feature sets, four artifacts, two sign-offs | yes |
 | `docs/2026-08-03-refactor-working-protocol.md` | **per-PR** rules inside a migration slice | yes |
 
 This document adds only the front of the pipeline — everything before a

--- a/docs/2026-08-16-hard-truths.md
+++ b/docs/2026-08-16-hard-truths.md
@@ -27,7 +27,10 @@ Two of those four are the ones a patient touches.
 
 ## 2. The test suite is large, and it is not the thing that finds defects
 
-**50,125 lines of test guard 29,446 lines of engine.** 3,151 tests pass.
+**50,429 lines of test guard 29,508 lines of engine.** 3,153 tests pass, at
+`4cb3771`. (First published as 50,125 / 29,446 / 3,151 — measured four merges
+earlier than the header claimed, with a collected count printed as a passing
+one. See the topology's note; the ratio and the point are unchanged.)
 
 All eight defects found on 2026-08-16 were found by **running the system**.
 Zero came from that suite. Three had passing tests sitting directly over them,

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -55,7 +55,13 @@ Measured 2026-08-16 by the set-2 evidence run
 
 ## Architecture ratchets
 
-Eight numbers that may only go down. `tests/test_ratchets.py` holds them.
+Six numbers that may only go down. `tests/test_ratchets.py` holds them, and
+the table below is all of them.
+
+The 2.0 playbook sets out eight ratchets. Two of the six here are pinned by a
+test; the playbook's other three have no pin, and `r6/routes.py` lines is a
+pin the playbook does not list. Saying "eight" here read as *eight numbers a
+test enforces*, which was never true.
 
 | Ratchet | 05 Aug | Today | 2.0 |
 |---|---|---|---|
@@ -68,8 +74,17 @@ Eight numbers that may only go down. `tests/test_ratchets.py` holds them.
 
 ## The two numbers that explain why this document exists
 
-**50,125 lines of test code guard 29,446 lines of engine — 1.7 to 1.**
-`3,151` tests pass on `main`.
+**50,429 lines of test code guard 29,508 lines of engine — 1.7 to 1.**
+**3,153** tests pass, 13 skip, 1 xfails.
+
+Measured at `4cb3771`, which is this document's branch point, with
+`git ls-files 'r6/**/*.py' 'r6/*.py' | xargs wc -l` and the same over
+`tests/*.py`. The first published version of this block carried 50,125 /
+29,446 / 3,151 — figures exact at `4ce28c3`, four merges earlier, under a
+header claiming they were measured on `main`. Worse, `3,151` was the
+*collected* count reported as a *passing* count. Corrected here, with the
+commit and the command stated so the next reader can re-run rather than
+trust.
 
 **All eight defects found on 2026-08-16 were found by running the system.
 Zero were found by that suite.** Three of the eight had passing tests sitting

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -58,10 +58,11 @@ Measured 2026-08-16 by the set-2 evidence run
 Six numbers that may only go down. `tests/test_ratchets.py` holds them, and
 the table below is all of them.
 
-The 2.0 playbook sets out eight ratchets. Two of the six here are pinned by a
-test; the playbook's other three have no pin, and `r6/routes.py` lines is a
-pin the playbook does not list. Saying "eight" here read as *eight numbers a
-test enforces*, which was never true.
+The 2.0 playbook sets out eight ratchets, and the two sets are not the same
+six. Five of the six pins below are playbook ratchets; the playbook's other
+three have no pin at all, and `r6/routes.py` lines is a sixth pin the playbook
+does not list. Saying "eight" here read as *eight numbers a test enforces*,
+which was never true of either set.
 
 | Ratchet | 05 Aug | Today | 2.0 |
 |---|---|---|---|

--- a/docs/2026-08-16-tester-program.md
+++ b/docs/2026-08-16-tester-program.md
@@ -94,9 +94,10 @@ the reward is professional rather than financial:
   scorecard. It cannot be honoured today and it fails twice. #525 — the probe
   requires the declared supported-parameter set to *equal ours*, `context-id`
   included, so a server that refuses a bad parameter perfectly correctively
-  still grades C, capping the deployment at B. And `scripts/guardrail_
-  conformance.py` puts the repo root on `sys.path` and imports
-  `r6.conformance`, so **a third party has to clone our application to grade
+  still grades C, capping the deployment at B. And the runner script
+  (`scripts/guardrail_conformance.py`) puts the repo root on `sys.path` and
+  imports `r6.conformance`, so **a third party has to clone our application to
+  grade
   their own server**. Every recruit would get a B for a reason that is our
   defect, not their server's. It returns when both close.
 - **A finding credited by name in the specification.** The stronger offer, and

--- a/docs/2026-08-16-tester-program.md
+++ b/docs/2026-08-16-tester-program.md
@@ -89,9 +89,23 @@ the reward is professional rather than financial:
   a spec other people implement is a real career artifact.
 - **A security hall of fame.** `SECURITY.md` exists; a "found this" list costs
   nothing and is the standard currency in this field.
-- **Conformance badge for their own server.** They run `$conformance` against
-  their FHIR deployment and get a scorecard they can publish. That is a carrot
-  *and* it is the set-2 evidence we need — the tester's reward is the artifact.
+- **~~Conformance badge for their own server.~~ Withdrawn, and this is why.**
+  The offer was: run `$conformance` against your FHIR deployment, publish the
+  scorecard. It cannot be honoured today and it fails twice. #525 — the probe
+  requires the declared supported-parameter set to *equal ours*, `context-id`
+  included, so a server that refuses a bad parameter perfectly correctively
+  still grades C, capping the deployment at B. And `scripts/guardrail_
+  conformance.py` puts the repo root on `sys.path` and imports
+  `r6.conformance`, so **a third party has to clone our application to grade
+  their own server**. Every recruit would get a B for a reason that is our
+  defect, not their server's. It returns when both close.
+- **A finding credited by name in the specification.** The stronger offer, and
+  it is already real: `docs/specs/guardrail-spec-0.1.0-draft.md` publishes a
+  Credits section before anyone is in it, and says that *a finding that a
+  check passed without its subject ever running is worth more to us than a
+  feature.* So the invitation is: run the harness against your own server and
+  tell us where it grades you wrongly. The first external run is a finding we
+  credit — and #525 is the one we already know about.
 - **Fast, real review of first PRs.** #184 already promises this. Honouring it
   visibly is the retention mechanism.
 
@@ -114,9 +128,12 @@ Hire individually rather than through a managed crowd-testing service. The
 enterprise platforms in this space price on a platform fee plus an annual
 consumption commitment, which is the wrong weight for a six-set pilot. Each
 contractor gets one feature set and the charter that already exists for it in
-`.claude/agents/owner-*.md` — those briefs are the statement of work: the
-standing orders, the four artifacts, and the PHI constraints are already
-written.
+`.claude/agents/owner-*.md`. **Those briefs are not in the repository** —
+`.claude/` is gitignored on purpose, and `git ls-files .claude` returns
+nothing. They read like a statement of work and no contractor can open one.
+Publishing the six under `docs/`, or writing a contractor-facing SOW that does
+not depend on them, is a prerequisite to hiring anyone and is tracked
+separately.
 
 Run one set end to end first (**set 2, connectors** — smallest, two of four
 kinds already proven, a real deadline attached) to find out what the gate

--- a/docs/prd/01-guardrail-core.md
+++ b/docs/prd/01-guardrail-core.md
@@ -1,6 +1,6 @@
 # PRD 1 — Guardrail core
 
-> Owner brief: `.claude/agents/owner-guardrail-core.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-guardrail-core.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/02-connectors.md
+++ b/docs/prd/02-connectors.md
@@ -1,6 +1,6 @@
 # PRD 2 — Upstream connectors
 
-> Owner brief: `.claude/agents/owner-connectors.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-connectors.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/03-consumer-journey.md
+++ b/docs/prd/03-consumer-journey.md
@@ -1,6 +1,6 @@
 # PRD 3 — CareAgents consumer journey
 
-> Owner brief: `.claude/agents/owner-consumer-journey.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-consumer-journey.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/04-action-rail.md
+++ b/docs/prd/04-action-rail.md
@@ -1,6 +1,6 @@
 # PRD 4 — Action rail
 
-> Owner brief: `.claude/agents/owner-action-rail.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-action-rail.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/05-clinical-rails.md
+++ b/docs/prd/05-clinical-rails.md
@@ -1,6 +1,6 @@
 # PRD 5 — Clinical rails
 
-> Owner brief: `.claude/agents/owner-clinical-rails.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-clinical-rails.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/06-surfaces.md
+++ b/docs/prd/06-surfaces.md
@@ -1,6 +1,6 @@
 # PRD 6 — Surfaces
 
-> Owner brief: `.claude/agents/owner-surfaces.md` · Process:
+> Owner brief (local only — `.claude/` is gitignored): `.claude/agents/owner-surfaces.md` · Process:
 > `docs/2026-08-16-delivery-process.md` · Topology:
 > `docs/2026-08-16-system-topology.md`
 >

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -24,7 +24,13 @@ a named tester and real data between "merged" and "done".
 
 ## How to read a gap table
 
-Every open issue in the tracker appears in exactly one of these seven pages.
+Every open issue in the tracker carries exactly one `set:` label, and appears
+on the page that owns it. **One issue is listed twice on purpose:** #214 is
+labelled `set: 1` and appears in both [01](01-guardrail-core.md) and
+[04](04-action-rail.md), because set 1 owns proving it and set 4 owns
+designing its closure. Page 04 explains that at the foot of its gap table.
+The label is the partition; a page listing is a reading aid and may
+cross-reference.
 The mapping was done by title on 2026-08-16 against 87 open issues, **52 of
 which carry no label at all** — so the tables are the current answer to "what
 is broken in this feature", and labelling the tracker to match is the first


### PR DESCRIPTION
**Candidate for the process documents themselves.** Found by the four-member review board convened on #519, #521, #524 and #526. #519 merged mid-review — auto-merge was armed on it and a lint fix turned the last check green — so its conditions land here instead of in it.

Each of these is a claim that reads stronger than the check behind it. That is the finding the documents were written about, which is why they are worth a commit rather than a shrug.

## 1. "Eight numbers that may only go down"

`tests/test_ratchets.py` holds **six** pins — and the table right below the sentence already listed six. One of the six (`r6/routes.py` lines) is not among the 2.0 playbook's eight, and three of the playbook's eight have no pin at all. "Eight" read as *eight numbers a test enforces*. Corrected, with the relationship to the playbook stated.

## 2. The LOC and test-count block

50,125 / 29,446 / 3,151 are exact at `4ce28c3` — **four merges before this document's branch point** — under a header saying every number was measured on `main`. And `3,151` is 3137 + 13 + 1: the **collected** count reported as a **passing** count.

Re-measured at `4cb3771` with the command written into the doc:

```
git ls-files 'r6/**/*.py' 'r6/*.py' | xargs wc -l   ->  29,508
git ls-files 'tests/*.py'          | xargs wc -l   ->  50,429
uv run pytest tests/ -q            -> 3153 passed, 13 skipped, 1 xfailed
```

The ratio and the argument are unchanged. What changes is that the next reader can re-run instead of trusting.

## 3. "Every open issue appears in exactly one of these seven pages"

#214 appears on two, deliberately — set 1 owns proving it, set 4 owns designing its closure, and page 04 explains that at the foot of its gap table. The absolute phrasing in the README contradicted a documented exception. The `set:` **label** is the partition (still exactly one per issue, all 91); a page listing is a reading aid.

## 4. The conformance-badge carrot — withdrawn

`docs/2026-08-16-tester-program.md` offered developer-testers "a conformance badge for their own server" as the headline non-financial reward. **It cannot be honoured, and it fails twice:**

- #525 — the probe requires the declared supported-parameter set to *equal ours*, `context-id` included. A server that refuses a bad parameter perfectly correctively still grades C, capping the deployment at B.
- `scripts/guardrail_conformance.py` puts the repo root on `sys.path` and imports `r6.conformance`. **A third party has to clone our application to grade their own server.**

Every recruit would have got a B for a reason that is our defect, not their server's — and the room on Tuesday is exactly the population it was aimed at.

Replaced by the offer the guardrail spec already publishes: a finding credited by name, where *"a finding that a check passed without its subject ever running is worth more to us than a feature."* That is the better carrot on its merits, it is real today, and it turns our worst artifact defect into the invitation.

## 5. "Those briefs **are** the statement of work"

They point at `.claude/agents/owner-*.md`. `.claude/` is gitignored on purpose and `git ls-files .claude` returns **nothing**. Eight published files linked a path that 404s on GitHub, and the tester program made the invisible thing load-bearing for hiring.

The six PRD headers now say local-only, and the tester program says plainly that no contractor can open one and that fixing it is a prerequisite to hiring.

## What is not in this PR

- **The identity leak** is #527, opened first because it was live on public `main`.
- **Gap tables do not yet list #520, #522, #523, #525, #528** — filed after the mapping, all `set:`-labelled.
- **The 87/52 figures** in three places are the state before labelling completed; the tracker reads 91 open / 0 unlabelled now.
- **The `hapi`/`generic` walkthrough scripts are still uncommitted**, which is what makes "2 of 4 proven live" — the topology's headline — currently unreproducible by anyone but its author.

Those four are tracked separately rather than folded in, so this PR stays reviewable.

## Verification

`3153 passed, 13 skipped, 1 xfailed`. `check_table_stakes.py` clean. Docs only, no code, no pins touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)