### PR TITLE
candidate: prod-watch watches careagents.cloud and the Telegram tile; the one flaky test no longer reaches the network (#537, #433)

### DIFF
--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -43,6 +43,13 @@ The build check (#258) closes a different blind spot with the same honesty
 limit: every other check here is equally satisfied by a months-old build, and
 this one proves WHICH ARTIFACT is deployed. It does not prove the code in that
 artifact works — a broken build carrying the right sha still passes it.
+
+The Telegram check (#537) has the same limit one layer down. It reads what an
+unauthenticated visitor reads — the landing page, and the home page only if
+that ever answers without a session — and fails on any live Telegram link or
+call to action there. The "connect →" tile #536 describes lives on /home
+behind sign-in, where this script cannot see it; what this guards is the
+public promise, and its detail says which pages it actually read.
 """
 from __future__ import annotations
 
@@ -51,13 +58,22 @@ import json
 import re
 import sys
 from datetime import datetime, timezone
+from html import unescape
 
 import requests
 
 G, R, Y, D, X = "\033[92m", "\033[91m", "\033[93m", "\033[2m", "\033[0m"
 
 HEALTHCLAW = "https://app.healthclaw.io"
-CAREAGENTS = "https://careagents-production.up.railway.app"
+# The origin people actually visit. Until #537 this was the Railway hostname,
+# which nobody visits, so a divergence between the two — DNS, routing, a
+# custom domain pinned to the wrong target — was invisible by construction
+# (#289): a green board said nothing about what a patient saw.
+CAREAGENTS = "https://careagents.cloud"
+# The Railway-issued hostname behind it. About to 308 everything except
+# /healthz to the origin, but /healthz there is what Railway's own health
+# check hits, so that one path stays watched under its own name.
+CAREAGENTS_RAILWAY = "https://careagents-production.up.railway.app"
 # Two MCP deployments by design: the real one is token-locked, the demo one is
 # unauthenticated but hard-pinned to a synthetic tenant.
 MCP_LOCKED = "https://mcp-server-production-5112.up.railway.app"
@@ -79,10 +95,45 @@ DEMO_PATIENTS = (
     "demo-ray",
 )
 BUILD_CHECK = "careagents: running the current build"
+TELEGRAM_CHECK = "careagents: telegram not advertised as live"
 # Same shape careagents/_build.py enforces on the way out. A "-dirty" marker
 # deliberately fails it: a build stamped from an uncommitted tree has no
 # provenance to assert.
 _SHA_RE = re.compile(r"[0-9a-f]{7,40}")
+
+# How a page advertises Telegram. A t.me (or tg://) link anywhere is a link,
+# full stop. Short of one, a call to action is the surface's name and an
+# inviting verb in the SAME piece of copy: "Telegram — connect →" on a tile,
+# "Open in Telegram" on a button. The piece of copy is what sits between two
+# block-closing tags, so a neighbouring tile's "connect →" cannot vouch for
+# or against Telegram, and "coming soon" on the Telegram tile means exactly
+# that. Script and style bodies are not copy anyone reads.
+_TG_LINK_RE = re.compile(r"(?i)\bt\.me/|\btg://")
+_TG_NAME_RE = re.compile(r"(?i)\btelegram\b")
+_TG_CTA_RE = re.compile(r"(?i)\b(?:open|connect|start|chat|join|pair|launch)\b")
+_BLOCK_END_RE = re.compile(
+    r"(?i)</(?:div|li|p|td|th|tr|a|button|h[1-6]|section|article|label|dt|dd)\s*>")
+_TAG_RE = re.compile(r"<[^>]*>")
+_SCRIPT_RE = re.compile(r"(?is)<(script|style)\b.*?</\1\s*>")
+
+
+def _telegram_advertised(html: str) -> str:
+    """How `html` presents Telegram as a live surface, or "" if it does not."""
+    if _TG_LINK_RE.search(html):
+        return "a t.me link"
+    # Source newlines are formatting, not boundaries: the real tile puts
+    # "Telegram" and "connect →" on different lines of the template. Collapse
+    # them first, then let only a block-closing tag end a piece of copy.
+    text = " ".join(_SCRIPT_RE.sub(" ", html).split())
+    text = _TAG_RE.sub(" ", _BLOCK_END_RE.sub("\n", text))
+    for line in unescape(text).splitlines():
+        line = " ".join(line.split())
+        if not _TG_NAME_RE.search(line) or "coming soon" in line.lower():
+            continue
+        if _TG_CTA_RE.search(line):
+            return f"a live call to action ({line[:60]!r})"
+    return ""
+
 
 results: list[tuple[str, bool, str]] = []
 
@@ -328,11 +379,67 @@ def run(timeout: float, expect_sha: list[str]) -> int:
                 "auto-deploy — redeploy per RELEASING.md §4.")
             build_info.update(asserted=True, ok=ok)
 
+    # The Railway hostname, readiness only: everything user-facing above and
+    # below is asked of the origin, because the origin is what a user gets.
+    # Its build marker rides along in the detail — shown, not asserted — so a
+    # deployment split between the two hosts is visible in the report rather
+    # than assumed away.
+    r = get(f"{CAREAGENTS_RAILWAY}/healthz", timeout)
+    rbody = {}
+    if getattr(r, "status_code", None) in (200, 503):
+        try:
+            rbody = r.json() or {}
+        except ValueError:
+            pass
+    check("careagents (railway host): ready (db reachable)",
+          getattr(r, "status_code", None) == 200 and rbody.get("accounts") is True,
+          f"status={getattr(r, 'status_code', r)} accounts={rbody.get('accounts')}"
+          f" build={str(rbody.get('build') or 'unknown').lower()}")
+
     r = get(f"{CAREAGENTS}/", timeout)
     html = getattr(r, "text", "") or ""
-    check("careagents: landing renders",
-          getattr(r, "status_code", None) == 200 and "/auth" in html,
-          str(getattr(r, "status_code", r)))
+    landing_status = getattr(r, "status_code", r)
+    landing_read = landing_status == 200
+    check("careagents: landing renders", landing_read and "/auth" in html,
+          str(landing_status))
+
+    # --- Telegram (#537) ------------------------------------------------------
+    # Twelve checks were green while the Telegram surface had been dead since
+    # June (#536): every check asked whether a process answers, and none asked
+    # whether a promise made to a user could be kept. This one cannot see the
+    # bot either — there is no token here, and a getMe would only prove a bot
+    # exists, not that anything services it — so it watches the promise
+    # instead: no live Telegram link or call to action on any page an
+    # unauthenticated visitor can read. A tile marked "coming soon" passes.
+    #
+    # The landing body is the one already fetched; a landing that was not
+    # read is not scanned, and not scanned is a failure, not a pass. /home is
+    # fetched without following its redirect: without a session it answers
+    # 302 to /auth, and following that would scan the sign-in page under
+    # /home's name.
+    pages = {"/": html} if landing_read else {}
+    r = get(f"{CAREAGENTS}/home", timeout, allow_redirects=False)
+    home_code = getattr(r, "status_code", None)
+    if home_code == 200:
+        pages["/home"] = getattr(r, "text", "") or ""
+    live = ""
+    for path, page in pages.items():
+        how = _telegram_advertised(page)
+        if how:
+            live = f"{path} shows {how}"
+            break
+    if not pages:
+        detail = f"landing not readable ({landing_status}), nothing was scanned"
+    elif live:
+        detail = (f"{live} — Telegram pairing is a dead end (#536) until its "
+                  "fix deploys; a tile marked coming soon passes")
+    else:
+        detail = ("no live Telegram link or call to action on "
+                  + ", ".join(pages)
+                  + ("" if "/home" in pages else
+                     f"; /home not scanned ({getattr(r, 'status_code', r)} "
+                     "without a session)"))
+    check(TELEGRAM_CHECK, bool(pages) and not live, detail)
 
     # The sign-in page is the front door; #181 broke exactly this and nothing
     # noticed. Codes are 8 digits — an input that cannot hold 8 is a dead door.

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -49,7 +49,16 @@ unauthenticated visitor reads — the landing page, and the home page only if
 that ever answers without a session — and fails on any live Telegram link or
 call to action there. The "connect →" tile #536 describes lives on /home
 behind sign-in, where this script cannot see it; what this guards is the
-public promise, and its detail says which pages it actually read.
+public promise, and its detail says which pages it actually read. It reads
+`/` and `/home` only — a Telegram invitation added to `/auth` would pass —
+and `_telegram_advertised` documents the wordings it cannot see.
+
+Which HOST answered is part of every CareAgents reading (#289). `requests`
+follows redirects, so a check named for one origin will happily measure
+another and report it under the first one's name; the origin's /healthz and
+landing therefore fail if the response came from anywhere else, and the
+Railway host's /healthz is fetched without following redirects at all. Two
+hosts that agree because one is the other are not two readings.
 """
 from __future__ import annotations
 
@@ -108,6 +117,16 @@ _SHA_RE = re.compile(r"[0-9a-f]{7,40}")
 # block-closing tags, so a neighbouring tile's "connect →" cannot vouch for
 # or against Telegram, and "coming soon" on the Telegram tile means exactly
 # that. Script and style bodies are not copy anyone reads.
+#
+# A CTA is also SHORT: a tile label or a button, not a sentence. Without that
+# bound the verb list matches ordinary prose that merely names the surface —
+# "Chat with your agent on the web today. Telegram and iMessage are not
+# available in the beta" contains `chat` and `Telegram` and is the opposite of
+# a promise. A monitor that reddens on the honest sentence trains its reader
+# to ignore it, which is the failure this file warns about two checks down.
+# Long copy carrying a real invitation almost always carries the link too, and
+# the link rule above has no length bound.
+_TG_COPY_MAX = 48
 _TG_LINK_RE = re.compile(r"(?i)\bt\.me/|\btg://")
 _TG_NAME_RE = re.compile(r"(?i)\btelegram\b")
 _TG_CTA_RE = re.compile(r"(?i)\b(?:open|connect|start|chat|join|pair|launch)\b")
@@ -118,7 +137,14 @@ _SCRIPT_RE = re.compile(r"(?is)<(script|style)\b.*?</\1\s*>")
 
 
 def _telegram_advertised(html: str) -> str:
-    """How `html` presents Telegram as a live surface, or "" if it does not."""
+    """How `html` presents Telegram as a live surface, or "" if it does not.
+
+    What it does NOT see, so the check's name is not read as more than it is:
+    text a script writes after load (the tile's own state is server-rendered,
+    so the one that matters is visible), an invitation worded outside the verb
+    list above, and a live call to action sharing one block with the words
+    "coming soon". Each of those is a green this returns without proof.
+    """
     if _TG_LINK_RE.search(html):
         return "a t.me link"
     # Source newlines are formatting, not boundaries: the real tile puts
@@ -130,9 +156,24 @@ def _telegram_advertised(html: str) -> str:
         line = " ".join(line.split())
         if not _TG_NAME_RE.search(line) or "coming soon" in line.lower():
             continue
-        if _TG_CTA_RE.search(line):
+        if len(line) <= _TG_COPY_MAX and _TG_CTA_RE.search(line):
             return f"a live call to action ({line[:60]!r})"
     return ""
+
+
+def _answered_elsewhere(r, url: str) -> str:
+    """Where `r` actually came from, if that is not the origin of `url`.
+
+    `requests` follows redirects, so a check NAMED for one host measures
+    whichever host the chain ends at. That is #289's blindness restated one
+    layer down: careagents.cloud 308ing to the Railway hostname would keep
+    every check here green while nothing verified what a user is served —
+    and the build marker, read from this origin's /healthz, would assert the
+    other host's build under this host's name. A response from somewhere else
+    is not a worse reading of the origin; it is no reading of it.
+    """
+    landed = str(getattr(r, "url", "") or url)
+    return "" if landed.startswith("/".join(url.split("/", 3)[:3])) else landed
 
 
 results: list[tuple[str, bool, str]] = []
@@ -313,12 +354,16 @@ def run(timeout: float, expect_sha: list[str]) -> int:
 
     # --- the consumer app ----------------------------------------------------
     r = get(f"{CAREAGENTS}/healthz", timeout)
+    # Off-origin is not a reading of this origin, so nothing downstream may
+    # speak for it: `healthz_read` stays False and the build check reports
+    # that it asserted nothing, exactly as it does for an unreadable /healthz.
+    elsewhere = _answered_elsewhere(r, f"{CAREAGENTS}/healthz")
     body = {}
     # Whether the deployment actually told us anything, as opposed to us
     # defaulting on its behalf. The build check below reads its one field from
     # this body and may only speak when this is True — see #272.
     healthz_read = False
-    if getattr(r, "status_code", None) in (200, 503):
+    if not elsewhere and getattr(r, "status_code", None) in (200, 503):
         try:
             body = r.json() or {}
             healthz_read = True
@@ -327,8 +372,10 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # /healthz round-trips the database, so this catches an app that booted but
     # cannot reach its store — the state a load balancer must not route into.
     check("careagents: ready (db reachable)",
-          getattr(r, "status_code", None) == 200 and body.get("accounts") is True,
-          f"status={getattr(r, 'status_code', r)} accounts={body.get('accounts')}")
+          not elsewhere and getattr(r, "status_code", None) == 200
+          and body.get("accounts") is True,
+          f"status={getattr(r, 'status_code', r)} accounts={body.get('accounts')}"
+          + (f" — answered by {elsewhere}, not the origin" if elsewhere else ""))
 
     # Same body, no second request. Every other check on this deployment is
     # satisfied just as well by a months-old build — in #258 both CareAgents
@@ -344,8 +391,10 @@ def run(timeout: float, expect_sha: list[str]) -> int:
         # which is the exact thing #258 exists to prevent. The readiness check
         # above already reports the outage, and its remedy is the right one.
         report(BUILD_CHECK,
-               f"not asserted — /healthz was not readable "
-               f"({getattr(r, 'status_code', r)}), so no build marker was read")
+               "not asserted — /healthz was "
+               + (f"answered by {elsewhere}, not the origin" if elsewhere else
+                  f"not readable ({getattr(r, 'status_code', r)})")
+               + ", so no build marker was read")
     else:
         deployed = str(body.get("build") or "unknown").lower()
         built = _stamp(body.get("built_at"))
@@ -384,24 +433,42 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # Its build marker rides along in the detail — shown, not asserted — so a
     # deployment split between the two hosts is visible in the report rather
     # than assumed away.
-    r = get(f"{CAREAGENTS_RAILWAY}/healthz", timeout)
+    #
+    # Not following the redirect is the whole point here. This host is about
+    # to 308 every other path to the origin; if /healthz joins them, following
+    # it would read the ORIGIN's health and build and print them beside the
+    # Railway host's name — the two hosts would agree by construction, which
+    # is the one thing this check exists to disprove. A 3xx is therefore a
+    # failure: it means this host no longer answers for itself, which is also
+    # what Railway's own health check would find.
+    r = get(f"{CAREAGENTS_RAILWAY}/healthz", timeout, allow_redirects=False)
+    rcode = getattr(r, "status_code", None)
     rbody = {}
-    if getattr(r, "status_code", None) in (200, 503):
+    if rcode in (200, 503):
         try:
             rbody = r.json() or {}
         except ValueError:
             pass
+    moved = ""
+    if isinstance(rcode, int) and 300 <= rcode < 400:
+        moved = str((getattr(r, "headers", None) or {}).get("Location") or
+                    "an undisclosed target")
     check("careagents (railway host): ready (db reachable)",
-          getattr(r, "status_code", None) == 200 and rbody.get("accounts") is True,
+          rcode == 200 and rbody.get("accounts") is True,
           f"status={getattr(r, 'status_code', r)} accounts={rbody.get('accounts')}"
-          f" build={str(rbody.get('build') or 'unknown').lower()}")
+          f" build={str(rbody.get('build') or 'unknown').lower()}"
+          + (f" — redirects to {moved}, so this host was not read; Railway's "
+             "own health check hits this path" if moved else ""))
 
     r = get(f"{CAREAGENTS}/", timeout)
     html = getattr(r, "text", "") or ""
     landing_status = getattr(r, "status_code", r)
