### PR TITLE
fix(mcp-apps): care-gaps app rendered "0 DUE" over an unevaluated patient (#538, #535)

### DIFF
--- a/e2e/tests/care-gaps-app.spec.ts
+++ b/e2e/tests/care-gaps-app.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Care Gaps MCP App — the page must not say "0 Due" over a patient it never
+ * looked at (#538), plus the client half of #535.
+ *
+ * Verified live 2026-08-31: a tenant with more than one Patient gets
+ * `unevaluated: "ambiguous-patient"` from $care-gaps and a note that nothing
+ * was examined. The page dropped the note and drew a "0 Due" tile over six
+ * cards saying "date of birth unknown" — artefacts of the call, not facts
+ * about the person. The Python guards (tests/test_mcp_app_care_gaps.py) pin
+ * the source's shape; this is the only place the render is watched paint.
+ *
+ * What it proves:
+ *   1. the seeded demo tenant really does answer ambiguous-patient — asserted
+ *      against the API first, so a fixture change reads as a fixture change
+ *      and not as a page regression
+ *   2. the page shows the engine's own note, no "0 Due", and no per-rule cards
+ *   3. Enter in the tenant box submits, and a 401 is explained as a spelling
+ *      or credential problem, not as a missing step-up token
+ *
+ * Requires the demo history: `flask --app main seed-demo-history`, which the
+ * e2e webServer runs at boot.
+ */
+import { test, expect } from '@playwright/test';
+
+const TENANT = 'desktop-demo';
+const headers = { 'X-Tenant-Id': TENANT };
+
+function param(parameters: any, name: string) {
+  const p = (parameters.parameter || []).find((x: any) => x.name === name);
+  return p ? JSON.parse(p.valueString) : null;
+}
+
+test.describe('care-gaps MCP App', () => {
+  test('an unevaluated tenant shows the engine note, not "0 Due"', async ({ page, request }) => {
+    // --- 1. The fixture, checked at the API --------------------------------
+    const res = await request.post('/r6/fhir/Patient/$care-gaps', {
+      headers: { ...headers, 'Content-Type': 'application/json' }, data: {},
+    });
+    expect(res.ok()).toBeTruthy();
+    const consumer = param(await res.json(), 'consumerSummary');
+    expect(consumer.unevaluated, 'fixture: desktop-demo must hold more than one Patient')
+      .toBe('ambiguous-patient');
+    expect(consumer.unevaluated_note).toContain('Nothing was examined');
+
+    // --- 2. The page -------------------------------------------------------
+    await page.goto(`/r6/fhir/mcp-apps/care-gaps/?tenant_id=${TENANT}`, {
+      waitUntil: 'load',
+    });
+    const box = page.locator('.consumer');
+    await expect(box).toBeVisible();
+    await expect(box.locator('h3')).toHaveText('Not evaluated');
+    await expect(box).toContainText('Nothing was examined');
+
+    // No count on this path is a count of anything. "0 Due" is the false
+    // statement the engine's docstring warns about.
+    const due = page.locator('.stat.due .num');
+    await expect(due).toBeVisible();
+    await expect(due).not.toHaveText('0');
+    await expect(due).toHaveText('—');
+    await expect(due).toHaveAttribute('aria-label', 'not evaluated');
+
+    // Six "date of birth unknown" cards described a record nobody opened.
+    await expect(page.locator('.card')).toHaveCount(0);
+    await expect(page.locator('#content')).toContainText('No screenings were evaluated.');
+  });
+
+  test('Enter submits, and a 401 is explained without "step-up"', async ({ page }) => {
+    // The e2e server runs with READ_AUTH_ENABLED unset, so a misspelled
+    // tenant reads here as an empty tenant (200, no-patient). Production
+    // runs with it on and answers 401 — the same 401 for "no such tenant"
+    // and "not yours", by design (existence disclosure). The intercept
+    // reproduces that production answer for the misspelled tenant only; what
+    // is under test is how the page explains it, and that Enter sent it.
+    await page.route(
+      (url) => url.pathname.endsWith('/Patient/$care-gaps'),
+      async (route) => {
+        if (route.request().headers()['x-tenant-id'] !== 'desktop-dmo') {
+          return route.continue();
+        }
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/fhir+json',
+          body: JSON.stringify({
+            resourceType: 'OperationOutcome',
+            issue: [{ severity: 'error', code: 'security',
+                      diagnostics: "Read access to tenant 'desktop-dmo' requires authentication" }],
+          }),
+        });
+      });
+
+    await page.goto('/r6/fhir/mcp-apps/care-gaps/', { waitUntil: 'load' });
+    const input = page.locator('#tenant-input');
+    await input.fill('desktop-dmo');
+    await input.press('Enter');
+
+    const err = page.locator('#err');
+    await expect(err).toBeVisible();
+    await expect(err).toContainText('HTTP 401');
+    await expect(err).toContainText('spelled correctly');
+    await expect(err).not.toContainText('step-up');
+  });
+});

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -56,6 +56,19 @@ _UNKNOWN_DEMOGRAPHICS = (
     "your date of birth and sex were not available to this check")
 
 
