### PR TITLE
test(e2e): a tester's first screen under CARE_REAL_RECORDS=off, in a browser

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -16,6 +16,22 @@ export const CARE_BASE_URL = `http://localhost:${CARE_PORT}`;
 export const CARE_LOG = '/tmp/e2e-careagents.log';
 const CARE_DB = '/tmp/e2e-careagents.db';
 
+// A THIRD app: the same CareAgents code with CARE_REAL_RECORDS=allowlist
+// (#553, council ruling 2026-09-02 D3). The switch is read once, at
+// create_app(), so one process can only ever be in one mode — proving in a
+// browser that an allowlisted account sees different tiles from a stranger
+// needs its own server, its own SQLite and its own log.
+export const CARE_ALLOW_PORT = process.env.CARE_ALLOW_E2E_PORT || '5102';
+export const CARE_ALLOW_BASE_URL = `http://localhost:${CARE_ALLOW_PORT}`;
+export const CARE_ALLOW_LOG = '/tmp/e2e-careagents-allow.log';
+const CARE_ALLOW_DB = '/tmp/e2e-careagents-allow.db';
+// Fixed, and synthetic. The allowlist is server env, so the address the spec
+// signs in with has to be known before the server boots — it cannot be the
+// per-test unique address the other specs use. `.test` is reserved (RFC 2606)
+// and can never be a real mailbox; nothing is ever sent anyway (the dev mail
+// stub logs to stderr).
+export const CARE_ALLOW_EMAIL = 'e2e-allowlisted@example.test';
+
 export default defineConfig({
   testDir: './tests',
   // Serial execution — shared SQLite instance, tests create resources
@@ -98,6 +114,44 @@ export default defineConfig({
         // Explicitly blank so a developer shell with a real Resend key still
         // gets the stderr mail stub — codes must never leave the machine.
         RESEND_API_KEY: '',
+        // The beta's real-record switch, pinned CLOSED for this server (#553,
+        // D3). Blank resolves to `off` exactly as unset does; the *unset*
+        // default is pinned by pytest (test_careagents.py::
+        // test_real_records_switch_defaults_to_off_and_parses_the_allowlist),
+        // and pinning it here stops a developer shell that exports
+        // CARE_REAL_RECORDS=on from quietly running the browser suite against
+        // the open path while its name still says closed.
+        CARE_REAL_RECORDS: '',
+        CARE_REAL_RECORDS_ALLOWLIST: '',
+      },
+    },
+    {
+      // CareAgents again, in allowlist mode — see CARE_ALLOW_* above.
+      command:
+        `rm -f ${CARE_ALLOW_DB} ${CARE_ALLOW_LOG} && cd .. && ` +
+        `uv run flask --app careagents.wsgi run --port ${CARE_ALLOW_PORT} ` +
+        `2>> ${CARE_ALLOW_LOG}`,
+      url: `${CARE_ALLOW_BASE_URL}/`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        CARE_ENV: 'development',
+        CARE_DATABASE_URL: `sqlite:///${CARE_ALLOW_DB}`,
+        // Dead port, for the same reason as the entry above.
+        HEALTHCLAW_BASE: 'http://127.0.0.1:9',
+        CARE_ORIGIN: CARE_ALLOW_BASE_URL,
+        CARE_RP_ID: 'localhost',
+        RESEND_API_KEY: '',
+        CARE_REAL_RECORDS: 'allowlist',
+        CARE_REAL_RECORDS_ALLOWLIST: CARE_ALLOW_EMAIL,
+        // Fasten key present and the wearables sidecar declared wired, so the
+        // ONLY thing between an account and a live real-record tile here is
+        // the allowlist. Without these two, `catalog()` would answer "soon"
+        // for its own reasons ("not configured on this deployment") and the
+        // allowlist test would pass while proving nothing. The key is never
+        // used: nothing in the spec starts a Fasten flow.
+        FASTEN_PUBLIC_KEY: 'e2e-not-a-real-fasten-key',
+        CARE_WEARABLES_ENABLED: '1',
       },
     },
   ],