-    landing_read = landing_status == 200
+    landing_elsewhere = _answered_elsewhere(r, f"{CAREAGENTS}/")
+    landing_read = landing_status == 200 and not landing_elsewhere
     check("careagents: landing renders", landing_read and "/auth" in html,
-          str(landing_status))
+          str(landing_status)
+          + (f" — served by {landing_elsewhere}, not the origin"
+             if landing_elsewhere else ""))
 
     # --- Telegram (#537) ------------------------------------------------------
     # Twelve checks were green while the Telegram surface had been dead since
@@ -420,6 +487,7 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     pages = {"/": html} if landing_read else {}
     r = get(f"{CAREAGENTS}/home", timeout, allow_redirects=False)
     home_code = getattr(r, "status_code", None)
+    home_status = getattr(r, "status_code", r)
     if home_code == 200:
         pages["/home"] = getattr(r, "text", "") or ""
     live = ""
@@ -428,17 +496,26 @@ def run(timeout: float, expect_sha: list[str]) -> int:
         if how:
             live = f"{path} shows {how}"
             break
+    # A 200 from the wrong host is not a readable landing, and saying only
+    # "(200)" would read as a contradiction on the line under a failing
+    # landing check. Name the host that answered instead.
+    landing_why = (f"{landing_status} from {landing_elsewhere}"
+                   if landing_elsewhere else str(landing_status))
     if not pages:
