### PR TITLE
fix(careagents): sign-in Terms and Privacy links pointed at the internal Railway host (#534)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -215,8 +215,8 @@ def create_app(config: Config | None = None,
         if session.get("account_id") and not enroll:
             return redirect(url_for("home"))
         return render_template("auth.html", rp_id=cfg.rp_id, enroll=enroll,
-                               terms_url=f"{cfg.healthclaw_base}/terms",
-                               privacy_url=f"{cfg.healthclaw_base}/privacy")
+                               terms_url=f"{cfg.healthclaw_public_base}/terms",
+                               privacy_url=f"{cfg.healthclaw_public_base}/privacy")
 
     @app.get("/home")
     @login_required
@@ -229,8 +229,8 @@ def create_app(config: Config | None = None,
             surfaces=data["surfaces"], has_passkey=svc.has_passkey(acct.id),
             telegram_bot=cfg.telegram_bot,
             imessage_handle=cfg.imessage_handle,
-            terms_url=f"{cfg.healthclaw_base}/terms",
-            privacy_url=f"{cfg.healthclaw_base}/privacy",
+            terms_url=f"{cfg.healthclaw_public_base}/terms",
+            privacy_url=f"{cfg.healthclaw_public_base}/privacy",
             advisors=advisors.catalog(),
             catalog=connectors.catalog(cfg))
 

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -34,6 +34,12 @@ class Config:
 
         self.healthclaw_base = (e.get("HEALTHCLAW_BASE")
                                 or "https://app.healthclaw.io").rstrip("/")
+        # `healthclaw_base` is for server-to-server calls and may be an
+        # internal host (in production it is the Railway-private hostname).
+        # `healthclaw_public_base` is for anything rendered into a page a
+        # person will click — Terms, Privacy — and must stay public (#534).
+        self.healthclaw_public_base = (e.get("HEALTHCLAW_PUBLIC_BASE")
+                                       or "https://app.healthclaw.io").rstrip("/")
         self.session_secret = e.get("CARE_SESSION_SECRET", "")
 
         # Build provenance (#258) — telemetry, never a gate. Deliberately not

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3936,6 +3936,50 @@ def test_auth_code_input_fits_minted_codes(app):
     assert f"{digits}-digit code" in body
 
 
+def _app_with_bases(svc, **env):
+    # Build a Config whose HealthClaw base looks like production: the
+    # server-to-server base is the internal Railway hostname (#534).
+    from careagents.app import create_app
+    cfg2 = Config(env={"CARE_DATABASE_URL": "sqlite:///:memory:",
+                       "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m",
+                       "HEALTHCLAW_BASE": "https://internal.up.railway.app",
+                       **env})
+    a = create_app(config=cfg2, client=FakeClient(), accounts=svc)
+    a.config["TESTING"] = True
+    return a
+
+
+def test_terms_and_privacy_links_never_use_the_internal_base(svc, monkeypatch):
+    # #534: /auth and /home built their Terms and Privacy links from
+    # HEALTHCLAW_BASE, which in production is deliberately the internal
+    # Railway hostname (server-to-server calls must not loop through the
+    # public one). A link a person clicks has to use the public hostname.
+    c = _app_with_bases(svc).test_client()
+    auth = c.get("/auth").get_data(as_text=True)
+    assert 'href="https://app.healthclaw.io/terms"' in auth
+    assert 'href="https://app.healthclaw.io/privacy"' in auth
+    assert "up.railway.app" not in auth
+
+    _login(c, svc, monkeypatch)
+    home = c.get("/home").get_data(as_text=True)
+    assert 'href="https://app.healthclaw.io/terms"' in home
+    assert 'href="https://app.healthclaw.io/privacy"' in home
+    assert "up.railway.app" not in home
+
+
+def test_terms_and_privacy_links_follow_healthclaw_public_base(svc, monkeypatch):
+    c = _app_with_bases(
+        svc, HEALTHCLAW_PUBLIC_BASE="https://example.test/").test_client()
+    auth = c.get("/auth").get_data(as_text=True)
+    assert 'href="https://example.test/terms"' in auth
+    assert 'href="https://example.test/privacy"' in auth
+
+    _login(c, svc, monkeypatch)
+    home = c.get("/home").get_data(as_text=True)
+    assert 'href="https://example.test/terms"' in home
+    assert 'href="https://example.test/privacy"' in home
+
+
 def test_healthz_and_manifest(app):
     c = app.test_client()
     assert c.get("/healthz").get_json()["accounts"] is True


### PR DESCRIPTION
Candidate for set 3 (consumer journey). Closes #534.

## What
`careagents.cloud/auth` and `/home` rendered Terms and Privacy as `https://healthclawguardrails-production.up.railway.app/...` (verified live 2026-08-31). Both were built from `cfg.healthclaw_base`, which in production is deliberately the internal Railway host: server-to-server calls must not loop through the public hostname (the 2026-08-06 fair-use block).

A link a person clicks is not server-to-server. This adds `Config.healthclaw_public_base` (`HEALTHCLAW_PUBLIC_BASE`, default `https://app.healthclaw.io`) and uses it for the four `terms_url`/`privacy_url` sites. `healthclaw_base` and every API call are untouched.

## Proof
- Two tests beside the existing `/auth` render tests: with `HEALTHCLAW_BASE=https://internal.up.railway.app` and no public base, both pages link `app.healthclaw.io`; with `HEALTHCLAW_PUBLIC_BASE=https://example.test/` they follow it (trailing slash exercised).
- Mutation: with only `careagents/app.py` reverted, both tests red; restored, green.
- `tests/test_careagents.py` 201 → 203; full suite 3159 passed, 13 skipped, 1 xfailed; ruff clean.
- Sweep `grep -rn "up\.railway\.app" careagents/ templates/ r6/ main.py`: one hit, `templates/index.html:267`, the public demo MCP endpoint, which is legitimately that host.

## What this does not do (the remaining 20-40%)
- **Not deployed.** CareAgents is a manual `railway up` from a staged directory (owner). The live page is wrong until then.
- **#539.** `fasten_connect_url` / `wearables_connect_url` still build browser-navigation URLs from the internal base. Not changed here because switching the connect origin depends on whether the Fasten widget key is origin-restricted, which nobody has verified. The `/home` assertion `"up.railway.app" not in home` in the new test proves less than it reads for that reason: the test's `FakeClient` masks the connect-tile URLs.
- No env-var reference doc exists for CareAgents to add `HEALTHCLAW_PUBLIC_BASE` to; the runbook's env list is a dated snapshot of what production carries, and this variable is optional with a correct default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)