### PR TITLE
fix(conformance): the grade measured resemblance to us, not conformance (#525)

### DIFF
--- a/docs/specs/guardrail-spec-0.1.0-draft.md
+++ b/docs/specs/guardrail-spec-0.1.0-draft.md
@@ -586,7 +586,7 @@ conformance**
 
 | Divergence | Consequence |
 |---|---|
-| **The local A contract requires the implementation's declared supported-parameter set to equal HealthClaw's exact eight** — `patient, code, status, _lastUpdated, _count, _sort, _summary, context-id` — including the HealthClaw-specific `context-id`. Executed evidence in §7, **G-A**. | A third-party server that refuses `datetime` just as correctively but supports a different parameter set caps at C on that check, which caps the property, which caps the deployment at Grade B. **No external implementation can currently score A on this property.** |
+| **The local A contract requires the implementation's declared supported-parameter set to equal HealthClaw's exact eight** — `patient, code, status, _lastUpdated, _count, _sort, _summary, context-id` — including the HealthClaw-specific `context-id`. Executed evidence in §7, **G-A**. | **Fixed in #525.** This row records what `0.1.0-draft` shipped with: a third-party server refusing `datetime` just as correctively but supporting a different parameter set capped at C, which capped the property, which capped the deployment at Grade B. The requirement is now shape-based and names no parameter of ours. See §7 G-A for the second mechanism that had to move with it. |
 | Requirement 5 is **[A]** and known-false in proxy mode. | HealthClaw scores B through the proxy. Cited from [#498](https://github.com/aks129/HealthClawGuardrails/issues/498); **not measured by the author of this document**. |
 | `proxy` and `mcp` default to `not_run`. | A local Grade A for this property is measured over one profile and says nothing about a deployment with an upstream configured. The report states `coverage=local-fhir-only`; a reader who stops at "A" will over-read it. |
 
@@ -884,10 +884,42 @@ healthclaw minus context-id        corrective=False grade=C
 
 The second row is a server whose refusal is equally corrective and whose
 supported set is `patient, code, status, category, date, _lastUpdated, _count,
-_sort, _summary, _include`. It grades C, which caps `error_fidelity`, which caps
-the deployment at Grade B. **An external implementation cannot currently score A
-on this property**, which makes §8 a statement of intent rather than of fact.
-Severity: high for the standard-setter thesis, none for our own deployment.
+_sort, _summary, _include`. It graded C, which capped `error_fidelity`, which
+capped the deployment at Grade B.
+
+**FIXED, #525.** The normative requirement is now what §3 P7 always said it
+was: the refusal **names the offending parameter and declares a non-empty,
+well-formed supported-parameter set that does not contain it.** Which
+parameters those are is the implementing server's business. No comparison to
+our set remains anywhere in the suite.
+
+**A second mechanism was found during the fix, and it is the reason a
+one-line change would not have worked.** `_outcome_has_unsafe_last_updated_
+suggestion` strips the declared-set sentence before scanning for
+`_lastUpdated` — because naming it among what you support is a fact, not a
+suggestion to use it in place of a clinical date. That strip *also* applied
+only when the set was exactly ours. `_lastUpdated` is one of ours, so the
+strip existed purely to let our own declaration through: every other server
+that truthfully listed `_lastUpdated` tripped the heuristic on its own
+legitimate sentence and was forced to C by a **second, independent path**.
+Relaxing set equality alone would have looked complete and changed nothing.
+
+Both moved together, each pinned by a two-way mutation
+(`tests/test_guardrail_conformance.py`). Restoring either one alone turns the
+tests red, which is what makes them independent rather than redundant.
+
+**What the fix deliberately does not do.** It cannot tell an unusual-but-real
+parameter from a plausible fake — `patiently, barcode` now grades as a
+declaration. That is accepted rather than overlooked: `context-id` looks
+invented from anyone else's side too, and the alternative is a whitelist of
+"real" FHIR parameters, which recreates this defect with more steps. A
+US Core-anchored family requirement is a candidate `0.2.0` tightening. The
+anti-vacuity checks that do not depend on resemblance all survive, including
+the one that matters most — `_lastUpdated` offered as a substitute for a
+clinical date is still refused.
+
+Severity was high for the standard-setter thesis, none for our own
+deployment. Our own grade is unchanged: A, 7/7.
 
 **G-B — "Immutable Audit Trail" is not tested for immutability.** No probe in
 `r6/conformance/probes.py` attempts to modify or delete an AuditEvent. The word

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -99,10 +99,6 @@ _HOSTILE_VALUE_TOKENS = (
 )
 _URL_SCHEME_TOKENS = ("http://", "https://")
 _REQUEST_ERROR_CODES = {"invalid", "structure", "value", "not-supported"}
-_LOCAL_SUPPORTED_PARAMETER_EVIDENCE = {
-    "patient", "code", "status", "_lastupdated",
-    "_count", "_sort", "_summary", "context-id",
-}
 _SUPPORTED_SET_RE = re.compile(
     r"(?:^|[.!?]\s+)supported parameters?\s*:\s*([^.!?]+)",
     re.IGNORECASE,
@@ -872,24 +868,51 @@ def _rejection_grade(status, body, expected_status=400) -> str:
     return "C"
 
 
+_PARAMETER_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_-]*")
+
+
+def _declared_supported_set(match: re.Match) -> set[str]:
+    """The parameters a server declares it supports, or empty if what follows
+    "supported parameters:" is not a well-formed declaration.
+
+    A declaration is a **list**: comma-separated items, each one parameter
+    token. Prose in that position — "use _lastUpdated instead of datetime" —
+    is a suggestion wearing a declaration's clothes, and treating it as a
+    declaration would strip the very sentence
+    `_outcome_has_unsafe_last_updated_suggestion` exists to catch.
+
+    Deliberately not a check against our own parameter names: which
+    parameters a server supports is its own business (#525). Only the
+    *shape* is checked.
+    """
+    items = [item.strip(" \t`'\"") for item in match.group(1).split(",")]
+    if not all(_PARAMETER_TOKEN_RE.fullmatch(item) for item in items):
+        return set()
+    return {item.lower() for item in items}
+
+
 def _outcome_has_unsafe_last_updated_suggestion(body) -> bool:
     """Reject `_lastUpdated` as a proposed substitute for clinical datetime.
 
-    A supported-parameter list may name `_lastUpdated` factually. Any mention
-    elsewhere in any issue is ambiguous or unsafe correction evidence.
+    A supported-parameter list may name `_lastUpdated` factually — **any**
+    server's list, not only ours. A mention outside such a declaration is
+    ambiguous or unsafe correction evidence.
+
+    This used to strip the declaration only when it was byte-for-byte our own
+    eight parameters. `_lastUpdated` is one of ours, so the strip existed
+    purely to let *our* declaration past this check: every other server that
+    truthfully listed `_lastUpdated` tripped this heuristic on its own
+    legitimate sentence and was forced to C. See #525.
     """
     if not _is_operation_outcome(body):
         return False
 
-    def strip_exact_supported_set(match: re.Match) -> str:
-        declared = {
-            token.lower()
-            for token in re.findall(
-                r"[A-Za-z_][A-Za-z0-9_-]*", match.group(1))
-        }
-        if declared == _LOCAL_SUPPORTED_PARAMETER_EVIDENCE:
-            return ""
-        return match.group(0)
+    def strip_declared_supported_set(match: re.Match) -> str:
+        # A well-formed declaration names at least one parameter. Naming
+        # `_lastUpdated` among what you support is a statement of fact; the
+        # unsafe pattern is offering it as a substitute for a clinical date,
+        # which happens outside a declaration.
+        return "" if _declared_supported_set(match) else match.group(0)
 
     for issue in body.get("issue", []):
         if not isinstance(issue, dict):
@@ -898,14 +921,21 @@ def _outcome_has_unsafe_last_updated_suggestion(body) -> bool:
         text = details.get("text", "") if isinstance(details, dict) else ""
         if (isinstance(text, str)
                 and "_lastupdated" in _SUPPORTED_SET_RE.sub(
-                    strip_exact_supported_set, text).lower()):
+                    strip_declared_supported_set, text).lower()):
             return True
     return False
 
 
 def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