-        detail = f"landing not readable ({landing_status}), nothing was scanned"
+        detail = f"landing not readable ({landing_why}), nothing was scanned"
     elif live:
         detail = (f"{live} — Telegram pairing is a dead end (#536) until its "
                   "fix deploys; a tile marked coming soon passes")
     else:
+        # Both gaps, not just the expected one. A run that read /home but not
+        # the landing would otherwise report the pages it managed to read and
+        # say nothing about the one a stranger actually opens.
+        gaps = ([] if "/" in pages else [f"/ not scanned ({landing_why})"])
+        if "/home" not in pages:
+            gaps.append(f"/home not scanned ({home_status} without a session)")
         detail = ("no live Telegram link or call to action on "
                   + ", ".join(pages)
-                  + ("" if "/home" in pages else
-                     f"; /home not scanned ({getattr(r, 'status_code', r)} "
-                     "without a session)"))
+                  + ("; " + "; ".join(gaps) if gaps else ""))
     check(TELEGRAM_CHECK, bool(pages) and not live, detail)
 
     # The sign-in page is the front door; #181 broke exactly this and nothing

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -323,7 +323,10 @@ def test_a_current_build_is_counted_as_a_real_check():
     # asserts the script counts an asserted build as a real check rather
     # than inflating the total — so it moves by exactly one here and the
     # property is unchanged.
