### PR TITLE
candidate: stop counting DocumentReferences nothing can open (#226)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -356,12 +356,18 @@ class AccountService:
                  .filter_by(id=conn_id, account_id=account_id).first())
             return _conn_dict(c) if c else None
 
-    def mark_synced(self, conn_id: str, count: int) -> dict:
+    def mark_synced(self, conn_id: str, count: int,
+                    uncounted: int | None = None) -> dict:
         """Record the end of a sync and report what changed since the last one.
 
         Returns {"new": int, "total": int} where `new` is the growth since the
         previous sync (0 on the first one, since there's no baseline to compare
         against and every record is arguably 'new').
+
+        `uncounted` baselines the types the count excludes (#226) on the same
+        terms. Passing None leaves the stored baseline untouched rather than
+        clearing it — a caller that could not measure documents must not erase
+        the last figure that was measured.
         """
         with self.session() as s:
             c = s.query(Connection).filter_by(id=conn_id).first()
@@ -369,6 +375,8 @@ class AccountService:
                 return {"new": 0, "total": count}
             previous = c.last_count
             c.last_count = count
+            if uncounted is not None:
+                c.last_uncounted = uncounted
             c.last_synced_at = now()
             new = 0 if previous is None else max(0, count - int(previous))
             return {"new": new, "total": count}
@@ -478,7 +486,8 @@ def _conn_dict(c: Connection) -> dict:
     return {"id": c.id, "kind": c.kind, "tenant_id": c.tenant_id,
             "label": c.label, "status": c.status, "provider": c.provider,
             "connected_at": c.connected_at,
-            "last_synced_at": c.last_synced_at, "last_count": c.last_count}
+            "last_synced_at": c.last_synced_at, "last_count": c.last_count,
+            "last_uncounted": c.last_uncounted}
 
 
 def _agent_dict(a: Agent) -> dict:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -636,24 +636,32 @@ def create_app(config: Config | None = None,
             # of decaying to zero while the patient is still reading it.
             baseline = conns[conn_tenant].get("last_count")
             if baseline is not None:
-                # The count covers what the patient can actually reach;
-                # DocumentReferences are ingested but unreadable, so they are
-                # out of it and the clause below says so (#226). The two are
-                # fetched together and reported together: a number whose
-                # "and there are notes missing from this" could not be
-                # established is the same silent omission the clause exists to
-                # end, so it is either both or neither.
                 try:
                     current = hc.record_count(conn_tenant)
+                except HealthClawError:
+                    current = None
+                # The count covers what the patient can actually reach;
+                # DocumentReferences are ingested but unreadable, so they are
+                # out of it and the sentence below says so (#226). When the
+                # probe itself fails we hedge rather than suppress: the count
+                # is a fact we did measure, and hiding it would trade one
+                # silence for another. State the known part, name the unknown
+                # — the posture the review relay already takes on an
+                # unestablished `confirmed`.
+                try:
                     uncounted = hc.uncounted_record_count(conn_tenant)
                 except HealthClawError:
-                    current = uncounted = None
+                    uncounted = None
                 if current is not None:
                     out["record_count"] = current
                     out["new_records"] = max(0, current - int(baseline))
-                    if uncounted:
+                    if uncounted is None:
                         out["uncounted_note"] = (
-                            "notes and documents are not yet readable here")
+                            "We could not check whether notes or documents "
+                            "were left out.")
+                    elif uncounted > 0:
+                        out["uncounted_note"] = (
+                            "Notes and documents are not yet readable here.")
             return jsonify(out)
         return jsonify({"status": "pending"})
 

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -510,7 +510,8 @@ def create_app(config: Config | None = None,
                 logger.warning(
                     "could not flip connection %s to active", conn_id)
             try:
-                svc.mark_synced(conn_id, hc.record_count(conn["tenant_id"]))
+                svc.mark_synced(conn_id, hc.record_count(conn["tenant_id"]),
+                                hc.uncounted_record_count(conn["tenant_id"]))
             except HealthClawError:
                 logger.warning("record_count after upload failed for %s",
                                conn_id)
@@ -593,9 +594,12 @@ def create_app(config: Config | None = None,
                             "consent_version": CONSENT_VERSION}), 428
 
         # Baseline the count BEFORE re-authorizing so the follow-up poll can
-        # report what the refresh actually added.
+        # report what the refresh actually added — documents on the same
+        # terms, so "notes arrived" is a measured delta rather than a restatement
+        # of "this tenant holds notes" (#226).
         try:
-            svc.mark_synced(conn_id, hc.record_count(conn["tenant_id"]))
+            svc.mark_synced(conn_id, hc.record_count(conn["tenant_id"]),
+                            hc.uncounted_record_count(conn["tenant_id"]))
         except HealthClawError:
             return jsonify({"error": "records service unavailable"}), 503
 