-    """A local rejection is corrective only if it identifies the bad key and
-    tells the caller which search parameters are supported."""
+    """A rejection is corrective if it identifies the bad key and tells the
+    caller which search parameters *this server* supports.
+
+    Which parameters those are is the implementing server's business. This
+    used to require the declared set to EQUAL ours — including `context-id`,
+    which no other FHIR server has — so no external implementation could score
+    A on error fidelity, and the grade measured resemblance to our
+    implementation rather than conformance to a contract. See #525.
+    """
     if not _is_operation_outcome(body):
         return False
     if _outcome_has_unsafe_last_updated_suggestion(body):
@@ -918,11 +948,7 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
         match = _SUPPORTED_SET_RE.search(text)
         if match is None:
             continue
-        declared = {
-            token.lower()
-            for token in re.findall(
-                r"[A-Za-z_][A-Za-z0-9_-]*", match.group(1))
-        }
+        declared = _declared_supported_set(match)
         parameter_lower = parameter.lower()
         remaining = text[:match.start()] + text[match.end():]
         parameter_token = re.escape(parameter_lower)
@@ -936,9 +962,12 @@ def _outcome_names_parameter_and_supported_set(body, parameter: str) -> bool:
             rf")\s*(?=[.!?]|$)",
             remaining.lower(),
         )
