### PR TITLE
candidate: proposed-action payload is immutable once confirmed (#528)

### DIFF
--- a/r6/actions/confirmations.py
+++ b/r6/actions/confirmations.py
@@ -33,6 +33,21 @@ def issue_confirmation(action_id, approved_via, ttl_minutes):
     return c
 
 
+def has_confirmation(action_id):
+    """True if any ActionConfirmation names action_id — committed, or still
+    pending in this session (the review route mints and commits in one
+    transaction). Backs the payload seal on ProposedAction (#528): once a
+    confirmation exists, the payload is what the human approved. Runs
+    without autoflush so a validator never flushes unrelated state as a
+    side effect; the pending scan covers what that flush would have found."""
+    for obj in db.session.new:
+        if isinstance(obj, ActionConfirmation) and obj.action_id == action_id:
+            return True
+    with db.session.no_autoflush:
+        return ActionConfirmation.query.filter_by(
+            action_id=action_id).first() is not None
+
+
 def consume_confirmation(action_id):
     """Atomically claim every unconsumed, unexpired confirmation for
     action_id. Returns True iff at least one row was consumed by THIS call

--- a/r6/actions/models.py
+++ b/r6/actions/models.py
@@ -17,6 +17,8 @@ import json
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy.orm import validates
+
 from models import db
 
 PROPOSAL_TTL_MINUTES = 30
@@ -44,6 +46,11 @@ _TRANSITIONS = {
 def _utcnow():
     # Stored naive-UTC; columns aren't timezone-aware, so this matches what other models' aware defaults become after DB round-trip.
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class PayloadSealed(RuntimeError):
+    """A write to payload_json after a confirmation exists for the action.
+    Same idiom as the AuditEvent immutability listeners in r6/models.py."""
 
 
 class ProposedAction(db.Model):
@@ -87,6 +94,23 @@ class ProposedAction(db.Model):
 
     def is_expired(self):
         return _utcnow() >= self.expires_at
+
+    @validates('payload_json')
+    def _seal_payload_once_confirmed(self, key, value):
+        """The confirmation is the human's signature over the payload they
+        saw; once one exists the payload is what was approved, and any write
+        to it means the ledger cannot say what was (human-gate spec §9 R2,
+        #528). Fires on every ORM assignment, including __init__ — a new row
+        has no id, so no confirmation, so construction passes. Bulk
+        Query.update() never reaches a validator; transition_action() refuses
+        payload_json in **fields for that writer."""
+        # Local import: confirmations.py imports _utcnow from this module.
+        from r6.actions.confirmations import has_confirmation
+        if self.id is not None and has_confirmation(self.id):
+            raise PayloadSealed(
+                'payload_json is sealed: a confirmation exists for action %s'
+                % self.id)
+        return value
 
     @property
     def payload(self):

--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -37,8 +37,8 @@ from dataclasses import dataclass, field
 from flask import render_template, request
 
 from models import db
-from r6.actions.confirmations import issue_confirmation
-from r6.actions.models import ProposedAction
+from r6.actions.confirmations import has_confirmation, issue_confirmation
+from r6.actions.models import PayloadSealed, ProposedAction
 from r6.actions.routes import _error, _tenant_or_none, actions_blueprint
 from r6.audit import record_audit_event
 from r6.models import R6Resource
@@ -386,6 +386,20 @@ def review_submit(action_id):
     if action is None:
         return _error(404, 'Unknown action')
 
+    # A submitted review is final. This route does NOT transition the action
+    # (the confirm route's claim does), so the loader above keeps accepting an
+    # action that has already been reviewed — and the payload is sealed the
+    # moment the first submit mints a confirmation (#528). Without this the
+    # second submit reaches the sealed assignment below and raises out of the
+    # handler as a 500; the review page calls r.json() on every response, so a
+    # Werkzeug HTML 500 rejects the promise and the patient sees nothing move
+    # at all. A phone double-tap is the ordinary way to reach that. Answer
+    # instead, before any FHIR work or QuestionnaireResponse row is created.
+    if has_confirmation(action_id):
+        return _error(409, 'This review has already been submitted. Your '
+                           'answers were recorded and approved; nothing '
+                           'further is needed.')
+
     # RE-POPULATE from FHIR: the server, not the client, decides which rows
     # exist and must be acted on. This is what makes the gate un-craftable.
     _questionnaire, patient, draft_qr, _content = _draft_qr(action, tenant_id)
@@ -446,11 +460,23 @@ def review_submit(action_id):
     # consent record. The confirmation is the human's signature over the
     # payload as it stands, and payload_json is sealed once it exists (#528)
     # — the other order minted the signature and then changed what it signed.
-    payload = action.payload
-    payload['reviewed_qr_id'] = qr_row.id
-    action.payload_json = json.dumps(payload)
-    issue_confirmation(action_id, approved_via='review-page', ttl_minutes=15)
-    db.session.commit()
+    # The pre-check above is not a lock: two submits milliseconds apart both
+    # pass it, and the loser reaches the seal here with the winner's
+    # confirmation already committed. Same answer as the pre-check — this is
+    # the branch that made it a 500, and the FHIR re-population between the
+    # two is exactly wide enough for a double-tap to land in it.
+    try:
+        payload = action.payload
+        payload['reviewed_qr_id'] = qr_row.id
+        action.payload_json = json.dumps(payload)
+        issue_confirmation(action_id, approved_via='review-page',
+                           ttl_minutes=15)
+        db.session.commit()
+    except PayloadSealed:
+        db.session.rollback()
+        return _error(409, 'This review has already been submitted. Your '
+                           'answers were recorded and approved; nothing '
+                           'further is needed.')
 
     record_audit_event(
         'update', resource_type='ProposedAction', resource_id=action.id,

--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -442,11 +442,14 @@ def review_submit(action_id):
     db.session.add(qr_row)
     db.session.flush()          # assign qr_row.id
 
-    # (6) Consent record for the review approval + hand-off marker for Task 8.
-    issue_confirmation(action_id, approved_via='review-page', ttl_minutes=15)
+    # (6) Hand-off marker for Task 8 goes into the payload FIRST, then the
+    # consent record. The confirmation is the human's signature over the
+    # payload as it stands, and payload_json is sealed once it exists (#528)
+    # — the other order minted the signature and then changed what it signed.
     payload = action.payload
     payload['reviewed_qr_id'] = qr_row.id
     action.payload_json = json.dumps(payload)
+    issue_confirmation(action_id, approved_via='review-page', ttl_minutes=15)
     db.session.commit()
 
     record_audit_event(

--- a/r6/actions/state.py
+++ b/r6/actions/state.py
@@ -16,7 +16,7 @@ def transition_action(action_id, from_states, to_state, actor, detail=None,
     (and writes one ActionEvent in the same commit), False if the WHERE matched
     nothing (concurrent claim / already advanced). Raises IllegalTransition if
     to_state isn't reachable from every from_state, if from_states is empty,
-    or if 'status' is passed via fields.
+    or if 'status' or 'payload_json' is passed via fields.
 
     extra_criteria: optional iterable of SQLAlchemy predicates appended to
     the guarded UPDATE's WHERE, making the claim STRICTER — e.g. the expiry
@@ -29,6 +29,14 @@ def transition_action(action_id, from_states, to_state, actor, detail=None,
     which apply atomically with the transition."""
     if 'status' in fields:
         raise IllegalTransition('status cannot be passed via fields')
+    if 'payload_json' in fields:
+        # The executable payload is what the human saw; no transition may
+        # rewrite it (#528). The bulk UPDATE below bypasses the model-level
+        # seal, so this is the only place this writer can be refused — and
+        # it is unconditional because the claim runs BEFORE the confirmation
+        # row is minted (see the confirm route), so "a confirmation exists"
+        # is not yet true at the one moment a swap would matter.
+        raise IllegalTransition('payload_json cannot be passed via fields')
     if not from_states:
         raise IllegalTransition('from_states must be non-empty')
     for fs in from_states:

--- a/tests/actions/test_payload_immutability.py
+++ b/tests/actions/test_payload_immutability.py
@@ -116,3 +116,49 @@ def test_constructing_a_new_action_is_not_sealed(app):
         db.session.add(a)
         db.session.commit()
         assert _stored_payload(a.id) == ORIGINAL
+
+
+# ---------------------------------------------------------------------------
+# The seal is an ORM-layer control. It fires on attribute assignment, and a
+# bulk UPDATE, raw SQL, or set_committed_value writes straight past it —
+# verified, not assumed. transition_action() is refused because it is the one
+# bulk writer that exists; nothing structural stops the NEXT one, and there is
+# no payload digest on ActionConfirmation that would make a bypass visible
+# after the fact. So pin the writer set.
+#
+# Blind spot, stated rather than discovered later: this is a file-level
+# allowlist. A NEW write added inside a file already on the list does not trip
+# it, and neither would a writer outside r6/ (there is none today). It catches
+# the realistic drift — another module starting to touch the executable
+# payload — in the PR that does it, which is what the ratchets exist for.
+# ---------------------------------------------------------------------------
+
+PAYLOAD_JSON_WRITER_ALLOWLIST = {
+    # __init__ assigns it on a row that has no id yet (construction).
+    'r6/actions/models.py',
+    # Annotates reviewed_qr_id BEFORE the confirmation is minted; sealed after.
+    'r6/actions/review.py',
+    # Does not write it — REFUSES it in **fields, which is the #528 guard.
+    'r6/actions/state.py',
+}
+
+
+def test_only_the_allowlisted_files_touch_the_executable_payload():
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    found = set()
+    for path in sorted((root / 'r6').rglob('*.py')):
+        source = path.read_text(encoding='utf-8')
+        # The ProposedAction co-mention scopes this to the action rail's
+        # column; r6/agent_runs has its own unrelated payload_json.
+        if 'payload_json' in source and 'ProposedAction' in source:
+            found.add(path.relative_to(root).as_posix())
+
+    assert found == PAYLOAD_JSON_WRITER_ALLOWLIST, (
+        'The set of files touching ProposedAction.payload_json changed.\n'
+        'Added: %s\nRemoved: %s\n'
+        'A new writer must be sealed (ORM assignment) or refused (bulk '
+        'UPDATE) before it goes on this list — see #528.'
+        % (sorted(found - PAYLOAD_JSON_WRITER_ALLOWLIST),
+           sorted(PAYLOAD_JSON_WRITER_ALLOWLIST - found)))

--- a/tests/actions/test_payload_immutability.py
+++ b/tests/actions/test_payload_immutability.py
@@ -1,0 +1,118 @@
+"""ProposedAction.payload_json is sealed once a confirmation exists (#528).
+
+The ActionConfirmation row is the human's signature over the payload they
+saw. A payload that changes after it is minted means the ledger cannot say
+what was approved (human-gate spec §9 R2). The seal fires on every ORM
+assignment, sees a confirmation that is still pending in the session, and
+leaves the stored value untouched. transition_action()'s **fields is the
+other writer — bulk UPDATE never reaches a validator — and
+tests/actions/test_state_transitions.py pins that one.
+"""
+import json
+
+import pytest
+
+from models import db
+from r6.actions.confirmations import consume_confirmation, issue_confirmation
+from r6.actions.models import PayloadSealed, ProposedAction
+
+ORIGINAL = {'to': 'CVS Pharmacy', 'body': 'ORIGINAL TEXT SHOWN TO HUMAN'}
+SWAPPED = {'to': 'someone else', 'body': 'SWAPPED AFTER APPROVAL'}
+
+
+def _make(status='awaiting_confirmation'):
+    a = ProposedAction(tenant_id='t1', kind='sms', payload=dict(ORIGINAL))
+    a.status = status
+    db.session.add(a)
+    db.session.commit()
+    return a.id
+
+
+def _stored_payload(aid):
+    db.session.expire_all()
+    return db.session.get(ProposedAction, aid).payload
+
+
+def test_payload_sealed_once_a_confirmation_is_committed(app):
+    with app.app_context():
+        aid = _make()
+        issue_confirmation(aid, approved_via='dashboard', ttl_minutes=15)
+        db.session.commit()
+
+        action = db.session.get(ProposedAction, aid)
+        with pytest.raises(PayloadSealed):
+            action.payload_json = json.dumps(SWAPPED)
+        db.session.commit()
+        assert _stored_payload(aid) == ORIGINAL
+
+
+def test_payload_sealed_while_the_confirmation_is_still_pending(app):
+    # The review route mints and commits in one transaction, so the seal
+    # must see a confirmation that has been added but not yet flushed.
+    with app.app_context():
+        aid = _make()
+        action = db.session.get(ProposedAction, aid)
+        issue_confirmation(aid, approved_via='review-page', ttl_minutes=15)
+
+        with pytest.raises(PayloadSealed):
+            action.payload_json = json.dumps(SWAPPED)
+        db.session.commit()
+        assert _stored_payload(aid) == ORIGINAL
+
+
+def test_consumed_confirmation_still_seals(app):
+    # /confirm issues and consumes in the same instant, then executes. A
+    # spent signature is still a signature: the payload stays what it was.
+    with app.app_context():
+        aid = _make('executing')
+        issue_confirmation(aid, approved_via='telegram', ttl_minutes=15)
+        db.session.flush()
+        assert consume_confirmation(aid) is True
+        db.session.commit()
+
+        action = db.session.get(ProposedAction, aid)
+        with pytest.raises(PayloadSealed):
+            action.payload_json = json.dumps(SWAPPED)
+        db.session.commit()
+        assert _stored_payload(aid) == ORIGINAL
+
+
+def test_payload_writable_before_any_confirmation(app):
+    # The seal is keyed on the confirmation, not the status: the review
+    # route annotates the payload (reviewed_qr_id) while the action awaits
+    # confirmation and only then mints the signature over the result.
+    with app.app_context():
+        aid = _make()
+        action = db.session.get(ProposedAction, aid)
+        payload = action.payload
+        payload['reviewed_qr_id'] = 'qr-1'
+        action.payload_json = json.dumps(payload)
+        db.session.commit()
+        assert _stored_payload(aid)['reviewed_qr_id'] == 'qr-1'
+
+
+def test_confirmation_for_another_action_does_not_seal(app):
+    # A seal keyed on "any confirmation exists" would pass the tests above
+    # and break every action after the first approval — the seal is scoped
+    # to the action the confirmation names.
+    with app.app_context():
+        aid = _make()
+        other = _make()
+        issue_confirmation(other, approved_via='dashboard', ttl_minutes=15)
+        db.session.commit()
+
+        action = db.session.get(ProposedAction, aid)
+        action.payload_json = json.dumps(SWAPPED)
+        db.session.commit()
+        assert _stored_payload(aid) == SWAPPED
+        assert _stored_payload(other) == ORIGINAL
+
+
+def test_constructing_a_new_action_is_not_sealed(app):
+    # __init__ assigns payload_json before the row has an id; a confirmation
+    # cannot exist for it, and the seal must not query for None.
+    with app.app_context():
+        a = ProposedAction(tenant_id='t1', kind='sms', payload=dict(ORIGINAL))
+        db.session.add(a)
+        db.session.commit()
+        assert _stored_payload(a.id) == ORIGINAL

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -449,6 +449,98 @@ def test_post_payload_is_final_before_the_confirmation_is_issued(
         assert seen['payload_json'] == action.payload_json
 
 
+def test_second_submit_answers_409_instead_of_raising_the_seal(
+        client, app, tenant_headers, auth_headers, monkeypatch):
+    """A resubmitted review is refused, not crashed (#528 follow-on).
+
+    This route never transitions the action, so _load_form_fill_action keeps
+    accepting it after a successful submit — and the payload is sealed from
+    the moment the first submit mints a confirmation. Before the pre-check,
+    the second POST raised PayloadSealed out of the handler: a Werkzeug HTML
+    500, which action_review.html's `r.json()` rejects with no .catch, so the
+    patient's screen does not move and a double-tap is the ordinary way in.
+
+    Pins the refusal AND that the first review is left completely alone: one
+    confirmation, the original reviewed_qr_id, and no second (orphan)
+    QuestionnaireResponse row.
+
+    Also pins what the pre-check specifically buys over the except branch
+    that backs it: the doomed request is refused BEFORE _draft_qr re-reads
+    the patient's record out of FHIR. Without that assertion the pre-check is
+    unpinned — the except branch answers 409 either way and the rollback
+    hides the QuestionnaireResponse insert.
+    """
+    import r6.actions.review as review
+    from r6.models import R6Resource
+
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    first = _post(client, auth_headers, action_id,
+                  {'med-0': 'yes', 'allergy-0': 'confirm'})
+    assert first.status_code == 200, first.get_data(as_text=True)
+    with app.app_context():
+        qr_id = db.session.get(ProposedAction, action_id).payload[
+            'reviewed_qr_id']
+        qr_count = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', tenant_id=tenant).count()
+
+    # Same action, DIFFERENT answers — the swap the seal exists to refuse.
+    # _draft_qr must not run: a request that cannot succeed does not re-read
+    # the record.
+    def _must_not_repopulate(*a, **kw):
+        raise AssertionError('re-read FHIR for an already-submitted review')
+
+    monkeypatch.setattr(review, '_draft_qr', _must_not_repopulate)
+    second = _post(client, auth_headers, action_id,
+                   {'med-0': 'no', 'allergy-0': 'remove', 'nka': 'true'})
+    monkeypatch.undo()
+    assert second.status_code == 409, second.get_data(as_text=True)
+    assert 'already been submitted' in second.get_json()['error']
+
+    with app.app_context():
+        action = db.session.get(ProposedAction, action_id)
+        assert action.status == 'awaiting_confirmation'
+        assert action.payload['reviewed_qr_id'] == qr_id
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 1
+        assert R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse',
+            tenant_id=tenant).count() == qr_count
+
+
+def test_second_submit_racing_the_precheck_answers_409_not_500(
+        client, app, tenant_headers, auth_headers, monkeypatch):
+    """The pre-check is not a lock. Two submits milliseconds apart both pass
+    it and the loser reaches the seal with the winner's confirmation already
+    committed. Neutralising the pre-check reproduces exactly that branch: it
+    must answer 409 too, not raise.
+
+    The validator does its own function-local import of has_confirmation, so
+    patching the name in this module reaches the route's pre-check only —
+    the seal itself still fires. That is the point of the test.
+    """
+    import r6.actions.review as review
+
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, ALLERGY_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    first = _post(client, auth_headers, action_id,
+                  {'med-0': 'yes', 'allergy-0': 'confirm'})
+    assert first.status_code == 200, first.get_data(as_text=True)
+
+    monkeypatch.setattr(review, 'has_confirmation', lambda _aid: False)
+    second = _post(client, auth_headers, action_id,
+                   {'med-0': 'no', 'allergy-0': 'remove', 'nka': 'true'})
+    assert second.status_code == 409, second.get_data(as_text=True)
+
+    with app.app_context():
+        assert ActionConfirmation.query.filter_by(
+            action_id=action_id).count() == 1
+
+
 def test_post_requires_step_up(client, app, tenant_headers, auth_headers):
     _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
     action_id = _staged_form_fill(client, tenant_headers, auth_headers)

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -415,6 +415,40 @@ def test_post_confirming_real_allergy_succeeds(client, app, tenant_headers,
         assert _nka_answer(qr) is not True   # NKA never inferred
 
 
+def test_post_payload_is_final_before_the_confirmation_is_issued(
+        client, app, tenant_headers, auth_headers, monkeypatch):
+    """The confirmation is the human's signature over the payload; the
+    payload must not move after it is minted (human-gate spec §9 R2, #528).
+
+    Snapshot payload_json at the instant issue_confirmation() runs and
+    compare it with what is stored after the request. Before the fix the
+    review route appended reviewed_qr_id AFTER minting, so the two differed
+    and the ledger could not say what was approved."""
+    import r6.actions.review as review
+    from r6.actions import confirmations
+
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    seen = {}
+
+    def _snapshotting_issue(aid, approved_via, ttl_minutes):
+        seen['payload_json'] = db.session.get(ProposedAction, aid).payload_json
+        return confirmations.issue_confirmation(aid, approved_via, ttl_minutes)
+
+    monkeypatch.setattr(review, 'issue_confirmation', _snapshotting_issue)
+
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'nka': 'true'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    with app.app_context():
+        action = db.session.get(ProposedAction, action_id)
+        assert action.payload['reviewed_qr_id']           # hand-off kept
+        assert seen['payload_json'] == action.payload_json
+
+
 def test_post_requires_step_up(client, app, tenant_headers, auth_headers):
     _seed(app, tenant_headers['X-Tenant-Id'], [PATIENT, MED_A])
     action_id = _staged_form_fill(client, tenant_headers, auth_headers)

--- a/tests/actions/test_state_transitions.py
+++ b/tests/actions/test_state_transitions.py
@@ -89,6 +89,25 @@ def test_status_via_fields_rejected(app):
         assert ActionEvent.query.filter_by(action_id=aid).count() == 0
 
 
+def test_payload_json_via_fields_rejected(app):
+    # The #528 repro: the guarded UPDATE took everything but status straight
+    # from **fields, so the claim could swap the executable payload after the
+    # human approved it — and bulk UPDATE never reaches the model validator,
+    # so this is the only place that writer can be refused.
+    with app.app_context():
+        aid = _make('awaiting_confirmation')
+        before = db.session.get(ProposedAction, aid).payload_json
+        with pytest.raises(IllegalTransition):
+            transition_action(aid, from_states=('awaiting_confirmation',),
+                              to_state='executing', actor='agent',
+                              payload_json='{"body": "SWAPPED AFTER APPROVAL"}')
+        db.session.expire_all()
+        row = db.session.get(ProposedAction, aid)
+        assert row.payload_json == before
+        assert row.status == 'awaiting_confirmation'
+        assert ActionEvent.query.filter_by(action_id=aid).count() == 0
+
+
 def test_extra_criteria_blocks_transition(app):
     # extra_criteria predicates join the guarded UPDATE's WHERE, making the
     # claim stricter (e.g. the expiry check on commit/confirm claims). A


### PR DESCRIPTION
## What

`ProposedAction.payload_json` is sealed once an `ActionConfirmation` exists for the action, and the review route now finalises the payload **before** it mints the confirmation.

- `r6/actions/review.py` — `reviewed_qr_id` is written into the payload first, then `issue_confirmation()` runs. The previous order minted the signature and then changed what it signed.
- `r6/actions/models.py` — `@validates('payload_json')` raises `PayloadSealed` on any ORM assignment once a confirmation names the action (pending or committed). A new row has no id, so construction passes.
- `r6/actions/confirmations.py` — `has_confirmation(action_id)` backs the seal: scans the session's pending rows, then queries without autoflush so a validator never flushes unrelated state as a side effect.
- `r6/actions/state.py` — `transition_action()` refuses `payload_json` in `**fields`, unconditionally, the same way it refuses `status`.

## Why

Human-gate spec §9 R2 (`docs/specs/2026-08-16-human-gate.md`): a confirmation is the human's signature over the payload they saw; a payload that changes after it means the ledger cannot say what was approved. Council ruling on the D2 dissent: land this guard now, ahead of any approve surface. Nothing from #215 / #520 is built here.

Two points that are stricter than "after a confirmation exists", on purpose:

- The `transition_action` refusal is **unconditional**, not confirmation-keyed. The `/confirm` route claims (`awaiting_confirmation -> executing`) *before* the confirmation row is minted (that ordering is the single-winner mutex, per its docstring), so at the one moment the #528 repro swaps the payload, "a confirmation exists" is still false. A confirmation-keyed check there would leave the repro open. No caller passes `payload_json` through `**fields` today.
- Bulk `Query.update()` never reaches a validator, which is why the transition writer needs its own guard rather than relying on the model seal.

## Writers covered

`grep -rn "payload_json" r6/` — every `ProposedAction.payload_json` site (the `agent_runs` hits are a different model's column):

| Site | What it is | Status |
| --- | --- | --- |
| `r6/actions/models.py` `__init__` | constructor, new row | passes the seal (no id yet), pinned by `test_constructing_a_new_action_is_not_sealed` |
| `r6/actions/review.py` (was `:449`) | `action.payload_json = ...` after `issue_confirmation` | reordered; now under the seal (mutation: restoring the old order trips `PayloadSealed` in 3 tests) |
| `r6/actions/state.py` `transition_action(**fields)` | bulk guarded UPDATE, the #528 repro | refused with `IllegalTransition` |

The two other bulk updates on `ProposedAction` (`routes.py` `external_ref` and `provider_request_at`) use literal dicts that cannot carry `payload_json`; they are unchanged and not reachable by the seal.

## Tests

- `tests/actions/test_review_flow.py::test_post_payload_is_final_before_the_confirmation_is_issued` — snapshots `payload_json` at the instant `issue_confirmation` runs and asserts it equals the stored value after the request. Red on `main` (snapshot lacked `reviewed_qr_id`).
- `tests/actions/test_payload_immutability.py` (new, 6 tests) — sealed after a committed confirmation, after a pending one, after a consumed one; still writable with no confirmation; scoped to the action (another action's confirmation does not seal); construction passes.
- `tests/actions/test_state_transitions.py::test_payload_json_via_fields_rejected` — the issue's exact repro raises, payload and status unchanged, no `ActionEvent`.

Each guard was mutation-tested: reverting the order, disabling the transition check, disabling the seal, dropping the pending scan, and widening the seal to any confirmation each produced a red test, then the code was restored.

Audit `detail` strings are unchanged; `PayloadSealed` carries only the action id.

## Ran

```
uv run ruff check .                                   # All checks passed!
uv run python -m pytest tests/ -q -p no:cacheprovider # 3165 passed, 13 skipped, 1 xfailed, 2 warnings in 106.47s
```

The 2 warnings are pre-existing (`tests/test_actions_routes.py:47` LegacyAPIWarning, `tests/test_ingest_resilience.py:96` SAWarning), untouched by this PR. Ratchets in `tests/test_ratchets.py` are green; `r6/routes.py` is not touched.

## What was NOT run

- No run against a live HealthClaw or the Postgres CI lane locally (SQLite in the suite; the Postgres lane is CI's).
- No e2e / Playwright.
- Not deployed; not merged.

## Noticed, deliberately not touched

- #528's suggested shape moves `reviewed_qr_id` out of the executable payload into its own column. That is a schema change beyond this guard; with the reorder the confirmation now covers the annotated payload, which is coherent, but the annotation still lives inside `payload_json`.
- The seal is keyed on the confirmation, not on leaving `proposed` (spec R2 says "after commit"). Keying on status would refuse the review route's own annotation and force the column move above. Follow-on if the team wants the stricter rule.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