-    assert code == 0 and "all 12 checks passing" in out
+    # MOVED PIN 12 -> 14 (#537): the CareAgents checks moved to the origin
+    # users reach, the Railway host kept its readiness check under its own
+    # name, and the Telegram surface gained a check. Two more, both real.
+    assert code == 0 and "all 14 checks passing" in out
 
 
 def test_an_unasserted_build_never_inflates_the_count():
@@ -333,9 +336,11 @@ def test_an_unasserted_build_never_inflates_the_count():
     # MOVED PIN 10 -> 11, same reason as above: one new check, and the gap
     # between this number and the one above is still exactly one, which is
     # the property being pinned.
+    # MOVED PIN 11 -> 13 (#537), same two checks as above; the gap is still
+    # exactly one.
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [])
-    assert code == 0 and "all 11 checks passing" in out
+    assert code == 0 and "all 13 checks passing" in out
 
 
 class _Refused:
@@ -360,7 +365,9 @@ def test_a_demo_server_that_stops_serving_keyless_callers_is_an_outage():
                                  demo_handshake=_Refused())
     assert code == 1, "a demo server refusing keyless callers must be an outage"
     assert "serves an unauthenticated handshake" in out
-    assert "all 12 checks passing" not in out
+    # The current total, or the assertion is vacuous: a number the script no
+    # longer prints is trivially absent.
+    assert "all 14 checks passing" not in out
 
 
 @pytest.mark.parametrize("supplied", ["", ",", " ", ",,"])

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -358,6 +358,177 @@ def test_an_unreadable_landing_is_not_reported_as_telegram_free(monkeypatch):
     assert "nothing was scanned" in detail and "ConnectionError" in detail
 
 
