### PR TITLE
candidate: $care-gaps stops evaluating a patient it never resolved; every eligible screening gets a patient line; BP cadence by age band (#542, #436)

### DIFF
--- a/docs/clinical/care-gap-rule-register.md
+++ b/docs/clinical/care-gap-rule-register.md
@@ -1,0 +1,280 @@
+# Care-gap rule register
+
+**For clinical review and initialling.** One page per what the preventive-care
+check actually does, so a reviewing clinician can say which rules are released
+to patients and which are not.
+
+Every value below is transcribed from `r6/caregaps/evaluate.py` —
+`CARE_GAP_RULES` and the evaluator around it — and not from anyone's
+recollection of a guideline. Where the code does not encode something a
+reviewer would want, the entry says **not encoded** rather than filling it in.
+That is deliberate: an unencoded value written here would become the thing the
+next reader trusts.
+
+Generated against the rule table as of this document's commit. If the rules
+move, this page is stale and the tests that pin the cadences
+(`tests/test_caregaps_evaluate.py`) are the source of truth.
+
+---
+
+## How to read this
+
+- **Population** — who the rule fires for. Age is in years at the date of the
+  check; sex is the FHIR `Patient.gender` value.
+- **Cadence** — the interval after which a previous record no longer counts.
+  A record older than this is treated as absent.
+- **What closes the gap** — the FHIR resource type and the exact code values
+  read. **No code system is checked**: a code matches on its value alone,
+  wherever it came from.
+- **What is NOT read** — evidence that satisfies this screening in practice and
+  that this check cannot see. This is the column that decides whether "due" is
+  a safe thing to tell someone.
+- **Status** — `released` (patients see a verdict), or
+  `indeterminate by design` (the rule deliberately declines to decide).
+
+Section [Applies to every rule](#applies-to-every-rule) carries the limits that
+are properties of the evaluator rather than of any one rule. **Read it before
+initialling any individual rule** — several of them change what a "due" or an
+"up to date" means.
+
+---
+
+## 1. `bp-screening` — Blood pressure check
+
+| Field | As encoded |
+| --- | --- |
+| Population | Any sex, ages 18–120 |
+| Cadence | **18–39: every 36 months. 40 and over: every 12 months.** |
+| Source | `uspstf` — "U.S. Preventive Services Task Force recommendations (adult, general population)." Guideline year: **not encoded** |
+| What closes the gap | `Observation` with code `8480-6`, `85354-9` or `55284-4` |
+| What is NOT read | The reading's own value. A recorded blood pressure closes the gap whether it was normal or not — so an under-40 patient on the 36-month band is placed there by age alone, not by having had normal readings |
+| Related eCQM | CMS22 (related, not implemented) |
+| Status | released |
+
+**Changed by council ruling D14 (2026-09-02).** This rule read every 12 months
+from age 18, which told an under-40 patient with a normal reading two years ago
+that they were due. The age band is encoded inside this one rule
+(`cadence_bands`) rather than as a second rule, so rule ids and the rule count
+are unchanged for every consumer.
+
+**For the reviewer:** the 36-month figure is the conservative end of a 3–5 year
+interval, and the guideline conditions that interval on the previous readings
+being normal — which, per the row above, this rule does not check.
+
+---
+
+## 2. `lipid-screening` — Cholesterol (lipid) screening
+
+| Field | As encoded |
+| --- | --- |
+| Population | Any sex, ages 40–75 |
+| Cadence | Every 60 months |
+| Source | `uspstf`. Guideline year: **not encoded** |
+| What closes the gap | `Observation` with code `2093-3`, `13457-7`, `2571-8` or `18262-6` |
+| What is NOT read | Risk factors of any kind. The interval is a flat 5 years for everyone in the age band |
+| Related eCQM | none — no clean mapping, recorded as `None` rather than guessed |
+| Status | released |
+
+---
+
+## 3. `diabetes-a1c` — Diabetes A1c monitoring
+
+| Field | As encoded |
+| --- | --- |
+| Population | Any sex, ages 18–120, **and** a diabetes diagnosis in the connected records |
+| Cadence | Every 6 months |
+| Source | `ada` — "American Diabetes Association Standards of Care." Guideline year: **not encoded** |
+| What closes the gap | `Observation` with code `4548-4` or `17856-6` |
+| What is NOT read | The A1c result itself — any recorded A1c closes the gap regardless of value, so the rule reports *monitoring*, never control. `Condition.clinicalStatus` is also ignored: a resolved or refuted diabetes Condition still puts a patient in the population |
+| Related eCQM | CMS122 (related, not implemented) |
+| Status | released — **and the one rule flagged as unreviewed** |
+
+**Diagnosis detection** reads `Condition` codes and matches:
+
+- ICD-10 / ICD-9 by prefix: `E10`, `E11`, `E13`, `250`
+- SNOMED exactly (never by prefix): `73211009`, `44054006`, `46635009`,
+  `190330002`, `422034002`
+
+**When no diagnosis is found**, the rule reports `not_applicable` with the note
+*"no diabetes diagnosis found in your connected records"*. Changed by council
+ruling D14 from *"applies to patients with a diabetes diagnosis"*, which read,
+beside a screening that had been set aside, as a finding that the person does
+not have diabetes. The gate established no such thing — it saw the Conditions
+that were shared.
+
+**For the reviewer:** PRD 5 records this rule as patient-visible with no
+clinician having passed on its 6-month cadence (#389). It is the rule this
+register most needs an initial against.
+
+---
+
+## 4. `colorectal-screening` — Colorectal cancer screening
+
+| Field | As encoded |
+| --- | --- |
+| Population | Any sex, ages 45–75 |
+| Cadence | Every 120 months (colonoscopy interval, taken as a conservative upper bound) |
+| Source | `uspstf`. Guideline year: **not encoded** |
+| What closes the gap | `Procedure` with code `45378`, `45380`, `45385`, `44388` or `45330` |
+| What is NOT read | **stool-based tests (FIT or Cologuard)** — accepted by USPSTF on their own schedules, and arriving as lab `Observation`s rather than `Procedure`s. This rule reads neither |
+| Related eCQM | CMS130 (related, not implemented) |
+| Status | **indeterminate by design** |
+
+Because a whole class of qualifying evidence is invisible to it, this rule never
+reports "due". A patient screening exactly as advised with annual FIT would
+have matched nothing and been told they were overdue. Instead it reports
+`indeterminate` and says what was not read, and the patient still gets a line
+telling them to raise it with their clinician (#425, #428, #436).
+
+---
+
+## 5. `cervical-screening` — Cervical cancer screening (Pap)
+
+| Field | As encoded |
+| --- | --- |
+| Population | **Female**, ages 21–65 |
+| Cadence | Every 36 months |
+| Source | `uspstf`. Guideline year: **not encoded** |
+| What closes the gap | `Procedure` with code `88175`, `88164` or `88142` |
+| What is NOT read | Which test was done. The 36-month interval is applied to any match, so cytology and co-testing are not distinguished, and hysterectomy history is not read at all |
+| Related eCQM | CMS124 (related, not implemented) |
+| Status | released |
+
+---
+
+## 6. `mammography` — Breast cancer screening (mammogram)
+
+| Field | As encoded |
+| --- | --- |
+| Population | **Female**, ages 40–74 |
+| Cadence | Every 24 months |
+| Source | `uspstf`. Guideline year: **not encoded** |
+| What closes the gap | `Procedure` with code `77067`, `77066` or `77065` |
+| What is NOT read | Personal or family history, prior abnormal results, or breast density — none of which the rule reads, so the interval does not shorten for anyone |
+| Related eCQM | CMS125 (related, not implemented) |
+| Status | released |
+
+---
+
+## 7. `flu-immunization` — Influenza (flu) vaccine
+
+| Field | As encoded |
+| --- | --- |
+| Population | Any sex, ages 18–120 |
+| Cadence | Every 12 months |
+| Source | `acip` — "CDC/ACIP adult immunization schedule." Schedule year: **not encoded** |
+| What closes the gap | `Immunization` with code `88`, `140`, `141`, `150`, `158`, `161` or `171` |
+| What is NOT read | The influenza season. The window is 12 rolling months from the last dose, not a season boundary, so someone vaccinated in one season reads as covered part-way into the next |
+| Related eCQM | CMS147 (related, not implemented) |
+| Status | released |
+
+---
+
+## Applies to every rule
+
+These are properties of the evaluator, not of any one rule, and each changes
+what a verdict above means.
+
+**Code matching**
+
+- A code matches on its **value alone** — `code.coding[].code`. The code system
+  is never compared, so an identical numeric code from a different system would
+  match. Encoded as such; there is no allowlist of systems.
+
+**Dates**
+
+- A record's date is read from the first of `effectiveDateTime`,
+  `performedDateTime`, `occurrenceDateTime`, `authoredOn`. A record carrying
+  none of these has **no date and cannot close a gap**.
+- **Future-dated records never close a gap**, so bad source data cannot produce
+  a false "up to date".
+- A matching record **older than the cadence** is treated exactly as if it were
+  absent.
+- A partial `birthDate` is padded to the earliest day — `YYYY` becomes 1 January,
+  `YYYY-MM` becomes the 1st. HealthClaw's own redaction truncates birth dates to
+  the year, so this is the ordinary case, and it carries **up to a year of age
+  error** at band boundaries.
+
+**Resource status**
+
+- The `status` of a closing record is **never checked**. A `Procedure`,
+  `Observation` or `Immunization` marked `entered-in-error` closes the gap. This
+  applies to all seven rules.
+- Soft-deleted records are excluded (#422).
+
+**When something is unknown**
+
+- Unknown age on an age-gated rule → `indeterminate`, never a false "due".
+  **`diabetes-a1c` is the exception**: its diagnosis gate runs *before* the age
+  gate, so with no date of birth on file it reports `not_applicable` — "no
+  diabetes diagnosis found in your connected records" — rather than declining
+  to decide. The sentence is true of the records that were read, but the rule
+  reaches it without ever establishing the person's age.
+- A rule with a sex requirement and no sex on file → `indeterminate`.
+- A patient the operation could not resolve at all → **no rules are evaluated**,
+  the result set is empty, and the audit records `evaluated=0` (#542). Nothing
+  in this register is asserted about someone who was never identified.
+
+**What the patient is told**
+
+- "Due" means **no satisfying record was found in the connected data**. It is
+  not a claim the screening was not done elsewhere, and the consumer wording
+  says so.
+- Every screening the patient is eligible for gets a patient-facing line,
+  including one that could not be decided — labelled *"could not check"* rather
+  than folded in with the due items (#436).
+- Cadences are **population-level adult defaults**. Individual risk — family
+  history, prior abnormal results, pregnancy — legitimately changes them, and
+  nothing in this engine reads any of it.
+
+**What this is not**
+
+- Not the Da Vinci DEQM `$care-gaps` operation, and not a certified eCQM. The
+  per-rule `related_ecqm` ids are for reconciling against a certified measure
+  engine and are **not** a claim that this rule implements that measure's logic.
+
+---
+
+## Known gaps in this register
+
+1. **No guideline year is encoded for any rule.** `REFERENCES` names the
+   organisation and nothing more. A reviewer cannot tell which revision of a
+   recommendation a cadence came from without reading the commit that set it.
+2. **`diabetes-a1c` is patient-visible and has never been clinically
+   reviewed** (#389, PRD 5 §3).
+3. **Resource `status` is ignored on every closing record**, so an
+   `entered-in-error` result can report a patient as up to date.
+4. **`diabetes-a1c` decides before it knows the patient's age.** The diagnosis
+   gate precedes the age gate, so an unknown date of birth yields
+   `not_applicable` rather than `indeterminate`. `Patient/$care-gaps` no longer
+   reaches this — since #542 it evaluates no rules at all for a subject it
+   could not resolve — but the appointment brief calls the evaluator directly
+   with no patient, and lands here every time.
+
+---
+
+## Sign-off
+
+Signing this page means: *these rules, these populations, these cadences, and
+these disclosed limits are what I am willing to have shown to a patient.*
+
+A rule marked `indeterminate by design` is asserting nothing about the patient
+and is released on that basis.
+
+**Reviewing clinician**
+
+- Name: ______________________________
+- Role / credential: ______________________________
+- Date: ______________________________
+- Rules released as written: ______________________________
+- Rules held back, and why: ______________________________
+- Signature: ______________________________
+
+**Engineer**
+
+- Name: ______________________________
+- Date: ______________________________
+- Confirms the values on this page were transcribed from
+  `r6/caregaps/evaluate.py` and are pinned by
+  `tests/test_caregaps_evaluate.py`: ______________________________
+- Signature: ______________________________

--- a/docs/clinical/care-gap-rule-register.md
+++ b/docs/clinical/care-gap-rule-register.md
@@ -11,9 +11,10 @@ reviewer would want, the entry says **not encoded** rather than filling it in.
 That is deliberate: an unencoded value written here would become the thing the
 next reader trusts.
 
-Generated against the rule table as of this document's commit. If the rules
-move, this page is stale and the tests that pin the cadences
-(`tests/test_caregaps_evaluate.py`) are the source of truth.
+Generated against the rule table as of this document's commit. The code is the
+source of truth: `tests/test_caregaps_evaluate.py` pins the cadences and bands,
+and `tests/test_care_gap_register_drift.py` fails if this page stops matching
+them.
 
 ---
 
@@ -190,10 +191,12 @@ what a verdict above means.
   a false "up to date".
 - A matching record **older than the cadence** is treated exactly as if it were
   absent.
-- A partial `birthDate` is padded to the earliest day — `YYYY` becomes 1 January,
-  `YYYY-MM` becomes the 1st. HealthClaw's own redaction truncates birth dates to
-  the year, so this is the ordinary case, and it carries **up to a year of age
-  error** at band boundaries.
+- A partial `birthDate` is padded to the earliest day: `YYYY` becomes 1 January,
+  `YYYY-MM` becomes the 1st, which carries **up to a year of age error** at band
+  boundaries. How often that happens depends on the source, not on us: this
+  check reads the stored Patient directly (`r6/caregaps/routes.py:106-109`), so
+  the redaction that truncates birth dates elsewhere does not apply here. A
+  partial date reaches this rule only if the record arrived that way.
 
 **Resource status**
 
@@ -275,6 +278,8 @@ and is released on that basis.
 - Name: ______________________________
 - Date: ______________________________
 - Confirms the values on this page were transcribed from
-  `r6/caregaps/evaluate.py` and are pinned by
-  `tests/test_caregaps_evaluate.py`: ______________________________
+  `r6/caregaps/evaluate.py`, that the cadences and bands are pinned by
+  `tests/test_caregaps_evaluate.py`, and that this page is held to those
+  values by `tests/test_care_gap_register_drift.py`:
+  ______________________________
 - Signature: ______________________________

--- a/r6/caregaps/evaluate.py
+++ b/r6/caregaps/evaluate.py
@@ -42,7 +42,20 @@ CARE_GAP_RULES = [
     {
         "id": "bp-screening", "title": "Blood pressure check",
         "applies": {"sex": None, "min_age": 18, "max_age": 120},
+        # The 40+ cadence, and the fallback for any age no band claims.
         "cadence_months": 12,
+        # USPSTF screens adults 18-39 with normal readings every 3-5 years and
+        # 40+ annually. One yearly figure from 18 told an under-40 patient
+        # with a normal reading two years ago that they were due — a gap the
+        # guideline does not describe. 36 months is the conservative end of
+        # the 3-5 year range.
+        #
+        # The band lives inside this rule rather than in a second rule
+        # because `summary.total` and the rule ids are read by the MCP App
+        # page, the brief and the eCQM crosswalk; a cadence correction should
+        # not move any of them.
+        "cadence_bands": [{"min_age": 18, "max_age": 39,
+                           "cadence_months": 36}],
         "satisfied_by": {"resource": "Observation",
                          "codes": {"8480-6", "85354-9", "55284-4"}},
         "source": "uspstf",
@@ -202,6 +215,21 @@ def _most_recent(resources, wanted_codes, as_of_date, cadence_months):
     return None  # found, but stale — treat as due (returns None = not satisfied)
 
 
+def _cadence_for(rule, age):
+    """Months between screenings for a patient of `age` under this rule.
+
+    A cadence may depend on age (USPSTF blood pressure: every 3-5 years at
+    18-39, annually at 40+). Only callable once the age gate has passed, since
+    without an age there is no band to pick — the rows that never get that far
+    report the rule's own `cadence_months`, which is also the fallback for any
+    age no band claims.
+    """
+    for band in rule.get("cadence_bands") or ():
+        if band["min_age"] <= age <= band["max_age"]:
+            return band["cadence_months"]
+    return rule["cadence_months"]
+
+
 def _cadence_desc(months):
     if months % 12 == 0:
         yrs = months // 12
@@ -238,11 +266,19 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
                             "status": "not_applicable",
                             "note": f"applies to {applies['sex']} patients"})
             continue
-        # Condition gate (e.g. A1c only for known diabetes)
+        # Condition gate (e.g. A1c only for known diabetes).
+        #
+        # The note is a claim about the DATA, not about the person. "Applies
+        # to patients with a diabetes diagnosis" reads, next to a screening
+        # that has been set aside, as a finding that this person does not have
+        # diabetes — which this gate never established. All it saw was the
+        # Conditions in the connected records, and those are routinely
+        # incomplete.
         if applies.get("requires_condition") and not diabetic:
             results.append({**base, "applicable": False,
                             "status": "not_applicable",
-                            "note": "applies to patients with a diabetes diagnosis"})
+                            "note": ("no diabetes diagnosis found in your "
+                                     "connected records")})
             continue
         # Age gate — unknown age on an age-gated rule is indeterminate, never a false due
         if age is None:
@@ -260,10 +296,19 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
                             "note": "sex not recorded — cannot determine eligibility"})
             continue
 
-        # Applicable — is there a satisfying record in the connected data?
+        # Applicable, and now old enough to have a cadence chosen for them.
+        # Resolved here rather than with `base` above because it needs an age:
+        # the not-applicable and indeterminate rows built before this point
+        # report the rule's default, which is the most that can be said when
+        # no age picked a band.
+        cadence_months = _cadence_for(rule, age)
+        cadence = _cadence_desc(cadence_months)
+        base = {**base, "cadence": cadence}
+
+        # Is there a satisfying record in the connected data?
         last = _most_recent(by_resource[rule["satisfied_by"]["resource"]],
                             rule["satisfied_by"]["codes"], as_of_date,
-                            rule["cadence_months"])
+                            cadence_months)
         if last is not None:
             results.append({**base, "applicable": True, "status": "up_to_date",
                             "last_done": last.isoformat(),

--- a/r6/caregaps/report.py
+++ b/r6/caregaps/report.py
@@ -83,6 +83,29 @@ def _consumer_line(r):
         return {"rule_id": r.get("rule_id"), "title": title, "status": status,
                 "message": (f"Your {title.lower()} looks up to date "
                             f"(last on {r.get('last_done')}).")}
+    # An undecided screening the person is ELIGIBLE for (#436). #428 made
+    # colorectal screening indeterminate rather than let it claim a gap it had
+    # not checked for, and its PR said the prompt to act survived the status
+    # change. It did not: lines were built for `due` and `up_to_date` only, so
+    # the note written for the patient reached the clinician-facing `detail`
+    # and stopped there. The person saw the screening named in
+    # `unevaluated_note` and nothing about what to do.
+    #
+    # `applicable is True` and not merely `indeterminate`: a rule that could
+    # not decide whether it applies AT ALL (sex or date of birth missing) has
+    # nothing to tell this person yet, and a line for it would put a screening
+    # in front of someone who may not need one. Those stay named in the marker,
+    # which claims no eligibility. The two causes are kept apart here for the
+    # same reason `_coverage_marker` keeps them apart below.
+    if status == "indeterminate" and r.get("applicable") is True:
+        return {"rule_id": r.get("rule_id"), "title": title, "status": status,
+                # The engine's own status travels, so `lines`, `detail` and
+                # `summary` never disagree about one screening. The label is
+                # the word for it a patient can read: the MCP App page renders
+                # a status by swapping underscores for spaces, which gives
+                # "due" and "up to date" and would give "indeterminate".
+                "status_label": "could not check",
+                "message": f"We could not check {title.lower()} ({cadence}). {note}"}
     return None
 
 
@@ -187,12 +210,15 @@ def build_consumer_summary(results, not_evaluated=None):
     hand over. The caller knows all three and the engine can see none of them,
     since an unidentifiable patient produces exactly the rule results a
     healthy one does."""
+    # Which statuses earn a line is `_consumer_line`'s decision alone. The
+    # status check used to be made here as well, so the rule lived in two
+    # places and the copies had to be changed together — the generator behind
+    # #387/#435 (docs/2026-08-06-two-generators-three-laws.md, Law 2).
     lines = []
     for r in results:
-        if r.get("status") in ("due", "up_to_date"):
-            line = _consumer_line(r)
-            if line:
-                lines.append(line)
+        line = _consumer_line(r)
+        if line:
+            lines.append(line)
     out = {"lines": lines, "note": _CONSUMER_NOTE}
     marker = _unevaluated_marker(results, not_evaluated)
     if marker:

--- a/r6/caregaps/routes.py
+++ b/r6/caregaps/routes.py
@@ -176,13 +176,37 @@ def register_caregaps_routes(blueprint, deps):
             return _resources_for(resource_type, subject, tenant_id) if subject else []
 
         as_of = date.today().isoformat()
-        results = evaluate_care_gaps(
-            patient, conditions=_for("Condition"),
-            observations=_for("Observation"),
-            immunizations=_for("Immunization"), procedures=_for("Procedure"),
-            as_of=as_of)
+        # A subject we could not resolve is not evaluated, full stop (#542).
+        # The route used to set `not_evaluated` and then run the rules anyway,
+        # against `patient=None`, which produced two false statements about a
+        # person nobody had identified:
+        #
+        #   - The condition gate in evaluate.py fires BEFORE the age gate, so
+        #     a rule with an empty condition list fell through to
+        #     `not_applicable` rather than `indeterminate`. A1c is the one
+        #     that showed it: `not_applicable: 1` for an unresolved subject.
+        #   - The audit detail counted those seven rules as `evaluated=7`.
+        #
+        # The consumer summary suppressed the rows (#389, #417), so the page
+        # looked right while the payload and the audit did not — which is the
+        # retro's shape exactly: a check that examined nothing printing the
+        # verdict of a check that examined everything
+        # (docs/2026-08-02-retro.md). Every other caller of this operation —
+        # the MCP tool, the Telegram summary, curl — read the rows.
+        if not_evaluated is not None:
+            results = []
+        else:
+            results = evaluate_care_gaps(
+                patient, conditions=_for("Condition"),
+                observations=_for("Observation"),
+                immunizations=_for("Immunization"),
+                procedures=_for("Procedure"), as_of=as_of)
 
         summary = build_caregaps_summary(results)
+        # An explicit flag a client can branch on without knowing the reason
+        # family. The MCP App page matches the reason list today (#538/#541)
+        # and can switch to this; both ship for one release (#542).
+        summary["evaluated"] = not_evaluated is None
         consumer = build_consumer_summary(results, not_evaluated=not_evaluated)
 
         record_audit_event(

--- a/tests/test_care_gap_register_drift.py
+++ b/tests/test_care_gap_register_drift.py
@@ -1,0 +1,197 @@
+"""The rule register must say what the rules say.
+
+`docs/clinical/care-gap-rule-register.md` is a sign-off document: a clinician
+initials it to say these populations and these cadences are what they are
+willing to have shown to a patient. A cadence that changes in code and not on
+that page turns the signature into cover for something nobody agreed to.
+
+This is the #295 shape aimed at a clinical artifact — documentation describing
+behaviour the system does not have — and the 08-02 retro's finding that
+"documentation is part of the product surface and it is the only part with no
+CI". Two guards exist for endpoint and tool-catalogue drift; this is the third.
+
+Deliberately NOT a full-text comparison. It pins the values a reviewer signs
+against — rule ids, age bands, cadence months, the codes that close each gap —
+and leaves the prose free to be edited.
+
+EVERY assertion is scoped to the rule's OWN section. The first version of this
+file searched the whole document, which made it a check that a number appeared
+*somewhere*: moving cervical screening from 36 to 60 months left it green,
+because lipid screening is 60 months and the register said so. That is
+docs/2026-08-02-retro.md's pattern reproduced inside the guard written against
+it — caught by mutating the rule table and watching nothing happen.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from r6.caregaps.evaluate import CARE_GAP_RULES
+
+REGISTER = (pathlib.Path(__file__).resolve().parent.parent
+            / "docs" / "clinical" / "care-gap-rule-register.md")
+
+#: `## 4. `colorectal-screening` — Colorectal cancer screening`
+_HEADING = re.compile(r"^## \d+\. `([a-z0-9-]+)` — (.+)$", re.MULTILINE)
+
+
+def _text():
+    return REGISTER.read_text(encoding="utf-8")
+
+
+def _sections():
+    """{rule_id: (title, the text of that rule's section)}.
+
+    A section runs to the next rule heading, so a value asserted below has to
+    appear against the rule it belongs to and not in a neighbour's row.
+    """
+    body = _text()
+    marks = list(_HEADING.finditer(body))
+    out = {}
+    for i, m in enumerate(marks):
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(body)
+        out[m.group(1)] = (m.group(2), body[m.start():end])
+    return out
+
+
+def test_the_register_exists_and_is_not_a_stub():
+    """Guard the guard: an empty file passes every `in` assertion below."""
+    assert REGISTER.exists(), f"{REGISTER} is missing"
+    body = _text()
+    assert len(body) > 2000, "the register collapsed to a stub"
+    assert "Sign-off" in body
+
+
+def test_the_sections_parse_and_cover_every_rule_exactly_once():
+    """The other guard on the guard. If `_sections` stops matching — someone
+    renumbers the headings, say — every per-rule test below would silently
+    assert against nothing.
+    """
+    sections = _sections()
+    assert set(sections) == {rule["id"] for rule in CARE_GAP_RULES}, (
+        f"register documents {set(sections)}; "
+        f"code has {{r['id'] for r in CARE_GAP_RULES}}")
+    for rule in CARE_GAP_RULES:
+        title, section = sections[rule["id"]]
+        assert title == rule["title"], (
+            f"{rule['id']}: register calls it {title!r}, code calls it "
+            f"{rule['title']!r}")
+        assert len(section) > 200, f"{rule['id']}: section is empty"
+
+
+def test_every_age_band_is_stated_as_the_code_has_it():
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        applies = rule["applies"]
+        span = f"{applies['min_age']}–{applies['max_age']}"
+        assert span in sections[rule["id"]][1], (
+            f"{rule['id']}: age range {span} not in its own section")
+
+
+def test_every_cadence_is_stated_in_the_months_the_code_uses():
+    """Months, not the prose form: "yearly" is shared across rules, and the
+    number has to sit in the section it describes.
+
+    MUTATION: change any rule's `cadence_months` -> red for that rule.
+    """
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        section = sections[rule["id"]][1]
+        months = rule["cadence_months"]
+        assert re.search(rf"\b{months} months\b", section), (
+            f"{rule['id']}: cadence of {months} months is not stated in its "
+            "own section")
+        for band in rule.get("cadence_bands") or ():
+            assert re.search(rf"\b{band['cadence_months']} months\b", section), (
+                f"{rule['id']}: age band cadence of "
+                f"{band['cadence_months']} months is not stated")
+            assert f"{band['min_age']}–{band['max_age']}" in section, (
+                f"{rule['id']}: age band "
+                f"{band['min_age']}-{band['max_age']} is not stated")
+
+
+def test_no_cadence_is_claimed_that_the_rule_does_not_have():
+    """The reverse: a stale month figure left behind after a cadence moved.
+
+    Without this, correcting a cadence and ADDING the new number while leaving
+    the old sentence in place reads as two cadences and passes the test above.
+    """
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        section = sections[rule["id"]][1]
+        allowed = {rule["cadence_months"]}
+        allowed |= {b["cadence_months"] for b in rule.get("cadence_bands") or ()}
+        claimed = {int(n) for n in re.findall(r"\b(\d+) months\b", section)}
+        assert claimed <= allowed, (
+            f"{rule['id']}: register states {sorted(claimed - allowed)} "
+            f"months, which the rule does not use (it uses {sorted(allowed)})")
+
+
+def test_every_code_that_closes_a_gap_is_listed_against_its_own_rule():
+    """The column a reviewer checks hardest: what actually counts as done.
+
+    MUTATION: add a code to any rule's `satisfied_by` -> red for that rule.
+    """
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        section = sections[rule["id"]][1]
+        satisfied = rule["satisfied_by"]
+        assert satisfied["resource"] in section, rule["id"]
+        for code in satisfied["codes"]:
+            assert f"`{code}`" in section, (
+                f"{rule['id']}: code {code} closes this gap and its section "
+                "does not list it")
+
+
+def test_no_code_is_listed_that_does_not_close_that_gap():
+    """A code removed from a rule but left on the page tells a clinician a
+    test counts when it no longer does."""
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        section = sections[rule["id"]][1]
+        # Backticked tokens that look like a code value: LOINC (1234-5), CPT
+        # and CVX (digits). Excludes prose and field names.
+        listed = {t for t in re.findall(r"`([0-9]+-?[0-9]*)`", section)}
+        extra = listed - set(rule["satisfied_by"]["codes"])
+        # The A1c section also lists the diagnosis codes that select the
+        # population, which are not codes that CLOSE the gap.
+        if rule["id"] == "diabetes-a1c":
+            from r6.caregaps.evaluate import (_DIABETES_PREFIXES,
+                                              _DIABETES_SNOMED)
+            extra -= set(_DIABETES_SNOMED) | set(_DIABETES_PREFIXES)
+        assert not extra, (
+            f"{rule['id']}: register lists {sorted(extra)} as closing this "
+            "gap; the rule does not match them")
+
+
+def test_a_rule_that_declines_to_decide_says_so_where_it_is_documented():
+    """`unread_evidence` is the whole reason a rule reports indeterminate
+    rather than due. It must reach the page a clinician signs, verbatim."""
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        evidence = rule.get("unread_evidence")
+        if evidence:
+            assert evidence in sections[rule["id"]][1], (
+                f"{rule['id']} declines to decide because it cannot read "
+                f"'{evidence}', and its section does not say so")
+
+
+def test_the_register_carries_no_guideline_year_it_cannot_source():
+    """`REFERENCES` encodes no years, so every Source row says "not encoded".
+
+    A four-digit year beside a source would be recalled rather than read, and
+    is exactly the value a clinician would trust hardest. If a year is ever
+    encoded in the rule table, this test is what tells you to update the page.
+
+    MUTATION: write "USPSTF 2021" into a source row -> red.
+    """
+    sections = _sections()
+    for rule in CARE_GAP_RULES:
+        rows = [ln for ln in sections[rule["id"]][1].splitlines()
+                if ln.startswith("| Source ")]
+        assert len(rows) == 1, f"{rule['id']}: expected one Source row"
+        assert "not encoded" in rows[0], rows[0]
+        assert not re.search(r"\b(19|20)\d{2}\b", rows[0]), (
+            f"{rule['id']}: a guideline year appears in a source row that no "
+            f"code encodes: {rows[0]}")

--- a/tests/test_care_gap_register_drift.py
+++ b/tests/test_care_gap_register_drift.py
@@ -111,6 +111,47 @@ def test_every_cadence_is_stated_in_the_months_the_code_uses():
                 f"{band['min_age']}-{band['max_age']} is not stated")
 
 
+def test_every_age_band_is_stated_against_the_cadence_it_actually_carries():
+    """A banded rule states TWO cadences, and which one goes with which age is
+    the whole of the change. The test above asserts both numbers and both age
+    spans appear in the section; it never asserts they appear *together*.
+
+    So the register could read "18–39: every 12 months. 40 and over: every 36
+    months" — the pairing inverted, every individual value still correct — and
+    the guard stayed green. That is precisely this file's own docstring
+    warning ("a check that a number appeared *somewhere*") surviving one level
+    down, and docs/2026-08-02-retro.md's pattern reproduced inside the guard
+    written against it. The clinician does not initial a set of numbers; they
+    initial the pairing.
+
+    The window `[^.|\\n]*` cannot cross a sentence, a table-cell boundary or a
+    line, so the band's cadence has to sit in the same clause as the band's
+    ages. Either order, because the register is free to write "every 36 months
+    for ages 18–39".
+
+    MUTATION (verified 2026-09-03): swap the two cadences in the bp-screening
+    Cadence row -> red here, green everywhere else in this file.
+    """
+    sections = _sections()
+    banded = [r for r in CARE_GAP_RULES if r.get("cadence_bands")]
+    assert banded, (
+        "no rule carries cadence_bands — this test would assert nothing; "
+        "delete it, or the band it was written for has been lost")
+    for rule in banded:
+        section = sections[rule["id"]][1]
+        for band in rule["cadence_bands"]:
+            span = f"{band['min_age']}–{band['max_age']}"
+            cadence = rf"\b{band['cadence_months']} months\b"
+            together = (rf"{re.escape(span)}[^.|\n]*{cadence}"
+                        rf"|{cadence}[^.|\n]*{re.escape(span)}")
+            assert re.search(together, section), (
+                f"{rule['id']}: the register states ages {span} and "
+                f"{band['cadence_months']} months somewhere in the section, "
+                "but never in the same clause — a reader cannot tell which "
+                "cadence belongs to which age, and an inverted pairing reads "
+                "as correct")
+
+
 def test_no_cadence_is_claimed_that_the_rule_does_not_have():
     """The reverse: a stale month figure left behind after a cadence moved.
 

--- a/tests/test_caregaps_evaluate.py
+++ b/tests/test_caregaps_evaluate.py
@@ -209,3 +209,121 @@ def test_future_dated_record_does_not_satisfy_a_gap():
         _patient(), observations=[_obs("8480-6", "2026-09-15")],
         as_of="2026-07-01")}
     assert res["bp-screening"]["status"] == "due"
+
+
+# ─────────────────────────────────────────────
+# Blood pressure: one cadence for two populations (council D14)
+#
+# The rule read `cadence_months: 12` from age 18, so someone under 40 with a
+# normal reading eighteen months ago was told they were due. USPSTF screens
+# adults 18-39 with normal blood pressure every 3-5 years and 40+ annually,
+# so the single yearly figure asserted a gap the guideline does not describe.
+#
+# Encoded as an age band inside the ONE `bp-screening` rule rather than as two
+# rules: rule ids and `summary.total` are read by the MCP App page, the brief
+# and the eCQM crosswalk, and splitting the rule would have moved all three to
+# fix a cadence.
+# ─────────────────────────────────────────────
+
+_AS_OF = "2026-07-01"
+
+
+def _months_before(as_of, months):
+    """A first-of-month date exactly `months` before `as_of`.
+
+    Written out rather than hardcoded: `_months_between` counts whole months,
+    so an off-by-one here would silently move a case to the other side of a
+    cadence boundary and the test would still pass, for the wrong reason.
+    """
+    total = int(as_of[:4]) * 12 + int(as_of[5:7]) - 1 - months
+    return f"{total // 12}-{total % 12 + 1:02d}-01"
+
+
+def _bp_result(age, months_ago):
+    """bp-screening for a patient of `age` whose last reading was that old."""
+    res = {r["rule_id"]: r for r in evaluate_care_gaps(
+        _patient(birth=f"{int(_AS_OF[:4]) - age}-01-01"),
+        observations=[_obs("8480-6", _months_before(_AS_OF, months_ago))],
+        as_of=_AS_OF)}
+    return res["bp-screening"]
+
+
+def test_the_reading_age_helper_lands_where_it_says_it_does():
+    """Guard the guard. Every case below is a claim about a number of months,
+    and all three would pass against a rule with no bands at all if this
+    arithmetic were wrong in the generous direction."""
+    assert _months_before(_AS_OF, 18) == "2025-01-01"
+    assert _months_before(_AS_OF, 40) == "2023-03-01"
+    assert _months_before(_AS_OF, 0) == _AS_OF
+
+
+def test_a_reading_18_months_old_still_covers_someone_under_40():
+    """The defect, stated as the person it reached: 18 months is inside the
+    3-5 year interval USPSTF describes for 18-39.
+
+    MUTATION: delete `cadence_bands` from the bp-screening rule -> red, the
+    rule falls back to 12 months and reports a gap the guideline does not.
+    """
+    bp = _bp_result(age=30, months_ago=18)
+    assert bp["status"] == "up_to_date", (
+        "an under-40 patient was told they were due 18 months after a normal "
+        "reading, on the 40+ annual cadence")
+    assert bp["cadence"] == "every 3 years"
+
+
+def test_the_same_reading_leaves_someone_over_40_due():
+    """The band must not become a blanket relaxation. 40+ is annual, and 18
+    months is past it.
+
+    MUTATION: widen the band to cover every age -> red.
+    """
+    bp = _bp_result(age=45, months_ago=18)
+    assert bp["status"] == "due"
+    assert bp["cadence"] == "yearly"
+
+
+def test_an_under_40_reading_does_go_stale_eventually():
+    """40 months is outside the band. Without this, the first test passes for
+    a rule that simply never expires under 40.
+
+    MUTATION: set the band's cadence_months above 40 -> red.
+    """
+    bp = _bp_result(age=30, months_ago=40)
+    assert bp["status"] == "due"
+
+
+def test_every_age_the_rule_applies_to_gets_a_cadence_somebody_chose():
+    """No age in the rule's own range may fall through to a cadence nobody
+    picked for it. Swept rather than sampled at the edges: a band that leaves
+    a hole reports the fallback, which looks like an answer.
+    """
+    rule = next(r for r in CARE_GAP_RULES if r["id"] == "bp-screening")
+    for age in range(rule["applies"]["min_age"], 90):
+        bp = _bp_result(age=age, months_ago=0)
+        assert bp["cadence"] == ("every 3 years" if age < 40 else "yearly"), age
+
+
+def test_the_a1c_gate_reports_what_the_records_held_not_what_the_person_has():
+    """A gate that read Conditions may only speak about Conditions.
+
+    "Applies to patients with a diabetes diagnosis", printed beside a
+    screening that has been set aside, reads as a finding that this person
+    does not have diabetes. The gate established no such thing — it saw the
+    Conditions in the connected records, which are routinely incomplete, and
+    the same absence is produced by a record that was never shared.
+
+    Same rule as "no known allergies is never inferred" (docs/constitution.md)
+    and the same shape as #389: an absence in our copy of the data reported as
+    an absence in the person.
+
+    MUTATION: restore the old wording -> red.
+    """
+    res = {r["rule_id"]: r for r in evaluate_care_gaps(
+        _patient(), conditions=[], as_of="2026-07-01")}
+    a1c = res["diabetes-a1c"]
+    assert a1c["status"] == "not_applicable"
+    note = a1c["note"]
+    assert note == "no diabetes diagnosis found in your connected records"
+    # The claim is bounded by where we looked.
+    assert "connected records" in note
+    assert "applies to patients" not in note

--- a/tests/test_caregaps_evaluate.py
+++ b/tests/test_caregaps_evaluate.py
@@ -298,8 +298,17 @@ def test_every_age_the_rule_applies_to_gets_a_cadence_somebody_chose():
     a hole reports the fallback, which looks like an answer.
     """
     rule = next(r for r in CARE_GAP_RULES if r["id"] == "bp-screening")
-    for age in range(rule["applies"]["min_age"], 90):
+    # To max_age inclusive, not to 90. The sweep stopped 31 years short of the
+    # ages the rule claims, so a band leaving a hole anywhere in 90-120 would
+    # have reported the fallback and the sweep would never have looked. The
+    # rule's own bounds are the only defensible end point for a test whose
+    # subject is "every age the rule applies to".
+    lo, hi = rule["applies"]["min_age"], rule["applies"]["max_age"]
+    for age in range(lo, hi + 1):
         bp = _bp_result(age=age, months_ago=0)
+        assert bp["status"] != "not_applicable", (
+            f"age {age} is inside the rule's own {lo}-{hi} range and was "
+            "dismissed as not applicable")
         assert bp["cadence"] == ("every 3 years" if age < 40 else "yearly"), age
 
 

--- a/tests/test_caregaps_report.py
+++ b/tests/test_caregaps_report.py
@@ -22,6 +22,23 @@ def _undecided(rule_id, title, why):
                    applicable=None, indeterminate_reason=why)
 
 
+def _unread(rule_id, title, evidence):
+    """An indeterminate rule the check knowingly cannot fully read.
+
+    `applicable` is True, as the engine emits it: the patient IS in the age
+    band, and it is our own coverage that could not decide. This fixture used
+    to inherit `applicable: None` from `_undecided`, which no test read until
+    #436 made it load-bearing — a hand-written fixture drifting from the
+    producer, which is the same shape as the brief's "due" key (#387/#435).
+    Pinned against the real evaluator by
+    `test_no_screening_reaches_the_patient_as_silence`.
+    """
+    out = _undecided(rule_id, title, "evidence-not-read")
+    out["applicable"] = True
+    out["unread_evidence"] = evidence
+    return out
+
+
 def test_summary_counts_by_status():
     results = [
         _result(status="due"),
@@ -67,13 +84,73 @@ def test_consumer_summary_up_to_date_line_mentions_last_done():
     assert "up to date" in line["message"].lower()
 
 
-def test_consumer_summary_skips_not_applicable_and_indeterminate():
+def test_an_undecided_screening_the_patient_is_eligible_for_gets_a_line():
+    """#436 — an indeterminate screening used to give the patient no line.
+
+    PIN FLIPPED: this test asserted `lines == []` for every indeterminate.
+    #428 made colorectal screening indeterminate and its PR claimed the prompt
+    to act survived the status change. It did not: `lines` was built only for
+    `due` and `up_to_date`, so the patient saw the screening named in the
+    unevaluated note and never a line telling them what to do about it.
+
+    Three rows, and only the third earns a line:
+
+      - `not_applicable` — the rule does not apply to this person. Silence is
+        correct; a line would invent a screening they do not need.
+      - `indeterminate` with `applicable: None` — we do not know whether it
+        applies, because a demographic was missing. A line here would surface
+        a screening that may well be for somebody else. It is named in
+        `unevaluated_titles` instead, which claims nothing about eligibility.
+      - `indeterminate` with `applicable: True` — the person IS eligible and
+        the check could not decide. That is the one with something to say.
+
+    MUTATION: build lines for `("due", "up_to_date")` again -> red.
+    """
     results = [
         _result(rule_id="mammography", status="not_applicable", applicable=False),
-        _result(rule_id="colorectal-screening", status="indeterminate", applicable=None),
+        _undecided("cervical-screening", "Cervical cancer screening (Pap)",
+                   "sex-unknown"),
+        _unread("colorectal-screening", "Colorectal cancer screening",
+                "stool-based tests (FIT or Cologuard)"),
     ]
     consumer = build_consumer_summary(results)
-    assert consumer["lines"] == []
+    assert [line["rule_id"] for line in consumer["lines"]] == [
+        "colorectal-screening"]
+
+
+def test_the_could_not_check_line_carries_its_own_status_and_the_rules_note():
+    """It sits BESIDE the due lines rather than under them, so it needs a
+    status of its own and a word for it a patient can read.
+
+    `status` stays the engine's own value, so a caller reading `lines` and a
+    caller reading `detail` or `summary` never disagree about one screening.
+    `status_label` exists because the MCP App page renders a status by
+    replacing underscores with spaces — which yields "due" and "up to date",
+    and would yield "indeterminate".
+    """
+    results = [_unread("colorectal-screening", "Colorectal cancer screening",
+                       "stool-based tests (FIT or Cologuard)")]
+    line = build_consumer_summary(results)["lines"][0]
+    assert line["status"] == "indeterminate"
+    assert line["status_label"] == "could not check"
+    assert line["title"] == "Colorectal cancer screening"
+    # The rule's own note, written for a patient, reaches the patient.
+    assert results[0]["note"] in line["message"]
+    assert "could not check" in line["message"].lower()
+
+
+def test_a_due_line_is_not_relabelled_by_the_could_not_check_line():
+    """The other half of the same property: adding a third kind of line must
+    not change the two that shipped."""
+    consumer = build_consumer_summary([
+        _result(status="due", note="confirm with your clinician"),
+        _result(rule_id="mammography", title="Breast cancer screening",
+                status="up_to_date", last_done="2026-03-01"),
+    ])
+    assert [line["status"] for line in consumer["lines"]] == [
+        "due", "up_to_date"]
+    for line in consumer["lines"]:
+        assert "status_label" not in line
 
 
 def test_consumer_summary_note_has_no_banned_words():
@@ -220,13 +297,6 @@ def test_one_undecided_rule_reads_as_one():
 # #425 — a coverage gap is not a gap in the record
 # ─────────────────────────────────────────────
 
-def _unread(rule_id, title, evidence):
-    """An indeterminate rule the check knowingly cannot fully read."""
-    out = _undecided(rule_id, title, "evidence-not-read")
-    out["unread_evidence"] = evidence
-    return out
-
-
 def test_a_coverage_gap_never_borrows_a_reason_about_the_person():
     """The reason has to name whose limitation it is.
 
@@ -292,3 +362,75 @@ def test_demographic_causes_alone_are_unchanged_by_the_split():
     assert out["unevaluated"] == "sex-unavailable"
     assert out["unevaluated_count"] == 2
     assert "sex was not recorded" in out["unevaluated_note"]
+
+
+# ─────────────────────────────────────────────
+# Nothing is dropped in silence (#436)
+# ─────────────────────────────────────────────
+
+def _every_screening_is_accounted_for(results, consumer):
+    """A line for every screening the person is eligible for; the rest named.
+
+    Written twice. The first version accepted "has a line OR is named in
+    `unevaluated_titles`", which was green BEFORE the fix — the marker already
+    named colorectal — so it would have shipped as evidence for a change it
+    could not see. That is the docs/2026-08-02-retro.md shape aimed at this
+    file, and the reason to state the property in terms of what #436 is
+    actually about:
+
+      - `applicable is True` — the person is eligible and the screening has
+        something to tell them, decided or not. It needs a LINE. Being named
+        in the marker is not enough; that was the defect.
+      - `applicable is None` — eligibility itself is undecided. Naming it is
+        the most that can be said without claiming it applies to this person.
+      - `not_applicable` — silence is correct.
+    """
+    lined = {line["rule_id"] for line in consumer["lines"]}
+    named = set(consumer.get("unevaluated_titles") or [])
+    for r in results:
+        if r["status"] == "not_applicable":
+            continue
+        if r["applicable"] is True:
+            assert r["rule_id"] in lined, (
+                f"{r['rule_id']} ({r['status']}) applies to this person and "
+                "got no patient-facing line")
+        else:
+            assert r["title"] in named, (
+                f"{r['rule_id']} ({r['status']}) was dropped in silence: not "
+                "decided, and not named as unchecked")
+
+
+def test_no_screening_reaches_the_patient_as_silence():
+    """Driven from the ENGINE's own output rather than hand-built rows.
+
+    A fixture written here is free to drift from what the evaluator emits,
+    which is how the brief came to require a "due" key the producer had never
+    written (#387/#435). Two records, because they exercise different gates:
+    a complete one, and one missing sex — routine in real feeds.
+
+    MUTATION: drop the indeterminate branch from `_consumer_line` -> red on
+    colorectal, which has a line and no other way to reach the patient.
+    """
+    from r6.caregaps.evaluate import evaluate_care_gaps
+
+    for patient in ({"resourceType": "Patient", "gender": "female",
+                     "birthDate": "1976-01-01"},
+                    {"resourceType": "Patient", "birthDate": "1976-01-01"}):
+        results = evaluate_care_gaps(patient, as_of="2026-07-01")
+        consumer = build_consumer_summary(results)
+        _every_screening_is_accounted_for(results, consumer)
+
+
+def test_the_could_not_check_line_is_no_excuse_to_stop_naming_it():
+    """A line AND the marker. The marker is what says how much of the answer
+    is missing; a per-rule line does not replace a count of them (#417)."""
+    from r6.caregaps.evaluate import evaluate_care_gaps
+
+    results = evaluate_care_gaps(
+        {"resourceType": "Patient", "gender": "female",
+         "birthDate": "1976-01-01"}, as_of="2026-07-01")
+    consumer = build_consumer_summary(results)
+    assert [line["rule_id"] for line in consumer["lines"]
+            if line["status"] == "indeterminate"] == ["colorectal-screening"]
+    assert consumer["unevaluated"] == "evidence-not-read"
+    assert consumer["unevaluated_titles"] == ["Colorectal cancer screening"]

--- a/tests/test_caregaps_routes.py
+++ b/tests/test_caregaps_routes.py
@@ -114,8 +114,9 @@ def test_care_gaps_with_no_subject_uses_the_tenants_own_patient(
     assert resolution == {"state": "tenant-default", "subject": "Patient/p-solo"}
 
     # The tenant's own Condition reached the evaluator: the diabetes rule is
-    # no longer dismissed as "applies to patients with a diabetes diagnosis".
-    # Against subject None it was, because the Condition never matched.
+    # no longer dismissed as "no diabetes diagnosis found in your connected
+    # records". Against subject None it was, because the Condition never
+    # matched.
     detail = json.loads(_resp_param(body, "detail")["valueString"])
     a1c = next(d for d in detail if d["rule_id"] == "diabetes-a1c")
     assert a1c["status"] != "not_applicable", (
@@ -407,7 +408,13 @@ def test_the_fallback_path_evaluates_the_patient_it_resolved(
     assert summary["due"] + summary["up_to_date"] == 5
 
     consumer = json.loads(_resp_param(body, "consumerSummary")["valueString"])
-    assert len(consumer["lines"]) == 5
+    # PIN MOVED with #436, in the PR that moved it: 5 -> 6. The five decided
+    # screenings are unchanged; colorectal now gets a line of its own saying
+    # it could not be checked, instead of appearing only in the note. The
+    # property this test exists for is untouched — the rules read the record.
+    assert len(consumer["lines"]) == 6
+    assert [line["status"] for line in consumer["lines"]].count(
+        "indeterminate") == 1
 
     # The point of #389 half two, stated directly: nothing is undecided for
     # want of demographics, because the evaluator was handed the record. The
@@ -445,7 +452,11 @@ def test_the_fallback_path_now_carries_a_reason_that_is_true(
                     json={})
     consumer = json.loads(
         _resp_param(r.get_json(), "consumerSummary")["valueString"])
-    assert len(consumer["lines"]) == 3
+    # PIN MOVED with #436, in the PR that moved it: 3 -> 4. Colorectal joins
+    # the lines with a "could not check" status; the two sex-gated screenings
+    # do not, because with no sex on file nothing here knows they apply to
+    # this person. All three stay named in the marker below.
+    assert len(consumer["lines"]) == 4
     assert consumer["unevaluated"] == "partly-unchecked"
     assert consumer["unevaluated_count"] == 3
     assert consumer["unevaluated_titles"] == [
@@ -493,7 +504,13 @@ def test_a_partial_screening_list_says_how_much_of_it_is_missing(
     # on annual FIT would have matched nothing. So the decided list drops from
     # four to three and a third screening joins the undecided set — for a
     # different reason than the other two.
-    assert len(consumer["lines"]) == 3
+    #
+    # PIN MOVED AGAIN with #436, in the PR that moved it: 3 -> 4. Colorectal
+    # is still undecided and still named in the marker; what changed is that
+    # it now also reaches the patient as a line, which is the whole of #436.
+    # The two sex-gated screenings get no line — nothing here knows whether
+    # they apply to a record with no sex on it.
+    assert len(consumer["lines"]) == 4
     assert consumer["unevaluated_count"] == 3
     assert consumer["unevaluated_titles"] == [
         "Colorectal cancer screening",
@@ -565,3 +582,138 @@ class TestCareGapsMcpApp:
         resp = client.get('/r6/fhir/mcp-apps/care-gaps/')
         assert resp.status_code == 200
         assert 'Enter a tenant id' in resp.get_data(as_text=True)
+
+
+# ─────────────────────────────────────────────
+# The rules do not run against a patient nobody resolved (#542)
+#
+# The route set `not_evaluated` and then called the evaluator anyway. Two
+# things came out of that, and the retro's shape is both of them: a check that
+# examined nothing printed the verdict of a check that examined everything
+# (docs/2026-08-02-retro.md).
+#
+#   1. FALSE not_applicable. With no patient the condition gate (evaluate.py,
+#      before the age gate) fires first, so the A1c rule reported
+#      "not_applicable" — a decision about a person nobody looked at.
+#   2. THE AUDIT LIED. detail read `evaluated=7` for seven evaluations that
+#      did not happen.
+#
+# The consumer summary already suppressed the rows (#389/#417), so this was
+# invisible from the page. The payload and the audit carried them to every
+# other caller — the MCP tool, the Telegram summary, curl.
+
+def _audit_details(app, tenant_id):
+    """Every care-gaps audit row this tenant has, newest last."""
+    from r6.models import AuditEventRecord
+    with app.app_context():
+        rows = AuditEventRecord.query.filter_by(
+            tenant_id=tenant_id, event_type="read",
+            resource_type="Patient").all()
+        return [r.detail for r in rows
+                if (r.detail or "").startswith("care-gaps;")]
+
+
+def test_an_unresolved_subject_evaluates_no_rules_at_all(
+        client, app, tenant_id, tenant_headers):
+    """Two Patient rows, no subject: nothing may be decided about either.
+
+    `summary.evaluated` is the flag a client branches on without knowing the
+    reason family. It is NOT sufficient on its own to catch the defect — it
+    stays False whether or not the evaluator ran — so the emptiness of the
+    rows is asserted directly.
+
+    MUTATION: call evaluate_care_gaps(patient, ...) unconditionally again ->
+    red on `detail`, on `not_applicable`, and on the audit row.
+    """
+    _seed_patient(app, tenant_id, pid="p-one")
+    _seed_patient(app, tenant_id, pid="p-two")
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    assert r.status_code == 200
+    body = r.get_json()
+
+    detail = json.loads(_resp_param(body, "detail")["valueString"])
+    assert detail == [], (
+        "the rules ran against a patient the route could not resolve")
+
+    summary = json.loads(_resp_param(body, "summary")["valueString"])
+    assert summary["evaluated"] is False
+    assert summary["total"] == 0
+    # The one that was patient-visible: A1c fell through the condition gate
+    # and reported "not applicable" for a person nobody identified.
+    assert summary["not_applicable"] == 0
+    assert summary["due"] == 0
+    assert summary["indeterminate"] == 0
+
+
+def test_the_audit_says_nothing_was_evaluated_when_nothing_was(
+        client, app, tenant_id, tenant_headers):
+    """One AuditEvent on the caller path, PHI-free, counting what happened.
+
+    MUTATION: restore the unconditional evaluate_care_gaps call -> red with
+    `evaluated=7`.
+    """
+    _seed_patient(app, tenant_id, pid="p-one")
+    _seed_patient(app, tenant_id, pid="p-two")
+
+    client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers, json={})
+
+    details = _audit_details(app, tenant_id)
+    assert len(details) == 1, f"expected exactly one care-gaps audit row: {details}"
+    assert details[0] == (
+        "care-gaps; subject=ambiguous-patient evaluated=0 due=0")
+
+
+def test_no_patient_row_evaluates_nothing_either(
+        client, app, tenant_id, tenant_headers):
+    """The other caller reason. Same property, and the more common one — a
+    tenant that has connected nothing yet."""
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    body = r.get_json()
+    assert json.loads(_resp_param(body, "detail")["valueString"]) == []
+    summary = json.loads(_resp_param(body, "summary")["valueString"])
+    assert summary["evaluated"] is False
+    assert summary["not_applicable"] == 0
+    assert _audit_details(app, tenant_id) == [
+        "care-gaps; subject=no-patient evaluated=0 due=0"]
+
+
+def test_a_subject_we_hold_no_record_for_evaluates_nothing(
+        client, app, tenant_id, tenant_headers):
+    """`check-incomplete` — a supplied subject naming a row we do not hold.
+
+    The third reason, and the one where `state` and the not-evaluated reason
+    differ: the subject WAS supplied, so the audit says so, and `evaluated=0`
+    carries the rest.
+    """
+    r = client.get("/r6/fhir/Patient/$care-gaps?subject=Patient/nope",
+                   headers=tenant_headers)
+    body = r.get_json()
+    assert json.loads(_resp_param(body, "detail")["valueString"]) == []
+    summary = json.loads(_resp_param(body, "summary")["valueString"])
+    assert summary["evaluated"] is False
+    assert _audit_details(app, tenant_id) == [
+        "care-gaps; subject=supplied evaluated=0 due=0"]
+
+
+def test_a_resolved_patient_is_still_evaluated_and_says_so(
+        client, app, tenant_id, tenant_headers):
+    """The guard must not become a blanket refusal to evaluate anyone.
+
+    MUTATION: return `results = []` unconditionally -> red.
+    """
+    _seed_patient(app, tenant_id, pid="p-real", gender="female",
+                  birth=_birth_date_for_age(50))
+
+    r = client.post("/r6/fhir/Patient/$care-gaps", headers=tenant_headers,
+                    json={})
+    body = r.get_json()
+    summary = json.loads(_resp_param(body, "summary")["valueString"])
+    assert summary["evaluated"] is True
+    assert summary["total"] == 7
+    detail = json.loads(_resp_param(body, "detail")["valueString"])
+    assert len(detail) == 7
+    assert _audit_details(app, tenant_id) == [
+        "care-gaps; subject=tenant-default evaluated=7 due=%d" % summary["due"]]


### PR DESCRIPTION
## What

Four clinical-honesty changes plus the rule register a reviewing clinician asks for in the first five minutes.

**#542 — an unresolved subject is not evaluated.** The route set `not_evaluated` and then ran the rules anyway against `patient=None`. Now `results = []`, `summary.evaluated` is `False`, and the audit detail says `evaluated=0`.

**#436 — every eligible screening gets a patient line.** An `indeterminate` result the person is eligible for now produces a consumer line carrying the rule's own note, labelled **could not check**.

**Blood pressure cadence by age band.** 18 to 39 every 36 months, 40 and over annually.

**A1c wording.** "Applies to patients with a diabetes diagnosis" becomes "no diabetes diagnosis found in your connected records".

**`docs/clinical/care-gap-rule-register.md`** — one page, every value transcribed from the rule table, with a sign-off block.

## Why

Council ruling 2026-09-02 D14.

On #542, running the rules against nobody produced two false statements. The condition gate fires before the age gate, so a rule with an empty condition list fell through to `not_applicable` rather than `indeterminate`, and the API asserted that A1c monitoring does not apply to a person whose record it never opened. The audit then recorded seven evaluations that did not happen. The consumer summary suppressed those rows, so the page looked right while the payload and the audit did not. That is the retro's shape: a check that examined nothing printing the verdict of a check that examined everything. Every other consumer of this operation, including the MCP tool and curl, read the rows.

On #436, PR #428 made colorectal screening `indeterminate` rather than let it claim a gap it had not checked for, and said the prompt to act survived the status change. It did not. Lines were built for `due` and `up_to_date` only, so the note written for the patient reached the clinician-facing `detail` and stopped there. The patient saw the screening named and nothing about what to do, which is the "the doctor's view says something mine doesn't" trust break.

The line is emitted only when `applicable is True`. A rule that could not decide whether it applies at all, because sex or date of birth is missing, has nothing to tell this person yet, and a line for it would put a screening in front of someone who may not need one. Those stay in the marker, which claims no eligibility.

On the cadence, USPSTF screens adults 18 to 39 with normal readings every three to five years and 40 and over annually. A single yearly figure from age 18 told an under-40 patient with a normal reading two years ago that they were due, which the guideline does not describe. Thirty-six months is the conservative end of the range.

On the A1c note, the gate never established that anyone lacks diabetes. All it saw was the Conditions in the connected records, and those are routinely incomplete. Beside a screening that has been set aside, the old wording reads as a finding about the person.

## Design notes worth a reviewer's attention

- **The age band lives inside the `bp-screening` rule**, not in a second rule. `summary.total` and the rule ids are read by the MCP App page, the brief and the eCQM crosswalk. A cadence correction should not move any of them. `total` stays 7 and no rule id changes.
- **The status check now lives in one place.** `build_consumer_summary` used to filter by status and `_consumer_line` checked again, so the rule existed twice and the copies had to change together. That is Law 2 from the two-generators write-up, and it is why this fix is small.
- **`status_label`** carries "could not check" beside the engine's own `status`, so `lines`, `detail` and `summary` never disagree about one screening. The page renders a status by swapping underscores for spaces, which would otherwise show the word "indeterminate" to a patient.

## Scope

`templates/mcp_apps/care_gaps.html` is untouched. PR #541 owns the page and is open. The page keeps matching the reason list; `summary.evaluated` is the flag it can switch to, and both ship for one release as #542 asks.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3181 passed, 13 skipped, 1 xfailed, 2 warnings in 102.45s (0:01:42)
```

Green including `tests/test_ratchets.py` and `tests/test_guardrail_conformance.py` (Grade A). `r6/routes.py` untouched.

New coverage: an unresolved subject evaluates nothing and says so, the audit reports `evaluated=0` on each of the three unresolved reasons, a resolved patient is still evaluated, both blood-pressure bands at the boundary, the A1c wording, a patient line for every eligible indeterminate, and a drift test that fails if the register stops matching the rules.

## What was NOT run

No live server and no real records. The clinician sign-off block in the register is blank by design and needs a person. No set-level duplicate evaluator and no document read path; both stay out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
