### PR TITLE
candidate: /curatr says what it checked, not what it did not (#458)

### DIFF
--- a/openclaw/bot.py
+++ b/openclaw/bot.py
@@ -632,8 +632,9 @@ async def cmd_curatr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
                                  'connect records first (/connect).', agent_id)
             return
         first = entries[0].get('resource', entries[0])
+        rtype = first.get('resourceType', 'Observation')
         result = _rpc('curatr_evaluate',
-                      resource_type=first.get('resourceType', 'Observation'),
+                      resource_type=rtype,
                       resource_id=first.get('id'))
         _chat_state.setdefault(chat_id, {})['last_curatr'] = result
 
@@ -643,8 +644,20 @@ async def cmd_curatr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         issues = result.get('issues', [])
         proposals = result.get('fix_proposals', result.get('proposals', []))
 
-        lines = [f'*Curatr Evaluation* — quality: {quality or "?"} '
-                 f'(score: {score})']
+        # One resource was graded, so the score is only ever shown beside the
+        # scope it belongs to (#458). N is the search Bundle's own `total` —
+        # a tenant-wide count. Never len(entries): this page asked for one, so
+        # falling back to it would print "1 of 1" and claim the record holds a
+        # single Observation.
+        total = search.get('total')
+        if not isinstance(total, int):
+            total = (search.get('bundle') or {}).get('total')
+        scope = (f'Checked 1 of {total} {rtype}s (most recent)'
+                 if isinstance(total, int)
+                 else f'Checked 1 of ? {rtype}s (most recent, count unknown)')
+
+        lines = [f'*Curatr Evaluation* — {scope} — '
+                 f'quality: {quality or "?"} (score: {score})']
         summary = result.get('summary')
         if summary:
             lines.append(summary)

--- a/r6/curatr.py
+++ b/r6/curatr.py
@@ -862,9 +862,16 @@ class CuratrEngine:
             quality = "good"
 
         if not issues:
+            # `evaluate` grades ONE resource. Duplication is a property of a
+            # set, so a single-resource pass cannot see it however many rules
+            # it gains — and "no data quality issues found" is a verdict on
+            # the whole record (#458). Say what was actually checked until a
+            # set-level evaluator exists.
             summary = (
-                "No data quality issues found in this "
-                f"{resource_type} record."
+                f"No coding or structural issues found in this one "
+                f"{resource_type} record. This checked one resource, not "
+                "your record; duplicates and other record types were not "
+                "examined."
             )
         else:
             c = severities.count("critical")

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -583,6 +583,69 @@ describe("Tool Execution Tests", () => {
     expect(summary.note).toContain("No Observation resources found");
   });
 