-        if (parameter_lower not in declared
-                and rejection is not None
-                and declared == _LOCAL_SUPPORTED_PARAMETER_EVIDENCE):
+        # Non-empty (the server actually named something), well-formed (the
+        # regex matched a declaration), and it does not list the parameter it
+        # just rejected — which would be self-contradictory.
+        if (declared
+                and parameter_lower not in declared
+                and rejection is not None):
             return True
     return False
 

--- a/tests/test_guardrail_conformance.py
+++ b/tests/test_guardrail_conformance.py
@@ -140,8 +140,6 @@ def test_local_contract_rejects_false_a_evidence():
         "Unsupported parameters: datetime, patient, code.",
         "The unsupported parameter datetime conflicts with patient and code.",
         "datetime is not a supported parameter; patient and code are examples.",
-        "datetime rejected. Supported parameters: patiently, barcode.",
-        "datetime rejected. Supported parameters: status-code, patientish.",
         "Supported parameters: patient, datetime, code.",
         "datetime is not invalid. Supported parameters: patient, code, status.",
         "datetime is not unsupported. Supported parameters: patient, code, status.",
@@ -150,8 +148,6 @@ def test_local_contract_rejects_false_a_evidence():
         "patient, code, status.",
         "datetime is unsupported. Use _lastUpdated instead. Supported parameters: "
         "patient, code, status, _lastUpdated, _count, _sort, _summary, context-id.",
-        "datetime is unsupported. Supported parameters: patient, code, status, "
-        "_lastUpdated, _count, _sort, _summary, context-id, invented-filter.",
     ):
         body = {
             "resourceType": "OperationOutcome",
@@ -162,6 +158,13 @@ def test_local_contract_rejects_false_a_evidence():
             }],
         }
         assert not _outcome_names_parameter_and_supported_set(body, "datetime")
+
+    # Three rows left this list in #525, and they are pinned as A in
+    # test_a_supported_set_that_is_not_ours_is_still_corrective below:
+    # "patiently, barcode", "status-code, patientish", and our own eight plus
+    # "invented-filter". Every one of them failed here for a single reason —
+    # the declared set was not byte-for-byte ours — which is the defect #525
+    # is about, not a property. What remains above is resemblance-independent.
 
     unrelated_warning = {
         "resourceType": "Bundle",
@@ -206,7 +209,12 @@ def test_local_contract_rejects_false_a_evidence():
             }],
         },
     }
