### PR TITLE
candidate: refuse non-string resource ids on ingest, pin the four id cases (#286)

### DIFF
--- a/r6/fasten/ingester.py
+++ b/r6/fasten/ingester.py
@@ -375,7 +375,8 @@ def _ingest_one(resource: dict, tenant_id: str,
 
     Returns ('ok', resource_id) on success, ('skipped', None) for unsupported
     types, ('forbidden', None) for a type excluded by `allowed_types`, or
-    ('invalid_id', None) for a caller-supplied id outside the FHIR id shape.
+    ('invalid_id', None) for a caller-supplied id outside the FHIR id shape
+    or not a string (an int is coerced; a bool, float, list or object is not).
     Raises on unexpected DB errors.
 
     `agent_id` and `detail` parameterize the audit event so a caller other
@@ -400,6 +401,12 @@ def _ingest_one(resource: dict, tenant_id: str,
 
     resource_id = resource.get('id')
     if resource_id is not None:
+        # An int keeps coercing to a string — pre-existing, and live on the
+        # Fasten connector. Any other non-string (bool, float, list, object)
+        # is refused BEFORE str(), because str(True) and str(1.5) both pass
+        # the id pattern. bool is a subclass of int, hence checked first (#286).
+        if isinstance(resource_id, bool) or not isinstance(resource_id, (str, int)):
+            return 'invalid_id', None
         resource_id = str(resource_id)
         if not _RESOURCE_ID_PATTERN.fullmatch(resource_id):
             return 'invalid_id', None

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -244,6 +244,36 @@ def test_any_other_non_string_resource_id_is_refused(client, tenant_id):
         tenant_id=tenant_id, resource_type="Observation").count() == 0
 
 
+def test_an_explicit_json_null_id_mints_a_uuid_rather_than_being_refused(
+        client, tenant_id):
+    """The fifth falsy id, which D8's four cases do not name: `"id": null`.
+
+    `resource.get('id')` cannot tell an absent key from a present `null`,
+    so a null id takes the absent branch and is MINTED, while `""` — the
+    other empty id — is refused. That divergence is the behaviour today and
+    this pins it as-is; it is not an endorsement. If null should instead be
+    refused (the argument: a UUID for an id the feed did send, but sent
+    empty, turns the next re-ingest into a duplicate row — the same
+    append-not-upsert shape #286 exists to stop), that is a product call,
+    and this test is what makes changing it deliberate rather than silent.
+
+    MUTATION: `if resource_id is not None:` -> `if resource_id:` makes the
+    blank-id test red while this one stays green, which is precisely the
+    asymmetry being recorded.
+    """
+    from r6.fasten.ingester import _ingest_one
+
+    result, rid = _ingest_one(
+        {"resourceType": "Observation", "id": None, "status": "final"},
+        tenant_id)
+
+    assert result == "ok"
+    assert uuid.UUID(rid)  # minted, not "" and not the string "None"
+    assert R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation", id=rid
+    ).first() is not None
+
+
 # ---------------------------------------------------------------------------
 # #293 / #306: a record we REFUSED is not a record we chose to skip, and the
 # SHC path never got the rollback the Fasten path was patched for on

--- a/tests/test_ingest_resilience.py
+++ b/tests/test_ingest_resilience.py
@@ -170,6 +170,81 @@ def test_resource_id_pattern_is_a_charset_control_not_a_length_control():
 
 
 # ---------------------------------------------------------------------------
+# #286 (council D8): what `_ingest_one` does with an id that is not a
+# well-formed string. Four cases, pinned in the shape the ruling gave them.
+# `invalid_id` is in REFUSED_OUTCOMES, so each refusal pages rather than
+# counting as a skip; keep it there.
+# ---------------------------------------------------------------------------
+def test_a_blank_resource_id_is_refused_as_invalid_id(client, tenant_id):
+    """`""` is not an absent id. It used to earn a fabricated UUID, which
+    turned every re-ingest of the same resource into a duplicate row
+    instead of an upsert on (tenant, type, id). Refused, and refused as a
+    refusal (#286).
+    """
+    from r6.fasten.ingester import REFUSED_OUTCOMES, _ingest_one
+
+    result, rid = _ingest_one(
+        {"resourceType": "Observation", "id": "", "status": "final"},
+        tenant_id)
+
+    assert (result, rid) == ("invalid_id", None)
+    assert "invalid_id" in REFUSED_OUTCOMES
+    assert R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation").count() == 0
+
+
+def test_an_absent_resource_id_gets_a_uuid_and_is_stored(client, tenant_id):
+    """No `id` key at all: mint one. This is the only case that fabricates
+    an id, and it is fine because there is nothing to upsert against."""
+    from r6.fasten.ingester import _ingest_one
+
+    result, rid = _ingest_one(
+        {"resourceType": "Observation", "status": "final"}, tenant_id)
+
+    assert result == "ok"
+    assert uuid.UUID(rid)  # a well-formed UUID, not "" or "None"
+    row = R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation", id=rid).first()
+    assert row is not None and row.is_deleted is False
+
+
+def test_an_integer_resource_id_keeps_coercing_to_a_string(client, tenant_id):
+    """Pre-existing and live on the Fasten connector: `123` is stored as
+    `"123"`. Not widened, not narrowed — pinned (#286)."""
+    from r6.fasten.ingester import _ingest_one
+
+    result, rid = _ingest_one(
+        {"resourceType": "Observation", "id": 123, "status": "final"},
+        tenant_id)
+
+    assert (result, rid) == ("ok", "123")
+    assert R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation", id="123"
+    ).first() is not None
+
+
+def test_any_other_non_string_resource_id_is_refused(client, tenant_id):
+    """`str()` of a bool or a float passes the id pattern — `True` becomes
+    `"True"`, `1.5` becomes `"1.5"` — so the type has to be checked before
+    the shape. `bool` is a subclass of `int`, so it is refused explicitly
+    rather than riding the int coercion. Objects and lists never passed the
+    pattern; they are here so the whole set is one pin (#286).
+
+    MUTATION: drop the isinstance guard in _ingest_one -> the first two red.
+    """
+    from r6.fasten.ingester import _ingest_one
+
+    for bad in (True, False, 1.5, {"a": 1}, [1]):
+        result, rid = _ingest_one(
+            {"resourceType": "Observation", "id": bad, "status": "final"},
+            tenant_id)
+        assert (result, rid) == ("invalid_id", None), repr(bad)
+
+    assert R6Resource.query.filter_by(
+        tenant_id=tenant_id, resource_type="Observation").count() == 0
+
+
+# ---------------------------------------------------------------------------
 # #293 / #306: a record we REFUSED is not a record we chose to skip, and the
 # SHC path never got the rollback the Fasten path was patched for on
 # 2026-07-08. Both call sites collapsed every non-'ok' outcome into `skipped`