+def caller_reasons():
+    """The `unevaluated` values that mean the rules never read a record.
+
+    For a caller that must branch on the family rather than the reason. The
+    MCP App page draws these with no counts and no cards, because every
+    number on this path is an artefact of the call (#538) — and it must not
+    keep its own copy of the list, or the engine adds a reason and the page
+    goes back to drawing "0 Due" for it. Sorted so the injected list is
+    stable.
+    """
+    return sorted(_NOT_EVALUATED_NOTES)
+
+
 def build_caregaps_summary(results):
     buckets = {"due": 0, "up_to_date": 0, "not_applicable": 0, "indeterminate": 0}
     gaps = []

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -71,6 +71,7 @@ from r6.curatr import (
     persist_curation_state as _persist_curation_state,
 )
 from r6.health_context import get as _hc_get
+from r6.caregaps.report import caller_reasons as _caregaps_caller_reasons
 
 _curatr_engine = CuratrEngine()
 
@@ -3419,11 +3420,17 @@ def mcp_app_care_gaps():
     `care_gaps` MCP tool via `_meta.ui.resourceUri`. Layout ported from
     SmartHealthConnect's care-gaps view (archived); data path rebuilt on
     the engine's own operation so redaction + audit apply by construction.
+
+    `not_evaluated_reasons` is the engine's own list of the `unevaluated`
+    values that mean no record was read (r6/caregaps/report.py). The page
+    branches on that family — placeholders, no cards — and must not keep a
+    copy of it (#538).
     """
     tenant_id = _mcp_app_tenant()
     html = render_template(
         'mcp_apps/care_gaps.html',
         tenant_id=tenant_id,
+        not_evaluated_reasons=_caregaps_caller_reasons(),
     )
     resp = Response(html, mimetype='text/html')
     resp.headers['Content-Type'] = 'text/html; profile=mcp-app'

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -3420,16 +3420,12 @@ def mcp_app_care_gaps():
     `care_gaps` MCP tool via `_meta.ui.resourceUri`. Layout ported from
     SmartHealthConnect's care-gaps view (archived); data path rebuilt on
     the engine's own operation so redaction + audit apply by construction.
-
-    `not_evaluated_reasons` is the engine's own list of the `unevaluated`
-    values that mean no record was read (r6/caregaps/report.py). The page
-    branches on that family — placeholders, no cards — and must not keep a
-    copy of it (#538).
     """
     tenant_id = _mcp_app_tenant()
     html = render_template(
         'mcp_apps/care_gaps.html',
         tenant_id=tenant_id,
+        # The engine's own "nothing was read" list; the page must not copy it (#538).
         not_evaluated_reasons=_caregaps_caller_reasons(),
     )
     resp = Response(html, mimetype='text/html')

--- a/templates/mcp_apps/care_gaps.html
+++ b/templates/mcp_apps/care_gaps.html
@@ -36,6 +36,7 @@
   .stat.due .num{color:var(--amber)}
   .stat.ok .num{color:var(--green)}
   .stat.na .num{color:var(--dim)}
+  .stats.unevaluated .num{color:var(--dim)}
   .card{background:var(--panel);border:1px solid var(--border);
     border-radius:8px;padding:16px;margin-bottom:12px}
   .card h3{margin:0 0 6px;font-size:15px;font-weight:600}
@@ -51,6 +52,9 @@
   .consumer h3{margin:0 0 8px;font-size:13px;color:var(--cyan);
     text-transform:uppercase;letter-spacing:.05em}
   .consumer li{margin:4px 0}
+  .consumer.unevaluated{background:rgba(251,191,36,.06);
+    border-color:rgba(251,191,36,.35)}
+  .consumer.unevaluated h3{color:var(--amber)}
   .empty{color:var(--dim);padding:24px;text-align:center}
   .err-box{color:var(--red);padding:12px;background:rgba(248,113,113,.06);
     border:1px solid rgba(248,113,113,.2);border-radius:6px;margin:0 0 16px}
@@ -90,6 +94,9 @@
 
 <script>
   const TENANT_ID = {{ tenant_id | tojson }};
+  // The engine's own list of the `unevaluated` values that mean no record was
+  // read (r6/caregaps/report.py). Injected by the route, never copied here.
+  const NOT_EVALUATED = {{ not_evaluated_reasons | tojson }};
   const errEl = document.getElementById('err');
   const contentEl = document.getElementById('content');
 
@@ -108,16 +115,28 @@
     const summary = param(parameters, 'summary') || {};
     const consumer = param(parameters, 'consumerSummary') || {};
     const detail = param(parameters, 'detail') || [];
+    // `unevaluated` comes in two families (r6/caregaps/report.py). A CALLER
+    // reason means the rules never read a record: every count is an artefact
+    // of the call and every "date of birth unknown" card describes a record
+    // nobody opened, so the note is the whole finding (#538). An ENGINE
+    // reason means a record WAS read; the counts and cards are real for what
+    // was evaluated and the note explains the rest.
+    const notEvaluated = NOT_EVALUATED.includes(consumer.unevaluated);
+    // Read before the box is built: this used to live inside a box gated on
+    // `lines`, which is empty on exactly the path that has a note to show.
+    const caveat = consumer.unevaluated_note
+      ? `<div class="note">${esc(consumer.unevaluated_note)}</div>` : '';
+    const tile = (cls, label, n) => `
+        <div class="stat ${cls}"><div class="num"${notEvaluated
+          ? ' aria-label="not evaluated" title="not evaluated"' : ''}>${
+          notEvaluated ? '—' : (n || 0)}</div>
+          <div class="label">${label}</div></div>`;
     const stats = `
-      <div class="stats">
-        <div class="stat due"><div class="num">${summary.due || 0}</div>
-          <div class="label">Due</div></div>
-        <div class="stat ok"><div class="num">${summary.up_to_date || 0}</div>
-          <div class="label">Up to date</div></div>
-        <div class="stat na"><div class="num">${summary.not_applicable || 0}</div>
-          <div class="label">Not applicable</div></div>
-        <div class="stat na"><div class="num">${summary.indeterminate || 0}</div>
-          <div class="label">Needs data</div></div>
+      <div class="stats${notEvaluated ? ' unevaluated' : ''}">
+        ${tile('due', 'Due', summary.due)}
+        ${tile('ok', 'Up to date', summary.up_to_date)}
+        ${tile('na', 'Not applicable', summary.not_applicable)}
+        ${tile('na', 'Needs data', summary.indeterminate)}
       </div>`;
     const cards = (detail || []).map(r => `
       <div class="card">
@@ -131,14 +150,22 @@
     // never had a populated list to draw (#417).
     const lines = (consumer.lines || [])
       .map(l => `<li>${esc(l.message || l)}</li>`).join('');
-    const consumerBox = lines ? `
-      <div class="consumer"><h3>In plain terms</h3><ul>${lines}</ul>
-        ${consumer.unevaluated_note
-          ? `<div class="note">${esc(consumer.unevaluated_note)}</div>` : ''}
-        ${consumer.note ? `<div class="note">${esc(consumer.note)}</div>` : ''}
+    // The caveat goes above the list it qualifies, so it is read first. The
+    // box draws whenever it has anything at all to say.
+    const parts = [];
+    if(caveat){ parts.push(caveat); }
+    if(lines){ parts.push(`<ul>${lines}</ul>`); }
+    if(consumer.note){ parts.push(`<div class="note">${esc(consumer.note)}</div>`); }
+    const consumerBox = parts.length ? `
+      <div class="consumer${notEvaluated ? ' unevaluated' : ''}">
+        <h3>${notEvaluated ? 'Not evaluated' : 'In plain terms'}</h3>
+        ${parts.join('')}
       </div>` : '';
-    contentEl.innerHTML = stats + consumerBox +
-      (cards || '<div class="empty">No screenings evaluated.</div>');
+    contentEl.innerHTML = notEvaluated
+      ? consumerBox + stats +
+        '<div class="empty">No screenings were evaluated.</div>'
+      : stats + consumerBox +
+        (cards || '<div class="empty">No screenings evaluated.</div>');
   }
 
   async function load(){
@@ -154,8 +181,14 @@
         body: '{}',
       });
       if(!res.ok){
+        // Step-up is the write gate; this is a read. The server answers the
+        // same 401 for a tenant that does not exist and one that is not
+        // yours — by design, so a probe cannot learn which — so the copy
+        // has to name both causes (#535).
         throw new Error('care-gaps returned HTTP ' + res.status +
-          (res.status === 401 ? ' — this tenant requires a step-up token' : ''));
+          (res.status === 401
+            ? ' — check the tenant id is spelled correctly, or this tenant needs a credential.'
+            : ''));
       }
       render(await res.json());
     }catch(e){
@@ -166,6 +199,9 @@
   }
 
   document.getElementById('load-btn').addEventListener('click', load);