+  // -- curatr.evaluate: the rollup must not out-claim the evaluation (#458) --
+  //
+  // `curatr_evaluate` grades ONE resource. Duplication is a property of a set,
+  // so no single-resource pass can see it. This rollup is what a direct MCP
+  // consumer reads instead of the engine's `summary`, and it carried its own
+  // copy of the record-level verdict — the demo path is Claude talking to the
+  // MCP server, so this is the string a clinician actually sees.
+
+  it("curatr.evaluate says it checked one resource, not the record", async () => {
+    // MUTATION: restore `No data quality issues found in this X record.` -> red.
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse({
+        resource_type: "Observation",
+        resource_id: "obs-1",
+        issue_count: 0,
+        overall_quality: "good",
+        summary: "engine summary",
+      })
+    );
+
+    const result = await tools.executeTool("curatr_evaluate", {
+      resource_type: "Observation",
+      resource_id: "obs-1",
+    });
+
+    const summary = (result as Record<string, unknown>)._mcp_summary as Record<
+      string,
+      unknown
+    >;
+    const note = summary.note as string;
+    expect(note).toContain("this one Observation record");
+    expect(note).toContain("checked one resource");
+    expect(note).toContain("not examined");
+    expect(note).not.toContain("No data quality issues found");
+
+    // "No action needed" is a claim about the record too — a clean single
+    // resource is not evidence that nothing needs attention.
+    const steps = summary.next_steps as string[];
+    expect(steps.join(" ")).not.toMatch(/no action needed/i);
+    expect(steps.join(" ")).toMatch(/one resource|duplicate/i);
+  });
+
+  it("curatr.evaluate still tells the agent what to do when issues exist", async () => {
+    // The scope caveat must not displace the issue workflow.
+    mockFetch.mockResolvedValueOnce(
+      fakeResponse({ issue_count: 2, overall_quality: "needs-review" })
+    );
+
+    const result = await tools.executeTool("curatr_evaluate", {
+      resource_type: "Condition",
+      resource_id: "c-1",
+    });
+
+    const summary = (result as Record<string, unknown>)._mcp_summary as Record<
+      string,
+      unknown
+    >;
+    expect(summary.note as string).toContain("2 issue(s)");
+    expect((summary.next_steps as string[]).join(" ")).toContain(
+      "curatr.apply_fix"
+    );
+  });
+
   it("fhir.search preserves a bounded backend OperationOutcome and HTTP status", async () => {
     const hostileText = "Patient Jane Doe https://internal.example?token=secret";
     const issue = {

--- a/services/agent-orchestrator/src/tools.test.ts
+++ b/services/agent-orchestrator/src/tools.test.ts
@@ -644,6 +644,16 @@ describe("Tool Execution Tests", () => {
     expect((summary.next_steps as string[]).join(" ")).toContain(
       "curatr.apply_fix"
     );
+    // QA addition (review of PR #555). The issues branch also gained the
+    // scope ("in this one Condition record"), and nothing pinned it: the
+    // assertion above passes against the pre-change string
+    // `Found 2 issue(s). Present each issue...` too, so reverting just the
+    // scope on this branch left the suite green. A count without a scope is
+    // the same defect as a verdict without one — "found 2 issues" reads as
+    // 2 issues in the record when 2 is all one resource could yield.
+    // MUTATION: drop `in this one ${resourceType} record` from the
+    // issue_count > 0 note in tools.ts -> red.
+    expect(summary.note as string).toContain("in this one Condition record");
   });
 
   it("fhir.search preserves a bounded backend OperationOutcome and HTTP status", async () => {

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -1850,9 +1850,13 @@ export class FHIRTools {
       resource: `${resourceType}/${resourceId}`,
       overall_quality: quality,
       issue_count: issueCount,
+      // This grades ONE resource. Duplication is a property of a set, so a
+      // single-resource pass cannot see it however many rules it gains, and
+      // "no data quality issues found" was a verdict on the whole record
+      // (#458). Kept in step with the engine's own summary in r6/curatr.py.
       note: issueCount === 0
-        ? `No data quality issues found in this ${resourceType} record.`
-        : `Found ${issueCount} issue(s). Present each issue to the patient in plain language before calling curatr.apply_fix.`,
+        ? `No coding or structural issues found in this one ${resourceType} record. This checked one resource, not the patient's record; duplicates and other record types were not examined.`
+        : `Found ${issueCount} issue(s) in this one ${resourceType} record. Present each issue to the patient in plain language before calling curatr.apply_fix.`,
       next_steps: issueCount > 0
         ? [
             "Present each issue.plain_language and issue.impact to the patient",
@@ -1860,7 +1864,13 @@ export class FHIRTools {
             "Ask patient which fixes they approve",
             "Call curatr.apply_fix with approved fixes and patient_intent",
           ]
-        : ["No action needed — data quality looks good."],
+        : [
+            // NOT "no action needed" — that is a claim about the record, and
+            // one clean resource is no evidence for it.
+            "Tell the patient this checked one resource, not their whole record",
+            "Do not describe the record as free of duplicates — that was not checked",
+            "Call curatr.evaluate on other resources to cover more of the record",
+          ],
       public_services_used: [
         "tx.fhir.org (SNOMED CT, LOINC)",
         "NLM Clinical Tables API (ICD-10-CM)",

--- a/tests/test_curatr_says_what_it_checked.py
+++ b/tests/test_curatr_says_what_it_checked.py
@@ -1,0 +1,226 @@
+"""/curatr must say what it checked, not what it did not (#458).
+
+Found by the physician advisor rehearsing the launch demo: /curatr answered
+"quality: good (score: 1), no data quality issues found" on a tenant holding
+a dozen duplicate Type 2 diabetes Conditions. Both halves of the reply were
+true of what ran and false of what they claimed. `cmd_curatr` fetches ONE
+Observation (`_count: 1`) and `CuratrEngine.evaluate` grades that single
+resource; duplication is a property of a set, so no single-resource pass can
+ever see it. "No data quality issues found" was a verdict on the record
+printed by a check that had examined one row of it.
+
+This is the repo's recurring shape (docs/2026-08-02-retro.md): a check that
+examined one thing printing the verdict of a check that examined everything.
+
+Council ruling D14: `/curatr` means "evaluate my record". Until a set-level
+evaluator exists (Cohort 2 — deliberately NOT built here), the output must
+say what it actually checked. Two strings carry that:
+
+  1. The engine's clean-record summary names the ONE resource it graded and
+     says duplicates and other types were not examined. The FHIR facade
+     route ($curatr-evaluate) returns `summary` verbatim, so pinning it at
+     the engine covers the route too.
+
+     NOT covered here: services/agent-orchestrator/src/tools.ts holds its
+     own second copy of the old sentence in `_mcp_summary.note`, which a
+     direct MCP consumer reads instead of `summary`. Out of scope for this
+     PR (TypeScript build lane); reported as a concern, not fixed silently.
+  2. The bot's headline says "Checked 1 of N <Type>s (most recent)" with N
+     from the search Bundle's `total`, and the score sits on the SAME line
+     as that scope so "good" can never be read alone. When the Bundle
+     carries no total the bot says "count unknown" — it never invents N.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from r6.curatr import CuratrEngine
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'test-token-for-curatr-scope')
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "openclaw"))
+
+import bot  # noqa: E402
+
+
+# --- the engine names the one resource it graded ----------------------------
+
+def _clean(resource_type: str) -> dict:
+    """A resource that produces zero issues once the terminology lookup is
+    stubbed valid — the only path that reaches the clean-record summary."""
+    common = {
+        "id": f"{resource_type.lower()}-clean",
+        "subject": {"reference": "Patient/pt-1"},
+    }
+    if resource_type == "Observation":
+        return {
+            "resourceType": "Observation",
+            "status": "final",
+            "code": {"coding": [{
+                "system": "http://loinc.org", "code": "2339-0",
+                "display": "Glucose",
+            }]},
+            "effectiveDateTime": "2026-04-20",
+            "valueQuantity": {"value": 100, "unit": "mg/dL"},
+            **common,
+        }
+    return {
+        "resourceType": "Condition",
+        "clinicalStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            "code": "active",
+        }]},
+        "verificationStatus": {"coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "code": "confirmed",
+        }]},
+        "code": {"coding": [{
+            "system": "http://hl7.org/fhir/sid/icd-10-cm", "code": "E11.9",
+            "display": "Type 2 diabetes mellitus without complications",
+        }]},
+        "onsetDateTime": "2020-01-01",
+        **common,
+    }
+
+
+@pytest.mark.parametrize("resource_type", ["Observation", "Condition"])
+def test_clean_record_summary_says_it_checked_one_resource(resource_type):
+    """MUTATION: restore "No data quality issues found in this X record." -> red.
+
+    The type in the sentence is the type that was evaluated, not a constant:
+    the Condition case fails if the string hard-codes Observation.
+    """
+    engine = CuratrEngine(timeout=1)
+    with patch.object(engine, '_lookup_code',
+                      return_value={"valid": True, "display": None, "message": None}):
+        result = engine.evaluate(_clean(resource_type))
+
+    assert result.issues == [], "fixture is not clean; the test proves nothing"
+    assert result.overall_quality == "good"
+    summary = result.summary
+    assert "checked one resource" in summary, summary
+    assert f"this one {resource_type} record" in summary, summary
+    assert "duplicates" in summary and "not examined" in summary, summary
+    assert "No data quality issues found" not in summary, (
+        f"the record-level verdict is back: {summary!r}")
+
+
+# --- the bot headline carries the scope beside the score --------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _update():
+    return SimpleNamespace(
+        effective_message=SimpleNamespace(text="/curatr"),
+        effective_chat=SimpleNamespace(id=4243),
+        effective_user=SimpleNamespace(username="advisor", id=99),
+        message=SimpleNamespace(text="/curatr"),
+    )
+
+
+def _search_bundle(total):
+    bundle = {
+        "resourceType": "Bundle",
+        "type": "searchset",
+        "entry": [{"resource": {"resourceType": "Observation", "id": "obs-1"}}],
+        # The MCP layer's own rollup, which coerces a missing total to 0
+        # (tools.ts searchResources: `result.total as number ?? 0`). Reading N
+        # from here instead of the Bundle would print "1 of 0" — a count that
+        # looks measured and is not. Present in both cases so the no-total
+        # test catches that substitution.
+        "_mcp_summary": {"total": total if total is not None else 0},
+    }
+    if total is not None:
+        bundle["total"] = total
+    return bundle
+
+
+_EVALUATE = {
+    "resource_type": "Observation",
+    "resource_id": "obs-1",
+    "overall_quality": "good",
+    "summary": (
+        "No coding or structural issues found in this one Observation record. "
+        "This checked one resource, not your record; duplicates and other "
+        "record types were not examined."
+    ),
+    "issue_count": 0,
+    "issues": [],
+    "quality_score": 1.0,
+}
+
+
+def _curatr(total):
+    """Drive cmd_curatr with the MCP bridge faked; return what was replied."""
+    sent = []
+
+    def rpc(tool, **params):
+        if tool == 'fhir_search':
+            assert params.get('params', {}).get('_count') == 1
+            return _search_bundle(total)
+        if tool == 'curatr_evaluate':
+            return dict(_EVALUATE)
+        raise AssertionError(f"unexpected tool {tool}")
+
+    with patch.object(bot, '_reply', side_effect=lambda u, t, a, **k: sent.append(t)), \
+         patch.object(bot, '_persist_turn'), \
+         patch.object(bot, '_rpc', side_effect=rpc):
+        _run(bot.cmd_curatr(_update(), SimpleNamespace(args=[])))
+    return sent
+
+
+def _headline(sent):
+    """The reply line that carries the score. There must be exactly one and it
+    must also carry the scope — a bare "quality: good (score: 1)" line is the
+    defect."""
+    body = [ln for msg in sent for ln in msg.splitlines() if 'score' in ln]
+    assert len(body) == 1, f"expected one score line, got {body}"
+    return body[0]
+
+
+def test_bot_says_checked_one_of_total_when_the_bundle_has_a_total():
+    """MUTATION: drop `total` from the headline -> red.
+
+    N is the Bundle's `total` (tenant-wide count for the type), not the
+    number of entries the `_count: 1` page returned.
+    """
+    sent = _curatr(total=12)
+    line = _headline(sent)
+    assert 'Checked 1 of 12 Observations (most recent)' in line, line
+    assert 'good' in line and 'score: 1.0' in line, (
+        f"the score moved off the scope line: {line}")
+
+
+def test_bot_says_count_unknown_when_the_bundle_has_no_total():
+    """MUTATION: fall back to len(entries) for N -> red.
+
+    A missing total is reported as unknown. Inventing N from the one-entry
+    page would print "1 of 1" — a false claim that the record holds one
+    Observation.
+    """
+    sent = _curatr(total=None)
+    line = _headline(sent)
+    assert 'Checked 1 of ? Observations' in line, line
+    assert 'count unknown' in line, line
+    assert 'of 1 Observations' not in line, f"N was invented: {line}"
+
+
+def test_bot_passes_the_engine_summary_through():
+    """The engine's scope sentence reaches the chat unchanged.
+
+    MUTATION: drop the `lines.append(summary)` branch -> red. The headline
+    alone would then be the whole verdict.
+    """
+    sent = _curatr(total=12)
+    body = "\n".join(sent)
+    assert "This checked one resource, not your record" in body, body

--- a/tests/test_curatr_says_what_it_checked.py
+++ b/tests/test_curatr_says_what_it_checked.py
@@ -21,10 +21,12 @@ say what it actually checked. Two strings carry that:
      route ($curatr-evaluate) returns `summary` verbatim, so pinning it at
      the engine covers the route too.
 
-     NOT covered here: services/agent-orchestrator/src/tools.ts holds its
-     own second copy of the old sentence in `_mcp_summary.note`, which a
-     direct MCP consumer reads instead of `summary`. Out of scope for this
-     PR (TypeScript build lane); reported as a concern, not fixed silently.
+     services/agent-orchestrator/src/tools.ts holds a second copy of the
+     sentence in `_mcp_summary.note`, which a direct MCP consumer reads
+     instead of `summary`. That copy was fixed in the same PR (commit
+     9ff27eb) and is pinned in `tools.test.ts`, not here — this file's
+     first commit described it as out of scope, which stopped being true
+     one commit later.
   2. The bot's headline says "Checked 1 of N <Type>s (most recent)" with N
      from the search Bundle's `total`, and the score sits on the SAME line
      as that scope so "good" can never be read alone. When the Bundle
@@ -224,3 +226,84 @@ def test_bot_passes_the_engine_summary_through():
     sent = _curatr(total=12)
     body = "\n".join(sent)
     assert "This checked one resource, not your record" in body, body
+
+
+# --- "(most recent)" is a contract, not a lucky default ---------------------
+#
+# QA addition (review of PR #555). The bot never sends `_sort`, and its
+# `_count: 1` does not survive the MCP bridge: the tool handler reads
+# `input._count` while `cmd_curatr` nests it under `arguments.params`, so the
+# search runs at the handler's default of 20. Verified live on 2026-09-03
+# against a seeded tenant — the bot's exact JSON-RPC payload came back with
+# `total: 25` and 20 entries, and `entry[0]` was the newest row.
+#
+# So "Checked 1 of N ... (most recent)" is true only because an unsorted
+# search defaults to `-_lastUpdated` (`r6/routes.py`). Nothing pinned that
+# default, which left a patient-facing claim resting on a line any refactor
+# could flip. Pin it beside the claim that depends on it.
+
+def _seed_observations(ids):
+    import json as _json
+    from datetime import datetime, timedelta, timezone as _tz
+
+    from models import db
+    from r6.models import R6Resource
+
+    base = datetime(2026, 4, 1, tzinfo=_tz.utc)
+    for offset, rid in enumerate(ids):
+        row = R6Resource(
+            resource_type='Observation',
+            resource_json=_json.dumps({
+                'resourceType': 'Observation', 'id': rid, 'status': 'final',
+                'code': {'coding': [{'system': 'http://loinc.org',
+                                     'code': '2339-0'}]},
+            }),
+            resource_id=rid,
+            tenant_id='test-tenant',
+        )
+        # The model stamps `last_updated` at construction, so every row would
+        # otherwise share a timestamp and the ordering under test would be
+        # decided by insertion order rather than by the sort.
+        row.last_updated = base + timedelta(days=offset)
+        db.session.add(row)
+    db.session.commit()
+
+
+def test_search_without_sort_returns_the_most_recent_first(
+        app, client, tenant_headers):
+    """MUTATION: flip the `_sort` default in `r6/routes.py` to ascending (or
+    make the else-branch `.asc()`) -> red.
+
+    The bot's headline calls the graded resource "(most recent)" while
+    sending no `_sort` and grading `entry[0]`. That word is true only while
+    an unsorted search answers newest-first.
+    """
+    with app.app_context():
+        _seed_observations(['obs-oldest', 'obs-middle', 'obs-newest'])
+        resp = client.get('/r6/fhir/Observation', headers=tenant_headers)
+        assert resp.status_code == 200
+        ids = [e['resource']['id'] for e in resp.get_json().get('entry', [])]
+        assert ids and ids[0] == 'obs-newest', (
+            "an unsorted search no longer answers newest-first, so the bot's "
+            f'"(most recent)" is now false: {ids}')
+
+
+def test_search_total_is_the_tenant_count_not_the_page_size(
+        app, client, tenant_headers):
+    """MUTATION: set `'total': len(entries)` in the local search branch of
+    `r6/routes.py` -> red.
+
+    The bot prints this number as "Checked 1 of N", a claim about how many
+    records of that type the tenant holds. If `total` ever tracked the page
+    instead, the headline would under-report the record by exactly the amount
+    that makes the caveat pointless — and it would still read as measured.
+    """
+    with app.app_context():
+        _seed_observations([f'obs-t{i:02d}' for i in range(7)])
+        resp = client.get('/r6/fhir/Observation?_count=2',
+                          headers=tenant_headers)
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert len(body.get('entry', [])) == 2
+        assert body['total'] == 7, (
+            f"total tracked the page, not the tenant: {body['total']}")


### PR DESCRIPTION
## What

`/curatr` now states the scope of what it graded, on **all three** surfaces that produced a verdict.

- **`r6/curatr.py:864`** — the engine's clean-record summary:

  > No coding or structural issues found in this one *{type}* record. This checked one resource, not your record; duplicates and other record types were not examined.

  `{type}` is the resource type actually evaluated, not a constant. Fixed in the **engine only**, so the `$curatr-evaluate` facade route inherits it and `r6/routes.py` is untouched (its 3927-line ratchet pin stands; the file is 3924).

- **`services/agent-orchestrator/src/tools.ts:1849`** — the MCP rollup carried its own second copy. `_mcp_summary.note` is now:

  > No coding or structural issues found in this one *{resourceType}* record. This checked one resource, not the patient's record; duplicates and other record types were not examined.

  and the issues-found branch names the scope too (`Found N issue(s) in this one {resourceType} record. …`). `next_steps` no longer says *"No action needed — data quality looks good."* — that is a claim about the record, which one clean resource is no evidence for. It now reads:

  > - Tell the patient this checked one resource, not their whole record
  > - Do not describe the record as free of duplicates — that was not checked
  > - Call curatr.evaluate on other resources to cover more of the record

  **This is the surface the clinician demo actually uses** (Claude → demo MCP server), so it is the copy a physician sees.

- **`openclaw/bot.py:634`** — the headline carries the scope *beside* the score on one line:

  > `*Curatr Evaluation* — Checked 1 of 12 Observations (most recent) — quality: good (score: 1.0)`

  N comes from the search Bundle's own `total`. With no total: `Checked 1 of ? Observations (most recent, count unknown)` — N is never invented. The bare `quality: good (score: 1)` line, readable as a verdict on the record, is gone.

- Tests: `tests/test_curatr_says_what_it_checked.py` (new, 5) and `services/agent-orchestrator/src/tools.test.ts` (+2).

**`grep -rn "No data quality issues" .` now returns nothing** — there was no third copy, and both known ones are fixed.

## Why

Closes the honesty half of #458 (council ruling **D14**).

The physician advisor rehearsing the launch demo got "quality: good (score: 1), no data quality issues found" on a tenant holding about a dozen duplicate Type 2 diabetes Conditions. Both halves were true of what ran and false of what they claimed.

`cmd_curatr` fetches **one** Observation (`_count: 1`); `CuratrEngine.evaluate` grades that single resource. Duplication is a property of a **set**, so no single-resource pass can surface it however many rules it gains — "no data quality issues found" on a 12-duplicate record was correct-by-construction and useless.

This is the shape `docs/2026-08-02-retro.md` is about: *a check that examined one thing printing the verdict of a check that examined everything.* The second copy in `tools.ts` is the retro's other pattern on top of it — one surface fixed, the rest drifting.

Ruling D14 is that `/curatr` means "evaluate my record". The set-level duplicate evaluator is **Cohort 2 scope and is deliberately not built here** — this PR changes only what the output claims. **#458 should stay open** for that evaluator.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3162 passed, 13 skipped, 1 xfailed, 2 warnings in 111.25s (0:01:51)
```

In `services/agent-orchestrator`:

```
npm ci                → added 439 packages, and audited 440 packages in 3s
npm test              → Test Suites: 8 passed, 8 total
                        Tests:       198 passed, 198 total
npm run lint          → tsc --noEmit, clean
npm run build         → tsc, clean
```

Green including `tests/test_ratchets.py` and `tests/test_guardrail_conformance.py`.

Each new test names the mutation that turns it red; all were confirmed red before the change and green after. The no-total fixture also carries an `_mcp_summary.total` of `0`, because the MCP layer coerces a missing total that way (`tools.ts` `searchResources`: `result.total as number ?? 0`) — sourcing N from there instead of the Bundle would print "1 of 0", a count that looks measured and is not.

> **`dependency-audit` is red on this PR and every other open one** — npm advisories fixed in unmerged PR #544. Not from this change; nothing to chase here.

## What was NOT run

- **No set-level duplicate evaluator.** Cohort 2, per the ruling. `/curatr` still grades one resource — it now says so everywhere.
- **Not exercised against a live bot or a running MCP server.** The bot tests fake `_rpc` and the TS tests mock `node-fetch`, so they prove the strings are *produced*, not that a live search returns a `total`. `r6/routes.py:938,1165` do populate `total` on search Bundles.
- No change to ingest, redaction, audit, tenant scoping, or any write path.

## Noticed, not touched

`cmd_curatr` sends `_count` nested under `arguments.params`, while the TS handler reads `input._count` directly. If `executeTool` does not flatten `params`, `_count: 1` is ignored today and the bot grades `entries[0]` of a 20-entry page. The new headline stays true either way — the Flask default sort is `-_lastUpdated` (`r6/routes.py:1102`), so `entries[0]` is the most recent — but the argument may not be doing what it reads like it does.