-    assert not _has_outcome_warning({
+    # #525: this warning names the ignored parameter and declares the set the
+    # server supports, so it IS corrective. It used to fail here for one
+    # reason — {patient, code} is not our eight — which measured resemblance,
+    # not conformance. The hostile-sibling case below is the property this
+    # fixture was really guarding, and it still holds.
+    assert _has_outcome_warning({
         "resourceType": "Bundle",
         "entry": [safe_warning],
     }, "datetime")
@@ -1221,3 +1229,84 @@ def test_a_deployment_that_answers_nothing_scores_f(tenant_id, step_up_token):
                              _ctx(None, tenant_id, step_up_token))
     assert report.grade == "F"
     assert [r.key for r in report.results if r.passed] == []
+
+
+def test_a_supported_set_that_is_not_ours_is_still_corrective():
+    """#525. The property is that the refusal NAMES the supported parameters.
+
+    Which parameters those are is the implementing server's business. Until
+    this landed, `_outcome_names_parameter_and_supported_set` demanded the
+    declared set EQUAL ours — `context-id` included, which no other FHIR
+    server has — so no external implementation could score A on error
+    fidelity, and the grade measured resemblance to our implementation rather
+    than conformance to a contract.
+
+    These three are the cases that flipped. Each one is a server refusing
+    `datetime` correctively and declaring a set we do not share.
+    """
+    from r6.conformance.probes import (
+        _outcome_names_parameter_and_supported_set,
+    )
+
+    for corrective in (
+        # Names we cannot tell from real ones. We should not try: `context-id`
+        # looks invented from anyone else's side too.
+        "datetime rejected. Supported parameters: patiently, barcode.",
+        "datetime rejected. Supported parameters: status-code, patientish.",
+        # Our own eight plus one more. A superset used to fail.
+        "datetime is unsupported. Supported parameters: patient, code, status, "
+        "_lastUpdated, _count, _sort, _summary, context-id, invented-filter.",
+    ):
+        body = {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": corrective},
+            }],
+        }
+        assert _outcome_names_parameter_and_supported_set(body, "datetime"), (
+            "a server that names the bad parameter and declares its own "
+            "supported set is corrective: %s" % corrective)
+
+
+def test_a_declaration_must_be_a_list_not_a_suggestion():
+    """The second #525 mechanism, and the one the issue did not name.
+
+    `_outcome_has_unsafe_last_updated_suggestion` strips the declared-set
+    sentence before scanning for `_lastUpdated`, because listing it among
+    what you support is a fact rather than a suggestion. That strip used to
+    apply only when the set was exactly ours — so every other server that
+    truthfully listed `_lastUpdated` tripped the heuristic on its own
+    legitimate sentence and was forced to C by a second, independent path.
+
+    Generalising the strip must not swallow the thing it exists to catch:
+    prose in the declaration position is a suggestion wearing a
+    declaration's clothes.
+    """
+    from r6.conformance.probes import (
+        _outcome_has_unsafe_last_updated_suggestion,
+    )
+
+    def outcome(text):
+        return {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "error",
+                "code": "invalid",
+                "details": {"text": text},
+            }],
+        }
+
+    # A list, from a server that is not us. Factual, so it does not trip.
+    assert not _outcome_has_unsafe_last_updated_suggestion(outcome(
+        "datetime rejected. Supported parameters: subject, _lastUpdated, "
+        "onset-date."))
+
+    # Prose in the same position, offering _lastUpdated as a substitute for a
+    # clinical date. Must still trip, and it is why the shape is checked.
+    assert _outcome_has_unsafe_last_updated_suggestion(outcome(
+        "Supported parameters: use _lastUpdated instead of datetime"))
+    assert _outcome_has_unsafe_last_updated_suggestion(outcome(
+        "datetime is unsupported. Use _lastUpdated instead. Supported "
+        "parameters: subject, _lastUpdated."))


