### PR TITLE
candidate: pin the kernel's uniform step-up token strip (#334)

### DIFF
--- a/docs/2026-08-03-access-kernel-spec.md
+++ b/docs/2026-08-03-access-kernel-spec.md
@@ -620,6 +620,20 @@ characterization test so they can become gates, because they should not become
 gates. §1.2b adds `has_grant`, which is the same decision returned rather than
 raised, and they adopt *that*. Slices 15–18 below.
 
+**Ruled, #334 (council D5, unanimous).** The kernel strips the step-up token
+uniformly, at every source (`_step_up_token`, `r6/access.py:353-369`). Five of
+the six pre-migration sites did not strip and `r6/read_auth.py` did; one rule
+replaces both. It is authority-neutral — the HMAC still has to verify for the
+tenant, so a padded valid token is the valid token and stripping admits nobody
+who was not already admitted. Slices 3–11 landed on this behaviour before the
+ruling was recorded, so it is retroactive with no behaviour change; the pin is
+`test_a_padded_token_is_admitted_and_padded_garbage_is_still_refused`. Two
+edges deliberately outside the ruling: the strip is `str.strip()` with no
+argument, which is Unicode-wide rather than the ASCII-only the ruling names —
+narrowing it is a separate decision, not a migration PR; and the **tenant
+header stays unstripped** (§1.1, `_validated`), because it is an identifier
+compared against a stored value, not an authority-neutral token.
+
 ### 2.5b Slices 15–18 — `has_grant`, the four predicates
 
 Landed first as a pure addition adopted by nothing (§1.2b). Then, one site per

--- a/r6/access.py
+++ b/r6/access.py
@@ -349,6 +349,7 @@ def _step_up_token(*, also_bearer: bool, also_body_field: str | None) -> str:
     is opt-in for the same reason TenantSource is: a reader must be able to
     see which inputs an endpoint trusts without reading this helper.
     """
+    # Stripped uniformly at every source: a padded valid token is valid (#334).
     token = (request.headers.get('X-Step-Up-Token') or '').strip()
     if token:
         return token

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -323,6 +323,47 @@ def test_a_read_scoped_token_does_buy_a_tenant_bound_grant(app, tenant_id):
     assert grant.scope is Scope.TENANT_BOUND
 
 
+def test_a_padded_token_is_admitted_and_padded_garbage_is_still_refused(
+        app, tenant_id):
+    """#334 (council D5): the kernel strips the step-up token uniformly.
+
+    A whitespace-padded valid token IS the valid token — the HMAC still has
+    to verify for this tenant, so stripping admits nobody who was not already
+    admitted. Six merged slices depend on this, so the ruling is retroactive
+    and this test pins the shipped behaviour rather than changing it. Note
+    the strip is `str.strip()` with no argument, which is Unicode-wide;
+    narrowing it to ASCII whitespace is a separate decision.
+
+    MUTATION: drop the .strip() in _step_up_token -> the first half red.
+    """
+    tenant = Tenant(id=tenant_id, source=TenantSource.HEADER)
+    padded = ' \t' + generate_step_up_token(tenant_id) + ' \t'
+    with app.test_request_context(headers=_headers(padded)):
+        grant = require_grant(scope=Scope.WRITE, tenant=tenant)
+    assert grant.tenant_id == tenant_id
+
+    with app.test_request_context(headers=_headers(' \tnot-a-token \t')):
+        with pytest.raises(StepUpDenied) as exc:
+            require_grant(scope=Scope.WRITE, tenant=tenant)
+    assert exc.value.checked is True
+
+
+def test_the_tenant_header_is_not_stripped_even_though_the_token_is(app,
+                                                                    tenant_id):
+    """#334, the other half: the strip is for the token only.
+
+    The tenant id is an identifier compared against a stored value, not an
+    authority-neutral token, so the padding that the token gate forgives
+    stays malformed here. Same padding, opposite answer, on purpose.
+
+    MUTATION: .strip() the value in _validated -> red.
+    """
+    with app.test_request_context(headers={'X-Tenant-Id': ' \tacme-1 \t'}):
+        with pytest.raises(TenantRejected) as exc:
+            tenant_from_request()
+    assert exc.value.reason == 'malformed'
+
+
 def test_the_bearer_header_is_ignored_unless_the_endpoint_opted_in(app,
                                                                   tenant_id):
     """MUTATION: read Authorization unconditionally -> the first half red."""


### PR DESCRIPTION
## What

Records the #334 ruling in the three places a reader would look, with no behaviour change:

- `tests/test_access_kernel.py` — two pin tests. `test_a_padded_token_is_admitted_and_padded_garbage_is_still_refused`: a valid token padded with `" \t"` on both sides yields a Grant; the same padding around garbage raises `StepUpDenied` with `checked=True`. `test_the_tenant_header_is_not_stripped_even_though_the_token_is`: the same padding on `X-Tenant-Id` is rejected as `malformed`.
- `r6/access.py` — one comment line at the strip in `_step_up_token`, citing #334.
- `docs/2026-08-03-access-kernel-spec.md` §2.5 — a "Ruled, #334" paragraph after the 2026-08-16 update, before §2.5b.

Verified the first test goes red under its named mutation (drop the `.strip()` at `r6/access.py:353`) and green with it.

## Why

Council D5, unanimous: "Strip uniformly, ASCII whitespace only. The kernel already does and six merged slices depend on it, so the ruling is retroactive and there is no behaviour change. Close #334 with one pin test, a one-line comment at the strip citing #334, and a §2.5 note. The tenant header stays unstripped: it is an identifier compared against a stored value, not an authority-neutral token."

The strip is authority-neutral: the HMAC still has to verify for the tenant, so a padded valid token is the valid token and stripping admits nobody who was not already admitted.

**One thing to note.** The shipped strip is `str.strip()` with no argument, which is Unicode-wide (it also removes e.g. U+00A0, U+2003), whereas the ruling names ASCII whitespace only. This PR pins what ships today, because six slices depend on it; narrowing to `.strip(" \t\r\n\f\v")` is a separate decision and is deliberately not made here. The spec note says so.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3159 passed, 13 skipped, 1 xfailed, 2 warnings in 108.23s (0:01:48)
```

Ratchets untouched: `r6/routes.py` not modified; nothing new imports `r6.routes`; no new raw tenant reads, direct step-up calls, or soft-delete-blind files.

## What was NOT run

- No live server. The change is a test, a comment and a doc paragraph; there is no runtime path to exercise beyond the unit tests.
- The Postgres CI lane runs on this PR, not locally.

Closes #334
