### PR TITLE
fix(careagents): a refused tile now announces itself, and the reassurance stops contradicting the tiles

### DIFF
--- a/careagents/connectors.py
+++ b/careagents/connectors.py
@@ -72,8 +72,11 @@ _WEARABLE_IDS = {p["id"] for p in WEARABLE_PROVIDERS}
 # unless the deployment's CARE_REAL_RECORDS switch opens them for this
 # account (council ruling 2026-09-02, D3) — the beta runs on synthetic data.
 REAL_RECORD_SOURCES = ("fasten", "wearable", "direct")
-_REAL_RECORDS_CLOSED = ("real-records connect isn't open on this beta "
-                        "deployment yet — start with the sample records")
+# The one sentence a refused tester reads, so it is a sentence: patient-facing
+# copy here is plain, sentence-cased and em-dash-free. Parallel to the closed
+# tile's own blurb ("Not open in this beta — start with the sample records.").
+_REAL_RECORDS_CLOSED = ("Connecting your own records isn't open in this beta "
+                        "yet. Start with the sample records.")
 
 
 def catalog(cfg, real_records: bool = False) -> list[dict]:

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -102,17 +102,30 @@
     if (anchor && el.previousElementSibling !== anchor) {
       anchor.insertAdjacentElement("afterend", el);
     }
-    el.textContent = text;
+    // #connect-msg is a live region, and a live region announces only a change
+    // made while it is IN the accessibility tree. Both things this function
+    // does take it out: `hidden` is display:none, and the move above is a
+    // remove-then-insert. Setting the text in the same task as either one is a
+    // change nothing is listening for — the refusal a closed tile gives would
+    // be read out by no screen reader at all. So show the empty region, let a
+    // frame paint, then write into it. Nested rAF because a single one runs
+    // BEFORE that paint, which is the same task as far as the a11y tree is
+    // concerned; two frames is ~32ms, under the threshold where an empty box
+    // is perceptible.
+    el.textContent = "";
     el.hidden = false;
-    // Only scrolls if it isn't already fully visible, and only as far as it
-    // has to — no jump when the message is already under the user's thumb.
-    // Never while a dialog is up: the message is behind the overlay, so the
-    // scroll moves nothing the user can see and everything they come back to
-    // (#269). Open state is the absence of `hidden` — that attribute is what
-    // openDialog() and the consent card toggle.
-    if (!document.querySelector(".modal:not([hidden])")) {
-      el.scrollIntoView({ block: "nearest" });
-    }
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      el.textContent = text;
+      // Only scrolls if it isn't already fully visible, and only as far as it
+      // has to — no jump when the message is already under the user's thumb.
+      // Never while a dialog is up: the message is behind the overlay, so the
+      // scroll moves nothing the user can see and everything they come back to
+      // (#269). Open state is the absence of `hidden` — that attribute is what
+      // openDialog() and the consent card toggle.
+      if (!document.querySelector(".modal:not([hidden])")) {
+        el.scrollIntoView({ block: "nearest" });
+      }
+    }));
   }
 
   // Scroll a section into view and pulse it — the in-page way to point at the

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -92,9 +92,19 @@
       </button>
       {% endfor %}
     </div>