+def test_the_telegram_line_names_an_unreadable_landing_too(monkeypatch):
+    """Both gaps, not only the expected one.
+
+    A run that reads /home but not the landing used to report "no live
+    Telegram link or call to action on /home" and say nothing about the page
+    a stranger actually opens — a measurement quietly covering less than its
+    name, which is #537's own shape. MUTATION: drop the "/" gap clause ->
+    this goes green with the landing unread.
+    """
+    real = _fake_get(home=SOON_TILE)
+
+    def get(url, timeout, **kw):
+        if url == f"{prod_watch.CAREAGENTS}/":
+            return "ConnectionError"
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    prod_watch.run(1.0, [TIP])
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is True, detail
+    assert "/home" in detail
+    assert "/ not scanned (ConnectionError)" in detail, detail
+
+
+# --- which host answered (#289 one layer down) ------------------------------
+#
+# `requests` follows redirects, so a check named for one origin will measure
+# whichever host the chain ends at and print the result under the first one's
+# name. Every fake below is faithful to that: a followed redirect sets `url`
+# to where the response actually came from, an unfollowed one carries
+# `Location`, exactly as `requests` does.
+
+def _resp_from(status, url, text="", payload=None):
+    r = _Resp(status, payload, text)
+    r.url = url
+    return r
+
+
+def test_an_origin_that_redirects_to_the_railway_host_is_not_a_reading(
+        monkeypatch):
+    """#289 is not "watch careagents.cloud", it is "measure what a user gets".
+
+    Retargeting the constant while still following redirects re-creates the
+    exact blindness: careagents.cloud 308ing to the Railway hostname would
+    keep every check on this origin green, the build marker would assert the
+    OTHER host's build under this host's name, and the two hosts would agree
+    by construction — which is the one thing the pair of checks exists to
+    disprove. MUTATION: drop `_answered_elsewhere` from the /healthz and
+    landing checks -> all green under a fully redirected origin.
+    """
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        if url.startswith(prod_watch.CAREAGENTS):
+            target = url.replace(prod_watch.CAREAGENTS,
+                                 prod_watch.CAREAGENTS_RAILWAY)
+            if kw.get("allow_redirects") is False:
+                r = _Resp(308)
+                r.headers = {"Location": target}
+                return r
+            inner = real(target, timeout, **kw)
+            return _resp_from(inner.status_code, target, inner.text,
+                              inner._payload)
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    assert prod_watch.run(1.0, [TIP]) == 1
+
+    (_, ok, detail), = _named("careagents: ready (db reachable)")
+    assert ok is False
+    assert prod_watch.CAREAGENTS_RAILWAY in detail and "not the origin" in detail
+
+    (_, ok, detail), = _named("careagents: landing renders")
+    assert ok is False, "a landing served by another host is not this origin's"
+
+    # And the build check may not speak for a host it never read (#272).
+    assert _named(prod_watch.BUILD_CHECK) == []
+    assert prod_watch.build_info["asserted"] is False
+
+
+def test_an_origin_pointed_at_a_healthy_looking_wrong_host_is_not_a_reading(
+        monkeypatch):
+    """The DNS half of #289, as it actually happened.
+
+    careagents.cloud resolved to a VPS that answered everything perfectly
+    while serving pre-#241 code, and a green board said nothing about what a
+    patient saw. A host that fails the other checks needs no guard — this one
+    passes all of them, so only the landed URL can tell the difference.
+    MUTATION: drop the off-host guard -> all 14 checks green while nothing on
+    the origin was read.
+    """
+    real = _fake_get()
+    other = "https://cloud-vps.example.net"
+
+    def get(url, timeout, **kw):
+        if url.startswith(prod_watch.CAREAGENTS):
+            target = url.replace(prod_watch.CAREAGENTS, other)
+            inner = real(target, timeout, **kw)
+            return _resp_from(inner.status_code, target, inner.text,
+                              inner._payload)
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    assert prod_watch.run(1.0, [TIP]) == 1
+    (_, ok, detail), = _named("careagents: ready (db reachable)")
+    assert ok is False
+    assert other in detail and "not the origin" in detail, detail
+
+
+def test_the_railway_healthz_is_read_without_following_a_redirect(monkeypatch):
+    """D7 sends every path but /healthz to the origin. If /healthz joins them,
+    following it reads the ORIGIN's health and build and prints them beside
+    the Railway host's name — the split deployment this check exists to
+    expose becomes invisible, and Railway's own health check is broken too.
+    MUTATION: drop `allow_redirects=False` -> green on a 308.
+    """
+    seen = {}
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        seen[url] = kw
+        if url == f"{prod_watch.CAREAGENTS_RAILWAY}/healthz":
+            r = _Resp(308)
+            r.headers = {"Location": f"{prod_watch.CAREAGENTS}/healthz"}
+            return r
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    assert prod_watch.run(1.0, [TIP]) == 1
+    assert seen[f"{prod_watch.CAREAGENTS_RAILWAY}/healthz"].get(
+        "allow_redirects") is False
+    (_, ok, detail), = _named("careagents (railway host): ready (db reachable)")
+    assert ok is False
+    assert "308" in detail and f"{prod_watch.CAREAGENTS}/healthz" in detail
+    assert "this host was not read" in detail, detail
+
+
+# --- copy that names Telegram without inviting anyone onto it ---------------
+
+@pytest.mark.parametrize("copy", [
+    # The beta batch queued behind this one adds a banner, refreshed landing
+    # copy and privacy sentences. Every line here names the surface and
+    # contains a verb from the CTA list, and every one is the honest opposite
+    # of a promise. A monitor that reddens on these trains its reader to
+    # ignore it — the failure this script warns about in the demo-tenant
+    # check — and the red would be indistinguishable from a real one.
+    '<p>Chat with your agent on the web today. Telegram and iMessage are not'
+    ' available in the beta.</p>',
+    '<p>We never share your chat transcript with Telegram or any third'
+    ' party.</p>',
+    '<p>We will not start a Telegram conversation without your consent.</p>',
+    '<p>Open source. Telegram support is planned for a later release.</p>',
+])
+def test_prose_that_merely_names_telegram_is_not_a_call_to_action(
+        monkeypatch, copy):
+    monkeypatch.setattr(prod_watch, "get", _fake_get(landing=START + copy))
+    assert prod_watch.run(1.0, [TIP]) == 0
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is True, detail
+
+
+def test_a_tile_sized_invitation_is_still_a_call_to_action():
+    """The bound above is a length, so it has to be pinned from both sides:
+    tiles and buttons are short, sentences of prose are not."""
+    for live in ('<div class="surface"><b>Telegram</b><span>connect →</span>'
+                 '</div>',
+                 '<a class="btn" href="/tg">Open in Telegram</a>',
+                 '<p>Chat with your agent on Telegram.</p>'):
+        assert prod_watch._telegram_advertised(live), live
+
+
 def test_a_stale_build_exits_2_and_names_the_remedy():
     # Exit 2, not 1: production is up. Whoever reads this at 03:00 should not
     # have to go looking for what to do about it.

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -6,7 +6,14 @@ than PR #241 while the monitor reported 9/9 green. This pins the check that
 closes that gap, and the exit-code split that keeps a stale build from being
 reported as an outage.
 