### PR DESCRIPTION
## What

`r6/fasten/ingester.py` `_ingest_one`: one type guard before the existing `str()` coercion. An `int` id still coerces to a string; any other non-string id (`bool`, `float`, `list`, `dict`/object) is refused as `invalid_id`. `bool` is a subclass of `int`, so it is checked explicitly before the int branch. The docstring's `invalid_id` line says so.

`tests/test_ingest_resilience.py`: four pins in the file's existing `_ingest_one` style, each driving the real ingester entry point and checking the row table afterwards.

| id | outcome | status |
|---|---|---|
| `""` | `invalid_id`, nothing stored | already the case, now pinned |
| absent | `ok`, a well-formed UUID, row stored | already the case, now pinned |
| `123` | `ok`, stored as `"123"` | already the case, now pinned |
| `True`, `False`, `1.5`, `{"a": 1}`, `[1]` | `invalid_id`, nothing stored | **new** for `True`/`False`/`1.5`; list/dict never passed the pattern |

The fourth test was red before the guard (`True` → `"True"` passed `_RESOURCE_ID_PATTERN`) and is green after. `invalid_id` stays in `REFUSED_OUTCOMES` (asserted in the blank-id test), so each refusal pages rather than counting as a skip.

## Why

Council D8: "Refuse a blank id as `invalid_id` (already the case); an absent id gets a UUID (already the case); an integer id keeps coercing to a string (pre-existing, live on the Fasten connector); any other non-string id (bool, float, object, list) is `invalid_id`, since `str()` of a bool or float passes the id pattern today. Pin all four."

The blank-id refusal is the right one: the pre-#267 behaviour fabricated a UUID for `""`, which turned every re-ingest of the same resource into a duplicate row instead of an upsert on `(tenant, type, id)`.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3161 passed, 13 skipped, 1 xfailed, 2 warnings in 105.00s (0:01:45)
```

Ratchets untouched: `r6/routes.py` not modified; nothing new imports `r6.routes`; no new raw tenant reads, direct step-up calls, or soft-delete-blind files.

## What was NOT run

- No live Fasten or SHC import. The guard sits inside `_ingest_one`, which every path shares, and the tests drive that function directly on SQLite; the Postgres CI lane runs on this PR, not locally.
- The `0` int case is not separately pinned; it rides the int-coercion pin (`123` → `"123"`) and stores as `"0"`, as the issue table says.

Closes #286