@@ -653,15 +657,36 @@ def create_app(config: Config | None = None,
                 except HealthClawError:
                     uncounted = None
                 if current is not None:
+                    new_records = max(0, current - int(baseline))
                     out["record_count"] = current
-                    out["new_records"] = max(0, current - int(baseline))
+                    out["new_records"] = new_records
+                    # Documents that demonstrably arrived since the refresh
+                    # baselined them. None when the probe failed or the
+                    # connection predates the baseline column — in both cases
+                    # arrival is unknown, and unknown is never claimed.
+                    doc_baseline = conns[conn_tenant].get("last_uncounted")
+                    new_documents = (
+                        None if uncounted is None or doc_baseline is None
+                        else max(0, uncounted - int(doc_baseline)))
                     if uncounted is None:
                         out["uncounted_note"] = (
                             "We could not check whether notes or documents "
                             "were left out.")
-                    elif uncounted > 0:
+                    elif new_records > 0 and uncounted > 0:
+                        # A standing caveat on a number the patient can act
+                        # on: what you can read grew, and this excludes notes.
                         out["uncounted_note"] = (
                             "Notes and documents are not yet readable here.")
+                    elif new_records == 0 and new_documents:
+                        # The refresh delivered documents and nothing readable.
+                        # Silence here is indistinguishable from a sync that
+                        # did nothing, so say what happened. Gated on the
+                        # delta, never on `uncounted > 0` — the latter is true
+                        # from the first tick for every tenant that already
+                        # holds notes, and would fire on every no-op refresh.
+                        out["uncounted_note"] = (
+                            "Notes and documents arrived, and they are not "
+                            "readable here yet.")
             return jsonify(out)
         return jsonify({"status": "pending"})
 

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -636,13 +636,24 @@ def create_app(config: Config | None = None,
             # of decaying to zero while the patient is still reading it.
             baseline = conns[conn_tenant].get("last_count")
             if baseline is not None:
+                # The count covers what the patient can actually reach;
+                # DocumentReferences are ingested but unreadable, so they are
+                # out of it and the clause below says so (#226). The two are
+                # fetched together and reported together: a number whose
+                # "and there are notes missing from this" could not be
+                # established is the same silent omission the clause exists to
+                # end, so it is either both or neither.
                 try:
                     current = hc.record_count(conn_tenant)
+                    uncounted = hc.uncounted_record_count(conn_tenant)
                 except HealthClawError:
-                    current = None
+                    current = uncounted = None
                 if current is not None:
                     out["record_count"] = current
                     out["new_records"] = max(0, current - int(baseline))
+                    if uncounted:
+                        out["uncounted_note"] = (
+                            "notes and documents are not yet readable here")
             return jsonify(out)
         return jsonify({"status": "pending"})
 

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -457,7 +457,17 @@ class HealthClawClient:
     # meaningful set rather than every supported type — this is a progress
     # signal for the patient, not an inventory.
     COUNTED_TYPES = ("Condition", "Observation", "MedicationRequest",
-                     "AllergyIntolerance", "Immunization", "DocumentReference")
+                     "AllergyIntolerance", "Immunization")
+
+    # Ingested and stored, deliberately NOT counted (#226, council D2 option
+    # 3). Nothing can open one: `careagents/agent.py` search_records omits
+    # DocumentReference from its enum, and gate G2 measured the attachments
+    # coming back empty anyway — r6/redaction.py strips `data`, `url` and
+    # `title` from anything carrying a `contentType`. Counting them told the
+    # patient "247 records synced" where the notes dominating that number
+    # were unreachable. They stay ingested; only the claim changes, and the
+    # day a read path lands this moves back above.
+    UNCOUNTED_TYPES = ("DocumentReference",)
 
     def record_count(self, tenant: str) -> int:
         """Total records across the counted resource types.
@@ -473,6 +483,23 @@ class HealthClawClient:
         """
         total = 0
         for rt in self.COUNTED_TYPES:
+            bundle = self.search(tenant, rt, {"_summary": "count"})
+            total += int(bundle.get("total") or 0)
+        return total
+
+    def uncounted_record_count(self, tenant: str) -> int:
+        """How many records were synced that `record_count` leaves out.
+
+        The source for the one clause that keeps the number above honest: it
+        is a true count of what the patient can reach, and would be a silent
+        omission without something saying documents exist and are not in it.
+
+        Raises HealthClawError on the same terms as `record_count` — a 0 here
+        reads as "no documents arrived", which is not the same fact as "could
+        not ask".
+        """
+        total = 0
+        for rt in self.UNCOUNTED_TYPES:
             bundle = self.search(tenant, rt, {"_summary": "count"})
             total += int(bundle.get("total") or 0)
         return total

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -84,6 +84,13 @@ class Connection(Base):
     # the next one can report "N new records" without diffing every resource.
     last_synced_at = Column(Float, nullable=True)
     last_count = Column(Integer, nullable=True)
+    # The same baseline for the types the count deliberately excludes —
+    # DocumentReferences, which are ingested but not readable (#226). Without
+    # it the only measurable fact is "this tenant holds documents", which is
+    # true from the first tick for every MEDENT tenant and so cannot tell an
+    # arrival from a record that has held notes all along. A plain integer:
+    # no patient data, nothing about the record's content.
+    last_uncounted = Column(Integer, nullable=True)
     account = relationship("Account", back_populates="connections")
     agents = relationship("Agent", back_populates="connection")
 
@@ -184,6 +191,10 @@ def _ensure_columns(engine) -> None:
             if "last_count" not in cols:
                 conn.execute(text(
                     "ALTER TABLE ca_connections ADD COLUMN last_count INTEGER"))
+            if "last_uncounted" not in cols:
+                conn.execute(text(
+                    "ALTER TABLE ca_connections ADD COLUMN last_uncounted "
+                    "INTEGER"))
 
 
 def make_engine(url: str):

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -470,8 +470,12 @@
       if (!r.ok) return;
       if (typeof d.new_records === "number" && d.new_records > 0) {
         clearInterval(iv);
+        // The server appends this only when documents arrived that the count
+        // deliberately excludes (#226) — the number covers what can actually
+        // be opened, and says so rather than quietly absorbing the rest.
+        const aside = d.uncounted_note ? ` — ${d.uncounted_note}` : "";
         msg.textContent = `${d.new_records} new record` +
-          (d.new_records === 1 ? "" : "s") + " added.";
+          (d.new_records === 1 ? "" : "s") + " added" + aside + ".";
       }
     }, 5000);
   }

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -468,16 +468,22 @@
         return;
       }
       if (!r.ok) return;
-      if (typeof d.new_records === "number" && d.new_records > 0) {
-        clearInterval(iv);
-        // A complete sentence from the server, present only when documents
-        // the count excludes arrived, or when it could not find out (#226).
-        // The number covers what can actually be opened and says so, rather
-        // than quietly absorbing the rest.
-        const aside = d.uncounted_note ? ` ${d.uncounted_note}` : "";
-        msg.textContent = `${d.new_records} new record` +
-          (d.new_records === 1 ? "" : "s") + " added." + aside;
-      }
+      if (typeof d.new_records !== "number") return;
+      // Four outcomes, not two. Gating the whole render on new_records > 0
+      // dropped the case where a refresh delivers only documents: the page
+      // said nothing, which a person cannot tell from a sync that did
+      // nothing (#226). `uncounted_note` is a complete sentence the server
+      // sends only when it established something worth saying.
+      if (d.new_records === 0 && !d.uncounted_note) return;   // genuinely quiet
+      const lead = d.new_records > 0
+        ? `${d.new_records} new record` +
+          (d.new_records === 1 ? "" : "s") + " added."
+        : "No new records you can read.";
+      msg.textContent = lead + (d.uncounted_note ? ` ${d.uncounted_note}` : "");
+      // Only a readable record ends the watch. The document-only and
+      // could-not-check messages are interim: readable records may still
+      // land, and the message should upgrade rather than freeze.
+      if (d.new_records > 0) clearInterval(iv);
     }, 5000);
   }
 

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -470,12 +470,13 @@
       if (!r.ok) return;
       if (typeof d.new_records === "number" && d.new_records > 0) {
         clearInterval(iv);
-        // The server appends this only when documents arrived that the count
-        // deliberately excludes (#226) — the number covers what can actually
-        // be opened, and says so rather than quietly absorbing the rest.
-        const aside = d.uncounted_note ? ` — ${d.uncounted_note}` : "";
+        // A complete sentence from the server, present only when documents
+        // the count excludes arrived, or when it could not find out (#226).
+        // The number covers what can actually be opened and says so, rather
+        // than quietly absorbing the rest.
+        const aside = d.uncounted_note ? ` ${d.uncounted_note}` : "";
         msg.textContent = `${d.new_records} new record` +
-          (d.new_records === 1 ? "" : "s") + " added" + aside + ".";
+          (d.new_records === 1 ? "" : "s") + " added." + aside;
       }
     }, 5000);
   }

