### PR TITLE
candidate: CareAgents beta batch — hide Telegram tile, CARE_REAL_RECORDS switch, beta banner, canonical-host 308 (#536, #264)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from collections import defaultdict, deque
 from functools import wraps
+from urllib.parse import quote
 
 from flask import (Flask, Response, jsonify, redirect, render_template,
                    request, session, url_for)
@@ -180,9 +181,23 @@ def create_app(config: Config | None = None,
         # every deploy unhealthy. Unset means no redirect (local, CI).
         if not cfg.canonical_host or request.path == "/healthz":
             return None
-        if request.host.lower() == cfg.canonical_host:
+        # Hostname only. A proxy that appends the default port
+        # (`careagents.cloud:443`) is on the canonical host and must not be
+        # bounced — the Werkzeug test client normalises that port away, a
+        # real request does not, so the strip has to be explicit or every
+        # such request pays a redirect. Config forbids a port in
+        # canonical_host, so the only `:` here is the request's own.
+        host = request.host.lower()
+        if ":" in host and not host.endswith("]"):   # not a bare IPv6 literal
+            host = host.rsplit(":", 1)[0]
+        if host == cfg.canonical_host:
             return None
-        target = f"https://{cfg.canonical_host}{request.path}"
+        # `request.path` arrives percent-DECODED, so it can carry bytes that
+        # are illegal in a header — `/%0d%0a...` produced a 500 rather than a
+        # redirect. Re-encode it; `safe` is RFC 3986's pchar set, so an
+        # ordinary path is unchanged byte for byte.
+        target = f"https://{cfg.canonical_host}" + quote(
+            request.path, safe="/:@-._~!$&'()*+,;=")
         if request.query_string:
             target += "?" + request.query_string.decode("utf-8", "replace")
         return redirect(target, code=308)

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -166,6 +166,27 @@ def create_app(config: Config | None = None,
 
     turns: dict[str, deque] = defaultdict(deque)
 
+    # --- canonical host (#264, D7) -------------------------------------------
+
+    @app.before_request
+    def _enforce_canonical_host():
+        # careagents.cloud is the sole origin. A request arriving under any
+        # other Host header (the platform's own *.up.railway.app name) is
+        # sent to the same path and query on the canonical host — 308, so a
+        # POST is replayed as a POST rather than downgraded to a GET. The
+        # target is built from config, never from the request, so a spoofed
+        # Host cannot steer it. `/healthz` is exempt: the platform's health
+        # check arrives on the internal hostname, and a 308 there would mark
+        # every deploy unhealthy. Unset means no redirect (local, CI).
+        if not cfg.canonical_host or request.path == "/healthz":
+            return None
+        if request.host.lower() == cfg.canonical_host:
+            return None
+        target = f"https://{cfg.canonical_host}{request.path}"
+        if request.query_string:
+            target += "?" + request.query_string.decode("utf-8", "replace")
+        return redirect(target, code=308)
+
     # --- auth plumbing -------------------------------------------------------
 
     def current_account():
@@ -232,7 +253,8 @@ def create_app(config: Config | None = None,
             terms_url=f"{cfg.healthclaw_base}/terms",
             privacy_url=f"{cfg.healthclaw_base}/privacy",
             advisors=advisors.catalog(),
-            catalog=connectors.catalog(cfg))
+            catalog=connectors.catalog(
+                cfg, real_records=cfg.real_records_open_for(acct.email)))
 
     @app.post("/logout")
     def logout():
@@ -341,14 +363,20 @@ def create_app(config: Config | None = None,
     @app.get("/api/connections/catalog")
     @login_required
     def connections_catalog():
-        return jsonify({"connectors": connectors.catalog(cfg)})
+        acct = current_account()
+        return jsonify({"connectors": connectors.catalog(
+            cfg, real_records=cfg.real_records_open_for(acct.email))})
 
     @app.post("/api/connections/<connector_id>")
     @login_required
     def add_connection(connector_id):
         acct = current_account()
         body = request.get_json(silent=True) or {}
-        plan = connectors.start(connector_id, body.get("provider"), cfg, hc)
+        # New connections only (D3): refresh, poll, upload and delete on an
+        # existing connection never consult the real-records switch.
+        plan = connectors.start(
+            connector_id, body.get("provider"), cfg, hc,
+            real_records=cfg.real_records_open_for(acct.email))
         if plan.get("error"):
             return jsonify({"error": plan["error"]}), plan.get("code", 400)
         if plan.get("soon"):

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -94,6 +94,22 @@ class Config:
         # means no redirect, which is what local and CI want.
         self.canonical_host = (
             e.get("CAREAGENTS_CANONICAL_HOST") or "").strip().lower()
+        # A bare hostname and nothing else. `https://careagents.cloud` is what
+        # an operator types by reflex, and it is not a harmless no-op: the
+        # comparison below never matches, so EVERY request — including one
+        # already on the real site — is answered 308 to a malformed
+        # `https://https//careagents.cloud/...`, and a trailing slash loops
+        # forever, one slash longer each hop. `/healthz` is exempt, so the
+        # platform keeps reporting the deploy healthy while the site is dead.
+        # Refuse to boot, exactly as CARE_REAL_RECORDS does above.
+        if self.canonical_host and (
+                "/" in self.canonical_host
+                or ":" in self.canonical_host
+                or any(c.isspace() for c in self.canonical_host)):
+            raise ConfigError(
+                "CAREAGENTS_CANONICAL_HOST must be a bare hostname — no "
+                "scheme, port, path or whitespace (got "
+                f"{self.canonical_host!r})")
         # Secret for minting step-up tokens for careagents' non-public tenants
         # on the HealthClaw layer (X-Internal-Secret). Server-side only.
         self.mint_secret = e.get("HEALTHCLAW_MINT_SECRET", "")

--- a/careagents/config.py
+++ b/careagents/config.py
@@ -68,6 +68,32 @@ class Config:
         # Otherwise Apple Health / wearables show as a "coming soon" tile.
         self.wearables_enabled = e.get(
             "CARE_WEARABLES_ENABLED", "").lower() in ("1", "true", "yes")
+        # Real-record sources (Fasten, wearables, direct FHIR) for the beta
+        # (council ruling 2026-09-02, D3). Gates NEW connections only: an
+        # existing connection keeps refreshing, polling and deleting whatever
+        # this says. `off` renders those tiles "coming soon" and refuses the
+        # connect POST; `allowlist` opens them to the account emails in
+        # CARE_REAL_RECORDS_ALLOWLIST (comma-separated, case-insensitive);
+        # `on` opens them to everyone. Unset is `off`: a deployment that
+        # forgets the variable must not open real records to strangers.
+        self.real_records = (
+            e.get("CARE_REAL_RECORDS") or "off").strip().lower()
+        if self.real_records not in ("off", "allowlist", "on"):
+            raise ConfigError(
+                "CARE_REAL_RECORDS must be one of off, allowlist, on "
+                f"(got {self.real_records!r})")
+        self.real_records_allowlist = frozenset(
+            x.strip().lower()
+            for x in (e.get("CARE_REAL_RECORDS_ALLOWLIST") or "").split(",")
+            if x.strip())
+        # Sole public hostname (#264, D7). When set, a request whose Host
+        # header differs is answered 308 to the same path and query on this
+        # host, so the platform's own *.up.railway.app name is not a second
+        # front door with its own passkey origin. `/healthz` is exempt (the
+        # platform's health check arrives on the internal hostname). Unset
+        # means no redirect, which is what local and CI want.
+        self.canonical_host = (
+            e.get("CAREAGENTS_CANONICAL_HOST") or "").strip().lower()
         # Secret for minting step-up tokens for careagents' non-public tenants
         # on the HealthClaw layer (X-Internal-Secret). Server-side only.
         self.mint_secret = e.get("HEALTHCLAW_MINT_SECRET", "")
@@ -176,3 +202,13 @@ class Config:
         if self.anthropic_api_key or self.anthropic_oauth_token:
             return "anthropic"
         return "openai"
+
+    def real_records_open_for(self, email) -> bool:
+        """May this account START a real-record connection? See
+        CARE_REAL_RECORDS above. The allowlist is consulted only in
+        `allowlist` mode — never as a back door around `off`."""
+        if self.real_records == "on":
+            return True
+        if self.real_records == "allowlist":
+            return (email or "").strip().lower() in self.real_records_allowlist
+        return False

--- a/careagents/connectors.py
+++ b/careagents/connectors.py
@@ -68,17 +68,40 @@ _CATALOG = [
 _BY_ID = {c["id"]: c for c in _CATALOG}
 _WEARABLE_IDS = {p["id"] for p in WEARABLE_PROVIDERS}
 
+# The sources that take a person's OWN records. Closed to new connections
+# unless the deployment's CARE_REAL_RECORDS switch opens them for this
+# account (council ruling 2026-09-02, D3) — the beta runs on synthetic data.
+REAL_RECORD_SOURCES = ("fasten", "wearable", "direct")
+_REAL_RECORDS_CLOSED = ("real-records connect isn't open on this beta "
+                        "deployment yet — start with the sample records")
 
-def catalog(cfg) -> list[dict]:
-    """The marketplace tiles with per-deployment availability resolved."""
+
+def catalog(cfg, real_records: bool = False) -> list[dict]:
+    """The marketplace tiles with per-deployment availability resolved.
+
+    `real_records` is whether the viewing account may START a real-record
+    connection (`cfg.real_records_open_for(email)`); the app passes it. The
+    default is closed so a caller that forgets fails safe.
+    """
     out = []
     for c in _CATALOG:
         item = {k: c[k] for k in ("id", "label", "blurb", "icon", "tier")}
+        if c["id"] in REAL_RECORD_SOURCES and not real_records:
+            # Coming soon, honestly: no consent card (nothing to consent
+            # to), and the tag says what a tester can do instead.
+            item["tier"] = "soon"
+            item["note"] = "coming soon"
+            item["blurb"] = ("Not open in this beta — start with the "
+                             "sample records.")
+            if "providers" in c:
+                item["providers"] = c["providers"]
+            out.append(item)
+            continue
         # Every live real-record source gets the consent card; sample
         # doesn't. `direct` (patient-provided FHIR bundle upload) is a
         # real-record source too — the file is the patient's own PHI, so
         # it rides the same consent gate as fasten/wearable.
-        if c["id"] in ("fasten", "wearable", "direct"):
+        if c["id"] in REAL_RECORD_SOURCES:
             item["requires_consent"] = True
         if c["id"] == "fasten" and not getattr(cfg, "fasten_public_key", ""):
             item["tier"] = "soon"
@@ -100,7 +123,8 @@ def get(connector_id: str) -> dict | None:
     return _BY_ID.get(connector_id)
 
 
-def start(connector_id: str, provider: str | None, cfg, client) -> dict:
+def start(connector_id: str, provider: str | None, cfg, client,
+          real_records: bool = False) -> dict:
     """Return a plan for the connection the app should persist, or a marker:
 
       {tenant, status, label, provider?, connect_url?}  — create this connection
@@ -108,11 +132,16 @@ def start(connector_id: str, provider: str | None, cfg, client) -> dict:
       {"error": msg, "code": int}                       — refuse
 
     The app layer owns persistence (account scoping) and any seeding; `start`
-    only decides the plan + builds provider URLs.
+    only decides the plan + builds provider URLs. `real_records` is as for
+    `catalog()`: a closed real-record source is refused with 503 here, not
+    waitlisted, so the hub never records intent for a tile the switch hid.
     """
     spec = _BY_ID.get(connector_id)
     if spec is None:
         return {"error": "unknown connector", "code": 404}
+
+    if connector_id in REAL_RECORD_SOURCES and not real_records:
+        return {"error": _REAL_RECORDS_CLOSED, "code": 503}
 
     if connector_id == "sample":
         # Synthetic data only — no personal data, so no consent gate. Keeping

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -56,6 +56,14 @@ h1, h2, .wordmark, .chat-name {
 }
 .guardrail-tag:hover { border-color: var(--sage); }
 
+/* --- beta banner (landing + hub) ---------------------------------------- */
+.beta-banner {
+  margin: 0 clamp(20px, 5vw, 56px) 4px; padding: 9px 14px;
+  font-size: 13.5px; color: var(--ink-soft);
+  background: #F6E6D9; border: 1px solid #EBD3C0; border-radius: 12px;
+}
+.beta-banner b { color: var(--clay-deep); }
+
 /* --- landing ---------------------------------------------------------- */
 .hero { padding: clamp(30px, 7vh, 90px) clamp(20px, 5vw, 56px) 30px; }
 .hero-inner { max-width: 880px; }
@@ -372,7 +380,6 @@ h1 em { font-style: italic; color: var(--clay); }
 .surface.on { border-color: #D8E2D8; background: #F3F7F3; cursor: default; }
 .surface.on span { color: var(--sage); font-weight: 600; }
 .surface.soon { opacity: .6; cursor: default; }
-#tg-surface:hover { border-color: var(--clay); }
 
 /* --- onboarding cues ----------------------------------------------------- */
 .onboard-lead { color: var(--ink-soft); font-size: 16px; margin: 2px 0 26px;

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -15,7 +15,11 @@
     tile.addEventListener("click", async () => {
       const id = tile.dataset.connector;
       if (tile.dataset.soon) {
-        await post("/api/connections/" + id);  // records intent, never errors
+        // Waitlist tiles record intent and answer 200. A real-record tile
+        // closed by CARE_REAL_RECORDS answers 503 — show that, rather than
+        // a "we'll let you know" the server never agreed to.
+        const res = await post("/api/connections/" + id);
+        if (!res.ok) return say(tile, $("connect-msg"), res.d.error || "Not available yet");
         tile.querySelector(".connector-tag").textContent = "we'll let you know";
         return;
       }

--- a/careagents/templates/_beta_banner.html
+++ b/careagents/templates/_beta_banner.html
@@ -1,0 +1,6 @@
+{# Beta posture (council ruling 2026-09-02, D3): one line, on the landing
+   page and the hub. Says what the records are and that it will break.
+   Tests pin it under fifteen words — keep it that way. #}
+<p class="beta-banner"><b>Beta:</b> synthetic records only. Things will break —
+  <a href="https://github.com/aks129/HealthClawGuardrails/issues"
+     target="_blank" rel="noopener">tell us</a>.</p>

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -243,6 +243,9 @@
      current owner before triggering the picker. -->
 <input type="file" id="upload-file" accept=".json,application/json,application/fhir+json" hidden>
 
-<script>window.CARE = { telegramBot: {{ (telegram_bot or '')|tojson }} };</script>
+{# `window.CARE = {telegramBot: ...}` used to be emitted here. Nothing reads
+   it (home.js builds the deep link from the server response), and with the
+   Telegram tile out of service for the beta (#536, D6) it only put the bot
+   handle in the page source. #}
 <script src="{{ url_for('static', filename='home.js') }}"></script>
 {% endblock %}

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -3,6 +3,7 @@
 {% block bodyclass %}page-home{% endblock %}
 {% block head %}<link rel="manifest" href="/manifest.webmanifest">{% endblock %}
 {% block content %}
+{% include "_beta_banner.html" %}
 <main class="hub">
   <div class="hub-head">
     <div>
@@ -101,8 +102,9 @@
     <div class="section-head"><h2>Where you can reach your agent</h2></div>
     <div class="surface-row">
       <div class="surface on"><b>Web</b><span>always on</span></div>
-      <div class="surface" id="tg-surface"><b>Telegram</b>
-        <span id="tg-state">connect →</span></div>
+      {# Not serviced in the beta (#536, D6): no webhook, no poller. No id, so
+         home.js has nothing to bind — the tile is a label, not a control. #}
+      <div class="surface soon"><b>Telegram</b><span>coming soon</span></div>
       {% if imessage_handle %}
       <div class="surface" id="im-surface"><b>iMessage</b>
         <span id="im-state">connect →</span></div>

--- a/careagents/templates/landing.html
+++ b/careagents/templates/landing.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block bodyclass %}page-landing{% endblock %}
 {% block content %}
+{% include "_beta_banner.html" %}
 <main class="hero">
   <div class="hero-inner">
     <p class="kicker">Your health, with someone finally on your side of the desk</p>

--- a/docs/beta-tester-guide.md
+++ b/docs/beta-tester-guide.md
@@ -56,12 +56,16 @@ every feature, break things freely, and screenshot anything.
 **Start here even if you intend to connect your own records.** It costs you ten
 minutes and tells you whether this is worth your real data.
 
-### Track 2: your own records (real data)
+### Track 2: your own records (real data) — not open in this cohort
 
-Connect a real provider, wearable, or health record source. This is where the
-product actually proves itself — and where you should be deliberate.
+Connecting a real provider, a wearable, or a record file you export yourself is
+**closed for this cohort**. Those tiles read "coming soon" in the hub, and if
+you press one the server answers "not open in this beta" rather than starting a
+connection. That is deliberate: this cohort runs on synthetic records only, and
+we would rather tell you up front than let you discover it mid-connect.
 
-Before you do:
+When it opens, this is where the product actually proves itself — and where you
+should be deliberate:
 
 - Understand where your data goes (next section).
 - Know you can disconnect and delete.
@@ -110,10 +114,12 @@ is not serviced in this beta.
    or Sunny Coach — this is tone only; capability is identical).
 4. **Ask it something.** Try "what are my recent labs?" or "am I due for
    anything?"
-5. **When you're ready**, connect a real source from the connect menu.
+5. **Tell us what you found.** Connecting a real source is not part of this
+   cohort (see Track 2 above).
 
-Sources marked **coming soon** aren't wired yet — that label is honest, not
-sandbagging. Please don't spend time trying to make them work.
+Sources marked **coming soon** are either not wired yet or not open in this
+beta — the tile says which. Either way the label is honest, not sandbagging.
+Please don't spend time trying to make them work.
 
 ---
 
@@ -161,8 +167,13 @@ publicly — see [SECURITY.md](../SECURITY.md).
 You can stop at any time and you don't owe us an explanation.
 
 - **Disconnect a source** — stops new data flowing in.
-- **Delete your data** — email support@healthclaw.io and we'll remove your
-  tenant and confirm when it's done.
+- **Delete the records** — the **Delete** button on a connection in the hub
+  purges that connection's records straight away and tells you how many rows
+  went. You don't have to ask us, and you don't have to wait.
+- **Delete the account** — your account is a separate record (email, passkey,
+  and which sources you connected; no health data). There's no self-serve
+  button for it yet. Email support@healthclaw.io and we'll remove it and
+  confirm when it's done.
 - **Just stop using it** — nothing will contact you.
 
 If deleting is ever harder than connecting was, that's a bug. Tell us.

--- a/docs/beta-tester-guide.md
+++ b/docs/beta-tester-guide.md
@@ -11,7 +11,7 @@ to. So this document is blunt about the limits.
 ## What this is
 
 CareAgents lets you connect your own health records and talk to an AI agent
-about them — on the web, or by text.
+about them — on the web.
 
 Underneath it sits **HealthClaw Guardrails**, an open-source safety layer
 between AI agents and health data. The guardrails run on the server, not in
@@ -90,11 +90,14 @@ your whole file, not continuously.
 
 ### A real limitation, stated plainly
 
-If you use the **Telegram or iMessage** surfaces: consumer chat apps are not
-encrypted medical channels. Messages pass through Apple's or Telegram's
-infrastructure under their terms, not under a healthcare agreement. You're
+If you use the **iMessage** surface (where it's offered): consumer chat apps
+are not encrypted medical channels. Messages pass through Apple's
+infrastructure under its terms, not under a healthcare agreement. You're
 choosing to reach your own data over a consumer channel. That's a legitimate
 choice — but make it knowingly. The web app doesn't have this exposure.
+
+The **Telegram** tile in the hub says "coming soon" and means it: that surface
+is not serviced in this beta.
 
 ---
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -404,7 +404,7 @@
         <li><strong>care-completion</strong> — preventive care-gap follow-through</li>
         <li><strong>medication-refills</strong> — refill windows and projections</li>
         <li><strong>diet-exercise</strong> — activity and nutrition coaching</li>
-        <li>Passkey sign-in, on web, Telegram and iMessage</li>
+        <li>Passkey sign-in, on the web &mdash; and iMessage where it&rsquo;s offered</li>
         <li>Every answer through the guardrail layer, with no PHI stored</li>
       </ul>
       <div class="card__more">Open CareAgents →</div>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -129,9 +129,17 @@
       <h3>CareAgents beta testers</h3>
       <p>
         A beta tester's tenant holds one fictional sample patient &mdash; one condition, three observations, one
-        medication and an intake questionnaire &mdash; plus your chat with the agent and anything you approve there, and nothing else about you.
-        Deleting it from the CareAgents hub purges those records immediately, in the same request, and reports the
-        row count back; the PHI-free audit trail, including the deletion itself, is retained.
+        medication and an intake questionnaire &mdash; plus your chat with the agent and anything you approve there,
+        and no other health data about you.
+        Deleting a connection from the CareAgents hub purges that tenant's records immediately, in the same
+        request, and reports the row count back.
+      </p>
+      <p>
+        Two things outlive that deletion, and neither holds health data. The PHI-free audit trail is retained,
+        including the deletion itself. Your CareAgents account &mdash; your email address, your passkey credential
+        and which sources you connected &mdash; is a separate record in CareAgents' own database, and deleting your
+        records does not delete it. There is no self-serve button for the account yet: email support@healthclaw.io
+        and we will remove it and confirm when it is done.
       </p>
 
       <h2 id="third-party">5. Third-Party Services</h2>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -126,6 +126,13 @@
         You control all retention. The software does not phone home. No data leaves your infrastructure unless
         you configure an upstream FHIR server or external service.
       </p>
+      <h3>CareAgents beta testers</h3>
+      <p>
+        A beta tester's tenant holds one fictional sample patient &mdash; one condition, three observations, one
+        medication and an intake questionnaire &mdash; plus your chat with the agent and anything you approve there, and nothing else about you.
+        Deleting it from the CareAgents hub purges those records immediately, in the same request, and reports the
+        row count back; the PHI-free audit trail, including the deletion itself, is retained.
+      </p>
 
       <h2 id="third-party">5. Third-Party Services</h2>
       <p>The software may connect to the following external services, depending on configuration:</p>

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -4772,3 +4772,108 @@ def test_the_tester_guide_no_longer_offers_text_as_a_surface():
     assert "on the web." in text
     assert "Telegram" not in text.split("## Where your data goes")[0], (
         "the guide's opening must not offer Telegram as a way in")
+
+
+# --- QA hardening for the beta batch (review of PR #553) ---------------------
+# Each of these pins a property the batch's own tests left open, and each was
+# reproduced against a running CareAgents before it was written.
+
+def test_canonical_host_refuses_a_value_that_is_not_a_bare_hostname():
+    """`https://careagents.cloud` is what an operator types by reflex, and it
+    is not a harmless no-op: the host comparison never matches, so every
+    request — including one already on the real site — is answered 308 to
+    `https://https//careagents.cloud/...`, and a trailing slash loops forever,
+    one slash longer per hop. `/healthz` is exempt, so the platform keeps
+    reporting the deploy healthy while the site is dead. Reproduced on
+    0931974 before the guard: Config accepted "https://careagents.cloud" and
+    GET https://careagents.cloud/home answered 308 with
+    Location: https://https//careagents.cloud/home."""
+    base = {"CARE_RP_ID": "localhost", "CARE_ORIGIN": "http://localhost",
+            "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m"}
+    for bad in ("https://careagents.cloud", "http://careagents.cloud",
+                "careagents.cloud/", "careagents.cloud/home",
+                "careagents.cloud:8080", "care agents.cloud"):
+        with pytest.raises(ConfigError):
+            Config(env={**base, "CAREAGENTS_CANONICAL_HOST": bad})
+    # Surrounding whitespace is still trimmed, not refused, and unset is unset.
+    assert Config(env={**base,
+                       "CAREAGENTS_CANONICAL_HOST": " CareAgents.Cloud "}
+                  ).canonical_host == "careagents.cloud"
+    assert Config(env=base).canonical_host == ""
+
+
+def test_canonical_host_compares_hostnames_not_host_and_port(svc):
+    """A proxy that appends the default port is still the canonical host.
+    `test_the_railway_hostname_308s_to_the_canonical_host` cannot see this:
+    the Werkzeug test client normalises `:443` out of `base_url`, so the
+    header has to be set by hand. On a running server
+    (`curl -H 'Host: careagents.cloud:443'`) 0931974 answered 308, costing
+    every such request a round trip."""
+    c = _beta_app(svc, CAREAGENTS_CANONICAL_HOST="careagents.cloud"
+                  ).test_client()
+    r = c.get("/", headers={"Host": "careagents.cloud:443"})
+    assert r.status_code == 200
+    assert "Location" not in r.headers
+    # A different host with a port is still redirected, port dropped.
+    r = c.get("/home",
+              headers={"Host": "careagents-production.up.railway.app:8080"})
+    assert r.status_code == 308
+    assert r.headers["Location"] == "https://careagents.cloud/home"
+
+
+def test_canonical_redirect_survives_a_path_that_cannot_go_in_a_header(svc):
+    """`request.path` arrives percent-DECODED, so a target built from it can
+    carry bytes that are illegal in a header. On 0931974 `/%0d%0aX` raised
+    ValueError("Header values must not contain newline characters") inside
+    `redirect()` and the Railway hostname answered 500 instead of 308."""
+    c = _beta_app(svc, CAREAGENTS_CANONICAL_HOST="careagents.cloud"
+                  ).test_client()
+    internal = "https://careagents-production.up.railway.app"
+    r = c.get("/%0d%0aSet-Cookie:%20a=b", base_url=internal)
+    assert r.status_code == 308
+    loc = r.headers["Location"]
+    assert loc.startswith("https://careagents.cloud/")
+    assert "\r" not in loc and "\n" not in loc
+    # An ordinary path is unchanged byte for byte by the re-encoding.
+    assert c.get("/api/connections/catalog", base_url=internal).headers[
+        "Location"] == "https://careagents.cloud/api/connections/catalog"
+
+
+def test_allowlist_mode_with_an_empty_list_is_closed_to_everyone(svc,
+                                                                 monkeypatch):
+    """`allowlist` with the address variable unset is the state a
+    half-finished deploy lands in. It must be closed, not open."""
+    base = {"CARE_RP_ID": "localhost", "CARE_ORIGIN": "http://localhost",
+            "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m"}
+    cfg = Config(env={**base, "CARE_REAL_RECORDS": "allowlist"})
+    assert cfg.real_records_allowlist == frozenset()
+    assert cfg.real_records_open_for("anyone@example.org") is False
+    # Only separators, no addresses, is the same state.
+    cfg = Config(env={**base, "CARE_REAL_RECORDS": "allowlist",
+                      "CARE_REAL_RECORDS_ALLOWLIST": " , ,, "})
+    assert cfg.real_records_open_for("anyone@example.org") is False
+    c = _beta_app(svc, CARE_REAL_RECORDS="allowlist").test_client()
+    _login(c, svc, monkeypatch, email="anyone@example.org")
+    assert c.post("/api/connections/fasten",
+                  json={"consent": True}).status_code == 503
+
+
+def test_the_tester_guide_matches_what_the_switch_actually_does():
+    """The guide is the first thing a tester reads, and D3 closed the door it
+    was sending them through. `Track 2` told ten testers to connect a real
+    provider; the connect POST answers 503. The `Leaving` section told them to
+    email us to delete, while the hub has had a self-serve Delete since #203 —
+    and it did not say the account row outlives it."""
+    import pathlib
+    guide = (pathlib.Path(__file__).resolve().parents[1] / "docs"
+             / "beta-tester-guide.md").read_text(encoding="utf-8")
+    track2 = guide.split("### Track 2")[1].split("---")[0]
+    assert "closed for this cohort" in track2
+    assert "not open in this beta" in track2
+    leaving = guide.split("## Leaving")[1].split("---")[0]
+    # The hub's own Delete, not a support ticket, is how records go.
+    assert "**Delete** button" in leaving
+    # ...and the account is named as a separate thing that survives it.
+    assert "Delete the account" in leaving
+    assert "no self-serve" in leaving
+    assert "support@healthclaw.io" in leaving

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2082,6 +2082,9 @@ def cfg():
                        "OPENAI_API_KEY": "k",
                        "HEALTHCLAW_MINT_SECRET": "mint-secret",
                        "FASTEN_PUBLIC_KEY": "pub123",
+                       # Real-record sources are closed by default (D3);
+                       # the connector tests exercise the open flows.
+                       "CARE_REAL_RECORDS": "on",
                        "CARE_TELEGRAM_BOT": "carebot",
                        "CARE_IMESSAGE_HANDLE": "im-test-handle"})
 
@@ -2742,12 +2745,13 @@ def test_wearable_connector_soon_by_default_live_when_enabled(svc, monkeypatch):
     from careagents.app import create_app
     from careagents.config import Config
     # default (no CARE_WEARABLES_ENABLED) → soon, no client call
-    assert connectors.start("wearable", "apple", svc.cfg, FakeClient()) == {
-        "soon": True}
+    assert connectors.start("wearable", "apple", svc.cfg, FakeClient(),
+                            real_records=True) == {"soon": True}
     # enabled → live connect URL routed through HealthClaw wearables OAuth
     cfg2 = Config(env={"CARE_DATABASE_URL": "sqlite:///:memory:",
                        "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m",
-                       "CARE_WEARABLES_ENABLED": "1"})
+                       "CARE_WEARABLES_ENABLED": "1",
+                       "CARE_REAL_RECORDS": "on"})
     a = create_app(config=cfg2, client=FakeClient(), accounts=svc)
     a.config["TESTING"] = True
     c = a.test_client()
@@ -4116,12 +4120,16 @@ def test_delete_confirmation_is_not_a_form_or_native_dialog():
 
 def test_hub_dialog_selector_contract():
     """home.js addresses these by id; a template rename would break the flow at
-    runtime only, with no server-side signal."""
+    runtime only, with no server-side signal.
+
+    `tg-surface` / `tg-state` are deliberately absent: the Telegram tile is
+    "coming soon" for the beta (#536, D6) and home.js guards its handler with
+    `if (tg)`. Put them back here when the surface is serviced again."""
     for sel in ('id="provider-picker"', 'id="picker-cancel"', 'id="picker-rows"',
                 'id="connect-msg"', 'id="surfaces-msg"', 'id="agents"',
                 'id="code-card"', 'id="pair-code"', 'id="copy-code"',
                 'id="copy-state"', 'id="code-instructions"', 'id="code-done"',
-                'id="tg-state"', 'id="im-state"', 'id="delete-modal"',
+                'id="im-state"', 'id="delete-modal"',
                 'id="delete-label"', 'id="delete-input"', 'id="delete-confirm"',
                 'id="delete-cancel"'):
         assert sel in _HOME_HTML, sel
@@ -4499,3 +4507,268 @@ def test_show_lab_timeline_with_no_match_emits_no_card_and_forbids_absence(
     assert events == []
     assert out["chart_shown"] is False
     assert "not the same as" in out["note"]
+
+
+# --- beta posture (council ruling 2026-09-02, D3 / D6 / D7) -------------------
+# The beta admits strangers. Real-record sources are closed by default, the
+# Telegram surface is not serviced, the hub says it is a beta, and the Railway
+# hostname is not a second front door.
+
+def _beta_app(svc, **env):
+    """An app whose Config carries only what the test names — so the DEFAULTS
+    of the new switches are what get exercised, not the fixture's `on`."""
+    from careagents.app import create_app
+    cfg2 = Config(env={"CARE_DATABASE_URL": "sqlite:///:memory:",
+                       "CARE_RP_ID": "localhost",
+                       "CARE_ORIGIN": "http://localhost",
+                       "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m",
+                       "FASTEN_PUBLIC_KEY": "pub123",
+                       "CARE_WEARABLES_ENABLED": "1",
+                       **env})
+    a = create_app(config=cfg2, client=FakeClient(), accounts=svc)
+    a.config["TESTING"] = True
+    return a
+
+
+_REAL_RECORD_TILES = ("fasten", "wearable", "direct")
+
+
+def test_real_records_switch_defaults_to_off_and_parses_the_allowlist():
+    base = {"CARE_RP_ID": "localhost", "CARE_ORIGIN": "http://localhost",
+            "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m"}
+    # Unset is closed. A deployment that forgets the variable must not open
+    # real records to strangers.
+    assert Config(env=base).real_records == "off"
+    assert Config(env=base).real_records_allowlist == frozenset()
+    for raw, expected in (("off", "off"), ("ALLOWLIST", "allowlist"),
+                          (" on ", "on")):
+        assert Config(env={**base, "CARE_REAL_RECORDS": raw}
+                      ).real_records == expected
+    # Emails are case-folded and whitespace-trimmed; empty entries vanish.
+    cfg = Config(env={**base, "CARE_REAL_RECORDS": "allowlist",
+                      "CARE_REAL_RECORDS_ALLOWLIST":
+                          " Dr.Who@Example.org ,, second@example.org,"})
+    assert cfg.real_records_allowlist == frozenset(
+        {"dr.who@example.org", "second@example.org"})
+    # A misspelling must not fall through to some default. Refuse to boot.
+    for bad in ("yes", "1", "open", "true"):
+        with pytest.raises(ConfigError):
+            Config(env={**base, "CARE_REAL_RECORDS": bad})
+
+
+def test_real_records_open_for_follows_the_switch():
+    base = {"CARE_RP_ID": "localhost", "CARE_ORIGIN": "http://localhost",
+            "OPENAI_API_KEY": "k", "HEALTHCLAW_MINT_SECRET": "m"}
+    off = Config(env={**base, "CARE_REAL_RECORDS": "off",
+                      "CARE_REAL_RECORDS_ALLOWLIST": "a@example.org"})
+    # `off` is off for everyone, including an address on the list: the list
+    # is consulted only in allowlist mode, never as a back door.
+    assert off.real_records_open_for("a@example.org") is False
+    on = Config(env={**base, "CARE_REAL_RECORDS": "on"})
+    assert on.real_records_open_for("anyone@example.org") is True
+    listed = Config(env={**base, "CARE_REAL_RECORDS": "allowlist",
+                         "CARE_REAL_RECORDS_ALLOWLIST": "Dr.Who@Example.org"})
+    assert listed.real_records_open_for("dr.who@example.org") is True
+    assert listed.real_records_open_for("DR.WHO@EXAMPLE.ORG") is True
+    assert listed.real_records_open_for(" dr.who@example.org ") is True
+    assert listed.real_records_open_for("someone.else@example.org") is False
+    assert listed.real_records_open_for("") is False
+    assert listed.real_records_open_for(None) is False
+
+
+def test_real_record_tiles_are_coming_soon_when_the_switch_is_off(
+        svc, monkeypatch):
+    # Fasten key set and wearables enabled, so without the switch every
+    # real-record tile would be live. The switch is unset -> off.
+    c = _beta_app(svc).test_client()
+    _login(c, svc, monkeypatch, email="tester@example.org")
+    cat = {m["id"]: m for m in
+           c.get("/api/connections/catalog").get_json()["connectors"]}
+    for tile in _REAL_RECORD_TILES:
+        assert cat[tile]["tier"] == "soon", tile
+        assert "requires_consent" not in cat[tile], tile
+        assert cat[tile]["note"] == "coming soon", tile
+    # Sample records are the beta's whole track; they stay live.
+    assert cat["sample"]["tier"] == "live"
+    body = c.get("/home").get_data(as_text=True)
+    for tile in _REAL_RECORD_TILES:
+        start = body.index(f'data-connector="{tile}"')
+        opening = body[body.rindex("<button", 0, start):body.index(">", start)]
+        assert 'data-soon="1"' in opening, tile
+        assert "data-consent" not in opening, tile
+        assert "tier-soon" in opening, tile
+    assert "Not open in this beta" in body
+
+
+def test_real_record_connect_posts_are_refused_with_503_when_off(
+        svc, monkeypatch):
+    c = _beta_app(svc).test_client()
+    _login(c, svc, monkeypatch, email="tester@example.org")
+    for tile, payload in (("fasten", {"consent": True}),
+                          ("wearable", {"provider": "apple", "consent": True}),
+                          ("direct", {"consent": True})):
+        r = c.post(f"/api/connections/{tile}", json=payload)
+        assert r.status_code == 503, tile
+        assert "beta" in r.get_json()["error"], tile
+    with svc.session() as s:
+        from careagents.models import Connection
+        assert s.query(Connection).count() == 0
+    # The synthetic track is untouched by the switch.
+    assert c.post("/api/connections/sample").status_code == 200
+
+
+def test_allowlisted_account_sees_and_can_use_real_record_tiles(
+        svc, monkeypatch):
+    app = _beta_app(svc, CARE_REAL_RECORDS="allowlist",
+                    CARE_REAL_RECORDS_ALLOWLIST="Dr.Who@Example.org")
+    # Listed, in a different case from the list entry.
+    c = app.test_client()
+    _login(c, svc, monkeypatch, email="dr.who@example.org")
+    cat = {m["id"]: m for m in
+           c.get("/api/connections/catalog").get_json()["connectors"]}
+    assert cat["fasten"]["tier"] == "live"
+    assert cat["wearable"]["tier"] == "live"
+    assert cat["direct"]["tier"] == "import"
+    for tile in _REAL_RECORD_TILES:
+        assert cat[tile].get("requires_consent") is True, tile
+    r = c.post("/api/connections/fasten", json={"consent": True})
+    assert r.status_code == 200 and r.get_json()["status"] == "pending"
+    # Not listed: same deployment, tiles closed, POST refused.
+    other = app.test_client()
+    _login(other, svc, monkeypatch, email="stranger@example.org")
+    cat = {m["id"]: m for m in
+           other.get("/api/connections/catalog").get_json()["connectors"]}
+    for tile in _REAL_RECORD_TILES:
+        assert cat[tile]["tier"] == "soon", tile
+    assert other.post("/api/connections/fasten",
+                      json={"consent": True}).status_code == 503
+
+
+def test_real_records_on_opens_the_tiles_to_every_account(svc, monkeypatch):
+    c = _beta_app(svc, CARE_REAL_RECORDS="on").test_client()
+    _login(c, svc, monkeypatch, email="anyone@example.org")
+    cat = {m["id"]: m for m in
+           c.get("/api/connections/catalog").get_json()["connectors"]}
+    assert cat["fasten"]["tier"] == "live"
+    assert c.post("/api/connections/direct",
+                  json={"consent": True}).status_code == 200
+
+
+def test_the_switch_gates_new_connections_only(cfg, svc, monkeypatch):
+    # The one clinician already onboarded keeps working when production runs
+    # `allowlist`: refresh, poll, upload and delete on an EXISTING connection
+    # never consult the switch.
+    from careagents.app import create_app
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    fasten = c.post("/api/connections/fasten",
+                    json={"consent": True}).get_json()
+    direct = c.post("/api/connections/direct",
+                    json={"consent": True}).get_json()["id"]
+    tenant = fasten["connect_url"].rsplit("/connect/", 1)[1]
+
+    monkeypatch.setattr(cfg, "real_records", "off")
+
+    assert c.post("/api/connections/fasten",
+                  json={"consent": True}).status_code == 503
+    r = c.post(f"/api/connections/{fasten['id']}/refresh")
+    assert r.status_code == 200 and r.get_json()["status"] == "reauth"
+    assert c.get(f"/api/connections/{tenant}/poll").status_code == 200
+    r = c.post(f"/api/connections/{direct}/upload", data=json.dumps(
+        {"resourceType": "Bundle", "type": "collection", "entry": []}),
+        content_type="application/fhir+json")
+    assert r.status_code == 200
+    assert c.delete(f"/api/connections/{fasten['id']}").status_code == 200
+
+
+def test_the_telegram_surface_is_coming_soon_for_the_beta(app, svc,
+                                                          monkeypatch):
+    # #536: no webhook and no poller since June, so the tile was a dead end
+    # for a stranger. It stays visible so nobody wonders where it went, but it
+    # is not a control: no id for home.js to bind, no "connect" affordance.
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    body = c.get("/home").get_data(as_text=True)
+    assert 'id="tg-surface"' not in body
+    assert 'id="tg-state"' not in body
+    start = body.index("<b>Telegram</b>")
+    tile = body[body.rindex("<div", 0, start):body.index("</div>", start)]
+    assert "soon" in tile and "coming soon" in tile
+    assert "connect" not in tile
+
+
+def test_the_beta_banner_is_on_the_landing_page_and_the_hub(app, svc,
+                                                            monkeypatch):
+    c = app.test_client()
+    landing = c.get("/").get_data(as_text=True)
+    assert 'class="beta-banner"' in landing
+    _login(c, svc, monkeypatch)
+    home = c.get("/home").get_data(as_text=True)
+    assert 'class="beta-banner"' in home
+    # One sentence, under fifteen words, and it says the two things a
+    # stranger needs: what the records are, and that it will break.
+    sentence = re.search(r'class="beta-banner"[^>]*>(.*?)</p>', home,
+                         re.S).group(1)
+    words = re.sub(r"<[^>]+>", "", sentence).split()
+    assert len(words) < 15, words
+    assert "Beta" in sentence and "synthetic" in sentence
+
+
+def test_no_canonical_host_means_no_redirect(app):
+    # Local, dev and this suite: unset is a no-op, whatever the Host header.
+    c = app.test_client()
+    r = c.get("/", base_url="https://careagents-production.up.railway.app")
+    assert r.status_code == 200
+    r = c.get("/healthz", base_url="https://careagents-production.up.railway.app")
+    assert r.status_code in (200, 503)
+
+
+def test_the_railway_hostname_308s_to_the_canonical_host(svc):
+    # #264 / D7: careagents.cloud is the sole origin. 308, not 301, so a POST
+    # that lands on the wrong host is replayed as a POST, not downgraded.
+    c = _beta_app(svc, CAREAGENTS_CANONICAL_HOST="careagents.cloud"
+                  ).test_client()
+    internal = "https://careagents-production.up.railway.app"
+    r = c.get("/home?x=1&y=two", base_url=internal)
+    assert r.status_code == 308
+    assert r.headers["Location"] == "https://careagents.cloud/home?x=1&y=two"
+    r = c.get("/auth", base_url=internal)
+    assert r.status_code == 308
+    assert r.headers["Location"] == "https://careagents.cloud/auth"
+    r = c.post("/api/auth/email", json={"email": "x@example.org"},
+               base_url=internal)
+    assert r.status_code == 308
+    assert r.headers["Location"] == "https://careagents.cloud/api/auth/email"
+    # Hostnames are case-insensitive; the canonical host itself is served.
+    assert c.get("/", base_url="https://careagents.cloud").status_code == 200
+    assert c.get("/", base_url="https://CareAgents.Cloud").status_code == 200
+    # The Location is built from config, never from the request. Deliberately
+    # a hostname with a port: nothing of it may survive into the redirect.
+    r = c.get("/home", base_url="http://evil.example:8080")
+    assert r.headers["Location"] == "https://careagents.cloud/home"
+
+
+def test_healthz_is_exempt_from_the_canonical_host_redirect(svc):
+    # Railway's health check reaches the container on its internal hostname.
+    # A 308 there would mark every deploy unhealthy.
+    c = _beta_app(svc, CAREAGENTS_CANONICAL_HOST="careagents.cloud"
+                  ).test_client()
+    r = c.get("/healthz", base_url="https://careagents-production.up.railway.app")
+    assert r.status_code in (200, 503)
+    assert "Location" not in r.headers
+
+
+def test_the_tester_guide_no_longer_offers_text_as_a_surface():
+    # D6: the guide's "on the web, or by text" became "on the web". Telegram
+    # is not serviced in the beta, and the guide is what a tester reads first.
+    import pathlib
+    guide = pathlib.Path(__file__).resolve().parents[1] / "docs" / (
+        "beta-tester-guide.md")
+    text = guide.read_text(encoding="utf-8")
+    assert "on the web, or by text" not in text
+    assert "on the web." in text
+    assert "Telegram" not in text.split("## Where your data goes")[0], (
+        "the guide's opening must not offer Telegram as a way in")

--- a/tests/test_metadata_security.py
+++ b/tests/test_metadata_security.py
@@ -138,6 +138,22 @@ class TestPrivacyReconciliation:
         assert 'support@healthclaw.io' in body
 
 
+class TestCareAgentsSurfaceCopy:
+    """The site's CareAgents card is landing copy for a product whose Telegram
+    surface is out of service for the beta (#536, D6). D6 hid the tile and
+    rewrote the tester guide; this bullet kept promising the surface from the
+    page a stranger reads before either of those. Documentation is part of the
+    product surface (docs/2026-08-02-retro.md, "reality drifted")."""
+
+    def test_landing_card_does_not_offer_telegram_as_a_careagents_surface(
+            self, client):
+        body = client.get('/').get_data(as_text=True)
+        card = body.split('<div class="card__title">careagents</div>')[1]
+        card = card.split('</a>')[0]
+        assert 'Passkey sign-in' in card, "the surface bullet moved or was renamed"
+        assert 'Telegram' not in card
+
+
 # ---------------------------------------------------------------------------
 # 3. Bot /start risk disclosure (source-content check)
 # ---------------------------------------------------------------------------

--- a/tests/test_metadata_security.py
+++ b/tests/test_metadata_security.py
@@ -109,17 +109,33 @@ class TestPrivacyReconciliation:
         assert 'exceeds the security posture of typical consumer health' in body
 
     def test_careagents_beta_tester_tenant_and_deletion_stated(self, client):
-        # Council ruling 2026-09-02 (D3): two sentences, derived from what the
-        # code does, not from what we would like it to do. The synthetic
-        # tenant is r6/seed.py's built-in set; deletion is careagents'
-        # DELETE /api/connections/<id> -> /internal/purge-tenant, which purges
-        # and commits in the same request and keeps the PHI-free audit rows.
+        # Council ruling 2026-09-02 (D3), derived from what the code does, not
+        # from what we would like it to do. The synthetic tenant is
+        # r6/seed.py's built-in set (Patient + 1 Condition + 3 Observations +
+        # 1 MedicationRequest + intake_questionnaire()); deletion is
+        # careagents' DELETE /api/connections/<id> -> /internal/purge-tenant,
+        # which purges and commits in the same request (r6/routes.py) and
+        # keeps the PHI-free audit rows (r6/purge.py).
         body = client.get('/privacy').get_data(as_text=True)
         assert 'CareAgents beta testers' in body
         assert 'one fictional sample patient' in body
-        assert 'nothing else about you' in body
-        assert 'purges those records immediately' in body
+        assert 'purges that tenant' in body
         assert 'audit trail' in body
+
+    def test_careagents_retention_names_everything_that_survives(self, client):
+        # A retention statement that lists only the audit trail reads as the
+        # exhaustive list. It is not: the CareAgents account row (email,
+        # passkey credential, which sources were connected) outlives a records
+        # deletion and has no self-serve removal (#554). The first draft of
+        # this paragraph also said the tenant held "nothing else about you",
+        # which contradicts docs/beta-tester-guide.md's own data table. This
+        # is a privacy-policy promise, so the page has to name both survivors.
+        body = client.get('/privacy').get_data(as_text=True)
+        assert 'nothing else about you' not in body
+        assert 'no other health data about you' in body
+        assert 'passkey credential' in body
+        assert 'deleting your' in body and 'does not delete it' in body
+        assert 'support@healthclaw.io' in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metadata_security.py
+++ b/tests/test_metadata_security.py
@@ -108,6 +108,19 @@ class TestPrivacyReconciliation:
         # Honest comparative point.
         assert 'exceeds the security posture of typical consumer health' in body
 
+    def test_careagents_beta_tester_tenant_and_deletion_stated(self, client):
+        # Council ruling 2026-09-02 (D3): two sentences, derived from what the
+        # code does, not from what we would like it to do. The synthetic
+        # tenant is r6/seed.py's built-in set; deletion is careagents'
+        # DELETE /api/connections/<id> -> /internal/purge-tenant, which purges
+        # and commits in the same request and keeps the PHI-free audit rows.
+        body = client.get('/privacy').get_data(as_text=True)
+        assert 'CareAgents beta testers' in body
+        assert 'one fictional sample patient' in body
+        assert 'nothing else about you' in body
+        assert 'purges those records immediately' in body
+        assert 'audit trail' in body
+
 
 # ---------------------------------------------------------------------------
 # 3. Bot /start risk disclosure (source-content check)


### PR DESCRIPTION
## What

Implements the beta batch from the 2026-09-02 council ruling (D3, D6, D7) in `careagents/`, plus the copy that goes with it. One commit; no `r6/` changes; no overlap with #540 (trial `git merge-tree` against its head merges clean).

- **Telegram tile is "coming soon"** (`careagents/templates/home.html`). The `id`s are gone, so `home.js`'s handler has nothing to bind — the tile is a label, not a control. `#tg-surface:hover` CSS removed with it. The `/api/surfaces/telegram` endpoint is untouched.
- **`CARE_REAL_RECORDS = off | allowlist | on`** (`careagents/config.py`, `careagents/connectors.py`, `careagents/app.py`). Default `off`; any other value raises `ConfigError` at boot. `off` renders Fasten / wearable / direct-FHIR as "coming soon" (no consent card, blurb "Not open in this beta — start with the sample records.") and refuses their connect POSTs with 503. `allowlist` consults `CARE_REAL_RECORDS_ALLOWLIST` (comma-separated, trimmed, case-insensitive) via `Config.real_records_open_for(email)`; `on` opens to everyone. Gates **new** connections only — refresh, poll, upload, delete on an existing connection never consult it. `connectors.catalog()` / `start()` take `real_records: bool` with a fail-closed default.
- **Soon-tile click is honest** (`careagents/static/home.js`): a refused POST is shown via `say()` instead of "we'll let you know".
- **Beta banner** (`careagents/templates/_beta_banner.html`, included on `/` and `/home`): "Beta: synthetic records only. Things will break — tell us." (10 words; tests pin < 15).
- **Privacy page** (`templates/privacy.html`, new "CareAgents beta testers" subsection under Data Storage & Retention). Two sentences derived from code: the tenant holds `r6/seed.py`'s one fictional patient (one condition, three observations, one medication, intake questionnaire) plus chat and anything approved, nothing else about the tester; deletion from the hub purges in the same request (`DELETE /api/connections/<id>` → `/internal/purge-tenant`, purge + audit + commit), reports the row count, retains the PHI-free audit trail.
- **Canonical host 308** (`careagents/app.py` `before_request`): when `CAREAGENTS_CANONICAL_HOST` is set and `request.host` (case-insensitive) differs, 308 to `https://<canonical>` + same path + query. `/healthz` exempt. Unset → no redirect. The `Location` is built from config only — never `request.host_url`.
- **Tester guide** (`docs/beta-tester-guide.md`): "on the web, or by text" → "on the web"; the consumer-channel caveat now names iMessage only and states that the Telegram tile means "coming soon". `docs/beta-program.md` had no Telegram claims.
- **Tests**: 12 new in `tests/test_careagents.py` (config parsing / defaults / invalid values; `real_records_open_for` semantics; tiles soon when off; 503 on POST when off with nothing persisted; allowlist case-insensitive, listed vs unlisted on the same deployment; `on`; existing-connection refresh/poll/upload/delete unaffected after flipping to off; Telegram tile; banner on both pages; no redirect when unset; 308 preserving path + query, POST too, case-insensitive host, spoofed Host/port cannot leak into Location; `/healthz` exempt; guide pin) and 1 in `tests/test_metadata_security.py` (privacy sentences). The `cfg` fixture and one ad-hoc `Config` set `CARE_REAL_RECORDS=on` so the existing connect-flow tests keep exercising the open path under the new fail-closed default; `test_hub_dialog_selector_contract` drops `tg-state`.

## Why

- **D6** — no webhook and no poller since June; the tile was a dead end for a stranger. Hide it as "coming soon", do not service the bot.
- **D3** — the beta admits strangers on synthetic records. Real-record sources must be closed by default and openable per account (the one onboarded clinician) without a deploy; a forgotten variable must fail closed. The banner and the privacy sentences say what the beta is, in words the code backs.
- **D7 / #264** — `careagents.cloud` is the sole origin; the Railway hostname must not be a second front door with its own passkey origin. 308, not 301, so a POST landing on the wrong host is replayed as a POST.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3171 passed, 13 skipped, 1 xfailed, 2 warnings in 113.23s (0:01:53)

git fetch origin pull/540/head && git merge-tree --write-tree HEAD FETCH_HEAD
8030f79176418c85db88b3e0871f73ba14c8ada2   (exit 0 — clean, no conflicts)
```

## What was NOT run

- No deploy. Nothing was set on Railway; `CARE_REAL_RECORDS` and `CAREAGENTS_CANONICAL_HOST` are both unset there, so on deploy real records close (default) and no redirect fires until the owner sets the host.
- Not tested against production or a running HealthClaw — the CareAgents suite fakes the client.
- The allowlist was not verified with a real account; the case-insensitive match is tested only with the fake login.
- The 308 was not exercised behind Railway's proxy. If the platform rewrites `Host` to the internal name, setting `CAREAGENTS_CANONICAL_HOST` would loop — verify with `curl -I https://<railway host>/` and `curl -I https://careagents.cloud/` after setting it, before leaving it set.

## Noticed, deliberately not touched

- `docs/beta-tester-guide.md` "Leaving" still says delete = email support; the hub has self-serve Delete and the privacy page now says deletion is immediate. Not a Telegram claim, so out of this batch's scope — worth its own line.
- There is no self-serve **account** deletion (email + passkey row in CareAgents' DB); the privacy sentences are about the tenant and are accurate as written.
- `docs/runbooks/careagents-durable-worker.md` lists the live env vars "at time of writing" and is pinned by `tests/test_careagents_runbook_railway_qa.py`; the two new variables are documented in `config.py` (the env-var reference) and not added there.

Closes #536
Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