### PR DESCRIPTION
Closes #525.

`$conformance` graded a third party on how closely its error text resembled ours. **Two independent mechanisms did it**, and the issue as filed named only one — so a PR that fixed the named one would have gone green on a hand-written test and changed nothing for any external server.

## The two paths

**1. The grading check.** `_outcome_names_parameter_and_supported_set` required the declared supported-parameter set to **equal our own eight** — `context-id` included, which no other FHIR server has.

**2. The `_lastUpdated` heuristic.** `_outcome_has_unsafe_last_updated_suggestion` strips the declared-set sentence before scanning for `_lastUpdated`, because listing it among what you support is a *fact*, not a suggestion to use it in place of a clinical date. **That strip also applied only when the set was exactly ours.** `_lastUpdated` is one of ours — so the strip existed purely to let *our* declaration through. Every other server that truthfully listed `_lastUpdated` tripped the heuristic **on its own legitimate sentence** and was forced to C by a second, independent path.

Both move together here.

## The requirement now

What P7 always said it was: the refusal **names the offending parameter and declares a non-empty, well-formed supported-parameter set that does not contain it.** No comparison to our set remains anywhere in the suite. `_LOCAL_SUPPORTED_PARAMETER_EVIDENCE` is deleted rather than left unused.

**"Well-formed" means a list**, and that check is load-bearing. Generalising the strip naively swallowed the sentence it exists to catch — the existing suite caught me doing it. `Supported parameters: use _lastUpdated instead of datetime` is prose in a declaration's position: a suggestion wearing a declaration's clothes. A declaration is comma-separated single tokens; prose is not.

## Two-way mutation, per mechanism

| Mutation | Result |
|---|---|
| restore set-equality in the grading check | `test_a_supported_set_that_is_not_ours_is_still_corrective` + `test_local_contract_rejects_false_a_evidence` red |
| restore set-equality in the `_lastUpdated` strip | `test_a_declaration_must_be_a_list_not_a_suggestion` + the grading test red |
| neither | **37 passed** |

Restoring *either* alone turns tests red. That is what makes the two independent rather than redundant, and it is the evidence that a single-line fix would have been a no-op.

## Four assertions moved from negative to positive

None was testing a property. Each failed for the single reason that the declared set was not byte-for-byte ours:

- `datetime rejected. Supported parameters: patiently, barcode.`
- `datetime rejected. Supported parameters: status-code, patientish.`
- our own eight **plus** `invented-filter`
- a bundle warning declaring `patient, code`

They are **pinned as positives** in a named test rather than deleted, so the loosening is recorded instead of disappearing. Every resemblance-independent anti-vacuity case survives — including the one that matters most, `_lastUpdated` offered as a substitute for a clinical date.

## Accepted limitation, written into the spec

This cannot tell an unusual-but-real parameter from a plausible fake: `patiently, barcode` now grades as a declaration. That is accepted, not overlooked. **`context-id` looks invented from anyone else's side too**, and the alternative is a whitelist of "real" FHIR parameters — which recreates this defect with more steps. A US Core-anchored family requirement is a candidate `0.2.0` tightening.

## Candidate for feature set 1

**Verified:** `3157 passed, 13 skipped, 1 xfailed`. `uv run ruff check .` clean. `test_our_deployment_records_full_conformance` passes — **our own grade is A, 7/7, unchanged**. Constitution lint clean.

**Not run:** no external FHIR server has been graded with this build. The change is proven against fixtures and our own deployment; the first real third-party run is still the outstanding evidence, and it is exactly the credited-finding invitation the tester program now leads with.

`docs/specs/guardrail-spec-0.1.0-draft.md` G-A is updated from a gap to a fix, with the second mechanism and the limitation written out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)