### PR TITLE
candidate: MCP phase 1 — protected-resource metadata and challenge behind MCP_CANONICAL_RESOURCE (#523, council D4)

### DIFF
--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -109,15 +109,40 @@ const AUTHORIZATION_SERVER_ISSUER = "https://app.healthclaw.io";
 const RESOURCE_SCOPES = ["fhir.read", "context.read"];
 const PRM_BASE_PATH = "/.well-known/oauth-protected-resource";
 
+// The check that matters is not "is this a URL" but "will the document we serve
+// survive RFC 9728 §3.3". A client derives the resource identifier by removing
+// the well-known segment from the URL it fetched, and rejects the document if
+// `resource` is not that string. So the configured value must already BE the
+// identifier a client derives, character for character — the constant is
+// advertised verbatim as `resource`, while the URL that carries it is built
+// from the parsed origin and path.
+//
+// Nine shapes parse as https URLs and fail that: a host or scheme in mixed case
+// (the URL parser lowercases both), an explicit `:443` (dropped), a `?query` or
+// `#fragment` (not in the path), `user:pass@` userinfo (also a credential we
+// would then publish in an unauthenticated, CORS-open document), a bare
+// trailing slash, and dot segments (resolved). Each one boots a server whose
+// own challenge points at a document the challenge's reader will refuse — the
+// §9.3 "confidently wrong" mode, which is the failure this check exists to
+// catch. Verified by starting the server on each value and fetching the
+// document at the URL its own challenge advertises.
 function parseCanonicalResource(raw: string | undefined): URL | null {
   if (!raw || !raw.trim()) return null;
+  const trimmed = raw.trim();
   let parsed: URL;
   try {
-    parsed = new URL(raw.trim());
+    parsed = new URL(trimmed);
   } catch {
     return null;
   }
   if (parsed.protocol !== "https:" || !parsed.hostname) return null;
+  // `origin` re-serializes: lowercased scheme and host, no userinfo, no default
+  // port. `pathname` is normalized and excludes query and fragment. A root path
+  // contributes nothing, because protectedResourceMetadataURL appends nothing
+  // for it and the identifier a client derives therefore has no trailing slash.
+  const canonicalForm =
+    parsed.pathname === "/" ? parsed.origin : `${parsed.origin}${parsed.pathname}`;
+  if (trimmed !== canonicalForm) return null;
   return parsed;
 }
 
@@ -857,8 +882,13 @@ function assertMCPCanonicalResourceConfigured(
   const raw = env.MCP_CANONICAL_RESOURCE;
   if (!raw || !raw.trim()) return; // Unset is the supported off state.
   if (!parseCanonicalResource(raw)) {
+    // Names the variable and the shape, never the value: the rejected value may
+    // be the reason it was rejected (userinfo credentials), and a boot crash is
+    // the loudest place in the system to print one.
     throw new Error(
-      "MCP_CANONICAL_RESOURCE must be an absolute https:// URL " +
+      "MCP_CANONICAL_RESOURCE must be an absolute https:// URL in canonical " +
+        "form — lowercase scheme and host, no userinfo, no default port, no " +
+        "query, no fragment, no trailing slash on a root path " +
         "(e.g. https://mcp.healthclaw.io/mcp)"
     );
   }

--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -92,6 +92,102 @@ function isMCPBearerCredential(authorization: string | undefined): boolean {
   );
 }
 
+// --- RFC 9728 protected-resource metadata (phase 1, behind the constant) ---
+//
+// docs/specs/2026-08-16-mcp-authorization.md §3.2/§3.4, as amended 2026-09-02.
+// The canonical resource identifier is one pinned string, and everything below
+// is derived from it. Unset, none of this runs: the well-known paths 404 and
+// the challenge stays a bare `Bearer`, which is today's behaviour. Read
+// per-request like MCP_AUTH_TOKEN so config is authoritative at call time;
+// assertMCPCanonicalResourceConfigured re-reads it at boot so a malformed value
+// refuses to start rather than disabling the feature in silence.
+//
+// This admits nobody. It adds two unauthenticated documents that hold no
+// secret, name no tenant and grant nothing, and two parameters on a refusal
+// that is still a refusal.
+const AUTHORIZATION_SERVER_ISSUER = "https://app.healthclaw.io";
+const RESOURCE_SCOPES = ["fhir.read", "context.read"];
+const PRM_BASE_PATH = "/.well-known/oauth-protected-resource";
+
+function parseCanonicalResource(raw: string | undefined): URL | null {
+  if (!raw || !raw.trim()) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" || !parsed.hostname) return null;
+  return parsed;
+}
+
+function canonicalResource(): URL | null {
+  return parseCanonicalResource(process.env.MCP_CANONICAL_RESOURCE);
+}
+
+// RFC 9728 §3.1 inserts the resource's path after the well-known segment, so
+// `https://host/mcp` is described at `<host>/.well-known/oauth-protected-resource/mcp`.
+// Built from the constant and never from req.hostname. RFC 9728 §3.3 has a
+// client reject a document whose `resource` is not the identifier it inserted
+// into the well-known path, so what we advertise cannot follow the request —
+// whatever any proxy in front of us does or does not rewrite.
+function protectedResourceMetadataURL(resource: URL): string {
+  const path = resource.pathname === "/" ? "" : resource.pathname;
+  return `${resource.origin}${PRM_BASE_PATH}${path}`;
+}
+
+// `resourceIdentifier` is the configured string as configured, not a
+// re-serialized URL, so it string-equals the audience the client will request
+// and the authorization server will record. Nothing here comes from the
+// request.
+function protectedResourceMetadata(resourceIdentifier: string): Record<string, unknown> {
+  return {
+    resource: resourceIdentifier,
+    authorization_servers: [AUTHORIZATION_SERVER_ISSUER],
+    scopes_supported: RESOURCE_SCOPES,
+    bearer_methods_supported: ["header"],
+    resource_name: "HealthClaw Guardrails",
+    resource_documentation: `${AUTHORIZATION_SERVER_ISSUER}/r6/fhir/docs/privacy-policy`,
+  };
+}
+
+// A document whose `resource` disagrees with the host it was fetched from is
+// rejected by a conformant client (RFC 9728 §3.3), and that reads to a partner
+// as our bug. Until DNS points the canonical name here, the platform hostname
+// keeps answering exactly as it does today.
+function hostIsCanonical(req: express.Request, resource: URL): boolean {
+  const host = req.headers.host;
+  if (typeof host !== "string" || !host) return false;
+  try {
+    return new URL(`https://${host}`).hostname === resource.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+function challengeHeader(req: express.Request): string {
+  const resource = canonicalResource();
+  if (!resource || !hostIsCanonical(req, resource)) return "Bearer";
+
+  const authorization = req.headers.authorization;
+  const credentialPresented =
+    typeof authorization === "string" && authorization.trim().length > 0;
+  // RFC 6750 §3.1: SHOULD NOT send `error` when no credential was presented —
+  // there is no token to call invalid. The description below distinguishes
+  // nothing on purpose: expired, wrong audience and not-a-token recover
+  // identically, and telling them apart is an oracle for a caller with no
+  // business getting one. It never carries the credential or a tenant.
+  const params = credentialPresented
+    ? [
+        'error="invalid_token"',
+        'error_description="The access token is invalid, expired, or was not issued for this resource."',
+      ]
+    : [];
+  params.push(`resource_metadata="${protectedResourceMetadataURL(resource)}"`);
+  params.push(`scope="${RESOURCE_SCOPES.join(" ")}"`);
+  return `Bearer ${params.join(", ")}`;
+}
+
 // Health probes and CORS preflight remain public. When configured, every MCP
 // network transport requires the deployment-scoped bearer credential.
 app.use((req, res, next) => {
@@ -106,7 +202,7 @@ app.use((req, res, next) => {
   }
 
   if (!isMCPBearerCredential(req.headers.authorization)) {
-    res.setHeader("WWW-Authenticate", "Bearer");
+    res.setHeader("WWW-Authenticate", challengeHeader(req));
     return res.status(401).json({ error: "Unauthorized" });
   }
   next();
@@ -677,6 +773,38 @@ app.post("/mcp/rpc", async (req, res) => {
   }
 });
 
+// --- Protected-resource metadata (RFC 9728) ---
+//
+// Mounted rather than declared per-path so the sub-path form always matches the
+// path inside the constant, which is the same path the challenge advertises. A
+// header pointing at a URL this server does not serve is the failure mode the
+// spec's §9.3 calls the worst one: confidently wrong beats absent, for the
+// partner reading the error.
+//
+// Both forms are served because clients try the sub-path first and the root
+// second. `next()` on every other case leaves the response byte-identical to
+// today's 404.
+app.use(PRM_BASE_PATH, (req, res, next) => {
+  if (req.method !== "GET" && req.method !== "HEAD") return next();
+
+  const resource = canonicalResource();
+  if (!resource || !hostIsCanonical(req, resource)) return next();
+
+  const isPathInsertionForm = req.path === resource.pathname;
+  const isRootForm = req.path === "/";
+  if (!isPathInsertionForm && !isRootForm) return next();
+
+  // Unauthenticated and readable cross-origin. A document a client must read
+  // before it can authenticate cannot itself require authentication, and a
+  // browser-context client that cannot read it is back at the dead end this
+  // phase removes (spec §9.4). The transport endpoint's origin allowlist is
+  // untouched.
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  return res.json(
+    protectedResourceMetadata((process.env.MCP_CANONICAL_RESOURCE || "").trim())
+  );
+});
+
 // --- Health Check ---
 
 app.get("/health", (_req, res) => {
@@ -720,8 +848,25 @@ function assertMCPAuthConfigured(env: NodeJS.ProcessEnv = process.env): void {
   }
 }
 
+// A value that cannot be an audience is a configuration error, and the failure
+// it would otherwise produce is silence: the routes 404 and the challenge stays
+// bare, so phase 1 looks deployed and is not.
+function assertMCPCanonicalResourceConfigured(
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const raw = env.MCP_CANONICAL_RESOURCE;
+  if (!raw || !raw.trim()) return; // Unset is the supported off state.
+  if (!parseCanonicalResource(raw)) {
+    throw new Error(
+      "MCP_CANONICAL_RESOURCE must be an absolute https:// URL " +
+        "(e.g. https://mcp.healthclaw.io/mcp)"
+    );
+  }
+}
+
 if (require.main === module) {
   assertMCPAuthConfigured();
+  assertMCPCanonicalResourceConfigured();
   app.listen(PORT, () => {
     console.error(`FHIR R6 MCP Server v${SERVER_VERSION} running on port ${PORT}`);
     console.error(`FHIR Base URL: ${FHIR_BASE_URL}`);
@@ -759,6 +904,7 @@ function getRuntimeStateForTests(): {
 export {
   app,
   assertMCPAuthConfigured,
+  assertMCPCanonicalResourceConfigured,
   cleanupExpiredRuntimeStateForTests,
   closeMCPServerForTests,
   getRuntimeStateForTests,

--- a/services/agent-orchestrator/src/protected-resource-metadata.test.ts
+++ b/services/agent-orchestrator/src/protected-resource-metadata.test.ts
@@ -276,4 +276,87 @@ describe("a malformed constant refuses to boot", () => {
   ])("starts with the constant %s", (_label, env) => {
     expect(() => assertMCPCanonicalResourceConfigured(env)).not.toThrow();
   });
+
+  // Each of these parses as an https URL, so "absolute and https" admits it.
+  // Each also boots a server whose challenge advertises a metadata URL at which
+  // the served document's `resource` is NOT the identifier the client derived
+  // from that URL — RFC 9728 §3.3, the client refuses, and the partner reads
+  // the refusal as our bug (spec §9.3). Measured by starting the server on each
+  // value and fetching the document at the URL its own challenge named.
+  it.each([
+    ["a mixed-case host, which the URL parser lowercases", "https://MCP.healthclaw.io/mcp"],
+    ["a mixed-case scheme, likewise", "HTTPS://mcp.healthclaw.io/mcp"],
+    ["an explicit default port, which is dropped", "https://mcp.healthclaw.io:443/mcp"],
+    ["a query string, which is not part of the path", "https://mcp.healthclaw.io/mcp?x=1"],
+    ["a fragment, likewise", "https://mcp.healthclaw.io/mcp#frag"],
+    ["userinfo, which we would then publish", "https://user:pass@mcp.healthclaw.io/mcp"],
+    ["a trailing slash on a root path", "https://mcp.healthclaw.io/"],
+    ["dot segments, which resolve away", "https://mcp.healthclaw.io/mcp/../admin"],
+    ["an empty authority", "https:///mcp"],
+  ])("refuses to boot on %s", (_label, value) => {
+    expect(() =>
+      assertMCPCanonicalResourceConfigured({ MCP_CANONICAL_RESOURCE: value })
+    ).toThrow(/MCP_CANONICAL_RESOURCE/);
+  });
+
+  it("never puts the rejected value in the boot error", () => {
+    // The shapes rejected above include one that carries a credential. A boot
+    // crash is logged, shipped to the platform's log drain, and pasted into
+    // support threads.
+    let message = "";
+    try {
+      assertMCPCanonicalResourceConfigured({
+        MCP_CANONICAL_RESOURCE: "https://user:s3cr3t-abc123@mcp.healthclaw.io/mcp",
+      });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("MCP_CANONICAL_RESOURCE");
+    expect(message).not.toContain("s3cr3t-abc123");
+  });
+
+  // Self-consistent values that are not the chosen one still have to boot:
+  // the check rejects documents that would be refused, not values it dislikes.
+  it.each([
+    ["a non-default port", "https://mcp.healthclaw.io:8443/mcp"],
+    ["a trailing slash on a non-root path", "https://mcp.healthclaw.io/mcp/"],
+    ["an uppercase path segment", "https://mcp.healthclaw.io/MCP"],
+    ["a bare origin with no path", "https://mcp.healthclaw.io"],
+    ["surrounding whitespace", "  https://mcp.healthclaw.io/mcp  "],
+  ])("still starts on %s", (_label, value) => {
+    expect(() =>
+      assertMCPCanonicalResourceConfigured({ MCP_CANONICAL_RESOURCE: value })
+    ).not.toThrow();
+  });
+});
+
+describe("whatever boots, the document agrees with the URL that named it", () => {
+  // The property behind the boot check, asserted end to end rather than as a
+  // parser unit test: take the challenge, follow its resource_metadata URL,
+  // derive the identifier the way RFC 9728 §3.3 has the client derive it, and
+  // require the served `resource` to equal it.
+  it.each([
+    ["the canonical value", CANONICAL],
+    ["a non-default port", "https://mcp.healthclaw.io:8443/mcp"],
+    ["a trailing slash on a non-root path", "https://mcp.healthclaw.io/mcp/"],
+    ["a bare origin with no path", "https://mcp.healthclaw.io"],
+  ])("agrees for %s", async (_label, value) => {
+    process.env.MCP_CANONICAL_RESOURCE = value;
+    const configured = new URL(value);
+
+    const challenge = (await initialize(configured.host)).headers["www-authenticate"];
+    const advertised = /resource_metadata="([^"]+)"/.exec(challenge)?.[1];
+    expect(advertised).toBeDefined();
+
+    const advertisedURL = new URL(advertised as string);
+    const res = await request(app)
+      .get(advertisedURL.pathname)
+      .set("Host", advertisedURL.host);
+    expect(res.status).toBe(200);
+
+    const derived =
+      advertisedURL.origin +
+      advertisedURL.pathname.replace("/.well-known/oauth-protected-resource", "");
+    expect(res.body.resource).toBe(derived);
+  });
 });

--- a/services/agent-orchestrator/src/protected-resource-metadata.test.ts
+++ b/services/agent-orchestrator/src/protected-resource-metadata.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Phase 1 of MCP authorization: the refusal says where to go, and nothing else
+ * changes.
+ *
+ * `docs/specs/2026-08-16-mcp-authorization.md` §3.2/§3.4, amended 2026-09-02
+ * (P1-a, P1-b). Today an unauthenticated POST /mcp answers `WWW-Authenticate:
+ * Bearer` and every well-known path 404s, so a conformant client has nowhere
+ * to go and asks the user for a Client ID that does not exist (#290, #523).
+ *
+ * Two properties this suite exists to pin, both of which are silent when
+ * broken:
+ *
+ *   1. Unset `MCP_CANONICAL_RESOURCE` is today's behaviour exactly — 404 and a
+ *      bare `Bearer`. The flag ships dark, so the "no change" half is the half
+ *      that has to be asserted.
+ *   2. The `resource_metadata` URL and the PRM `resource` are built from the
+ *      pinned constant and never from the request Host. A proxy that rewrites
+ *      Host would otherwise mint a second identity for this server, and the
+ *      document would be confidently wrong rather than absent — the worse
+ *      failure, per the spec's §9.3.
+ *
+ * Who gets in does not change anywhere in this file: the static-token path
+ * still admits exactly `MCP_AUTH_TOKEN` and nothing else.
+ */
+
+import request from "supertest";
+import {
+  app,
+  assertMCPCanonicalResourceConfigured,
+  closeMCPServerForTests,
+} from "./index";
+
+const CANONICAL = "https://mcp.healthclaw.io/mcp";
+const CANONICAL_HOST = "mcp.healthclaw.io";
+const RAILWAY_HOST = "mcp-server-production-5112.up.railway.app";
+const PRM_SUBPATH = "/.well-known/oauth-protected-resource/mcp";
+const PRM_ROOT = "/.well-known/oauth-protected-resource";
+const STATIC_TOKEN = "static-mcp-token-for-tests";
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv.MCP_CANONICAL_RESOURCE = process.env.MCP_CANONICAL_RESOURCE;
+  savedEnv.MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN;
+  savedEnv.MCP_PUBLIC_DEMO = process.env.MCP_PUBLIC_DEMO;
+  delete process.env.MCP_CANONICAL_RESOURCE;
+  delete process.env.MCP_PUBLIC_DEMO;
+  process.env.MCP_AUTH_TOKEN = STATIC_TOKEN;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+afterAll(() => {
+  closeMCPServerForTests();
+});
+
+function initialize(host: string) {
+  return request(app)
+    .post("/mcp")
+    .set("Host", host)
+    .send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+    });
+}
+
+describe("with MCP_CANONICAL_RESOURCE unset, nothing changes", () => {
+  it("serves no protected-resource metadata at either path", async () => {
+    for (const path of [PRM_SUBPATH, PRM_ROOT]) {
+      const res = await request(app).get(path).set("Host", CANONICAL_HOST);
+      expect({ path, status: res.status }).toEqual({ path, status: 404 });
+    }
+  });
+
+  it("challenges with a bare Bearer, as it does today", async () => {
+    const res = await initialize(CANONICAL_HOST);
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toBe("Bearer");
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("challenges with a bare Bearer when a credential was presented too", async () => {
+    const res = await initialize(CANONICAL_HOST).set("Authorization", "Bearer not-the-token");
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toBe("Bearer");
+  });
+});
+
+describe("with the constant set, the canonical host serves the metadata", () => {
+  beforeEach(() => {
+    process.env.MCP_CANONICAL_RESOURCE = CANONICAL;
+  });
+
+  it("returns the RFC 9728 document at the header-pointed sub-path", async () => {
+    const res = await request(app).get(PRM_SUBPATH).set("Host", CANONICAL_HOST);
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body).toEqual({
+      resource: CANONICAL,
+      authorization_servers: ["https://app.healthclaw.io"],
+      scopes_supported: ["fhir.read", "context.read"],
+      bearer_methods_supported: ["header"],
+      resource_name: "HealthClaw Guardrails",
+      resource_documentation: "https://app.healthclaw.io/r6/fhir/docs/privacy-policy",
+    });
+  });
+
+  it("returns the same document at the root fallback path", async () => {
+    const subPath = await request(app).get(PRM_SUBPATH).set("Host", CANONICAL_HOST);
+    const root = await request(app).get(PRM_ROOT).set("Host", CANONICAL_HOST);
+    expect(root.status).toBe(200);
+    expect(root.body).toEqual(subPath.body);
+  });
+
+  it("serves the document to a caller with no credential, with the lock configured", async () => {
+    // The PRM sits outside the lock on purpose: a document a client must read
+    // before it can authenticate cannot itself require authentication.
+    const res = await request(app).get(PRM_SUBPATH).set("Host", CANONICAL_HOST);
+    expect(res.status).toBe(200);
+    expect(process.env.MCP_AUTH_TOKEN).toBe(STATIC_TOKEN);
+  });
+
+  it("carries the CORS header a browser-context client needs to read it", async () => {
+    const res = await request(app)
+      .get(PRM_SUBPATH)
+      .set("Host", CANONICAL_HOST)
+      .set("Origin", "https://claude.ai");
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  });
+
+  it("does not answer at a well-known sub-path the constant does not name", async () => {
+    const res = await request(app)
+      .get("/.well-known/oauth-protected-resource/something-else")
+      .set("Host", CANONICAL_HOST);
+    expect(res.status).toBe(404);
+  });
+
+  it("names the metadata URL and the scopes in the challenge, with no error", async () => {
+    const res = await initialize(CANONICAL_HOST);
+    expect(res.status).toBe(401);
+    const challenge = res.headers["www-authenticate"];
+    expect(challenge).toContain(
+      `resource_metadata="https://mcp.healthclaw.io/.well-known/oauth-protected-resource/mcp"`
+    );
+    expect(challenge).toContain(`scope="fhir.read context.read"`);
+    // RFC 6750 §3.1: SHOULD NOT send `error` when no credential was presented.
+    // There is no token to call invalid, and a client reads one as a rejection
+    // of something it never sent.
+    expect(challenge).not.toContain("error=");
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("says invalid_token only when a credential was presented and rejected", async () => {
+    const res = await initialize(CANONICAL_HOST).set("Authorization", "Bearer not-the-token");
+    expect(res.status).toBe(401);
+    const challenge = res.headers["www-authenticate"];
+    expect(challenge).toContain(`error="invalid_token"`);
+    expect(challenge).toContain(
+      `resource_metadata="https://mcp.healthclaw.io/.well-known/oauth-protected-resource/mcp"`
+    );
+    // The description distinguishes nothing: expired, wrong audience and not a
+    // token at all recover identically, and telling them apart is an oracle.
+    expect(challenge).not.toContain("not-the-token");
+  });
+
+  it("builds both the document and the header from the constant, not the Host", async () => {
+    // MUTATION: build the URL from req.hostname instead and this goes red.
+    // Not because a proxy is known to rewrite Host — Railway preserves it,
+    // measured 2026-09-03. Because RFC 9728 §3.3 has a client reject a
+    // document whose `resource` is not the identifier it inserted into the
+    // well-known path, so what we advertise cannot follow the request.
+    const spoofed = `${CANONICAL_HOST.toUpperCase()}:8443`;
+    const prm = await request(app).get(PRM_SUBPATH).set("Host", spoofed);
+    expect(prm.status).toBe(200);
+    expect(prm.body.resource).toBe(CANONICAL);
+
+    const challenge = (await initialize(spoofed)).headers["www-authenticate"];
+    expect(challenge).toContain(
+      `resource_metadata="https://mcp.healthclaw.io/.well-known/oauth-protected-resource/mcp"`
+    );
+    expect(challenge).not.toContain("8443");
+  });
+});
+
+describe("with the constant set, a non-canonical host is unchanged", () => {
+  beforeEach(() => {
+    process.env.MCP_CANONICAL_RESOURCE = CANONICAL;
+  });
+
+  it("serves no metadata on the platform hostname", async () => {
+    // RFC 9728 §3.3: a client rejects a document whose `resource` is not the
+    // identifier it inserted into the well-known path. Serving this one on the
+    // Railway hostname would hand that client a rejection instead of a 404.
+    for (const path of [PRM_SUBPATH, PRM_ROOT]) {
+      const res = await request(app).get(path).set("Host", RAILWAY_HOST);
+      expect({ path, status: res.status }).toEqual({ path, status: 404 });
+    }
+  });
+
+  it("keeps the bare Bearer challenge on the platform hostname", async () => {
+    const res = await initialize(RAILWAY_HOST);
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toBe("Bearer");
+  });
+});
+
+describe("who gets in does not change", () => {
+  it.each([
+    ["unset", undefined],
+    ["set", CANONICAL],
+  ])("admits the static token on both hosts with the constant %s", async (_label, value) => {
+    if (value === undefined) delete process.env.MCP_CANONICAL_RESOURCE;
+    else process.env.MCP_CANONICAL_RESOURCE = value;
+
+    for (const host of [CANONICAL_HOST, RAILWAY_HOST]) {
+      const res = await request(app)
+        .post("/mcp")
+        .set("Host", host)
+        .set("Authorization", `Bearer ${STATIC_TOKEN}`)
+        .send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+      expect({ host, status: res.status }).toEqual({ host, status: 200 });
+      expect(Array.isArray(res.body?.result?.tools)).toBe(true);
+    }
+  });
+
+  it.each([
+    ["unset", undefined],
+    ["set", CANONICAL],
+  ])("keeps /health public on both hosts with the constant %s", async (_label, value) => {
+    if (value === undefined) delete process.env.MCP_CANONICAL_RESOURCE;
+    else process.env.MCP_CANONICAL_RESOURCE = value;
+
+    for (const host of [CANONICAL_HOST, RAILWAY_HOST]) {
+      const res = await request(app).get("/health").set("Host", host);
+      expect({ host, status: res.status }).toEqual({ host, status: 200 });
+      expect(res.body.status).toBe("healthy");
+    }
+  });
+
+  it("leaves the pinned-tenant demo endpoint unauthenticated", async () => {
+    // The demo deployment runs without a credential by design. Phase 1 must
+    // not put a challenge in front of it, and must not add a lock it never had.
+    process.env.MCP_CANONICAL_RESOURCE = CANONICAL;
+    process.env.MCP_PUBLIC_DEMO = "true";
+
+    const res = await initialize(CANONICAL_HOST);
+    expect(res.status).toBe(200);
+    expect(res.headers["www-authenticate"]).toBeUndefined();
+  });
+});
+
+describe("a malformed constant refuses to boot", () => {
+  // Fail at start, not at the first client: a value that cannot be an audience
+  // would otherwise disable phase 1 silently and look like it shipped.
+  it.each([
+    ["http, not https", "http://mcp.healthclaw.io/mcp"],
+    ["not absolute", "mcp.healthclaw.io/mcp"],
+    ["not a URL", "not a url at all"],
+  ])("rejects a value that is %s", (_label, value) => {
+    expect(() =>
+      assertMCPCanonicalResourceConfigured({ MCP_CANONICAL_RESOURCE: value })
+    ).toThrow(/MCP_CANONICAL_RESOURCE/);
+  });
+
+  it.each([
+    ["unset", {}],
+    ["empty", { MCP_CANONICAL_RESOURCE: "" }],
+    ["the canonical value", { MCP_CANONICAL_RESOURCE: CANONICAL }],
+  ])("starts with the constant %s", (_label, env) => {
+    expect(() => assertMCPCanonicalResourceConfigured(env)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of `docs/specs/2026-08-16-mcp-authorization.md`, behind `MCP_CANONICAL_RESOURCE`. MCP server only; no Flask change, no phase 2, no phase 3.

Two commits: `a701ad9` serves the metadata and enriches the challenge; `b11a359` is the QA fix to boot validation described under Review below.

- `MCP_CANONICAL_RESOURCE` unset (today, and after this merges): both well-known routes 404 and the challenge is a bare `Bearer`. Asserted in tests, and measured at the socket by QA against a server built from `origin/main` — 33 requests, byte-identical after stripping `Date`, `ETag` and `/health`'s timestamp.
- Set to a canonical value, **and** the request `Host` names that host: the RFC 9728 document is served at `/.well-known/oauth-protected-resource/mcp` (the header-pointed sub-path) and at `/.well-known/oauth-protected-resource` (root fallback), with `Access-Control-Allow-Origin: *` on those two routes only, and the 401 on `/mcp` carries `resource_metadata` and `scope`.
- Set to a value that is not canonical: **the server refuses to start.** The rule is the property, not a list — the configured string must already be, character for character, the identifier a client derives from the URL we advertise (`origin + pathname`, or `origin` alone for a root path). The boot error names the variable and the shape, never the value.
- `resource` and the advertised metadata URL are both built from the constant, never from `req.hostname` (amendment P1-a) — because RFC 9728 §3.3 has a client reject a document whose `resource` is not the identifier it inserted into the well-known path. A mutation that builds the URL from the request host turns three tests red.
- `error="invalid_token"` appears only when a credential was presented; a credential-less 401 carries no `error` (amendment P1-c, RFC 6750 §3.1).

Who gets in does not change: `MCP_AUTH_TOKEN` remains the only accepted credential, `assertMCPAuthConfigured` is untouched, and `isPublicDemo()` still bypasses the challenge entirely (pinned).

Two things worth naming rather than leaving to be found:

- **The challenge carries `scope="fhir.read context.read"` as well as `resource_metadata`.** §3.4's two worked 401 examples both carry it, and assertion A1 requires `WWW-Authenticate` to contain `resource_metadata=` **and** `scope=`. The MCP specification marks `scope` SHOULD.
- **The enriched challenge applies to `/sse` and `/messages` too**, because it is built in the one auth middleware that guards all three transports. The same 401 needs the same way forward on any transport.

## Why

#523 — a conformant client that receives our 401 has no path to a credential, which is the mechanism behind #290. Council ruling D4 (2026-09-02): canonical resource `https://mcp.healthclaw.io/mcp`, issuer `https://app.healthclaw.io`, phase 1 merges now behind the flag and does not deploy until DNS.

This PR closes nothing on its own. #523 closes when phase 1 is deployed and verified; #568 tracks phases 2 and 3.

## Review

QA reviewed against two real servers rather than supertest: **FAIL at `a701ad9`**, **PASS at `b11a359`**.

The finding: the boot check refused a value that was not absolute or not `https:`, which is three of twelve malformed shapes an operator can plausibly type. The other nine — mixed-case scheme or host, an explicit `:443`, `?query`, `#fragment`, `user:pass@` userinfo, a bare trailing slash, dot segments, an empty authority — parse as https URLs and boot a server whose challenge advertises a document that the challenge's own reader then refuses under RFC 9728 §3.3. That is the spec's §9.3 mode: confidently wrong, which reads to a partner as our bug where a 404 reads as a gap.

The userinfo shape is worse than the others: the configured string is served verbatim as `resource`, so `user:pass@` puts a credential into an unauthenticated, CORS-open document. `b11a359` replaces the rule with the property above; ten new boot rows pin it, and removing the rule turns all ten red.

## Owner-only, before this is deployed

Nothing here is deployable by me, and the flag is unset in every environment, so merging changes no running behaviour.

1. **#522 first — repoint `mcp.healthclaw.io` from Vercel to the Railway service.** Verify over DoH, never `dig` on the operator machine:
   ```
   curl 'https://dns.google/resolve?name=mcp.healthclaw.io&type=CNAME'
   ```
2. Then set `MCP_CANONICAL_RESOURCE=https://mcp.healthclaw.io/mcp` on the MCP service, and only there.
3. Then the four verification curls:
   ```
   curl -sS -o /dev/null -D - -X POST https://mcp.healthclaw.io/mcp \
        -H 'content-type: application/json' \
        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
   # expect: 401, WWW-Authenticate with resource_metadata= and scope=, no error=

   curl -sS https://mcp.healthclaw.io/.well-known/oauth-protected-resource/mcp
   # expect: 200 JSON, resource == https://mcp.healthclaw.io/mcp

   curl -sS -o /dev/null -w '%{http_code}\n' \
        https://mcp-server-production-5112.up.railway.app/.well-known/oauth-protected-resource/mcp
   # expect: 404 — the platform hostname must not serve a document whose
   # resource disagrees with the host it was fetched from (RFC 9728 §3.3)

   curl -sS -o /dev/null -D - -X POST https://mcp.healthclaw.io/mcp \
        -H 'content-type: application/json' -H "authorization: Bearer $MCP_AUTH_TOKEN" \
        -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
   # expect: 200 and the full tool list — the static path is unchanged
   ```

**Two open items belong on that checklist. Neither blocks merging a branch that ships inert; both block the deploy.** QA handed them back rather than patch them.

- **`resource_documentation` points at a URL that returns 400 to the reader it is for.** The document sends a partner to `https://app.healthclaw.io/r6/fhir/docs/privacy-policy`, which answers `400 {"diagnostics":"X-Tenant-Id header is required"}` unauthenticated (live, 2026-09-03). The tenant gate stands in front of the one human-readable pointer we publish, and the caller reading the PRM has no tenant by construction. The value comes from spec §3.2 and this PR implements it faithfully; the choice between exempting the route, repointing the field, and dropping it (RFC 9728 §2 marks it OPTIONAL) is an owner decision. Being tracked separately by the coordinator; the three options are recorded in the spec's §9.3 on #560.
- **CORS on the 401 is deferred, and the reason is stronger than scope.** Spec §9.4 asks for `Access-Control-Allow-Origin` on the refusal as well as on the PRM paths. Measured on this build, `OPTIONS /mcp` with `Origin: https://claude.ai` returns 204 with no `access-control-allow-origin`: a browser's `POST /mcp` with a JSON content type is preflighted, and **the preflight is refused before the 401 exists**. Adding the header to the 401 alone would look like the fix and not be one — a control that appears to do one thing and does another, which is the `docs/2026-08-02-retro.md` shape. The refusal and its preflight have to move together. That is part 2 of #523, and §9.4 on #560 now says so. Doing it here would also break this PR's byte-identity property, since it changes the flag-off path.

Positively: the PRM document itself *is* readable from a browser context. It is the challenge pointing at it that is not, so phase 1's reachability claim covers a server-side fetcher and not a browser one.

**Railway preserves `Host`, so the gate works — measured, not assumed.**

```
curl -sS 'https://app.healthclaw.io/r6/fhir/Condition?_count=1'
# fullUrl: http://app.healthclaw.io/r6/fhir/Condition/…
```

That `fullUrl` is built from `request.host_url` (`r6/routes.py:1128`), so the container behind the proxy sees the public custom domain. Measured 2026-09-03. No `X-Forwarded-Host` handling is needed, and none is added — QA confirmed the header is not read and does not get the document out of the platform hostname.

What the same measurement does show is that the proxy loses the **scheme**: every production authorization-server URL is `http://` on an https-only deployment. That is #567, not this PR's, and it is the live example of what building URLs from a request costs.

## Ran

Re-run at `b11a359`, in `services/agent-orchestrator`:
- `npm test` — `Test Suites: 9 passed, 9 total` / `Tests: 239 passed, 239 total` (43 of them in `protected-resource-metadata.test.ts`)
- `npm run lint` (`tsc --noEmit`) — clean
- `npm run build` (`tsc`) — clean

At the repo root:
- `uv run ruff check .` — `All checks passed!`
- `uv run python -m pytest tests/ -q -p no:cacheprovider` — `3157 passed, 13 skipped, 1 xfailed, 2 warnings in 104.46s`

CI: every check green except `dependency-audit`, which fails on `npm audit --audit-level=high` for two `browserslist` advisories (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g). Not this PR — it touches no `package.json` or lockfile, and the same job is red on the docs-only PR #560. The fix is in unmerged #544.

## NOT run

- **Nothing was executed against a deployed server.** QA's measurements were against locally built servers; the four curls above are the first measurement against production, and they are the owner's.
- **No client was run.** This makes no claim about what claude.ai or any other hosted connector does with the document. That is the spec's §8.4 end-user run, which is what closes #290.