--- a/e2e/tests/careagents-sync-message.spec.ts
+++ b/e2e/tests/careagents-sync-message.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * The four outcomes of a post-refresh sync poll, rendered by the real
+ * careagents/static/home.js in a real browser (#226).
+ *
+ * Why this file exists: the branch selection in `watchForNewRecords` was
+ * verified by inspection, and inspection is what missed the defect it now
+ * covers. `home.js` gated its entire render on `new_records > 0`, so a
+ * refresh that delivered only DocumentReferences — ingested, uncountable,
+ * unreadable — displayed NOTHING. A person who had just watched a sync run
+ * could not tell that from a sync that did nothing.
+ *
+ * Why it needs no backend: `page.route` fulfils both calls the journey makes
+ * (the refresh POST and the poll GET), so the four bodies below are the
+ * contract `careagents/app.py::poll_connection` is tested against on the
+ * Python side. What runs here is the shipped JavaScript, served by the app
+ * under test at /static/home.js — not a copy, not a port of the rule.
+ *
+ * The fixture page carries only the markup `home.js` touches. It is loaded
+ * over a routed same-origin URL so the script's own <script src> resolves to
+ * the real file. `#new-agent-btn` is present because home.js dereferences it
+ * unguarded at module scope; without it the IIFE throws before the assertions
+ * mean anything.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { CARE_BASE_URL } from '../playwright.config';
+
+test.use({ baseURL: CARE_BASE_URL });
+
+const TENANT = 'care-e2e-tenant';
+const CONN = 'conn-e2e-1';
+const FIXTURE = `${CARE_BASE_URL}/__e2e-sync-fixture`;
+
+const FIXTURE_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>sync fixture</title></head>
+<body>
+  <button id="new-agent-btn" type="button">new agent</button>
+  <div class="conn-card" data-tenant="${TENANT}">
+    <button class="conn-refresh" type="button" data-conn="${CONN}">Refresh</button>
+    <p class="conn-refresh-msg" hidden></p>
+  </div>
+  <div id="consent-modal" hidden>
+    <button id="consent-agree" type="button">agree</button>
+    <button id="consent-cancel" type="button">cancel</button>
+  </div>
+  <script src="/static/home.js"></script>
+</body></html>`;
+
+// `watchForNewRecords` polls on a 5s interval, so the first answer lands just
+// past Playwright's 5s default. Every assertion below must outlast a tick, or
+// it races the thing it is measuring.
+const TICK = 15_000;
+
+/** Counts poll requests so a test can prove the poll actually happened. */
+interface Watch { polls(): number; }
+
+/**
+ * Serve the fixture, answer the refresh with a reauth_url (the only branch
+ * that starts the watch), and answer every poll with `body`.
+ */
+async function watchWith(page: Page, body: Record<string, unknown>,
+                         status = 200): Promise<Watch> {
+  let polls = 0;
+  await page.route(FIXTURE, (route) =>
+    route.fulfill({ contentType: 'text/html', body: FIXTURE_HTML }));
+
+  // The handler opens this in a new tab; keep it same-origin and trivial so
+  // no third party is contacted and no popup stalls the run.
+  await page.route('**/__e2e-reauth', (route) =>
+    route.fulfill({ contentType: 'text/html', body: '<html></html>' }));
+
+  await page.route(`**/api/connections/${CONN}/refresh`, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'reauth', connection_id: CONN,
+                             reauth_url: `${CARE_BASE_URL}/__e2e-reauth` }),
+    }));
+
+  await page.route(`**/api/connections/${TENANT}/poll`, (route) => {
+    polls += 1;
+    return route.fulfill({
+      status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  await page.goto(FIXTURE);
+  await page.locator('.conn-refresh').click();
+  return { polls: () => polls };
+}
+
+const message = (page: Page) => page.locator('.conn-refresh-msg');
+
+test.describe('what a refresh reports when the poll comes back', () => {
+  test('readable records: the count, with the standing document caveat', async ({
+    page,
+  }) => {
+    await watchWith(page, {
+      status: 'active', record_count: 105, new_records: 5,
+      uncounted_note: 'Notes and documents are not yet readable here.',
+    });
+    await expect(message(page)).toHaveText(
+      '5 new records added. Notes and documents are not yet readable here.',
+      { timeout: TICK });
+  });
+
+  test('readable records only: the count alone', async ({ page }) => {
+    await watchWith(page, {
+      status: 'active', record_count: 105, new_records: 5,
+    });
+    await expect(message(page)).toHaveText('5 new records added.',
+                                           { timeout: TICK });
+  });
+
+  test('documents only: says so instead of saying nothing', async ({ page }) => {
+    // The defect this file was written for. Before the fix the poll returned
+    // exactly this body and the page rendered the previous "Finish signing
+    // in…" text forever.
+    await watchWith(page, {
+      status: 'active', record_count: 100, new_records: 0,
+      uncounted_note:
+        'Notes and documents arrived, and they are not readable here yet.',
+    });
+    await expect(message(page)).toHaveText(
+      'No new records you can read. Notes and documents arrived, and they ' +
+      'are not readable here yet.', { timeout: TICK });
+  });
+
+  test('nothing at all: the message does not change', async ({ page }) => {
+    // A refresh that genuinely brought nothing stays quiet — the watcher is
+    // still running, so the "Finish signing in" text set by the click must
+    // survive a zero-and-zero poll rather than being overwritten.
+    const watch = await watchWith(page, {
+      status: 'active', record_count: 100, new_records: 0,
+    });
+    // Prove the poll ACTUALLY RAN before concluding it stayed quiet —
+    // otherwise this passes on a route that never fired, which is how a
+    // "quiet" assertion becomes decoration.
+    await expect.poll(() => watch.polls(), { timeout: TICK })
+      .toBeGreaterThan(0);
+    await expect(message(page)).toHaveText(
+      'Finish signing in to your provider — new records appear here.');
+  });
+
+  test('the probe failed: the count stands and names what it could not check',
+    async ({ page }) => {
+      await watchWith(page, {
+        status: 'active', record_count: 105, new_records: 5,
+        uncounted_note:
+          'We could not check whether notes or documents were left out.',
+      });
+      await expect(message(page)).toHaveText(
+        '5 new records added. We could not check whether notes or documents ' +
+        'were left out.', { timeout: TICK });
+    });
+
+  test('an unreachable record store is reported, not rendered as nothing new',
+    async ({ page }) => {
+      // Pre-existing behaviour, pinned here because the branch above it moved.
+      await watchWith(page, {
+        status: 'unavailable', error: 'records_unavailable',
+        message: "We couldn't reach your records right now.",
+      }, 503);
+      await expect(message(page)).toHaveText(
+        "We couldn't reach your records right now.", { timeout: TICK });
+    });
+});
+
+test.describe('the watch keeps running until readable records land', () => {
+  test('a document-only poll upgrades to the count when records arrive',
+    async ({ page }) => {
+      // The interim message must not freeze: `clearInterval` fires only on a
+      // readable record, so a later poll replaces it.
+      //
+      // MUTATION: call clearInterval unconditionally -> red, the message
+      // stays on the document-only sentence.
+      let polls = 0;
+      await page.route(FIXTURE, (route) =>
+        route.fulfill({ contentType: 'text/html', body: FIXTURE_HTML }));
+      await page.route('**/__e2e-reauth', (route) =>
+        route.fulfill({ contentType: 'text/html', body: '<html></html>' }));
+      await page.route(`**/api/connections/${CONN}/refresh`, (route) =>
+        route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ reauth_url: `${CARE_BASE_URL}/__e2e-reauth` }),
+        }));
+      await page.route(`**/api/connections/${TENANT}/poll`, (route) => {
+        polls += 1;
+        const body = polls === 1
+          ? { status: 'active', record_count: 100, new_records: 0,
+              uncounted_note:
+                'Notes and documents arrived, and they are not readable here yet.' }
+          : { status: 'active', record_count: 105, new_records: 5 };
+        return route.fulfill({ contentType: 'application/json',
+                               body: JSON.stringify(body) });
+      });
+
+      await page.goto(FIXTURE);
+      await page.locator('.conn-refresh').click();
+
+      await expect(message(page)).toHaveText(
+        'No new records you can read. Notes and documents arrived, and they ' +
+        'are not readable here yet.', { timeout: TICK });
+      // The poller ticks every 5s; the second answer replaces the first.
+      await expect(message(page)).toHaveText('5 new records added.',
+                                             { timeout: TICK });
+    });
+});

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2959,6 +2959,63 @@ def test_the_count_is_hedged_not_hidden_when_the_document_probe_fails(
     assert "not yet readable" not in note, note
 
 
+# QA addition (review of PR #561). `home.js` renders the clause as
+# `"... added." + " " + uncounted_note`, and the author verified that by
+# inspection only — there is no JS harness in this repo. What makes the join
+# safe here, and on the next surface to carry it (a notification, an email,
+# the worker), is the sentence's own shape. Assert it on the string the poll
+# actually emitted, not on a copy: a fragment appended to "5 new records
+# added." reads as one run-on claim, and a clause with its own leading space
+# doubles the caller's.
+
+def _assert_joins_cleanly(note):
+    assert note == note.strip(), f"padded, so the join doubles a space: {note!r}"
+    assert note.endswith("."), f"a fragment, not a sentence: {note!r}"
+    assert not note.endswith(".."), f"doubled full stop: {note!r}"
+    assert note[0].isupper(), f"does not open a sentence: {note!r}"
+    assert note.count(".") == 1, f"more than one sentence: {note!r}"
+    # The rendered line, per careagents/static/home.js.
+    line = "5 new records added." + " " + note
+    assert ".." not in line and "  " not in line, line
+
+
+def test_the_documents_clause_joins_the_count_cleanly(cfg, svc, monkeypatch):
+    """MUTATION: drop the trailing period from either sentence in
+    `poll_connection`, or pad one with a leading space -> red.
+    """
+    d = _poll_after_sync(cfg, svc, monkeypatch, documents=2)
+    assert d["uncounted_note"] == "Notes and documents are not yet readable here."
+    _assert_joins_cleanly(d["uncounted_note"])
+
+
+def test_the_hedge_clause_joins_the_count_cleanly(cfg, svc, monkeypatch):
+    """Same property for the sentence a failed probe produces, which is the
+    one a patient sees during an incident — the worst time for the copy to
+    render as a fragment.
+    """
+    from careagents.app import create_app
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/fasten",
+                     json={"consent": True}).get_json()
+    conn = created["id"]
+    tenant = created["connect_url"].rsplit("/connect/", 1)[1]
+    assert c.post(f"/api/connections/{conn}/refresh").status_code == 200
+    fake.counted = 105
+
+    def down(_tenant):
+        raise HealthClawError("search DocumentReference failed (503)", 503)
+    fake.uncounted_record_count = down
+
+    d = c.get(f"/api/connections/{tenant}/poll").get_json()
+    assert d["uncounted_note"] == (
+        "We could not check whether notes or documents were left out.")
+    _assert_joins_cleanly(d["uncounted_note"])
+
+
 def test_the_poll_says_the_engine_is_unreachable_rather_than_pending(
         cfg, svc, monkeypatch):
     """The patient-visible half of #403.

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2872,9 +2872,23 @@ def test_poll_reports_new_records_added_since_the_refresh(cfg, svc, monkeypatch)
 
 def _poll_after_sync(cfg, svc, monkeypatch, documents):
     """Refresh, land five readable records plus `documents`, return the poll."""
+    return _refresh_then_deliver(cfg, svc, monkeypatch,
+                                 documents_before=documents,
+                                 readable_after=105,
+                                 documents_after=documents)[0]
+
+
+def _refresh_then_deliver(cfg, svc, monkeypatch, documents_before,
+                          readable_after, documents_after, fake=None):
+    """Baseline at a refresh, then let the provider deliver, then poll.
+
+    Returns (poll body, fake). The refresh is what records both baselines, so
+    what the poll reports is growth since the patient asked for it — not a
+    restatement of what the tenant already held.
+    """
     from careagents.app import create_app
-    fake = FakeClient()
-    fake.uncounted = documents
+    fake = fake or FakeClient()
+    fake.uncounted = documents_before
     app = create_app(config=cfg, client=fake, accounts=svc)
     app.config["TESTING"] = True
     c = app.test_client()
@@ -2885,8 +2899,9 @@ def _poll_after_sync(cfg, svc, monkeypatch, documents):
     tenant = created["connect_url"].rsplit("/connect/", 1)[1]
 
     assert c.post(f"/api/connections/{conn}/refresh").status_code == 200
-    fake.counted = 105
-    return c.get(f"/api/connections/{tenant}/poll").get_json()
+    fake.counted = readable_after
+    fake.uncounted = documents_after
+    return c.get(f"/api/connections/{tenant}/poll").get_json(), fake
 
 
 def test_the_poll_says_documents_are_not_readable_when_some_arrived(
@@ -3014,6 +3029,189 @@ def test_the_hedge_clause_joins_the_count_cleanly(cfg, svc, monkeypatch):
     assert d["uncounted_note"] == (
         "We could not check whether notes or documents were left out.")
     _assert_joins_cleanly(d["uncounted_note"])
+
+
+# --- the fourth outcome: a refresh that delivers only documents -------------
+#
+# `home.js` gated its whole render on new_records > 0, so this case said
+# NOTHING — indistinguishable from a sync that did nothing, for the patient
+# who just watched one happen. The sentence needs a real delta: `uncounted`
+# is a tenant TOTAL, true from the first tick for every tenant that already
+# holds notes, so gating on it would fire on every no-op refresh for exactly
+# the MEDENT tenants this issue is about. Hence the `last_uncounted`
+# baseline, recorded by the same refresh that baselines the readable count.
+
+def test_a_refresh_that_delivers_only_documents_says_so(
+        cfg, svc, monkeypatch):
+    """MUTATION: gate the clause on `uncounted > 0` instead of the delta ->
+    still green here, red in the no-op test below. Both rows are the pin.
+
+    MUTATION: drop the `new_records == 0` arm entirely -> red (silence).
+    """
+    d, _ = _refresh_then_deliver(cfg, svc, monkeypatch,
+                                 documents_before=0,
+                                 readable_after=100,   # unchanged
+                                 documents_after=2)
+    assert d["new_records"] == 0
+    assert d["uncounted_note"] == (
+        "Notes and documents arrived, and they are not readable here yet.")
+    _assert_joins_cleanly(d["uncounted_note"])
+
+
+def test_a_refresh_that_delivers_nothing_stays_quiet(cfg, svc, monkeypatch):
+    """The case that makes the delta load-bearing.
+
+    This tenant ALREADY holds two documents, and the refresh brings nothing.
+    A clause gated on `uncounted > 0` would announce documents on every such
+    refresh; gated on the delta it says nothing, which is the truth.
+
+    MUTATION: gate the clause on `uncounted > 0` -> red.
+    """
+    d, _ = _refresh_then_deliver(cfg, svc, monkeypatch,
+                                 documents_before=2,
+                                 readable_after=100,   # unchanged
+                                 documents_after=2)    # unchanged
+    assert d["new_records"] == 0
+    assert "uncounted_note" not in d, d
+
+
+def test_documents_that_predate_the_baseline_are_not_called_new(
+        cfg, svc, monkeypatch):
+    """The first refresh after this column ships, for an account that already
+    holds documents.
+
+    The refresh records the baseline at its current value, so the follow-up
+    poll measures growth from there — the notes the record already held are
+    not announced as having just arrived.
+
+    MUTATION: treat a null baseline as 0 -> red (all 4 read as new).
+    """
+    d, _ = _refresh_then_deliver(cfg, svc, monkeypatch,
+                                 documents_before=4,   # already on file
+                                 readable_after=100,
+                                 documents_after=4)
+    assert d["new_records"] == 0
+    assert "uncounted_note" not in d, d
+
+
+def test_a_connection_with_no_document_baseline_claims_no_arrival(
+        cfg, svc, monkeypatch):
+    """A row written before `last_uncounted` existed: the baseline is NULL, so
+    arrival cannot be computed and is never claimed.
+
+    MUTATION: `int(doc_baseline or 0)` instead of the None check -> red, every
+    document on file reads as newly arrived.
+    """
+    from careagents.app import create_app
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/fasten",
+                     json={"consent": True}).get_json()
+    conn = created["id"]
+    tenant = created["connect_url"].rsplit("/connect/", 1)[1]
+
+    # A pre-migration refresh: readable baselined, documents never were.
+    svc.mark_synced(conn, 100)
+    fake.uncounted = 7
+
+    d = c.get(f"/api/connections/{tenant}/poll").get_json()
+    assert d["new_records"] == 0
+    assert "uncounted_note" not in d, d
+
+
+def test_the_refresh_baselines_documents_as_well_as_records(
+        cfg, svc, monkeypatch):
+    """The delta above is only honest if the refresh actually records it.
+
+    MUTATION: drop the `uncounted` argument at the refresh call site -> red.
+    """
+    from careagents.app import create_app
+    fake = FakeClient()
+    fake.uncounted = 3
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/fasten",
+                     json={"consent": True}).get_json()
+    conn = created["id"]
+    assert c.post(f"/api/connections/{conn}/refresh").status_code == 200
+
+    # Read the row back, not the response: the point is that the refresh
+    # PERSISTED both baselines, which is what the next poll subtracts from.
+    with svc.session() as s:
+        from careagents.models import Connection
+        row = s.query(Connection).filter_by(id=conn).first()
+        assert row.last_count == 100
+        assert row.last_uncounted == 3
+
+
+def test_the_document_baseline_column_is_added_to_an_existing_table(tmp_path):
+    """An account created before this column shipped must get it on boot.
+
+    `create_all()` adds missing TABLES, never missing COLUMNS, so a live
+    deployment reaches the new code with an old `ca_connections`. Build that
+    table exactly as it shipped, then run the migration the app runs at start.
+
+    The ALTER is plain `ADD COLUMN ... INTEGER`, which SQLite and Postgres
+    both accept; this exercises the SQLite lane, and CI's Postgres lane runs
+    the same path.
+
+    MUTATION: delete the `last_uncounted` block from `_ensure_columns` -> red.
+    """
+    from sqlalchemy import create_engine, inspect, text
+    from careagents.models import _ensure_columns
+
+    # A bare engine, NOT make_engine: that helper runs create_all() and
+    # _ensure_columns() itself, which is the very thing under test. A file
+    # rather than :memory: keeps it clear of any other fixture's database.
+    engine = create_engine(f"sqlite:///{tmp_path}/legacy.db")
+    with engine.begin() as conn:
+        # The pre-#226 shape: everything except last_uncounted.
+        conn.execute(text(
+            "CREATE TABLE ca_connections ("
+            "id VARCHAR(40) PRIMARY KEY, account_id VARCHAR(40), "
+            "kind VARCHAR(24), tenant_id VARCHAR(64), label VARCHAR(120), "
+            "status VARCHAR(16), provider VARCHAR(64), connected_at FLOAT, "
+            "consented_at FLOAT, consent_version VARCHAR(16), "
+            "last_synced_at FLOAT, last_count INTEGER)"))
+        conn.execute(text(
+            "INSERT INTO ca_connections (id, last_count) VALUES ('c1', 42)"))
+
+    assert "last_uncounted" not in {
+        c["name"] for c in inspect(engine).get_columns("ca_connections")}
+
+    _ensure_columns(engine)
+
+    cols = {c["name"] for c in inspect(engine).get_columns("ca_connections")}
+    assert "last_uncounted" in cols
+    with engine.connect() as conn:
+        row = conn.execute(text(
+            "SELECT last_count, last_uncounted FROM ca_connections "
+            "WHERE id='c1'")).first()
+    # NULL, not 0 — the difference between "no baseline recorded" and "there
+    # were no documents", which is what keeps the first refresh honest.
+    assert row[0] == 42 and row[1] is None
+    # Idempotent: boot runs this every time.
+    _ensure_columns(engine)
+
+
+def test_mark_synced_without_a_document_count_keeps_the_last_one(
+        cfg, svc, monkeypatch):
+    """An upload path that could not measure documents must not erase the
+    figure the last refresh established — a cleared baseline would make every
+    document on file read as new on the next poll.
+
+    MUTATION: assign `c.last_uncounted = uncounted` unconditionally -> red.
+    """
+    acct = _make_account(svc, monkeypatch, "baseline@example.com").id
+    conn = svc.add_connection(acct, "fasten", "t-baseline", "Test")
+    svc.mark_synced(conn, 10, 4)
+    svc.mark_synced(conn, 12)          # documents unknown this time
+    assert svc.get_connection(acct, conn)["last_uncounted"] == 4
 
 
 def test_the_poll_says_the_engine_is_unreachable_rather_than_pending(

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1883,6 +1883,13 @@ class FakeClient:
     def record_count(self, tenant):
         return self.counted
 
+    # DocumentReferences that landed but are deliberately not in `counted`
+    # (#226). Settable the same way.
+    uncounted = 0
+
+    def uncounted_record_count(self, tenant):
+        return self.uncounted
+
     purge_fails = False
 
     def purge_tenant(self, tenant):
@@ -1941,7 +1948,7 @@ class FakeClient:
 # for a proven client:
 #   * Behaviour. Signature parity says a call is *accepted*, never that it does
 #     the same thing. `FakeClient.record_count` returns a settable int;
-#     `HealthClawClient.record_count` sums six `_summary=count` searches and
+#     `HealthClawClient.record_count` sums five `_summary=count` searches and
 #     raises if any of them could not be asked. Both signatures are
 #     `(tenant)`.
 #   * Wire format. Nothing here talks to a running HealthClaw, so a body or
@@ -2853,6 +2860,93 @@ def test_poll_reports_new_records_added_since_the_refresh(cfg, svc, monkeypatch)
     assert d["status"] == "active"
     assert d["record_count"] == 112
     assert d["new_records"] == 12
+
+
+# --- #226: the count says what it leaves out ---------------------------------
+#
+# DocumentReferences are ingested but nothing can open one, so they are out of
+# the counted set (careagents/healthclaw.py COUNTED_TYPES). This poll is the
+# one place a count derived from `record_count` reaches a person — home.js
+# renders it as "N new records added." The unit-level half of this lives in
+# tests/test_uncounted_documents.py.
+
+def _poll_after_sync(cfg, svc, monkeypatch, documents):
+    """Refresh, land five readable records plus `documents`, return the poll."""
+    from careagents.app import create_app
+    fake = FakeClient()
+    fake.uncounted = documents
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/fasten",
+                     json={"consent": True}).get_json()
+    conn = created["id"]
+    tenant = created["connect_url"].rsplit("/connect/", 1)[1]
+
+    assert c.post(f"/api/connections/{conn}/refresh").status_code == 200
+    fake.counted = 105
+    return c.get(f"/api/connections/{tenant}/poll").get_json()
+
+
+def test_the_poll_says_documents_are_not_readable_when_some_arrived(
+        cfg, svc, monkeypatch):
+    """MUTATION: drop the clause from `poll_connection` -> red.
+
+    The number is true about what the patient can reach and silent about what
+    it omits. Without this there is nothing anywhere telling them the notes
+    are not in it (#226).
+    """
+    d = _poll_after_sync(cfg, svc, monkeypatch, documents=2)
+    assert d["new_records"] == 5
+    note = d.get("uncounted_note", "")
+    assert "not yet readable" in note, d
+    assert "notes and documents" in note, d
+
+
+def test_the_poll_adds_no_clause_when_no_documents_arrived(
+        cfg, svc, monkeypatch):
+    """MUTATION: emit the clause unconditionally -> red.
+
+    A standing disclaimer would be noise, and would imply documents exist for
+    someone who has none.
+    """
+    d = _poll_after_sync(cfg, svc, monkeypatch, documents=0)
+    assert d["new_records"] == 5
+    assert "uncounted_note" not in d, d
+
+
+def test_no_count_at_all_when_the_document_probe_could_not_answer(
+        cfg, svc, monkeypatch):
+    """MUTATION: catch the probe separately and default it to 0 -> red.
+
+    A count whose "and there are notes missing from this" could not be
+    established would be published as if complete — the same silent omission
+    the clause exists to end, and #403's "unknown is never zero" applied to
+    the clause rather than the number.
+    """
+    from careagents.app import create_app
+    fake = FakeClient()
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    created = c.post("/api/connections/fasten",
+                     json={"consent": True}).get_json()
+    conn = created["id"]
+    tenant = created["connect_url"].rsplit("/connect/", 1)[1]
+    assert c.post(f"/api/connections/{conn}/refresh").status_code == 200
+
+    fake.counted = 105
+    # The readable count answers; only the document probe is down.
+    def down(_tenant):
+        raise HealthClawError("search DocumentReference failed (503)", 503)
+    fake.uncounted_record_count = down
+
+    d = c.get(f"/api/connections/{tenant}/poll").get_json()
+    assert d["status"] == "active"
+    assert "record_count" not in d and "new_records" not in d, d
+    assert "uncounted_note" not in d, d
 
 
 def test_the_poll_says_the_engine_is_unreachable_rather_than_pending(

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -2901,7 +2901,9 @@ def test_the_poll_says_documents_are_not_readable_when_some_arrived(
     assert d["new_records"] == 5
     note = d.get("uncounted_note", "")
     assert "not yet readable" in note, d
-    assert "notes and documents" in note, d
+    assert "Notes and documents" in note, d
+    # A statement, not a hedge — here we know they arrived.
+    assert "could not check" not in note, d
 
 
 def test_the_poll_adds_no_clause_when_no_documents_arrived(
@@ -2916,14 +2918,15 @@ def test_the_poll_adds_no_clause_when_no_documents_arrived(
     assert "uncounted_note" not in d, d
 
 
-def test_no_count_at_all_when_the_document_probe_could_not_answer(
+def test_the_count_is_hedged_not_hidden_when_the_document_probe_fails(
         cfg, svc, monkeypatch):
-    """MUTATION: catch the probe separately and default it to 0 -> red.
+    """MUTATION: default the failed probe to 0 -> red (the clause vanishes and
+    the count is published as though complete).
 
-    A count whose "and there are notes missing from this" could not be
-    established would be published as if complete — the same silent omission
-    the clause exists to end, and #403's "unknown is never zero" applied to
-    the clause rather than the number.
+    #403's "unknown is never zero" applies to the clause, not only the number:
+    a silent count would imply nothing was left out. But suppressing the count
+    trades one silence for another — the growth is a fact we did measure. So
+    the known part is stated and the unknown is named.
     """
     from careagents.app import create_app
     fake = FakeClient()
@@ -2945,8 +2948,15 @@ def test_no_count_at_all_when_the_document_probe_could_not_answer(
 
     d = c.get(f"/api/connections/{tenant}/poll").get_json()
     assert d["status"] == "active"
-    assert "record_count" not in d and "new_records" not in d, d
-    assert "uncounted_note" not in d, d
+    # The count we did measure is still reported ...
+    assert d["record_count"] == 105
+    assert d["new_records"] == 5
+    # ... and the sentence says what could not be established, rather than
+    # the "not yet readable" claim, which would assert documents exist.
+    note = d["uncounted_note"]
+    assert "could not check" in note, note
+    assert "notes or documents" in note, note
+    assert "not yet readable" not in note, note
 
 
 def test_the_poll_says_the_engine_is_unreachable_rather_than_pending(

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -152,7 +152,7 @@ def test_record_count_zero_must_not_be_how_an_outage_is_reported(
         stub_base, reset_mode):
     """A 503 from the engine must not read as "you have no records".
 
-    `record_count` sums six `_summary=count` searches. It used to swallow
+    `record_count` sums five `_summary=count` searches. It used to swallow
     `HealthClawError` per type and carry on, so a total outage returned 0 —
     the same value as a genuinely empty tenant.
 

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -204,6 +204,7 @@ def _call(client, name):
         "interpret_labs": lambda: client.interpret_labs("t"),
         "care_gaps": lambda: client.care_gaps("t"),
         "record_count": lambda: client.record_count("t"),
+        "uncounted_record_count": lambda: client.uncounted_record_count("t"),
         "tenant_has_records": lambda: client.tenant_has_records("t"),
         "purge_tenant": lambda: client.purge_tenant("t"),
         "action_status": lambda: client.action_status("t", "a1"),
@@ -235,6 +236,13 @@ EVERY_SEAM_METHOD = [
     "ingest_bundle", "create_agent_run", "get_agent_run", "agent_run_events",
     "claim_agent_run", "agent_worker_health", "finalize_agent_run",
     "search", "read", "interpret_labs", "care_gaps", "record_count",
+    # QA addition (review of PR #561). The document probe is a seam method the
+    # poll catches BY EXCEPTION TYPE (`careagents/app.py` catches
+    # HealthClawError and only that). Left off this list, its typed-failure
+    # promise held by construction and was exercised by nothing — the #287
+    # ensemble gap. A raw requests exception here 500s the poll, and the
+    # patient gets neither the count nor the hedge this PR added.
+    "uncounted_record_count",
     "tenant_has_records", "purge_tenant", "action_status", "start_form_action",
     "confirm_action", "fetch_review_page", "submit_review", "seed",
     "mint_token", "bind_telegram", "conformance_badge",
@@ -365,6 +373,26 @@ def test_a_wrongly_shaped_count_body_is_a_typed_failure(body, stub_base,
     _set(status=200, body=body)
     with pytest.raises(HealthClawError):
         _client(stub_base).record_count("t")
+
+
+@pytest.mark.parametrize("body", WRONG_SHAPE)
+def test_a_wrongly_shaped_uncounted_body_is_a_typed_failure(body, stub_base,
+                                                            reset_mode):
+    """QA addition (review of PR #561). The sibling of the `record_count` case
+    above, for the probe added beside it.
+
+    `uncounted_record_count` calls `.get("total")` on whatever the 200 body
+    decoded to. A bare AttributeError is not a HealthClawError, and
+    `poll_connection` catches only HealthClawError — so the poll would 500 and
+    the patient would see neither the number nor the sentence naming what
+    could not be checked. The property comes from the boundary check inside
+    `search`, one layer down; this pins that the new caller inherits it.
+
+    MUTATION: drop the `isinstance(body, dict)` arm from `_json_object` -> red.
+    """
+    _set(status=200, body=body)
+    with pytest.raises(HealthClawError):
+        _client(stub_base).uncounted_record_count("t")
 
 
 def test_worker_health_type_checks_its_200_body(stub_base, reset_mode):

--- a/tests/test_uncounted_documents.py
+++ b/tests/test_uncounted_documents.py
@@ -1,0 +1,110 @@
+"""Stop counting DocumentReferences the patient cannot open (#226).
+
+MEDENT ingest brings in DocumentReferences and `COUNTED_TYPES` counted them,
+so the patient was told "247 records synced" while the notes and discharge
+summaries dominating that count could not be opened by anything:
+
+  * `careagents/agent.py` `search_records` omits DocumentReference from its
+    resource enum entirely, so the agent cannot ask for one.
+  * Gate G2, measured against the live demo tenant on 2026-08-01, found the
+    attachments come back EMPTY anyway — `r6/redaction.py::_redact_recursive`
+    strips `data`, `url` and `title` from any object carrying a
+    `contentType`, which is every attachment.
+
+So the number counted rows nothing could read. Same shape as the retro's
+recurring defect (docs/2026-08-02-retro.md): a measure of one thing
+presented as a measure of another.
+
+Council ruling D2 (clinical) picks **option 3** from #226 — the honest
+stopgap. Documents stay OUT of the number until a tool can open them, and
+where the number is shown it says so. This changes what the number CLAIMS,
+never what is stored: ingest is untouched, the DocumentReferences are still
+there, and the day a read path exists they can be counted again.
+
+This file covers the client: the counted set and the two sums over it. The
+patient-visible half — the connection poll that carries the clause — is in
+tests/test_careagents.py, beside the other poll cases and the app fixtures
+they need.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from careagents.healthclaw import HealthClawClient, HealthClawError
+
+
+# --- the counted set ---------------------------------------------------------
+
+def test_documentreference_is_not_in_the_counted_set():
+    """MUTATION: put "DocumentReference" back in COUNTED_TYPES -> red.
+
+    Pinned by name rather than by count: a set that merely has six entries
+    again would pass a length check while re-counting the unreadable type.
+    """
+    assert "DocumentReference" not in HealthClawClient.COUNTED_TYPES, (
+        "DocumentReference is back in the synced count while nothing can "
+        "open one (#226)")
+    # The clinically meaningful types the patient CAN ask about stay counted;
+    # emptying the set would also satisfy the assertion above.
+    for readable in ("Condition", "Observation", "MedicationRequest",
+                     "AllergyIntolerance", "Immunization"):
+        assert readable in HealthClawClient.COUNTED_TYPES, readable
+
+
+class _Counts(HealthClawClient):
+    """A client whose only faked seam is the count search itself.
+
+    Everything above `search` — COUNTED_TYPES, the summing, the uncounted
+    probe — is the real code under test.
+    """
+
+    def __init__(self, totals):
+        super().__init__("http://127.0.0.1:9", "unused-secret", timeout=0.1)
+        self.totals = totals
+        self.asked = []
+
+    def search(self, tenant, resource_type, params=None):
+        self.asked.append(resource_type)
+        return {"resourceType": "Bundle", "type": "searchset",
+                "total": self.totals.get(resource_type, 0)}
+
+
+# 5 Observations + 2 DocumentReferences — the issue's own shape.
+_SYNCED = {"Observation": 5, "DocumentReference": 2}
+
+
+def test_a_bundle_of_five_observations_and_two_documents_counts_five():
+    """MUTATION: restore DocumentReference to COUNTED_TYPES -> red at 7.
+
+    7 was the old answer, and 7 is what the patient was told they had.
+    """
+    hc = _Counts(_SYNCED)
+    assert hc.record_count("t") == 5
+    assert "DocumentReference" not in hc.asked, (
+        "the counted sum still asks for DocumentReference")
+
+
+def test_the_documents_are_still_reported_separately_not_forgotten():
+    """The clause needs a source. MUTATION: return 0 unconditionally -> red.
+
+    This is what makes the difference between "not counted" and "not
+    mentioned" — the second would be a quieter version of the same
+    dishonesty.
+    """
+    assert _Counts(_SYNCED).uncounted_record_count("t") == 2
+    assert _Counts({"Observation": 5}).uncounted_record_count("t") == 0
+
+
+def test_an_outage_during_the_uncounted_probe_is_not_reported_as_zero():
+    """`record_count` raises rather than under-reporting (#403); the probe
+    beside it must not quietly answer 0, which reads as "no documents".
+
+    MUTATION: swallow the error and return 0 -> red.
+    """
+    class _Down(_Counts):
+        def search(self, tenant, resource_type, params=None):
+            raise HealthClawError("search failed (503)", 503)
+
+    with pytest.raises(HealthClawError):
+        _Down({}).uncounted_record_count("t")


### PR DESCRIPTION
## What

DocumentReferences leave the synced count, and where the count is shown it says so.

- **`careagents/healthclaw.py:459`** — `DocumentReference` moves out of `COUNTED_TYPES` into a new `UNCOUNTED_TYPES`, with `uncounted_record_count()` as the source for the sentence. It **raises** on failure on the same terms as `record_count`: a `0` there reads as "no documents arrived", which is not the same fact as "could not ask" (#403).
- **`careagents/models.py:87`** — a new `last_uncounted` baseline on `ca_connections`, added through the existing inline `_ensure_columns` pattern. Plain `ADD COLUMN ... INTEGER`, which SQLite and Postgres both accept. NULL means "no baseline recorded", which is never read as an arrival.
- **`careagents/accounts.py:359`** — `mark_synced` takes an optional `uncounted` and leaves the stored figure alone when it is None: a caller that could not measure documents must not erase the last one that did.
- **`careagents/app.py:639`** — both refresh/upload call sites baseline documents; the poll emits one of three sentences, or none.
- **`careagents/static/home.js:471`** — four outcomes, and the interim ones do not stop the poller.

**Ingest is unchanged.** The DocumentReferences are still fetched and still stored. This PR changes what the number *claims*, not what is kept — the day a read path lands, the type moves back into `COUNTED_TYPES`.

## Why

Closes the counting half of #226 (council ruling **D2**, clinical — **option 3** from the issue's own list).

MEDENT ingest brings in DocumentReferences and `COUNTED_TYPES` counted them, so the patient was told "N records synced" while the notes and discharge summaries dominating that number could not be opened by anything:

- `careagents/agent.py` `search_records` omits `DocumentReference` from its resource enum, so the agent cannot ask for one.
- Gate **G2**, measured against the live demo tenant on 2026-08-01, found the attachments come back **empty** regardless — `r6/redaction.py::_redact_recursive` strips `data`, `url` **and** `title` from any object carrying a `contentType`, which is every attachment.

So the number counted rows nothing could read — the retro's recurring shape (`docs/2026-08-02-retro.md`): a measure of one thing presented as a measure of another. G2's own stated exit was *"the tool cannot help; drop it and say so"* (`docs/2026-08-01-webinar-delivery-plan.md:51`). This is that.

### What the patient sees — the four outcomes

| after a refresh | rendered |
| --- | --- |
| readable records arrived, tenant holds documents | `5 new records added. Notes and documents are not yet readable here.` |
| readable records arrived, no documents | `5 new records added.` |
| **only documents arrived** | `No new records you can read. Notes and documents arrived, and they are not readable here yet.` |
| nothing arrived | *(nothing — the sync message is left as it was)* |
| the document probe failed | `5 new records added. We could not check whether notes or documents were left out.` |

### Two rulings this went through, and why the second one moved the scope

**Hedge, don't suppress.** An earlier revision dropped the *whole count* when the document probe raised. That trades one silence for another — the growth is a fact we did measure — so the count now stands with a sentence naming what could not be checked. Known part stated, unknown named, the posture the review relay already takes on an unestablished `confirmed`.

**The fourth outcome needed a measurement that did not exist.** `home.js` gated its entire render on `new_records > 0`, so a refresh delivering only DocumentReferences showed **nothing** — indistinguishable from a sync that did nothing, and worse than the misleading count this PR set out to remove.

Saying so honestly turned out to require a schema change. `uncounted_record_count` is a tenant **total**, so "documents arrived" could not be established from it; and a clause gated on `uncounted > 0` would have fired at the first 5s tick of *every* refresh, including every no-op, for exactly the tenants that already hold notes. Announcing an arrival from a number that cannot distinguish arrival from pre-existing would have put this PR's own defect class inside the fix for it.

So the refresh now baselines documents the way it already baselines readable records, and the arrival sentence is gated on the delta. That is a column on `ca_connections`, which is wider than this PR's original "changes what the number claims, not what is stored" scope — **authorized deliberately**, because the measurement showed the narrower scope could not produce an honest answer.

### The first refresh for an account that already holds documents

The baseline is recorded **by the refresh itself**, before re-authorization, so a delta is available from the very first refresh after this ships: an account holding four notes baselines at 4, and only notes arriving *after* that are reported. Nothing already on file is ever announced as newly arrived.

A connection whose row predates the column has `last_uncounted = NULL`. That is treated as "arrival unknown", not zero, so no arrival is claimed until a refresh records a baseline. Both are pinned (`test_documents_that_predate_the_baseline_are_not_called_new`, `test_a_connection_with_no_document_baseline_claims_no_arrival`).

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3178 passed, 13 skipped, 1 xfailed, 2 warnings in 121.85s (0:02:01)
```

In `e2e/`, against the app booted by the harness:

```
npx playwright test careagents-sync-message --project=chromium
7 passed (47.6s)
```

Green including `tests/test_ratchets.py` and `tests/test_guardrail_conformance.py`. No TypeScript touched, so the orchestrator's npm lane is unaffected by this branch.

**The branch selection is verified in a browser, not by inspection.** `e2e/tests/careagents-sync-message.spec.ts` serves a fixture page carrying only the markup `home.js` touches, loads the **real shipped file** from `/static/home.js`, and fulfils both requests the journey makes (the refresh POST and the poll GET) with `page.route`. No backend, no HealthClaw, and no re-implementation of the rule in another language. All five outcomes above run there, plus the upgrade case: a document-only message followed by a poll carrying readable records replaces it, because `clearInterval` fires only on a readable record.

Mutations run and confirmed red, then restored:

| mutation | result |
| --- | --- |
| gate the arrival clause on `uncounted > 0` instead of the delta | 3 red (`..._stays_quiet`, `..._predate_the_baseline...`, `..._no_document_baseline...`) |
| restore `if (d.new_records === 0) return;` in home.js | 2 red **in the browser suite** — the exact defect, and nothing in the Python suite catches it |
| delete the `last_uncounted` block from `_ensure_columns` | 1 red (`..._added_to_an_existing_table`) |

The "nothing arrived stays quiet" test asserts the poll **actually fired** before concluding it stayed silent — otherwise it would pass on a route that never ran.

## What was NOT run

- **No read path for documents.** Options 1 and 2 from the issue (patient-controlled attachment preservation; server-side extraction into a redacted summary) are untouched, and `search_records` still omits `DocumentReference`. This is only the honest stopgap — **#226 should stay open** for the read-path decision.
- **The Postgres lane was not run locally** — no `psql` and no Docker daemon on this machine. The migration is exercised against SQLite (a table built in the pre-#226 shape, then migrated) and the ALTER is plain `ADD COLUMN ... INTEGER`, valid on both. **CI's Postgres lane is the check that matters here**; a reviewer should confirm it went green before merging, since a column that appears only on the local lane is precisely the failure this note exists for.
- **Only the sync-message spec was run in the browser**, not the whole Playwright suite. The retro flags this gate's `webServer` boot as fragile; the other specs were left alone rather than fought with.
- **The endpoint tests use `FakeClient`**, so per the repo's standing trap they prove the call is made and the sentence is wired — *not* that the engine answers. Mitigating: the Flask route already served `_summary=count` for `DocumentReference` (it was in the counted set until this commit), so no new engine surface is introduced. The unit tests cover the sum logic against the real client.
- **Not run against a live stack.** No `flask init-db` / seeded-tenant walkthrough.
- No change to redaction, audit, tenant scoping, or any write path.
- **This does add a schema column** (`ca_connections.last_uncounted`) — see the scope note above. It is a nullable integer holding a count; no patient data, nothing about a record's content, and CareAgents' no-PHI rule is untouched.

## Sweeps, so nobody repeats them

- `grep -rn "records synced" docs/ careagents/` — **no hits.** No doc or template quotes the wording; the issue's "247 records synced" is the author's paraphrase of the UI, which actually says "N new records added."
- `grep -rn "last_count\|record_count" careagents/` — the only patient-visible surface fed by `record_count` is this poll. `last_count` is a refresh baseline and never reaches a template.
- `grep -rn "def record_count" careagents/ scripts/ tests/` — only `HealthClawClient` and the test `FakeClient` implement it, so no third client can reach the poll's new call without the method. `mark_synced`'s new argument is optional, so no caller breaks.
- The greeting totals (`careagents/app.py:~720`, conditions / medications / labs) never included `DocumentReference` and are unchanged.
- `docs/2026-08-01-webinar-delivery-plan.md` mentions `DocumentReference` at lines 34 and 51; neither claims documents are in the synced count, so nothing there went stale.

## Cost

One extra `_summary=count` request per poll tick after a refresh (every 5s, capped at 60 ticks by `watchForNewRecords`), plus one more at each refresh to record the baseline. Negligible, but they are real added calls.

Also: a document-only or probe-failed message no longer ends the watch, so those polls now run to the 60-tick ceiling instead of stopping early. That is the point — the message upgrades when readable records land — but it is more polls than before on those paths.