+  document.getElementById('tenant-input').addEventListener('keydown', (e)=>{
+    if(e.key === 'Enter'){ load(); }
+  });
   if(TENANT_ID){ load(); }
 </script>
 </body>

--- a/templates/mcp_apps/care_gaps.html
+++ b/templates/mcp_apps/care_gaps.html
@@ -129,7 +129,7 @@
     const tile = (cls, label, n) => `
         <div class="stat ${cls}"><div class="num"${notEvaluated
           ? ' aria-label="not evaluated" title="not evaluated"' : ''}>${
-          notEvaluated ? '—' : (n || 0)}</div>
+          notEvaluated ? '—' : esc(n || 0)}</div>
           <div class="label">${label}</div></div>`;
     const stats = `
       <div class="stats${notEvaluated ? ' unevaluated' : ''}">

--- a/tests/test_mcp_app_care_gaps.py
+++ b/tests/test_mcp_app_care_gaps.py
@@ -1,0 +1,167 @@
+"""Guards for the Care Gaps MCP App.
+
+Verified live 2026-08-31 (#538): a tenant holding more than one Patient gets
+`unevaluated: "ambiguous-patient"` from $care-gaps and a note saying nothing
+was examined. The page threw the note away and drew a large "0 Due" tile
+over six cards reading "date of birth unknown" — every one of them an
+artefact of the call, not a fact about the person (see the docstring on
+r6/caregaps/report.py `_unevaluated_marker`). The cause was a render that
+showed the note only inside a box gated on `consumer.lines`, which is empty
+on exactly this path.
+
+What these prove, and what they do not. CI has no browser for the Python
+job, so, as in tests/test_mcp_app_lab_trends.py, they assert the route
+contract and the SHAPE of the source: the caller-reason family is injected
+from the engine rather than copied by hand, the placeholder branch exists,
+the 401 copy no longer names the write gate, and the exact shape of the
+defect — a ternary on `lines` wrapping the note — is gone. They do not prove
+a browser paints any of it. That is e2e/tests/care-gaps-app.spec.ts, which
+walks the ambiguous-patient path against the seeded demo tenant.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+from r6.caregaps.report import caller_reasons
+
+TEMPLATE = (pathlib.Path(__file__).resolve().parent.parent
+            / "templates" / "mcp_apps" / "care_gaps.html")
+
+#: The three reasons that mean the rules never read a record. Spelled out
+#: here on purpose: a change to the engine's set should read as a change,
+#: not vanish into `caller_reasons()` agreeing with itself.
+CALLER_REASONS = ["ambiguous-patient", "check-incomplete", "no-patient"]
+
+
+def _source() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def _code_only() -> str:
+    """The template with comments stripped — comments here quote the wording
+    they forbid, and a guard that reads its own documentation as evidence is
+    not a guard (the trap tests/test_mcp_app_lab_trends.py records)."""
+    src = re.sub(r"<!--.*?-->", "", _source(), flags=re.S)
+    return re.sub(r"(?<!:)//[^\n]*", "", src)
+
+
+def _render_body(code: str) -> str:
+    """The body of the page's `render()` function, up to `load()`."""
+    match = re.search(r"function render\(.*?\n  }\n", code, flags=re.S)
+    assert match, "render() not found in the template"
+    return match.group(0)
+
+
+# --- the route injects the caller-reason family --------------------------
+
+def test_the_route_renders_and_injects_the_caller_reasons(client):
+    """MUTATION: drop `not_evaluated_reasons` from render_template -> red.
+
+    The page branches on which FAMILY `unevaluated` belongs to, and the
+    families are the engine's. The rendered HTML must carry the engine's
+    caller-reason set as a JSON array, so the page has one source of truth.
+    """
+    r = client.get("/r6/fhir/mcp-apps/care-gaps")
+    assert r.status_code == 200
+    assert r.headers["X-MCP-App"] == "care-gaps"
+    body = r.get_data(as_text=True)
+    match = re.search(r"const NOT_EVALUATED = (\[[^\]]*\]);", body)
+    assert match, "the page does not declare NOT_EVALUATED as a JSON array"
+    assert json.loads(match.group(1)) == CALLER_REASONS
+    assert json.loads(match.group(1)) == caller_reasons()
+
+
+def test_the_caller_reasons_are_not_copied_into_the_template_by_hand():
+    """MUTATION: write the three strings into the template -> red.
+
+    A second copy drifts: the engine adds a reason and the page keeps
+    drawing "0 Due" for it. The strings must reach the page through the
+    route (above) and appear nowhere in the template file itself.
+    """
+    src = _source()
+    for reason in CALLER_REASONS:
+        assert reason not in src, f"{reason!r} is hand-copied into the template"
+    assert "not_evaluated_reasons | tojson" in src
+
+
+# --- the note is never gated on the plain-terms list ----------------------
+
+def test_the_note_is_not_gated_on_the_plain_terms_list():
+    """MUTATION: restore `const consumerBox = lines ? ... unevaluated_note
+    ... : ''` -> red.
+
+    Proven here: the exact shape of #538 is absent. No ternary in render()
+    branches on `lines`, and the note is read from the consumer summary
+    before the box is assembled, so it cannot be the box's own conditional
+    content. NOT proven here: that the note reaches the screen — the e2e
+    spec asserts that in a browser.
+    """
+    body = _render_body(_code_only())
+    assert "consumer.unevaluated_note" in body
+    assert re.search(r"\blines\s*\?", body) is None, (
+        "render() still branches on `lines` with a ternary — the shape of #538")
+    assert body.index("consumer.unevaluated_note") < body.index("consumerBox"), (
+        "the note must be read before the consumer box is built, not inside it")
+
+
+def test_the_caller_reason_path_draws_placeholders_not_counts():
+    """MUTATION: interpolate `summary.due || 0` on the caller path -> red.
+
+    On a caller reason every count is zero because nothing was read, and a
+    "0 Due" tile is the false statement the engine's docstring warns about.
+    The tiles must carry a placeholder, labelled for assistive tech, and the
+    cards must give way to a single line saying so.
+    """
+    body = _render_body(_code_only())
+    assert "NOT_EVALUATED.includes(" in body
+    assert "'—'" in body, "no placeholder branch for the stat tiles"
+    assert 'aria-label="not evaluated"' in body
+    assert 'title="not evaluated"' in body
+    assert "Not evaluated" in body, "the caller-reason heading is missing"
+    assert "No screenings were evaluated." in body
+
+
+def test_every_interpolated_string_is_still_escaped():
+    """The note and the heading are new interpolations; they go through
+    `esc()` like everything else on the page. MUTATION: interpolate
+    `${consumer.unevaluated_note}` bare -> red."""
+    body = _render_body(_code_only())
+    assert "${consumer.unevaluated_note}" not in body
+    assert "esc(consumer.unevaluated_note)" in body
+    assert "${consumer.note}" not in body
+    assert "esc(consumer.note)" in body
+
+
+# --- #535, the client half --------------------------------------------------
+
+def test_the_401_message_does_not_name_the_write_gate():
+    """MUTATION: restore "this tenant requires a step-up token" -> red.
+
+    Step-up is the WRITE gate. This is a read, and the common cause of a
+    401 here is a misspelled tenant. The server's answer stays the same for
+    a missing tenant and an unauthorised one (existence disclosure, P5), so
+    the client copy is what can help.
+    """
+    code = _code_only()
+    assert "requires a step-up token" not in code
+    assert "step-up" not in code.lower()
+    assert "check the tenant id is spelled correctly" in code
+    assert "or this tenant needs a credential" in code
+
+
+def test_enter_in_the_tenant_input_submits():
+    """MUTATION: drop the keydown listener -> red. The sibling pages wire
+    Enter; a tenant box that needs a mouse click reads as a broken page."""
+    code = _code_only()
+    assert re.search(
+        r"getElementById\('tenant-input'\)\.addEventListener\('keydown'", code), (
+        "no keydown listener on #tenant-input")
+    assert "e.key === 'Enter'" in code
+
+
+def test_the_footer_disclaimer_is_still_there():
+    """The page keeps its footer disclaimer whatever the render path."""
+    src = _source()
+    assert "not a diagnosis or a directive" in src

--- a/tests/test_mcp_app_care_gaps.py
+++ b/tests/test_mcp_app_care_gaps.py
@@ -132,6 +132,7 @@ def test_every_interpolated_string_is_still_escaped():
     assert "esc(consumer.unevaluated_note)" in body
     assert "${consumer.note}" not in body
     assert "esc(consumer.note)" in body
+    assert "esc(n || 0)" in body  # the tile counts (engine ints, still escaped)
 
 
 # --- #535, the client half --------------------------------------------------


### PR DESCRIPTION
Candidate for feature set 6 (surfaces — MCP Apps). Closes #538; client half of #535.

## What was wrong

Verified live 2026-08-31: a tenant holding more than one Patient gets `unevaluated: "ambiguous-patient"` from `$care-gaps` and a note saying nothing was examined. The MCP App page threw the note away and drew a large **0 Due** tile over six cards reading "date of birth unknown" — every one an artefact of the call, not a fact about the person.

Cause: the note was rendered only inside a box gated on `consumer.lines`, which is empty on exactly the path that has a note to show.

## What changed

- The route injects the engine's own caller-reason family (`caller_reasons()` in `r6/caregaps/report.py`) so the page has one source of truth and never keeps a copy of the list.
- On a **caller** reason (`no-patient`, `ambiguous-patient`, `check-incomplete`): tiles show `—` (labelled for assistive tech), cards give way to "No screenings were evaluated.", the box is headed **Not evaluated** with the engine's note.
- On an **engine** reason (e.g. `sex-unavailable`): counts and cards stay; the caveat is drawn above the list it qualifies.
- 401 copy no longer names the write gate. It says to check the tenant id spelling or that the tenant needs a credential (#535, client half).
- Enter in the tenant box submits, like the sibling pages.

## Evidence

- `tests/test_mcp_app_care_gaps.py` — 8 source-shape guards, comments stripped before matching (the `test_mcp_app_lab_trends.py` pattern). Mutation-verified: restoring the `lines ?` ternary goes red in both the Python guard and the Playwright spec.
- `e2e/tests/care-gaps-app.spec.ts` — asserts the fixture at the API first (so a fixture change reads as a fixture change), then watches the render paint against the seeded demo tenant; second test intercepts a production-shaped 401 for a misspelled tenant and checks the copy.
- Local: 39 passed (care-gaps app + lab-trends + report tests), 2/2 Playwright on `E2E_PORT=5099`, `uv run ruff check .` clean.

## What was NOT run / remaining 20–40%

- Not exercised through a real MCP host (`_meta.ui.resourceUri` embedding). The Playwright spec loads the page directly.
- Not run against a tenant with real records. Synthetic demo tenant only.
- Route-layer half is **not** in this PR and is filed separately: `$care-gaps` still calls the evaluator with `patient=None` when `not_evaluated` is set, so `detail` carries false `not_applicable` rows and the audit detail records `evaluated=7`. The page now hides those rows on the caller path, but the payload still carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