--- a/e2e/tests/careagents-connect-tiles.spec.ts
+++ b/e2e/tests/careagents-connect-tiles.spec.ts
@@ -48,10 +48,10 @@ const PHONE = {
 /** The three sources that take a person's OWN records (connectors.py:74). */
 const REAL_RECORD_TILES = ['fasten', 'wearable', 'direct'] as const;
 
-/** connectors.py:75 — verbatim. This is the sentence a tester reads. */
+/** connectors.py:78-79 — verbatim. This is the sentence a tester reads. */
 const REFUSED =
-  "real-records connect isn't open on this beta deployment yet — " +
-  'start with the sample records';
+  "Connecting your own records isn't open in this beta yet. " +
+  'Start with the sample records.';
 
 /** connectors.py:94 — the blurb that replaces the live one when closed. */
 const CLOSED_BLURB = 'Not open in this beta — start with the sample records.';

--- a/e2e/tests/careagents-connect-tiles.spec.ts
+++ b/e2e/tests/careagents-connect-tiles.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  CARE_ALLOW_BASE_URL, CARE_ALLOW_EMAIL, CARE_ALLOW_LOG,
+  CARE_BASE_URL, CARE_LOG,
+} from '../playwright.config';
+import { blockThirdParty, signIn, uniqueEmail } from './careagents-fixtures';
+
+/**
+ * A beta tester's first screen, in a browser (#553, council ruling
+ * 2026-09-02 D3/D6).
+ *
+ * The review of #553 proved the server side of the CARE_REAL_RECORDS switch —
+ * the catalog JSON, the 503 on a closed connect POST — and left one gap in
+ * writing: "nothing has confirmed *in a browser* that home.js's soon-tile
+ * handler renders the 503 text under the tile on a phone." That is what this
+ * file closes, at 390x844, which is the device this product is used on.
+ *
+ * WHAT THESE TESTS PROVE
+ *   The browser RENDERS a given state: which tiles a signed-in account sees,
+ *   what words are on them, what appears under one when a thumb taps it, and
+ *   that a tile the beta closed opens no dialog and starts no connection.
+ *   Every assertion is on text or DOM a person could read off the screen, not
+ *   on a network call.
+ *
+ * WHAT THEY DO NOT PROVE
+ *   That HealthClaw accepted anything. Both CareAgents servers here run with
+ *   HEALTHCLAW_BASE on a dead local port (playwright.config.ts), so no records
+ *   service exists to accept or reject a thing: no tenant is created, no
+ *   bundle is ingested, and the sample-records flow gets exactly as far as the
+ *   call to HealthClaw and no further. Cross-boundary behaviour needs a
+ *   running HealthClaw and is out of scope here, deliberately.
+ *   Also not proven: the Fasten and wearable flows themselves (nothing here
+ *   starts one), and anything about the deployed site.
+ *
+ * Synthetic addresses only (@example.test, RFC 2606). No mail is sent: the
+ * dev-mode stub logs each sign-in code to stderr, and the spec reads it back.
+ */
+
+// A phone, because that is where a tester meets this: the hub's marketplace
+// is a single column here, and the refusal has to land where a thumb is.
+const PHONE = {
+  viewport: { width: 390, height: 844 },
+  isMobile: true,
+  hasTouch: true,
+  deviceScaleFactor: 3,
+};
+
+/** The three sources that take a person's OWN records (connectors.py:74). */
+const REAL_RECORD_TILES = ['fasten', 'wearable', 'direct'] as const;
+
+/** connectors.py:75 — verbatim. This is the sentence a tester reads. */
+const REFUSED =
+  "real-records connect isn't open on this beta deployment yet — " +
+  'start with the sample records';
+
+/** connectors.py:94 — the blurb that replaces the live one when closed. */
+const CLOSED_BLURB = 'Not open in this beta — start with the sample records.';
+
+/** _beta_banner.html — eleven words, on the landing page and the hub. */
+const BANNER = 'Beta: synthetic records only. Things will break — tell us.';
+
+const tile = (page: Page, id: string) =>
+  page.locator(`.connector-tile[data-connector="${id}"]`);
+
+/** The one shared #connect-msg, but only where say() moved it: directly
+ *  after the tapped tile. A CSS sibling selector, so it retries. */
+const msgUnder = (page: Page, id: string) =>
+  page.locator(`.connector-tile[data-connector="${id}"] + #connect-msg`);
+
+test.describe('CareAgents hub — real records closed (CARE_REAL_RECORDS off)', () => {
+  test.use({ baseURL: CARE_BASE_URL, ...PHONE });
+
+  test.beforeEach(async ({ page }) => {
+    await blockThirdParty(page);
+    // A fresh account per test: no connections, no leftovers, and the first
+    // screen is what a new tester actually gets.
+    await signIn(page, uniqueEmail(), CARE_LOG);
+  });
+
+  test('the Fasten, wearable and upload tiles read "coming soon"', async ({
+    page,
+  }) => {
+    for (const id of REAL_RECORD_TILES) {
+      const t = tile(page, id);
+      await expect(t, `${id} tile missing`).toBeVisible();
+      // The words on the tile, as read off the screen.
+      await expect(t.locator('.connector-tag')).toHaveText('coming soon');
+      await expect(t.locator('.connector-blurb')).toHaveText(CLOSED_BLURB);
+      await expect(t).toHaveClass(/tier-soon/);
+      // ...and it is not dressed as a connection that will happen: no consent
+      // card is promised, because there is nothing to consent to.
+      await expect(t).toHaveAttribute('data-soon', '1');
+      expect(await t.getAttribute('data-consent'),
+        `${id} still carries the consent flag`).toBeNull();
+    }
+    // What the eye actually gets, which the DOM text alone does not say: the
+    // tag is CSS-uppercased ("COMING SOON" on screen, `coming soon` in the
+    // node above), and the tile is drawn with a dashed border — the visual
+    // difference between a source you can tap into and one that is parked.
+    const tag = await tile(page, 'fasten').locator('.connector-tag').evaluate(
+      (el) => getComputedStyle(el).textTransform);
+    expect(tag, 'the "coming soon" tag is no longer uppercased on screen')
+      .toBe('uppercase');
+    const border = await tile(page, 'fasten').evaluate(
+      (el) => getComputedStyle(el).borderStyle);
+    expect(border, 'a closed tile is drawn as a solid, tappable card')
+      .toBe('dashed');
+
+    // The labels stay — a tester should see the source exists and is not yet
+    // open, rather than wonder where it went.
+    await expect(tile(page, 'fasten').locator('.connector-label'))
+      .toHaveText('Your provider (verified)');
+    await expect(tile(page, 'wearable').locator('.connector-label'))
+      .toHaveText('Apple Health & wearables');
+    await expect(tile(page, 'direct').locator('.connector-label'))
+      .toHaveText('Upload records');
+  });
+
+  test('tapping a closed tile shows the refusal under that tile', async ({
+    page,
+  }) => {
+    for (const id of REAL_RECORD_TILES) {
+      await tile(page, id).click();
+
+      const msg = msgUnder(page, id);
+      await expect(msg, `no refusal under the ${id} tile`).toBeVisible();
+      await expect(msg).toHaveText(REFUSED);
+      // On a phone the message is worthless if it lands off-screen.
+      await expect(msg).toBeInViewport();
+
+      // Nothing else happened: no consent card, no provider picker (the
+      // wearable tile still carries its provider list), no popup window, no
+      // connection on the hub.
+      await expect(page.locator('#consent-modal')).toBeHidden();
+      await expect(page.locator('#provider-picker')).toBeHidden();
+      expect(page.context().pages().length,
+        'a tap on a closed tile opened a window').toBe(1);
+      await expect(page.locator('#connections .conn-card')).toHaveCount(0);
+      // And the tile does not promise a follow-up it will not send: the
+      // waitlist wording belongs to genuinely-soon sources, not to one the
+      // beta switch closed.
+      await expect(tile(page, id).locator('.connector-tag'))
+        .toHaveText('coming soon');
+    }
+  });
+
+  test('the sample-records tile is still live and still opens its flow',
+    async ({ page }) => {
+      const t = tile(page, 'sample');
+      await expect(t).toBeVisible();
+      await expect(t).toHaveClass(/tier-live/);
+      await expect(t.locator('.connector-label'))
+        .toHaveText('Try it with sample records');
+      // A live tile carries no tag at all — nothing telling a tester to wait.
+      await expect(t.locator('.connector-tag')).toHaveCount(0);
+      expect(await t.getAttribute('data-soon')).toBeNull();
+
+      await t.click();
+
+      // What this can honestly assert: the tap reached the LIVE path. This
+      // harness points HEALTHCLAW_BASE at a dead port on purpose, so the flow
+      // runs as far as the records service and stops there. That message can
+      // only come from the live branch — a closed tile is refused before
+      // HealthClaw is ever called, with the sentence asserted above. So the
+      // two paths are distinguishable here, and this is the live one.
+      // NOT asserted: that a sample tenant was created or seeded. That needs
+      // a running HealthClaw and belongs in a cross-boundary test.
+      const msg = msgUnder(page, 'sample');
+      await expect(msg).toBeVisible();
+      await expect(msg).toHaveText('records service unavailable');
+      await expect(page.locator('#consent-modal')).toBeHidden();
+    });
+
+  test('the Telegram surface is a label, not a control', async ({ page }) => {
+    const tg = page.locator('.surface', { hasText: 'Telegram' });
+    await expect(tg).toBeVisible();
+    await expect(tg.locator('b')).toHaveText('Telegram');
+    await expect(tg.locator('span')).toHaveText('coming soon');
+    await expect(tg).toHaveClass(/soon/);
+    // #536/D6: the ids are gone, so home.js has nothing to bind.
+    expect(await tg.getAttribute('id')).toBeNull();
+    await expect(page.locator('#tg-surface')).toHaveCount(0);
+    await expect(page.locator('#tg-state')).toHaveCount(0);
+
+    // And a tap does nothing at all: no request, no dialog, no text change.
+    const calls: string[] = [];
+    page.on('request', (r) => {
+      if (r.url().includes('/api/')) calls.push(`${r.method()} ${r.url()}`);
+    });
+    await tg.click();
+    // Proving an absence, so give the handler that does not exist time to
+    // run: a bound handler would have fired its fetch well inside this.
+    await page.waitForTimeout(500);
+    expect(calls, 'the Telegram tile called the API').toEqual([]);
+    await expect(page.locator('#code-card')).toBeHidden();
+    await expect(page.locator('#surfaces-msg')).toBeHidden();
+    await expect(tg.locator('span')).toHaveText('coming soon');
+  });
+
+  test('screenshot: the hub as a beta tester first sees it', async ({
+    page,
+  }, testInfo) => {
+    const first = testInfo.outputPath('hub-real-records-off-390x844.png');
+    await page.screenshot({ path: first, fullPage: true });
+    await testInfo.attach('hub — CARE_REAL_RECORDS off (390x844)',
+      { path: first, contentType: 'image/png' });
+
+    // ...and the state nobody had seen: the refusal, under the thumb.
+    await tile(page, 'fasten').click();
+    await expect(msgUnder(page, 'fasten')).toBeVisible();
+    const refused = testInfo.outputPath('hub-closed-tile-refused-390x844.png');
+    await page.screenshot({ path: refused, fullPage: true });
+    await testInfo.attach('hub — a closed tile tapped (390x844)',
+      { path: refused, contentType: 'image/png' });
+  });
+});
+
+test.describe('CareAgents beta banner', () => {
+  test.use({ baseURL: CARE_BASE_URL, ...PHONE });
+
+  test.beforeEach(async ({ page }) => {
+    await blockThirdParty(page);
+  });
+
+  test('renders on the landing page', async ({ page }) => {
+    await page.goto('/');
+    const banner = page.locator('.beta-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveText(BANNER);
+    await expect(banner).toBeInViewport();
+  });
+
+  test('renders on the hub', async ({ page }) => {
+    await signIn(page, uniqueEmail(), CARE_LOG);
+    const banner = page.locator('.beta-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveText(BANNER);
+    // Above the fold on a phone — a tester should not have to scroll to
+    // learn the records are synthetic.
+    await expect(banner).toBeInViewport();
+  });
+});
+
+test.describe('CareAgents hub — CARE_REAL_RECORDS=allowlist', () => {
+  // A second server, same code, allowlist mode (playwright.config.ts). Fasten
+  // key and wearables are wired there, so the allowlist is the only thing
+  // deciding what these two accounts see.
+  test.use({ baseURL: CARE_ALLOW_BASE_URL, ...PHONE });
+
+  test.beforeEach(async ({ page }) => {
+    await blockThirdParty(page);
+  });
+
+  test('the allowlisted account sees the real tiles live', async ({ page }) => {
+    await signIn(page, CARE_ALLOW_EMAIL, CARE_ALLOW_LOG);
+
+    for (const id of REAL_RECORD_TILES) {
+      const t = tile(page, id);
+      await expect(t).toBeVisible();
+      await expect(t).not.toHaveClass(/tier-soon/);
+      expect(await t.getAttribute('data-soon'),
+        `${id} still closed for an allowlisted account`).toBeNull();
+      // Live real-record tiles carry the consent gate; the closed ones cannot.
+      await expect(t).toHaveAttribute('data-consent', '1');
+    }
+    // "Live" has no badge of its own, so the absence of the tag IS the
+    // rendering: no "coming soon" for a tester to wait on.
+    await expect(tile(page, 'fasten').locator('.connector-tag')).toHaveCount(0);
+    await expect(tile(page, 'wearable').locator('.connector-tag'))
+      .toHaveCount(0);
+    await expect(tile(page, 'direct').locator('.connector-tag'))
+      .toHaveText('import');
+    await expect(tile(page, 'wearable'))
+      .toHaveAttribute('data-providers', /Apple Health/);
+    // The live blurb is back — the beta closure sentence is gone.
+    await expect(tile(page, 'fasten').locator('.connector-blurb')).toHaveText(
+      'Log in to your clinic or hospital portal. Verified; we never see ' +
+      'your password.');
+    await expect(page.locator('.marketplace')).not.toContainText(CLOSED_BLURB);
+  });
+
+  test('an account that is not on the list sees "coming soon" on the same deployment',
+    async ({ page }) => {
+      await signIn(page, uniqueEmail(), CARE_ALLOW_LOG);
+
+      for (const id of REAL_RECORD_TILES) {
+        const t = tile(page, id);
+        await expect(t.locator('.connector-tag')).toHaveText('coming soon');
+        await expect(t).toHaveAttribute('data-soon', '1');
+        expect(await t.getAttribute('data-consent')).toBeNull();
+      }
+      // And the refusal is per account, not per deployment: the same server
+      // that just showed live tiles refuses this one, in words.
+      await tile(page, 'fasten').click();
+      await expect(msgUnder(page, 'fasten')).toHaveText(REFUSED);
+      // The synthetic track stays open to everyone.
+      await expect(tile(page, 'sample')).toHaveClass(/tier-live/);
+    });
+});

--- a/e2e/tests/careagents-fixtures.ts
+++ b/e2e/tests/careagents-fixtures.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared CareAgents browser fixtures.
+ *
+ * Lifted verbatim out of careagents.spec.ts when a second CareAgents spec
+ * appeared (the beta connect tiles), so both suites sign a session in the same
+ * way rather than drifting apart. Not a `*.spec.ts`, so Playwright's default
+ * testMatch never collects this file as a suite.
+ *
+ * Every helper here talks ONLY to a CareAgents server booted by
+ * playwright.config.ts, whose HEALTHCLAW_BASE points at a dead local port.
+ */
+
+import { expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+
+/**
+ * Fail the journey shut at the network edge: only the app under test may be
+ * contacted. This is both a determinism fix — a slow or blocked third party
+ * stalls the `load` event that page.goto waits on — and a standing check that
+ * the covered journey needs no third party.
+ */
+export async function blockThirdParty(page: Page): Promise<void> {
+  await page.route('**/*', (route) => {
+    const url = route.request().url();
+    if (!url.startsWith('http')) return route.continue();
+    const host = new URL(url).hostname;
+    return host === 'localhost' || host === '127.0.0.1'
+      ? route.continue()
+      : route.abort();
+  });
+}
+
+/**
+ * Unique per test. Reusing an address breaks reruns: within RESEND_COOLDOWN
+ * (30s, careagents/accounts.py:36) start_email_code mints nothing and
+ * /api/auth/email answers {"sent": false, "reason": "cooldown"} (#262) — so
+ * no new code would ever reach the log.
+ */
+export const uniqueEmail = () =>
+  `e2e-${Date.now()}-${Math.floor(Math.random() * 1e4)}@example.test`;
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * With no RESEND_API_KEY the mail stub (careagents/mail.py:19) logs
+ *   "DEV email — <verb> for <email>: <8 digits>"
+ * to stderr instead of sending, and the webServer command redirects that
+ * into a log file. Match on this test's own address so a code minted for
+ * another test can never satisfy this poll.
+ *
+ * `logPath` is explicit — there is more than one CareAgents server now, and
+ * polling the wrong one's log is a ten-second timeout with a confusing
+ * message instead of a clear failure.
+ */
+export async function codeFromLog(
+  email: string,
+  logPath: string,
+): Promise<string> {
+  let code = '';
+  await expect
+    .poll(
+      () => {
+        const log = fs.existsSync(logPath)
+          ? fs.readFileSync(logPath, 'utf8')
+          : '';
+        const re = new RegExp(
+          `DEV email — [^\\n]* for ${escapeRe(email)}: (\\d{8})`, 'g');
+        for (let m = re.exec(log); m !== null; m = re.exec(log)) code = m[1];
+        return code;
+      },
+      // The stub logs before /api/auth/email even responds, so this is
+      // generous; if it expires, the server was not booted through this
+      // harness (or a real RESEND_API_KEY leaked into its env).
+      { timeout: 10_000, message: `no DEV email code logged for ${email}` },
+    )
+    .toMatch(/^\d{8}$/);
+  return code;
+}
+
+/** Walk the auth UI up to the code-entry step for a fresh email. */
+export async function requestCode(page: Page, email: string): Promise<void> {
+  await page.goto('/auth');
+  await page.locator('#email').fill(email);
+  await page.locator('#email-btn').click();
+  await expect(page.locator('#step-code')).toBeVisible();
+  await expect(page.locator('#code-email')).toHaveText(email);
+}
+
+/**
+ * The whole email-code journey, ending on the hub. Same steps the
+ * 'email-code sign-in reaches the hub' test asserts one by one — this is the
+ * arrangement other tests need before they can look at anything signed in.
+ */
+export async function signIn(
+  page: Page,
+  email: string,
+  logPath: string,
+): Promise<void> {
+  await requestCode(page, email);
+  const code = await codeFromLog(email, logPath);
+  await page.locator('#code').fill(code);
+  await page.locator('#verify-btn').click();
+
+  // On a WebAuthn-capable browser the first verified sign-in offers passkey
+  // enrolment (auth.js:72); elsewhere it goes straight to the hub. Creating a
+  // passkey is out of scope here and needs a virtual authenticator.
+  if (await page.evaluate(() => !!window.PublicKeyCredential)) {
+    await expect(page.locator('#step-passkey')).toBeVisible();
+    await page.locator('#skip-passkey-btn').click();
+  }
+  await expect(page).toHaveURL(/\/home$/);
+}

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -1,6 +1,8 @@
-import { test, expect, Page } from '@playwright/test';
-import * as fs from 'fs';
+import { test, expect } from '@playwright/test';
 import { CARE_BASE_URL, CARE_LOG } from '../playwright.config';
+import {
+  blockThirdParty, codeFromLog, requestCode, uniqueEmail,
+} from './careagents-fixtures';
 
 /**
  * CareAgents core journey (issue #233) — the first browser-level coverage of
@@ -12,90 +14,25 @@ import { CARE_BASE_URL, CARE_LOG } from '../playwright.config';
  *          session · email-code sign-in reaches the hub · /healthz reports
  *          the account store reachable.
  *
- * NOT covered, on purpose: chat/LLM turns, any HealthClaw call, passkey
- *          registration or passkey sign-in (WebAuthn is not driven here —
- *          only the enrolment *prompt* is asserted, then skipped), and the
- *          connect/wearable/Telegram/iMessage dialogs (#224 is rebuilding
- *          those, so assertions there would collide and rot).
+ * NOT covered here, on purpose: chat/LLM turns, any HealthClaw call, and
+ *          passkey registration or passkey sign-in (WebAuthn is not driven —
+ *          only the enrolment *prompt* is asserted, then skipped). The
+ *          connect tiles, the beta banner and the Telegram surface moved to
+ *          careagents-connect-tiles.spec.ts, which covers what a beta tester
+ *          sees under CARE_REAL_RECORDS.
  *
  * The app is booted by the second webServer entry in playwright.config.ts
  * with HEALTHCLAW_BASE pointed at a dead local port, so the server cannot
- * reach a real records service; blockThirdParty() below closes the same door
- * on the browser side.
+ * reach a real records service; blockThirdParty() closes the same door on the
+ * browser side.
  */
 
 // CareAgents runs on its own port; every test in this file targets it.
 test.use({ baseURL: CARE_BASE_URL });
 
-/**
- * Fail the journey shut at the network edge: only the app under test may be
- * contacted. This is both a determinism fix — base.html pulls Google Fonts,
- * and a slow or blocked CDN stalls the `load` event that page.goto waits on —
- * and a standing check that the covered journey needs no third party.
- */
-async function blockThirdParty(page: Page): Promise<void> {
-  await page.route('**/*', (route) => {
-    const url = route.request().url();
-    if (!url.startsWith('http')) return route.continue();
-    const host = new URL(url).hostname;
-    return host === 'localhost' || host === '127.0.0.1'
-      ? route.continue()
-      : route.abort();
-  });
-}
-
 test.beforeEach(async ({ page }) => {
   await blockThirdParty(page);
 });
-
-/**
- * Unique per test. Reusing an address breaks reruns: within RESEND_COOLDOWN
- * (30s, careagents/accounts.py:35) start_email_code mints nothing and
- * /api/auth/email answers {"sent": false, "reason": "cooldown"} (#262) — so
- * no new code would ever reach the log.
- */
-const uniqueEmail = () =>
-  `e2e-${Date.now()}-${Math.floor(Math.random() * 1e4)}@example.test`;
-
-const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-/**
- * With no RESEND_API_KEY the mail stub (careagents/mail.py:19) logs
- *   "DEV email — <verb> for <email>: <8 digits>"
- * to stderr instead of sending, and the webServer command redirects that
- * into CARE_LOG. Match on this test's own address so a code minted for
- * another test can never satisfy this poll.
- */
-async function codeFromLog(email: string): Promise<string> {
-  let code = '';
-  await expect
-    .poll(
-      () => {
-        const log = fs.existsSync(CARE_LOG)
-          ? fs.readFileSync(CARE_LOG, 'utf8')
-          : '';
-        const re = new RegExp(
-          `DEV email — [^\\n]* for ${escapeRe(email)}: (\\d{8})`, 'g');
-        for (let m = re.exec(log); m !== null; m = re.exec(log)) code = m[1];
-        return code;
-      },
-      // The stub logs before /api/auth/email even responds, so this is
-      // generous; if it expires, the server was not booted through this
-      // harness (or a real RESEND_API_KEY leaked into its env).
-      { timeout: 10_000, message: `no DEV email code logged for ${email}` },
-    )
-    .toMatch(/^\d{8}$/);
-  return code;
-}
-
-/** Walk the auth UI up to the code-entry step for a fresh email. */
-async function requestCode(page: Page, email: string): Promise<void> {
-  await page.goto('/auth');
-  await page.locator('#email').fill(email);
-  await page.locator('#email-btn').click();
-  await expect(page.locator('#step-code')).toBeVisible();
-  await expect(page.locator('#code-email')).toHaveText(email);
-}
 
 test.describe('CareAgents landing', () => {
   test('renders the hero and its CTA reaches sign-in', async ({ page }) => {
@@ -131,7 +68,7 @@ test.describe('CareAgents auth', () => {
     await requestCode(page, email);
     // Derive a guaranteed-wrong code from the real one (flip the last
     // digit) — deterministic, unlike guessing a fixed 8-digit string.
-    const real = await codeFromLog(email);
+    const real = await codeFromLog(email, CARE_LOG);
     const wrong =
       real.slice(0, 7) + ((parseInt(real[7], 10) + 1) % 10).toString();
     await page.locator('#code').fill(wrong);
@@ -151,7 +88,7 @@ test.describe('CareAgents auth', () => {
   test('email-code sign-in reaches the hub', async ({ page }) => {
     const email = uniqueEmail();
     await requestCode(page, email);
-    const code = await codeFromLog(email);
+    const code = await codeFromLog(email, CARE_LOG);
     await page.locator('#code').fill(code);
     await page.locator('#verify-btn').click();
 

--- a/e2e/tests/careagents.spec.ts
+++ b/e2e/tests/careagents.spec.ts
@@ -17,9 +17,10 @@ import {
  * NOT covered here, on purpose: chat/LLM turns, any HealthClaw call, and
  *          passkey registration or passkey sign-in (WebAuthn is not driven —
  *          only the enrolment *prompt* is asserted, then skipped). The
- *          connect tiles, the beta banner and the Telegram surface moved to
- *          careagents-connect-tiles.spec.ts, which covers what a beta tester
- *          sees under CARE_REAL_RECORDS.
+ *          connect tiles, the beta banner and the Telegram surface are
+ *          covered in careagents-connect-tiles.spec.ts, which asserts what a
+ *          beta tester sees under CARE_REAL_RECORDS. Only the four sign-in
+ *          helpers moved out of this file (careagents-fixtures.ts).
  *
  * The app is booted by the second webServer entry in playwright.config.ts
  * with HEALTHCLAW_BASE pointed at a dead local port, so the server cannot


### PR DESCRIPTION
> **Merge order is a hard constraint: #571 must merge before this.**
>
> This branch pins the refusal sentence verbatim, on purpose, because it is the one line a closed-out tester reads. A later commit here updated that pin to the rewritten sentence, which exists only on #571. Measured both ways by the review:
>
> - this branch on its own base: **2 failed, 46 passed** — the two assertions on the refusal string
> - #571's branch with this branch's `e2e/` overlaid, i.e. the post-merge state: **48 passed**
>
> Parts of the description below predate that commit: the sentence quoted under **What**, the run count, and two of the items under **Noticed** which #571 fixes. They are left as written rather than quietly edited, since the review's measurements refer to them.

---

## What

Nine Playwright tests at 390x844 (`e2e/tests/careagents-connect-tiles.spec.ts`), plus a
third `webServer` entry so the suite runs a second CareAgents server in
`CARE_REAL_RECORDS=allowlist` mode. Tests only. No production file changes.

With the switch closed (the fail-closed default):

1. Fasten, wearable and upload tiles render `coming soon` with the beta blurb "Not open
   in this beta — start with the sample records.", `data-soon="1"`, no `data-consent`, a
   dashed border and a CSS-uppercased tag. Each one reads as a label, not as a button
   that promises a connection.
2. Tapping one puts the server's refusal directly under that tile, in the viewport:
   "real-records connect isn't open on this beta deployment yet — start with the sample
   records". Asserted as visible text on a sibling selector, not as a network call. No
   consent card, no provider picker, no popup, no connection row, and the tag keeps
   reading `coming soon` rather than "we'll let you know".
3. The sample tile is still live, carries no tag, and its tap reaches the live branch.
4. The Telegram tile is a `div` with no id, reads `coming soon`, and a tap issues no
   request and changes nothing.
5. Two phone screenshots are attached to the run: the hub as first seen, and the same
   hub after a closed tile is tapped.

With `CARE_REAL_RECORDS=allowlist` on the second server:

6. The allowlisted account sees the three tiles live, each with `data-consent="1"` and
   no closure blurb. A second account on the same deployment sees `coming soon` and gets
   the same refusal on tap.

The beta banner is asserted on the landing page and on the hub, in the viewport, with
its full sentence.

`careagents.spec.ts` keeps every assertion it had. Its four helpers move to
`e2e/tests/careagents-fixtures.ts` (not a `*.spec.ts`, so Playwright does not collect
it) so both specs sign a session in the same way. `codeFromLog` now takes the log path,
because there is more than one CareAgents server to read a code from.

## Why

The review of #553 named this gap in writing:

> **Playwright: not run.** [...] **The gap that leaves:** nothing has confirmed *in a
> browser* that `home.js`'s soon-tile handler renders the 503 text under the tile on a
> phone. The server side is proven (503 body above) and the handler reads correctly, but
> the DOM path is unverified. Worth one manual tap on the deployed build.

Its owner list item 8 asked for one manual tap on a phone. This makes that tap a test
that runs on every PR, and takes the screenshot a human can look at.

The allowlist mode needs its own server because `Config` resolves `CARE_REAL_RECORDS`
once at `create_app()`. One process can only be in one mode, so proving the per-account
difference in a browser needs two. That server sets `FASTEN_PUBLIC_KEY` and
`CARE_WEARABLES_ENABLED`, so the allowlist is the only thing deciding what its two
accounts see. Without those, `catalog()` would answer "soon" for its own reasons and the
test would pass while proving nothing.

## Base note

Stacks on #553. Base is `feat/careagents-beta-batch`, not `main`, and the diff is only
this commit. Merge #553 first. Nothing here changes production code, so it can also be
retargeted at `main` after #553 lands.

## What these tests prove, and what they do not

They prove the browser renders a state: which tiles an account sees, what words are on
them, and what appears under one when a thumb taps it.

They do not prove HealthClaw accepted anything. Both CareAgents servers point
`HEALTHCLAW_BASE` at a dead local port, so no records service exists to accept or reject
a thing. No tenant is created and nothing is ingested. The sample-records tap gets as far
as the call to HealthClaw and stops. That is what makes it a usable discriminator: the
app refuses a closed tile before it calls HealthClaw at all. That distinction is stated in
the spec docstring and in each affected test.

Synthetic `@example.test` addresses only (RFC 2606 reserved). No mail leaves the machine:
the dev-mode stub logs each code to stderr.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3178 passed, 13 skipped, 1 xfailed, 2 warnings in 121.14s (0:02:01)

cd e2e && E2E_PORT=5199 npm test
48 passed (25.7s)
```

`E2E_PORT=5199` because :5000 is macOS AirPlay and :5099 held another worktree's server.
CI keeps the default.

Mutation runs, to show the new tests bite. Each mutation was reverted:

| Mutation | Result |
|---|---|
| `home.js` soon-branch ignores a refused POST and sets "we'll let you know" | 3 red: refusal-under-tile, screenshot, unlisted-account |
| harness boots the closed server with `CARE_REAL_RECORDS=on` | 3 red: tiles-coming-soon, refusal-under-tile, screenshot |
| `home.html` restores `id="tg-surface"` / `id="tg-state"` with "connect" | 1 red: Telegram-is-a-label |
| allowlist server booted with an empty `CARE_REAL_RECORDS_ALLOWLIST` | 1 red: allowlisted-sees-live-tiles |

The last one leaves "an unlisted account sees coming soon" green, correctly: an empty
allowlist is closed to everyone, so that account's view does not change.

## What was NOT run

- Nothing ran against a real HealthClaw, a real Fasten key, or the deployed site. See the
  section above.
- No Fasten or wearable flow was started, in either mode. The allowlist test asserts the
  tiles render live and stops there.
- No deploy, no config change on Railway. `CARE_REAL_RECORDS` stays unset there, which is
  closed.
- Chromium only, one viewport (390x844, `isMobile`). No WebKit, no in-app browser, no
  real device. An in-app browser is the stated primary surface and remains untested.
- No passkey path. The spec skips enrolment exactly as `careagents.spec.ts` does.
- I did not run `gh pr checks`. `dependency-audit` is red on every open PR from npm
  advisories whose fix sits in the unmerged #544. Nothing here touches a JS dependency.

## Screenshots

Written by the run to
`e2e/test-results/careagents-connect-tiles-*-chromium/` and attached to the Playwright
report. Both paths are gitignored, so no binary is committed, and CI keeps neither on a
green run: `ci.yml` uploads `playwright-report/` only `if: failure()`. To see the two
images, run the spec locally. Regenerate with:

```
cd e2e && npx playwright test tests/careagents-connect-tiles.spec.ts
```

## Noticed, not touched

- The marketplace footer note still reads "Verified provider & wearable logins happen on
  the provider's own site — we never see your password." It sits directly under three
  tiles that say the beta has not opened those logins. The landing page's step 1 has the
  same problem. Copy for Product to decide, not a switch defect.
- The refusal sentence starts lowercase and has no full stop, so it reads as a fragment
  next to the rest of the hub's copy. Product call.

Refs #553, #536, #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