-No network: `prod_watch.get` is replaced wholesale.
+No network. `prod_watch.get` AND `prod_watch.post` are replaced wholesale in
+the autouse fixture, and `requests.get`/`requests.post` are tripwired under
+them, so a test here that reaches the network fails loudly instead of passing
+on production's say-so. Until #433 this docstring made the same claim while
+only `get` was faked: the public demo's keyless `initialize` POST went to the
+live MCP server on every run, with a one-second timeout, and one CI run went
+red on it. Nothing in this file is marked as reaching the network, because
+nothing in it does.
 """
 
 from __future__ import annotations
@@ -18,6 +25,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
@@ -39,7 +47,8 @@ class _Resp:
 
 
 def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A",
-              demo_patients=None):
+              demo_patients=None, landing='<a href="/auth">start</a>',
+              home=None):
     def get(url, timeout, **kw):
         if url.endswith("/r6/fhir/health"):
             return _Resp(200)
@@ -63,12 +72,27 @@ def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A",
                                "built_at": built_at})
         if url.endswith("/auth"):
             return _Resp(200, text='<input maxlength="8">')
+        if url.endswith("/home"):
+            # Production's answer without a session is a redirect to /auth.
+            # `home` is the page a hypothetical public /home would render.
+            return _Resp(302) if home is None else _Resp(200, text=home)
         if url.endswith("/mcp"):
             return _Resp(401)
         if url.endswith("/health"):
             return _Resp(200)
-        return _Resp(200, text='<a href="/auth">start</a>')
+        return _Resp(200, text=landing)
     return get
+
+
+def _fake_post(url, timeout, **kw):
+    # The public demo's keyless `initialize` — the one POST in the script.
+    return _Resp(200, {"jsonrpc": "2.0", "id": 1, "result": {}})
+
+
+def _no_network(url, *a, **kw):
+    # Not a RequestException on purpose: prod_watch.get/post swallow those
+    # into a status string, which is exactly how the real POST hid (#433).
+    raise AssertionError(f"a test in this file reached the network: {url}")
 
 
 _FRESH_BUILD_INFO = {"deployed": None, "built_at": None, "built": None,
@@ -88,6 +112,13 @@ def _isolate(monkeypatch):
     # otherwise find its human output on stderr.
     monkeypatch.setattr(prod_watch, "_human_to_stderr", False)
     monkeypatch.setattr(prod_watch, "get", _fake_get())
+    # Both verbs, not one. The script has exactly one POST, and leaving it
+    # real made CI green depend on a production service (#433).
+    monkeypatch.setattr(prod_watch, "post", _fake_post)
+    # And the layer under them, so a fake a later test forgets to install
+    # cannot fall through to a real request and pass anyway.
+    monkeypatch.setattr(requests, "get", _no_network)
+    monkeypatch.setattr(requests, "post", _no_network)
     yield
     prod_watch.results.clear()
     prod_watch.build_info.update(_FRESH_BUILD_INFO)
@@ -100,6 +131,231 @@ def _named(name):
 def test_a_current_build_passes():
     assert prod_watch.run(1.0, [TIP]) == 0
     assert _named(prod_watch.BUILD_CHECK)[0][1] is True
+
+
+def test_the_demo_handshake_never_leaves_the_process():
+    """#433: this file said "No network" while its one POST was real.
+
+    `test_a_current_build_passes` made a live HTTPS POST to the public demo
+    MCP server on every run, with a one-second timeout, so CI green depended
+    on a production deployment and a slow answer became an unexplained red.
+    The fixture now fakes `post` and tripwires `requests.post` beneath it.
+    MUTATION: drop the `post` fake from `_isolate` -> the tripwire fires here.
+    """
+    assert prod_watch.run(1.0, [TIP]) == 0
+    (_, ok, detail), = _named(
+        "mcp (public demo): serves an unauthenticated handshake")
+    assert ok is True, detail
+    assert "keyless initialize -> 200" in detail
+
+
+# --- the host users reach, and the surface nobody could see (#537, #289) ----
+
+def _requested(monkeypatch, **fake_kw):
+    """Run against the fake and return every URL the run asked for."""
+    real = _fake_get(**fake_kw)
+    seen = []
+
+    def get(url, timeout, **kw):
+        seen.append(url)
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    prod_watch.run(1.0, [TIP])
+    return seen
+
+
+def test_the_monitor_watches_the_origin_people_visit(monkeypatch):
+    """#537/#289: every CareAgents check ran against the Railway hostname,
+    which nobody visits. A DNS or routing divergence between it and
+    careagents.cloud was invisible by construction.
+
+    MUTATION: point CAREAGENTS back at the Railway host -> red.
+    """
+    assert prod_watch.CAREAGENTS == "https://careagents.cloud"
+    seen = _requested(monkeypatch)
+    for path in ("/healthz", "/", "/auth", "/home"):
+        assert f"https://careagents.cloud{path}" in seen, (path, seen)
+    # The build marker comes from the origin, not the Railway host: #289's
+    # point is that the alarm was pinned to the wrong address.
+    assert seen.index("https://careagents.cloud/healthz") < seen.index(
+        f"{prod_watch.CAREAGENTS_RAILWAY}/healthz")
+
+
+def test_the_railway_host_keeps_its_readiness_check(monkeypatch):
+    """/healthz on the Railway hostname is what Railway's own health check
+    hits, and the one path that keeps answering directly once everything
+    else there redirects to the origin. It stays watched, labelled as what
+    it is, so the two hosts can be seen to diverge rather than assumed equal.
+    """
+    seen = _requested(monkeypatch)
+    assert f"{prod_watch.CAREAGENTS_RAILWAY}/healthz" in seen
+    railway = [u for u in seen if u.startswith(prod_watch.CAREAGENTS_RAILWAY)]
+    assert railway == [f"{prod_watch.CAREAGENTS_RAILWAY}/healthz"], (
+        "only /healthz is asked of the Railway host — everything else there "
+        "is about to redirect, and the user-facing checks belong to the origin")
+    (_, ok, detail), = _named("careagents (railway host): ready (db reachable)")
+    assert ok is True
+    assert "build=4f2a91cbeef1" in detail, (
+        "the Railway host's build is shown beside the origin's so a split "
+        "deployment is visible in the report")
+
+
+START = '<a href="/auth">start</a>'  # what "landing renders" looks for
+LIVE_TILE = ('<div class="surface on"><b>Web</b><span>always on</span></div>'
+             '<div class="surface" id="tg-surface"><b>Telegram</b>'
+             '<span id="tg-state">connect →</span></div>'
+             '<div class="surface soon"><b>iMessage</b>'
+             '<span>coming soon</span></div>')
+SOON_TILE = ('<div class="surface soon"><b>Telegram</b>'
+             '<span>coming soon</span></div>')
+
+
+def test_a_landing_that_does_not_mention_telegram_passes():
+    """What production's landing page looks like today."""
+    prod_watch.run(1.0, [TIP])
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is True, detail
+    # The check names what it read and what it could not, because a check
+    # that quietly covers less than its name suggests is the shape of #537.
+    assert "/" in detail
+    assert "/home not scanned (302 without a session)" in detail
+
+
+@pytest.mark.parametrize("landing,how", [
+    ('<a href="https://t.me/care_bot?start=x">Open in Telegram</a>', "t.me"),
+    ('<a class="btn" href="/tg">Open in Telegram</a>', "Open in Telegram"),
+    ('<p>Chat with your agent on Telegram.</p>', "Chat with your agent"),
+    (LIVE_TILE, "Telegram connect"),
+])
+def test_a_live_telegram_link_or_button_on_the_landing_is_an_outage(
+        monkeypatch, landing, how):
+    """#537: the surface had been dead since June while the board was green.
+
+    Advertising a surface that cannot pair is the defect; the monitor's job
+    is to say so where a person will read it. MUTATION: drop the Telegram
+    check from run() -> red.
+    """
+    monkeypatch.setattr(prod_watch, "get", _fake_get(landing=START + landing))
+    rc = prod_watch.run(1.0, [TIP])
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is False
+    assert how in detail, detail
+    # The remedy, on the line: red here is the truth about #536, not noise.
+    assert "#536" in detail and "coming soon" in detail
+    assert rc == 1, "a surface advertised as live but dead is an outage"
+    assert [n for n, ok, _ in prod_watch.results if not ok] == [
+        prod_watch.TELEGRAM_CHECK], "nothing else about this page is wrong"
+
+
+@pytest.mark.parametrize("page", [
+    SOON_TILE,
+    # Neighbours must not vouch for or against each other: a live iMessage
+    # tile beside a coming-soon Telegram tile is fine either way round.
+    SOON_TILE + '<div class="surface" id="im-surface"><b>iMessage</b>'
+                '<span id="im-state">connect →</span></div>',
+    '<div class="surface" id="im-surface"><b>iMessage</b>'
+    '<span id="im-state">connect →</span></div>' + SOON_TILE,
+    '<p>Telegram and iMessage are coming soon.</p>',
+    # Prose that names the surface without inviting anyone onto it.
+    '<p>Every surface — web, Telegram, iMessage — goes through the guardrail'
+    ' layer.</p>',
+    # Script and style bodies are not copy anyone reads.
+    '<script>window.CARE = {telegramBot: "care_bot"};</script>',
+])
+def test_a_telegram_tile_marked_coming_soon_passes(monkeypatch, page):
+    monkeypatch.setattr(prod_watch, "get", _fake_get(landing=START + page))
+    assert prod_watch.run(1.0, [TIP]) == 0
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is True, detail
+
+
+HOME_TEMPLATE = (Path(__file__).parent.parent / "careagents" / "templates"
+                 / "home.html").read_text()
+LANDING_TEMPLATE = (Path(__file__).parent.parent / "careagents" / "templates"
+                    / "landing.html").read_text()
+
+
+def test_the_detector_reads_the_tile_the_real_home_page_renders():
+    """Tied to the markup it guards, not to a hand-written copy of it.
+
+    The first cut of this detector passed a one-line tile and missed the
+    real one: the template breaks the line between `<b>Telegram</b>` and
+    `<span>connect →</span>`, and a source newline was being read as the end
+    of a piece of copy. The Jinja in the template is inert here; the tile is
+    literal markup.
+
+    Asserted as agreement with the template's own state rather than as a
+    prediction of it, so the change that marks the tile "coming soon" (the
+    fix for #536's dead end, in flight separately) turns this into the proof
+    that the monitor will read that tile as no promise — which is what lets
+    the check go green after it deploys.
+    """
+    how = prod_watch._telegram_advertised(HOME_TEMPLATE)
+    if '<span id="tg-state">connect →</span>' in HOME_TEMPLATE:
+        assert how.startswith("a live call to action"), how
+        assert "Telegram connect" in how, how
+    else:
+        assert how == "", (
+            "the Telegram tile changed and the monitor still reads it as a "
+            f"live call to action: {how}")
+    # The landing page makes no such promise — which is why the check is
+    # green on production while #536 is open: the tile is behind sign-in,
+    # where an unauthenticated monitor cannot see it.
+    assert prod_watch._telegram_advertised(LANDING_TEMPLATE) == ""
+
+
+def test_the_home_page_is_scanned_only_when_it_answers_without_a_session(
+        monkeypatch):
+    """The tile #536 describes lives on /home, behind sign-in. This monitor
+    runs unauthenticated, so it can only ever see /home if that page starts
+    answering without a session — and then it must look, because that is
+    the moment the tile becomes a public promise.
+    """
+    monkeypatch.setattr(prod_watch, "get", _fake_get(home=LIVE_TILE))
+    assert prod_watch.run(1.0, [TIP]) == 1
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is False
+    assert detail.startswith("/home shows"), detail
+
+    prod_watch.results.clear()
+    monkeypatch.setattr(prod_watch, "get", _fake_get(home=SOON_TILE))
+    assert prod_watch.run(1.0, [TIP]) == 0
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is True
+    assert "/, /home" in detail and "not scanned" not in detail
+
+
+def test_the_home_page_is_fetched_without_following_its_redirect(monkeypatch):
+    # Following /home -> /auth would scan the sign-in page under /home's name
+    # and report the home page as read when it was not.
+    seen = {}
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        seen[url] = kw
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    prod_watch.run(1.0, [TIP])
+    assert seen[f"{prod_watch.CAREAGENTS}/home"].get("allow_redirects") is False
+
+
+def test_an_unreadable_landing_is_not_reported_as_telegram_free(monkeypatch):
+    """Nothing read, nothing verified. A pass here would be the exact
+    green-for-the-wrong-reason this check was added to end."""
+    real = _fake_get()
+
+    def get(url, timeout, **kw):
+        if url == f"{prod_watch.CAREAGENTS}/":
+            return "ConnectionError"
+        return real(url, timeout, **kw)
+
+    monkeypatch.setattr(prod_watch, "get", get)
+    assert prod_watch.run(1.0, [TIP]) == 1
+    (_, ok, detail), = _named(prod_watch.TELEGRAM_CHECK)
+    assert ok is False
+    assert "nothing was scanned" in detail and "ConnectionError" in detail
 
 
 def test_a_stale_build_exits_2_and_names_the_remedy():


