### PR TITLE
candidate: revive a tombstoned row on context-builder re-ingest (#509 defect 2)

### DIFF
--- a/r6/context_builder.py
+++ b/r6/context_builder.py
@@ -90,6 +90,9 @@ class ContextBuilder:
 
                 if existing:
                     existing.update_resource(resource_json)
+                    # A re-ingest of a tombstoned (tenant, type, id) revives
+                    # it, as r6/fasten/ingester.py does (#509 defect 2).
+                    existing.is_deleted = False
                     r6_resource = existing
                 else:
                     r6_resource = R6Resource(

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -4,6 +4,9 @@ Tests for the Context Builder service.
 
 import json
 
+from models import db
+from r6.models import R6Resource
+
 
 class TestContextBuilder:
     """Test context builder functionality."""
@@ -77,3 +80,35 @@ class TestContextBuilder:
         data = resp.get_json()
         assert 'expires_at' in data
         assert data['expires_at'] is not None
+
+    def test_reingest_revives_a_tombstoned_row(self, client, sample_bundle,
+                                               sample_observation, tenant_id,
+                                               tenant_headers):
+        """#509 defect 2: the upsert lands on a soft-deleted row and must
+        clear the flag, as the Fasten ingester does. Before the fix it wrote
+        the new content into the tombstone and reported success — data that
+        was there, and that no read path could see.
+        """
+        stale = dict(sample_observation, status='preliminary')
+        row = R6Resource(
+            resource_type='Observation',
+            resource_json=json.dumps(stale, separators=(',', ':'), sort_keys=True),
+            resource_id=sample_observation['id'],
+            tenant_id=tenant_id,
+        )
+        row.is_deleted = True
+        db.session.add(row)
+        db.session.commit()
+
+        resp = client.post('/r6/fhir/Bundle/$ingest-context',
+                           data=json.dumps(sample_bundle),
+                           content_type='application/json',
+                           headers=tenant_headers)
+        assert resp.status_code == 201, resp.get_data(as_text=True)
+
+        row = R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type='Observation',
+            id=sample_observation['id']).first()
+        assert row.is_deleted is False
+        assert row.version_id == 2
+        assert json.loads(row.resource_json)['status'] == 'final'

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -112,3 +112,47 @@ class TestContextBuilder:
         assert row.is_deleted is False
         assert row.version_id == 2
         assert json.loads(row.resource_json)['status'] == 'final'
+
+    def test_a_revived_row_is_readable_again_through_the_read_path(
+            self, client, sample_bundle, sample_observation, tenant_id,
+            tenant_headers, step_up_token):
+        """#509 defect 2, stated as the symptom rather than the column.
+
+        The sibling test asserts `is_deleted is False`. That is the fix's
+        mechanism; THIS is the thing a patient notices — the record was
+        unreadable, and after the re-ingest it reads. Asserting the symptom
+        is what keeps the pin honest if the read path ever stops filtering
+        `is_deleted` (then the 404 below fails and someone has to think),
+        and it is the half that would have caught the original bug: the
+        ingest reported success while every read still returned 404.
+
+        MUTATION: drop `existing.is_deleted = False` in
+        r6/context_builder.py -> the final GET returns 404, red.
+        """
+        stale = dict(sample_observation, status='preliminary')
+        row = R6Resource(
+            resource_type='Observation',
+            resource_json=json.dumps(stale, separators=(',', ':'), sort_keys=True),
+            resource_id=sample_observation['id'],
+            tenant_id=tenant_id,
+        )
+        row.is_deleted = True
+        db.session.add(row)
+        db.session.commit()
+
+        url = f"/r6/fhir/Observation/{sample_observation['id']}"
+        read_headers = dict(tenant_headers, **{'X-Step-Up-Token': step_up_token})
+
+        # The tombstone is invisible: this is the state the bug left behind.
+        before = client.get(url, headers=read_headers)
+        assert before.status_code == 404, before.get_data(as_text=True)
+
+        resp = client.post('/r6/fhir/Bundle/$ingest-context',
+                           data=json.dumps(sample_bundle),
+                           content_type='application/json',
+                           headers=tenant_headers)
+        assert resp.status_code == 201, resp.get_data(as_text=True)
+
+        after = client.get(url, headers=read_headers)
+        assert after.status_code == 200, after.get_data(as_text=True)
+        assert after.get_json()['status'] == 'final'


### PR DESCRIPTION
## What

`r6/context_builder.py`, in `ingest_bundle`'s upsert branch: one line, `existing.is_deleted = False`, with a two-line comment citing the issue. The select stays unfiltered on `is_deleted` — it has to find the tombstone or it would insert a duplicate composite PK.

`tests/test_context_builder.py`: `test_reingest_revives_a_tombstoned_row`, in the file's existing class and route-driven style. It seeds an Observation row at `is_deleted=True` with `status: preliminary`, POSTs the standard `sample_bundle` to `/r6/fhir/Bundle/$ingest-context`, and asserts the row is `is_deleted is False`, `version_id == 2`, and its JSON now says `status: final`. Red before the fix (`assert True is False` on `is_deleted`), green after.

## Why

Council D13, unanimous "today": "`existing.is_deleted = False` in `r6/context_builder.py` where the upsert lands on a tombstone, matching what the Fasten ingester already does (`r6/fasten/ingester.py:422`)."

This is the opposite failure from #422: not a deleted row being read, but a live write landing in a grave. The ingest reported success, the data was there, and no read path could see it — the more confusing of the two to debug.

**Can #509 close?** Yes, once this merges. Defect 1 (`form_fill.py` loading a soft-deleted QuestionnaireResponse) was fixed in `b265cfa`, which is an ancestor of `origin/main` (`r6/actions/rails/form_fill.py:63-72` carries the `is_deleted=False` filter and a comment naming the issue). The maintainer's comment on #509 kept it open on defect 2 alone; this PR is defect 2. I used `Refs` rather than `Closes` so the close is a human call after review.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3158 passed, 13 skipped, 1 xfailed, 2 warnings in 105.33s (0:01:45)
```

Ratchets untouched: `r6/routes.py` not modified; nothing new imports `r6.routes`; no new raw tenant reads, direct step-up calls, or soft-delete-blind files (the test file imports `R6Resource` to seed and read a row directly, which is the same thing `tests/test_ingest_resilience.py` already does).

## What was NOT run

- No live server. The route path is exercised through the Flask test client on SQLite; the Postgres CI lane runs on this PR, not locally.
- Not reachable in production yet, per the issue: `is_deleted = True` is written on one line today (the demo walkthrough, on Permission rows) and no route accepts DELETE. This fixes the writer before the delete path ships.

Refs #509