-    <p class="inline-msg" id="connect-msg" hidden></p>
+    {# The only channel for a refusal: tap a closed tile and this paragraph is
+       the whole of what the deployment says back. Same live-region treatment
+       as .conn-refresh-msg above; say() shows it before writing into it. #}
+    <p class="inline-msg" id="connect-msg" role="status" aria-live="polite"
+       hidden></p>
+    {# True, and worth keeping — but only where the logins it describes are
+       open. Under three "not open in this beta" tiles it contradicted the
+       screen it sat on. #}
+    {% if catalog | selectattr('id', 'in', ['fasten', 'wearable'])
+                  | rejectattr('tier', 'equalto', 'soon') | list %}
     <p class="add-note">Verified provider &amp; wearable logins happen on the
       provider’s own site — we never see your password.</p>
+    {% endif %}
   </section>
 
   <!-- SURFACES -->

--- a/careagents/templates/landing.html
+++ b/careagents/templates/landing.html
@@ -35,9 +35,11 @@
     <li>
       <span class="step-n">1</span>
       <h3>Sign in with your face</h3>
+      {# The provider-login clause is gone rather than made conditional: this
+         page is public, gets no account, and so cannot resolve the
+         CARE_REAL_RECORDS switch that decides whether those logins are open. #}
       <p>A passkey — Face ID, Touch ID, or your security key — is your login.
-      No password to phish or forget. Then connect your records through your
-      provider’s own verified login.</p>
+      No password to phish or forget. Then connect your records.</p>
     </li>
     <li>
       <span class="step-n">2</span>

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -5238,3 +5238,88 @@ def test_the_tester_guide_matches_what_the_switch_actually_does():
     assert "Delete the account" in leaving
     assert "no self-serve" in leaving
     assert "support@healthclaw.io" in leaving
+
+
+# --- browser pass over the beta batch (#553) ---------------------------------
+# Three defects a screen reader and a pair of eyes found on the hub that no
+# server-side assertion could see.
+
+def test_the_connect_refusal_is_announced_to_a_screen_reader():
+    """`#connect-msg` is the ONLY channel for a refusal: tap a closed tile and
+    this paragraph is the whole of what the deployment says back. Without the
+    live-region attributes a blind tester taps and is told nothing at all.
+
+    Its sibling `.conn-refresh-msg` has carried `role="status"` +
+    `aria-live="polite"` since the refresh flow landed; this is the same
+    treatment on the same kind of element.
+    """
+    tag = _HOME_HTML[_HOME_HTML.index('<p class="inline-msg" id="connect-msg"'):]
+    tag = tag[:tag.index(">") + 1]
+    assert 'role="status"' in tag, tag
+    assert 'aria-live="polite"' in tag, tag
+
+    # ...and the attributes alone are not the fix. A live region announces a
+    # change made while it is IN the accessibility tree; `hidden` is
+    # display:none, and say() also MOVES the element (a remove-then-insert).
+    # Writing the text in the same task as either one is a change nothing is
+    # listening for. So the region is shown first and written into after.
+    body = re.sub(r"//[^\n]*", "",
+                  _HOME_JS.split("function say(")[1].split("\n  }")[0])
+    assert body.index("el.hidden = false") < body.index("el.textContent = text")
+    assert "requestAnimationFrame" in body
+
+
+def test_the_password_reassurance_is_absent_while_those_logins_are_closed(
+        svc, monkeypatch):
+    """"Verified provider & wearable logins happen on the provider's own site"
+    rendered directly beneath three tiles saying those logins are not open in
+    this beta. The sentence is true and stays — for the deployment where the
+    tiles it describes are live."""
+    closed = _beta_app(svc).test_client()
+    _login(closed, svc, monkeypatch, email="tester@example.org")
+    body = closed.get("/home").get_data(as_text=True)
+    assert "never see your password" not in body
+    # The tiles it contradicted are the ones on screen.
+    assert "Not open in this beta" in body
+
+    app = _beta_app(svc, CARE_REAL_RECORDS="allowlist",
+                    CARE_REAL_RECORDS_ALLOWLIST="dr.who@example.org")
+    listed = app.test_client()
+    _login(listed, svc, monkeypatch, email="dr.who@example.org")
+    body = listed.get("/home").get_data(as_text=True)
+    assert "never see your password" in body
+    # Same deployment, an account that is not on the list: no sentence.
+    other = app.test_client()
+    _login(other, svc, monkeypatch, email="stranger@example.org")
+    assert "never see your password" not in other.get("/home").get_data(
+        as_text=True)
+
+
+def test_the_landing_page_does_not_promise_a_provider_login_the_beta_closes(
+        app):
+    """Step 1 sent a stranger to "your provider's own verified login", which
+    the switch closes for all but an allowlisted account. The landing page is
+    public and gets no account, so it cannot resolve the switch — the clause
+    goes rather than being made conditional."""
+    body = app.test_client().get("/").get_data(as_text=True)
+    assert "verified login" not in body
+    assert "connect your records" in body
+
+
+def test_the_refusal_under_a_closed_tile_is_a_sentence(svc, monkeypatch):
+    """It read `real-records connect isn't open on this beta deployment yet —
+    start with the sample records`: lowercase start, no full stop, an em dash
+    this repo does not use in patient-facing copy. It is the one sentence a
+    refused tester gets."""
+    from careagents.connectors import _REAL_RECORDS_CLOSED as msg
+    assert msg == ("Connecting your own records isn't open in this beta yet. "
+                   "Start with the sample records.")
+    assert "—" not in msg and "--" not in msg
+    c = _beta_app(svc).test_client()
+    _login(c, svc, monkeypatch, email="tester@example.org")
+    for tile, payload in (("fasten", {"consent": True}),
+                          ("wearable", {"provider": "apple", "consent": True}),
+                          ("direct", {"consent": True})):
+        r = c.post(f"/api/connections/{tile}", json=payload)
+        assert r.status_code == 503, tile
+        assert r.get_json()["error"] == msg, tile

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -5266,7 +5266,13 @@ def test_the_connect_refusal_is_announced_to_a_screen_reader():
     body = re.sub(r"//[^\n]*", "",
                   _HOME_JS.split("function say(")[1].split("\n  }")[0])
     assert body.index("el.hidden = false") < body.index("el.textContent = text")
-    assert "requestAnimationFrame" in body
+    # MUTATION (QA review): `"requestAnimationFrame" in body` passed with a
+    # SINGLE rAF — the case say()'s own comment says does not announce, because
+    # one frame's callback runs BEFORE the paint that puts the region in the
+    # accessibility tree. The count is the property, so the count is pinned.
+    assert body.count("requestAnimationFrame") == 2, body
+    assert re.search(
+        r"requestAnimationFrame\(\(\)\s*=>\s*requestAnimationFrame\(", body), body
 
 
 def test_the_password_reassurance_is_absent_while_those_logins_are_closed(
@@ -5274,11 +5280,18 @@ def test_the_password_reassurance_is_absent_while_those_logins_are_closed(
     """"Verified provider & wearable logins happen on the provider's own site"
     rendered directly beneath three tiles saying those logins are not open in
     this beta. The sentence is true and stays — for the deployment where the
-    tiles it describes are live."""
+    tiles it describes are live.
+
+    Keyed on the `add-note` element, not on the words in it (QA review): the
+    live Fasten tile's own blurb ends "we never see your password", so a
+    phrase match is satisfied by the tile whether or not the note rendered,
+    and deleting the note outright left the assertion green.
+    """
+    note = 'class="add-note"'
     closed = _beta_app(svc).test_client()
     _login(closed, svc, monkeypatch, email="tester@example.org")
     body = closed.get("/home").get_data(as_text=True)
-    assert "never see your password" not in body
+    assert note not in body
     # The tiles it contradicted are the ones on screen.
     assert "Not open in this beta" in body
 
@@ -5287,12 +5300,47 @@ def test_the_password_reassurance_is_absent_while_those_logins_are_closed(
     listed = app.test_client()
     _login(listed, svc, monkeypatch, email="dr.who@example.org")
     body = listed.get("/home").get_data(as_text=True)
+    assert note in body
     assert "never see your password" in body
     # Same deployment, an account that is not on the list: no sentence.
     other = app.test_client()
     _login(other, svc, monkeypatch, email="stranger@example.org")
-    assert "never see your password" not in other.get("/home").get_data(
-        as_text=True)
+    assert note not in other.get("/home").get_data(as_text=True)
+
+
+def test_the_password_reassurance_needs_a_login_tile_not_just_an_open_switch(
+        svc, monkeypatch):
+    """The gate is `fasten`/`wearable`, not "any real-record source is open".
+
+    A deployment can have the switch fully ON and still have neither login:
+    `catalog()` marks Fasten "soon" without a `FASTEN_PUBLIC_KEY` and the
+    wearable tile "soon" without the Open Wearables sidecar, while `direct`
+    (upload a bundle) stays live — it needs no provider login. Widening the
+    gate to include `direct` would put "Verified provider & wearable logins
+    happen on the provider's own site" back under two tiles that say those
+    logins are not configured here. MUTATION (QA review): that widening left
+    the whole suite green, so the distinction is pinned here.
+    """
+    note = 'class="add-note"'
+    open_no_logins = _beta_app(svc, CARE_REAL_RECORDS="on",
+                               FASTEN_PUBLIC_KEY="",
+                               CARE_WEARABLES_ENABLED="")
+    c = open_no_logins.test_client()
+    _login(c, svc, monkeypatch, email="tester@example.org")
+    body = c.get("/home").get_data(as_text=True)
+    tiers = {t["id"]: t["tier"] for t in
+             c.get("/api/connections/catalog").get_json()["connectors"]}
+    # The arrangement this pins: switch open, both logins unconfigured, upload
+    # live. Assert it, or a future default change makes the test vacuous.
+    assert tiers["fasten"] == "soon" and tiers["wearable"] == "soon", tiers
+    assert tiers["direct"] == "import", tiers
+    assert note not in body
+
+    # ...and one configured login is enough to bring it back.
+    one = _beta_app(svc, CARE_REAL_RECORDS="on", CARE_WEARABLES_ENABLED="")
+    c2 = one.test_client()
+    _login(c2, svc, monkeypatch, email="tester2@example.org")
+    assert note in c2.get("/home").get_data(as_text=True)
 
 
 def test_the_landing_page_does_not_promise_a_provider_login_the_beta_closes(


### PR DESCRIPTION
## What

Three fixes to the beta hub, all found by the browser pass over #553.

**1. A refused tile now announces itself.** `#connect-msg` had no `role="status"`
and no `aria-live`, while its sibling `.conn-refresh-msg` (home.html:75) has
carried both since the refresh flow landed. #553 made `#connect-msg` the carrier
of the one sentence a tester gets when a closed tile refuses them, so a blind
tester tapped a tile and was told nothing at all. The element now carries the
sibling's exact attributes.

The attributes alone would not have fixed it. A live region announces only a
change made while it is *in* the accessibility tree, and `say()` (home.js:101)
did two things that take it out — `hidden` is `display:none`, and the element is
MOVED next to the tapped tile, which is a remove-then-insert — in the same task
as the write. `say()` now clears the region, unhides it, lets a frame paint
(nested `requestAnimationFrame`; a single one runs *before* the paint, which is
the same tick as far as the a11y tree is concerned), then writes the text. The
scroll nudge moved into the deferred callback so `block: "nearest"` measures the
final height.

**The sibling likely needs the same treatment.** `.conn-refresh-msg` has the
attributes but its writer (`report()`, home.js:252) sets `textContent` *before*
`hidden = false` — the same ordering defect, on the element this fix was modelled
on. Not touched here; it belongs to the refresh flow, not this batch.

**2. The reassurance no longer contradicts the tiles.** "Verified provider &
wearable logins happen on the provider's own site — we never see your password"
rendered directly beneath three tiles saying those logins are not open in this
beta. The sentence is true and is kept verbatim, now rendered only when the
catalog says the tiles it describes are live.

**3. The refusal reads as a sentence.** It was lowercase, unpunctuated and
em-dashed.

## Base note

**This stacks on #553** (`feat/careagents-beta-batch`), not on `main` — one
commit here; review it, not the diff against `main`. **#569 also
stacks on that same base and needs a one-line string update**; details and merge
order below.

## The new string — **#569 needs a one-line update**

```
Connecting your own records isn't open in this beta yet. Start with the sample records.
```

(was: `real-records connect isn't open on this beta deployment yet — start with
the sample records`)

**#569 stacks on this same base and asserts the old string verbatim** as its
`REFUSED` constant (`e2e/tests/careagents-connect-tiles.spec.ts:52`). That file
was deliberately not edited here. Two of its assertions fail against this branch,
both on that constant and nothing else:

- `tapping a closed tile shows the refusal under that tile` (:127)
- `an account that is not on the list sees "coming soon" on the same deployment` (:295)

Whoever merges second updates `REFUSED` to the string above. **Merge order:** if
#569 goes first, this PR's change makes it red until that one line lands; if this
goes first, #569 needs the line updated before it can go green. The other seven
tests in that spec pass against this branch — including `toBeVisible`,
`toBeInViewport` and the sibling-selector locator, so the `say()` rework does not
disturb them.

No existing Python test pinned the string exactly — the closest
(`test_real_record_connect_posts_are_refused_with_503_when_off`) asserts
`"beta" in error`, which passes either way. A new test pins the new sentence on
the wire for all three closed tiles.

`connectors.py:158/225` carry a *different* message ("isn't configured on this
deployment yet") for an unconfigured Fasten key — deliberately left alone.

## Why

The browser pass over #553. #553 shipped the CARE_REAL_RECORDS switch and proved
its server side; what it could not see was the screen. All three of these are
only visible with a rendered page and, for the first, a screen reader.

## Two judgement calls worth reviewing

- **The gate is `fasten`/`wearable`, not all three real-record tiles.** The
  sentence is about provider and wearable *logins*. `direct` (upload a FHIR
  bundle) is a real-record source but not a login, so a deployment with the
  switch on but no Fasten key and no wearables sidecar would still have shown the
  sentence under two "not configured" tiles. Strict subset of the brief's
  condition, same goal.
- **The landing page's clause is deleted, not made conditional.** `landing()`
  (app.py:240) passes only `me`; the page is public and gets no account, so it
  cannot resolve a switch that is evaluated per account. Step 1 now ends "Then
  connect your records."

## Ran

- `uv run ruff check .` → `All checks passed!`
- `uv run python -m pytest tests/ -q -p no:cacheprovider` →
  `3182 passed, 13 skipped, 1 xfailed, 2 warnings in 104.53s`
- `cd e2e && npm test` → `39 passed (21.6s)`
- #569's spec, overlaid from its branch and then removed → `2 failed, 7 passed`,
  the two named above.

Ports: `E2E_PORT=5297 CARE_E2E_PORT=5301` (5000 is AirPlay; 5099 and 5199 were
held by other agents on this machine — with `reuseExistingServer` on, 5199's
foreign server silently gave one false red before the ports were moved).

## What was NOT run

- No screen reader. The announcement is verified structurally only: the
  attributes on the tag, and the unhide-before-write ordering inside `say()`
  (`tests/test_careagents.py::test_the_connect_refusal_is_announced_to_a_screen_reader`).
  Someone with VoiceOver or NVDA should confirm the refusal is actually spoken.
- Nothing against a running HealthClaw. The e2e harness pins `HEALTHCLAW_BASE` to
  a dead port; no ids crossed the boundary here, and none needed to.
- Nothing deployed.

`dependency-audit` is red on every open PR from npm advisories already fixed in
unmerged PR #544.