### PR DESCRIPTION
## What

- `scripts/prod_watch.py`: `CAREAGENTS` is now `https://careagents.cloud`, the origin users reach. The Railway hostname keeps a readiness check under its own name, `careagents (railway host): ready (db reachable)`, because `/healthz` there is what Railway's own health check hits and the one path that keeps answering once everything else 308s; its build marker rides along in the detail so a split deployment is visible.
- One new check, `careagents: telegram not advertised as live`. Fails on any `t.me/`/`tg://` link, or a Telegram call to action ("Open in Telegram", "Telegram — connect →") on any page an unauthenticated visitor can read: the landing page, plus `/home` only if it answers 200 without a session (fetched without following its redirect). A tile marked "coming soon" passes. A landing that could not be read is a failure, not a pass. The detail names which pages were read. No `getMe` probe — no bot token in this script's environment.
- `tests/test_prod_watch_build.py`: the autouse fixture fakes `prod_watch.post` beside `get` and tripwires `requests.get`/`requests.post` beneath both, so any test in the file that reaches the network fails loudly. Docstring corrected. New tests for #433, the host retarget, and the Telegram check — including one that runs the detector on the real `careagents/templates/home.html` and asserts agreement with the template's state (so the in-flight "coming soon" change does not turn it red on `main`).
- `tests/test_build_marker_stamp.py`: pinned totals move 12 → 14 and 11 → 13 (MOVED PIN comments, per the file's convention); the gap of exactly one is the property pinned, and it holds.

## Why

- **Council D2 item 4 (#537):** the monitor watched a hostname nobody visits and could not see Telegram. Twelve checks were green while the surface had been dead since June (#536). Also the fix #289 asked for (not auto-closed here; maintainer's call).
- **Council D13 (#433), unanimous "fix today":** the file said "No network" while `test_a_current_build_passes` made a real HTTPS POST to the public demo MCP server on every run, with a 1-second timeout. CI green depended on a production service. Delivery-process amendment 4 (D1): no test in this file reaches the network now, and the docstring says so truthfully.

## Measured, not assumed: the Telegram check is green on production today

The brief expected red. It is green, and the detail says why:

```
 OK  careagents: telegram not advertised as live — no live Telegram link or call to action on /; /home not scanned (302 without a session)
```

The only Telegram CTA on production is the `/home` tile, and `/home` answers `302 → /auth` without a session. The public landing page does not mention Telegram at all (verified with curl and with the detector on `landing.html`). An unauthenticated monitor cannot see the tile #536 describes — which is the same scope limit the script's docstring already states for the signed-in journey (#243), now written down for this check too. The detector does read the real tile: `_telegram_advertised(home.html)` → `"a live call to action ('Telegram connect →')"`, pinned by test. What this check guards is the public promise; it goes red the moment a Telegram link or CTA reaches a page a stranger can read, or `/home` starts answering without a session.

## Ran

Reproduction of #433 with a dead proxy, before the fix:
```
$ HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 uv run python -m pytest tests/test_prod_watch_build.py::test_a_current_build_passes -q -p no:cacheprovider
FAIL mcp (public demo): serves an unauthenticated handshake — keyless initialize -> None (no JSON-RPC result)
1 failed in 0.58s
```
After:
```
1 passed in 0.10s
```
Mutation (drop the `post` fake from `_isolate`): the tripwire fires — `AssertionError: a test in this file reached the network: https://mcp-demo-production-ee2c.up.railway.app/mcp` — restored.

Full suite and lint:
```
$ uv run python -m pytest tests/ -q -p no:cacheprovider
3175 passed, 13 skipped, 1 xfailed, 2 warnings in 108.25s (0:01:48)
$ uv run ruff check .
All checks passed!
```

Read-only run against production (no `--expect-sha`, so the build is reported, not asserted):
```
$ uv run python scripts/prod_watch.py
 OK  careagents: ready (db reachable) — status=200 accounts=True
INFO careagents: running the current build — 89b42fbd0e66 built 2026-08-31T02:27Z (informational — no --expect-sha given)
 OK  careagents (railway host): ready (db reachable) — status=200 accounts=True build=89b42fbd0e66
 OK  careagents: landing renders — 200
 OK  careagents: telegram not advertised as live — no live Telegram link or call to action on /; /home not scanned (302 without a session)
...
all 13 checks passing
exit=0
```

## What was NOT run

- The scheduled workflow (`.github/workflows/prod-watch.yml`) was not exercised; it passes `--expect-sha`, so its run will count 14 checks. Nothing in the workflow references the host or the check names.
- No authenticated probe of `/home`; the script is unauthenticated by design and this PR does not change that.
- No Telegram `getMe`/`getWebhookInfo` probe, per the ruling.
- Nothing writes to production; every request is a GET plus the existing keyless MCP `initialize`.

Closes #433
Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
