### PR TITLE
probe: what actually happens to /healthz under concurrent chat turns (#219)

### DIFF
--- a/docs/evidence/2026-09-03-probe-219-thread-saturation.md
+++ b/docs/evidence/2026-09-03-probe-219-thread-saturation.md
@@ -1,0 +1,763 @@
+# Probe — what actually happens to `/healthz` under concurrent chat turns (#219)
+
+- **Date:** 2026-09-03
+- **Branch / HEAD:** `probe/219-thread-saturation` off `origin/main` @ `89b42fb`
+- **Script:** `scripts/probe_219_thread_saturation.py` (committed; re-runnable
+  from `main` by a non-author with
+  `uv run python scripts/probe_219_thread_saturation.py`)
+- **Production was not touched.** No load was sent to `careagents.cloud` or
+  `app.healthclaw.io`. Every number below comes from a local gunicorn plus a
+  fake HealthClaw on loopback.
+- **One redaction:** the operator's home-directory name in pasted shell output
+  reads `<user>`. Nothing else in any transcript is altered.
+
+## Verdict: **REPRODUCES DIFFERENTLY**
+
+The starvation half is real and worse than stated. The restart half does not
+happen, and most of the data-loss half is already false.
+
+| # | Claim in the issue | Measured |
+|---|---|---|
+| 1 | "One worker, 8 threads" | **Wrong.** `--workers 2 --threads 4`. Still 8 threads, but the split makes saturation start *earlier* and *non-deterministically* |
+| 2 | "Each chat turn holds a thread ... 6 tool rounds × 25s + 90s LLM" | **Wrong mechanism, right symptom.** The web tier runs no inference since #257. The hold is the SSE replay loop, bounded by the 120s run deadline |
+| 3 | "8 concurrent turns block everything including `/healthz`" | **Confirmed at 8, intermittent from 6.** At the code's own worst case `/healthz` waits **118s** |
+| 4 | "Railway marks the container unhealthy → restart" | **Does not happen.** Railway's healthcheck is deploy-time only; it does not monitor a running container |
+| 5 | "All chat histories wiped" | **False.** Transcripts live in HealthClaw, per tenant |
+| 6 | "Rate-limit state wiped" | **Half true.** The in-process *burst* limiter resets (by design); the durable daily cap and the login-code attempt counter both survive |
+| — | *(not in the issue)* | **`/healthz` breaks its own 5s probe budget at zero load**, because it makes a 25s-timeout call to HealthClaw |
+| — | *(not in the issue)* | **Each open chat turn polls HealthClaw 4×/s.** 8 turns ≈ **31 req/s** aimed at the HealthClaw that serves the clinician |
+
+---
+
+## 1. What the code actually does (the premise moved under the issue)
+
+The issue is quoted from the 2026-08-01 architecture audit
+(`docs/2026-08-01-alignment-review.md:44`). Since then #257 moved inference out
+of the web process, which changes the mechanism the issue describes.
+
+A later review already caught this. `docs/2026-08-05-pattern-first-architecture-review.md:161`
+describes the same component as "**8 request slots held by 150s SSE turns**" —
+the correct mechanism, four days after the audit #219 quotes. The issue was
+never updated to match, and has been read since as if the audit's version were
+current. This probe confirms the 08-05 reading and measures it.
+
+`careagents/wsgi.py:3`:
+
+> The WSGI process only authenticates, enqueues, and replays durable run
+> events. Inference and tools execute in ``python -m careagents.worker``.
+
+So `/api/chat` (`careagents/app.py:873`) claims the inbound message, creates a
+durable run, and returns an SSE stream. The gunicorn thread is held by
+`_stream_run` (`careagents/app.py:833`), which polls HealthClaw for run events
+every `run_sse_poll_seconds` until the run is terminal.
+
+The numbers the issue multiplies together are the *worker's* budget, not the
+web tier's:
+
+| Setting | Value | Where |
+|---|---|---|
+| `MAX_TOOL_ROUNDS` | 6 | `careagents/agent.py:24` |
+| HealthClaw client read timeout | 25.0s | `careagents/healthclaw.py:54` |
+| `run_deadline_seconds` | 120 | `careagents/config.py` |
+| `run_sse_timeout_seconds` | 150 | `careagents/config.py` |
+| `run_sse_poll_seconds` | 0.25 | `careagents/config.py` |
+| gunicorn | `--workers 2 --threads 4 --timeout 180` | `deploy/careagents/Dockerfile:54` |
+
+Two consequences the issue does not account for:
+
+- **The turn is already bounded.** `run_deadline_seconds` is 120 and the worker
+  checks it between calls (`careagents/worker.py:439`). `llm._attempt_timeout`
+  derives the model budget from it, explicitly so a call cannot outlive the
+  deadline by more than one in-flight request. Mitigation 1 in the issue
+  ("bound the turn") is substantially shipped; the remaining lever is
+  *lowering* 120, not adding a bound.
+- **The web thread hold is the SSE stream, and it can chain.** When a stream
+  hits 150s before the run is terminal it emits `reconnect`, and the browser
+  reopens `/api/chat/runs/<id>/events` (`careagents/static/chat.js:301`). One
+  user's hold is therefore "until the run is terminal", across reconnects.
+
+## 2. Rig — what was faked and why
+
+Real: `careagents.wsgi:app` under the Dockerfile's own gunicorn invocation, the
+real `HealthClawClient` with its real 25s timeout, real sessions, real
+rate limiters, real sqlite account store.
+
+Faked: **HealthClaw only**, as a loopback `ThreadingHTTPServer`, with
+`HEALTHCLAW_BASE` pointed at it. Nothing is monkeypatched inside gunicorn, so
+the client and its timeouts are exercised as shipped. The fake answers
+token-mint, message-claim, run-create and worker-health instantly, and holds a
+run in `running` for a controlled number of seconds. **That controlled duration
+is the independent variable** — it is exactly how long a chat turn holds a
+gunicorn thread, without needing a model or a network.
+
+The LLM is not faked because the web tier never calls it.
+
+Two settings were changed for the rig and are disclosed here because they could
+otherwise fake a result: `CARE_CHAT_TURNS` and `CARE_CHAT_TURNS_PER_DAY` are
+raised, so that a rate-limited turn — which returns 429 instantly and holds no
+thread — cannot masquerade as a held thread. Every scenario reports how many
+turns actually received their `accepted` event.
+
+One macOS-only workaround: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`, without
+which gunicorn's pre-fork children crash on this machine. The container runs
+Linux, where the variable is inert.
+
+## 3. Item 1 — does `/healthz` starve? Yes: total at N=8, intermittent at N=6
+
+```
+### Item 1 — does /healthz starve? ###
+  [2w x 4t (8 threads)] N=0   started=0/0   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [2w x 4t (8 threads)] N=4   started=4/4   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 4t (8 threads)] N=6   started=6/6   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 4t (8 threads)] N=8   started=7/8   healthz(5s) 3/4 healthz(30s) 1/1 true wait 18.19s
+  [2w x 4t (8 threads)] N=10  started=8/10  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.13s
+  [2w x 4t (8 threads)] N=16  started=8/16  healthz(5s) 0/4 healthz(30s) 0/1 true wait 38.32s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  0    20s           0/0  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.01s       0.0
+  4    20s           4/4  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.00s     109.9
+  6    20s           6/6  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.00s     165.3
+  8    20s           7/8  3/4 ok, max 5.00s 1/1 ok, max 18.19s     18.19s      30.9
+ 10    20s          8/10  1/4 ok, max 5.00s 1/1 ok, max 18.12s     18.13s      38.4
+ 16    20s          8/16  0/4 ok, max 5.00s 0/1 ok, max 30.00s     38.32s      31.2
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+  [1w x 8t (8 threads)] N=0   started=0/0   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=4   started=4/4   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=6   started=6/6   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=8   started=8/8   healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.18s
+  [1w x 8t (8 threads)] N=10  started=8/10  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.28s
+  [1w x 8t (8 threads)] N=16  started=8/16  healthz(5s) 0/4 healthz(30s) 0/1 true wait 38.49s
+
+/healthz under N concurrent chat turns — 1w x 8t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  0    20s           0/0  4/4 ok, max 0.01s  1/1 ok, max 0.01s      0.01s       0.0
+  4    20s           4/4  4/4 ok, max 0.00s  1/1 ok, max 0.00s      0.01s     110.3
+  6    20s           6/6  4/4 ok, max 0.00s  1/1 ok, max 0.01s      0.01s     165.5
+  8    20s           8/8  1/4 ok, max 5.00s 1/1 ok, max 18.18s     18.18s      31.0
+ 10    20s          8/10  1/4 ok, max 5.00s 1/1 ok, max 18.27s     18.28s      37.6
+ 16    20s          8/16  0/4 ok, max 5.00s 0/1 ok, max 30.00s     38.49s      30.8
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+```
+
+The two budget columns are comparisons, not CareAgents' own settings: 5s is
+the Dockerfile's `HEALTHCHECK --timeout`, and 30s is the `healthcheckTimeout`
+this repo's `railway.toml` sets for *HealthClaw* (and Railway's
+`healthcheckTimeout` is a deploy-window total, not a per-probe timeout).
+`/healthz` was the only route measured; every route shares the same thread
+pool by construction, but that was not separately exercised.
+
+**Reading it.** `/healthz` does not fail closed or refuse a connection; it
+connects instantly and then waits for a free thread. The wait is the remaining
+lifetime of whichever turn frees first, which is why "true wait" tracks the
+hold (20s) rather than growing with N. Above the thread count, waits stack:
+at N=16 the second batch of turns starts before the first releases, so the
+measured wait is **38.32s** for a 20s hold, and only 8 of the 16 turns get a
+thread at all within the settle window.
+
+**The 2×4 split makes it worse, not better.** Gunicorn pre-fork workers accept
+from a shared socket, so six turns do not spread three-and-three. When they
+land five-and-one, one worker is saturated at 4 while the other idles, and
+`/healthz` starves or not depending on which worker accepts it. That is a coin
+flip, and a single sample cannot show it:
+
+```
+### Why 2w x 4t starves below 8 — N=6, repeated ###
+  arrivals in the same millisecond (burst):
+  run 1/6: /healthz true wait 18.11s  (5s budget 3/4 ok)
+  run 2/6: /healthz true wait 18.13s  (5s budget 1/4 ok)
+  run 3/6: /healthz true wait 0.01s  (5s budget 1/4 ok)
+  run 4/6: /healthz true wait 18.27s  (5s budget 1/4 ok)
+  run 5/6: /healthz true wait 0.01s  (5s budget 4/4 ok)
+  run 6/6: /healthz true wait 18.21s  (5s budget 3/4 ok)
+
+  N=6 on 2w x 4t, 6 runs: /healthz stalled in 4/6. Waits: [18.11, 18.13, 0.01, 18.27, 0.01, 18.21]
+
+  arrivals spread 0.3s apart (closer to real traffic):
+  run 1/6: /healthz true wait 17.00s  (5s budget 1/4 ok)
+  run 2/6: /healthz true wait 0.01s  (5s budget 4/4 ok)
+  run 3/6: /healthz true wait 0.01s  (5s budget 1/4 ok)
+  run 4/6: /healthz true wait 16.99s  (5s budget 1/4 ok)
+  run 5/6: /healthz true wait 16.97s  (5s budget 2/4 ok)
+  run 6/6: /healthz true wait 16.97s  (5s budget 1/4 ok)
+
+  N=6 on 2w x 4t, 6 runs: /healthz stalled in 4/6. Waits: [17.0, 0.01, 0.01, 16.99, 16.97, 16.97]
+```
+
+Bimodal, as the mechanism predicts: either ~0.0s (accepted by the free worker)
+or ~18s (accepted by the saturated one). **The shipping configuration
+intermittently starves at 6 concurrent turns, not 8.**
+
+Both arrival patterns were run because a same-millisecond burst is a plausible
+rig artifact — it could bias gunicorn's accept race toward whichever worker
+woke first, and real arrivals are spread over seconds. **Spreading the arrivals
+does not remove the stall**, which is the point that matters: staggering them
+0.3s apart produced the same bimodal shape and a comparable rate.
+
+The *rate* itself should not be quoted precisely. Across three attempts at
+N=6 — one earlier burst run not reproduced here, plus the two above — the
+stall count was 2, 4 and 4 out of 6. On six trials that spread is ordinary
+noise, so the honest statement is "intermittent, roughly a third to two thirds
+of the time", not "4 in 6". What is stable across all three is the shape: the
+wait is either ~0s or ~18s, never in between, because it depends on which
+worker accepted the probe.
+
+## 4. Item 2 — the real per-turn thread hold
+
+```
+### Item 2 — real per-turn thread hold ###
+
+Per-turn web-thread hold (one turn, 2w x 4t)
+--------------------------------------------
+ run duration   thread held   accepted after   poll reqs  events
+           2s         2.09s           0.018s           9  accepted,text,done
+          10s        10.13s           0.025s          40  accepted,text,done
+          30s        30.02s           0.007s         116  accepted,text,done
+```
+
+The web thread is held for the whole life of the run, to within ~0.1s, and the
+poll count confirms ~3.9 requests/second per open stream. Typical and worst
+case are therefore not properties of the web tier at all — they are whatever
+the *run* takes, bounded by:
+
+- **typical:** one model round, no tools — a few seconds.
+- **worst case as the code stands:** `run_deadline_seconds` = **120s**, plus at
+  most one in-flight provider call that the between-calls deadline check cannot
+  cancel (`careagents/worker.py:299` says so explicitly). Then the SSE emits
+  `reconnect` at 150s and the browser reopens, so the *user-visible* hold
+  chains until the run is terminal.
+
+At that worst case:
+
+```
+### Worst case — 8 turns each holding 120s (the run deadline) ###
+  [2w x 4t (8 threads)] N=8   started=8/8   healthz(5s) 0/4 healthz(30s) 0/1 true wait 118.12s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8   120s           8/8  0/4 ok, max 5.00s 0/1 ok, max 30.00s    118.12s      30.7
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+```
+
+**8 concurrent turns at the code's own deadline make `/healthz` wait 118
+seconds.** That is the load-bearing number for everything below.
+
+## 5. Item 3 — what the platform's health check actually requires
+
+This is the finding that decides the issue, and it is documentary, not
+measured.
+
+**Railway does not probe a running container.** From
+<https://docs.railway.com/guides/healthchecks>:
+
+> The healthcheck endpoint is currently **not used for continuous monitoring**
+> as it is only called at the start of the deployment.
+
+The default timeout is 300s, and on failure "the deploy will be marked as
+failed" — the new deployment is not activated and traffic stays on the previous
+version. The docs do not describe honouring a Dockerfile `HEALTHCHECK`.
+
+**The Dockerfile's own arithmetic, since the question was asked.**
+`deploy/careagents/Dockerfile:39` sets
+`HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3`. A
+probe that exceeds 5s counts as one failure, and three consecutive failures
+30s apart mark the container `unhealthy` — so **90 seconds of continuous
+saturation**. The 118s worst case in §4 does exceed that. Two caveats make it
+moot on the hosts CareAgents actually runs on:
+
+- **Docker does not restart an unhealthy container.** `unhealthy` is a status;
+  something else (Swarm, Kubernetes, a `--restart` supervisor acting on it) has
+  to convert it into a restart. Neither of CareAgents' hosts does.
+- **Railway does not evaluate it at all** (the quote above), and the VPS
+  alternative `deploy/careagents/careagents.service` has `Restart=on-failure`
+  with *no* health check — systemd restarts on process *exit*, which saturation
+  does not cause. Gunicorn's `--timeout 180` does not cause one either: it is a
+  master-to-worker heartbeat that the worker's main loop refreshes on every
+  poll iteration, and busy pool threads do not block that loop. It never fires
+  from saturation, at any hold length.
+
+**So there is no mechanism, on either host, to convert a slow `/healthz` into a
+restart.** No restart, no wipe, no loop. The answer to "how many consecutive
+slow health checks trigger a restart" is: on a Docker-native orchestrator that
+acts on HEALTHCHECK, three (90s); on Railway and on the systemd VPS, no number
+exists, because nothing is watching.
+
+What saturation *does* cost on Railway is real but different: **a deploy that
+lands while the container is saturated fails its health check and does not go
+live.** Traffic stays on the old version. That is a stuck deploy, not an
+outage.
+
+## 6. Item 4 — is the data-loss half real? Mostly not.
+
+```
+### Item 4 — what a restart actually loses ###
+DEV email — Verify your email for restart-probe-1788474575@example.invalid: 89021758
+  burst limiter (CARE_CHAT_TURNS=3), 4 turns before restart: [200, 200, 200, 429]
+  first turn AFTER restart: 200 data: {"type": "accepted", "run_id": "run-4", "next_cursor": 0}
+
+id: 1
+data: {"t
+  durable daily counter (UsageDay.turns) across the restart: [4]
+  login-code attempts read back through a new engine: 2
+  chat turns persisted to HealthClaw, not CareAgents memory: 3 POSTs to /command-center/api/conversations
+```
+
+Four stores, measured separately:
+
+| State | Where it lives | Survives a restart? |
+|---|---|---|
+| Chat transcripts | HealthClaw `cc_conversation_messages`, per tenant (`careagents/healthclaw.py:571`, `r6/command_center/models.py:62`) | **Yes** — it is not in CareAgents at all |
+| Login-code attempts | `EmailToken.attempts`, a DB column (`careagents/models.py:145`) | **Yes** — read back as 2 through a fresh engine |
+| Durable daily turn cap | `UsageDay` (`careagents/models.py:117`) | **Yes** — counted 4 across the restart |
+| Chat *burst* limiter | in-process `turns` deque (`careagents/app.py:167`) | **No** — 429 before the restart, 200 after |
+
+Only the last one is lost, and `careagents/config.py` already documents it as
+deliberate:
+
+> The burst limiter above is in-process, so it resets on restart and multiplies
+> by gunicorn worker count; this one is DB-backed and is what actually bounds
+> what a single account can cost the operator in a day.
+
+**"Every chat history ... wiped" is false.** CareAgents stores no chat history
+to lose — that is the published invariant (`docs/agent-task-guide.md:55`,
+"CareAgents and SmartHealthConnect store **no PHI**") working as designed.
+Restarting CareAgents cannot wipe a transcript any more than restarting a
+browser can.
+
+## 7. Item 5 — measured effect of each proposed mitigation
+
+```
+### Item 5 — measured effect of each mitigation ###
+
+(a) bound the turn: same N, shorter run
+  [2w x 4t (8 threads)] N=8   started=4/8   healthz(5s) 3/4 healthz(30s) 1/1 true wait 0.01s
+  [2w x 4t (8 threads)] N=16  started=8/16  healthz(5s) 3/4 healthz(30s) 1/1 true wait 13.73s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8     5s           4/8  3/4 ok, max 5.00s  1/1 ok, max 8.49s      0.01s      15.1
+ 16     5s          8/16  3/4 ok, max 5.00s  1/1 ok, max 3.24s     13.73s      21.1
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+(b) drop the HealthClaw read timeout 25s -> 10s
+  b1. /healthz's own call, no chat load:
+  HealthClaw hangs, no chat load, client read timeout 25s (shipping default): /healthz took [25.01, 25.01] -> [503, 503]
+----------------------------------------
+Exception occurred during processing of request from ('127.0.0.1', 51180)
+Traceback (most recent call last):
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 691, in process_request_thread
+    self.finish_request(request, client_address)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 361, in finish_request
+    self.RequestHandlerClass(request, client_address, self)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 755, in __init__
+    self.handle()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 440, in handle
+    self.handle_one_request()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 428, in handle_one_request
+    method()
+  File "/Users/<user>/Git/HealthClawGuardrails/.claude/worktrees/agent-a078e2964ba2642fb/scripts/probe_219_thread_saturation.py", line 155, in do_GET
+    return self._reply(200, {"available": True, "workers": 1})
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/<user>/Git/HealthClawGuardrails/.claude/worktrees/agent-a078e2964ba2642fb/scripts/probe_219_thread_saturation.py", line 115, in _reply
+    self.wfile.write(raw)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 834, in write
+    self._sock.sendall(b)
+BrokenPipeError: [Errno 32] Broken pipe
+----------------------------------------
+  HealthClaw hangs, no chat load, client read timeout 10s (proposed): /healthz took [10.01, 10.01] -> [503, 503]
+```
+
+| Mitigation | Measured effect | Verdict |
+|---|---|---|
+| **Bound the turn** | Shortening the turn 20s → 5s dropped the `/healthz` wait from **18.19s → 0.01s** at N=8, and **38.32s → 13.73s** at N=16. The starvation window tracks the turn length | **The lever that moves the number** — but the bound already exists (`run_deadline_seconds` = 120). The change is lowering it, which trades a hung page for a cut-off answer |
+| **Read timeout 25s → 10s** | **Nothing while HealthClaw is healthy** — those calls return in milliseconds, so the saturation tables do not move. It binds only when HealthClaw *hangs*, and then in two places: `/healthz`'s own call (25.01s → 10.01s) and the thread hold itself, since `_stream_run` has no `except` and the timeout is what ends the generator | Real but narrow: it converts a 25s hang into a 10s hang. It does not help the healthy-but-busy case, which is the one #219 describes |
+| **Raise threads (2×8 = 16)** | **Fixes N=8 outright** (18.19s → **0.00s**, 5s budget 3/4 → 4/4 ok). At N=16 it halves the wait (38.32s → **18.23s**) and starts all 16 turns instead of 8, but `/healthz` still blows the 5s budget 3 times in 4 | Buys roughly one doubling of headroom and no more. The failure moves from 8 concurrent to 16, it does not go away |
+
+```
+(c) raise threads: 2w x 8t (16 threads)
+----------------------------------------
+Exception occurred during processing of request from ('127.0.0.1', 51824)
+Traceback (most recent call last):
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 691, in process_request_thread
+    self.finish_request(request, client_address)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 361, in finish_request
+    self.RequestHandlerClass(request, client_address, self)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 755, in __init__
+    self.handle()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 442, in handle
+    self.handle_one_request()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 408, in handle_one_request
+    self.raw_requestline = self.rfile.readline(65537)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socket.py", line 718, in readinto
+    return self._sock.recv_into(b)
+           ^^^^^^^^^^^^^^^^^^^^^^^
+ConnectionResetError: [Errno 54] Connection reset by peer
+----------------------------------------
+  [2w x 8t (16 threads)] N=8   started=8/8   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 8t (16 threads)] N=16  started=16/16  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.23s
+
+/healthz under N concurrent chat turns — 2w x 8t (16 threads)
+-------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           8/8  4/4 ok, max 0.00s  1/1 ok, max 0.00s      0.00s     222.3
+ 16    20s         16/16  1/4 ok, max 5.00s 1/1 ok, max 18.23s     18.23s      61.8
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+```
+
+### 7b. The read timeout under load, measured
+
+```
+  b2. under load — HealthClaw hangs on run events, so the read timeout IS the thread hold (N=8):
+  [2w x 4t (8 threads)] N=8   started=8/8   healthz(5s) 0/4 healthz(30s) 1/1 true wait 23.03s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           8/8  0/4 ok, max 5.00s 1/1 ok, max 23.04s     23.03s       0.3
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+  [2w x 4t (8 threads)] N=8   started=4/8   healthz(5s) 2/4 healthz(30s) 1/1 true wait 18.07s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           4/8  2/4 ok, max 5.00s  1/1 ok, max 0.01s     18.07s       0.4
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+```
+
+With HealthClaw hanging on the run-events endpoint, the read timeout *is* the
+thread hold: `_stream_run` has no `except`, so the client giving up is what
+ends the generator and releases the thread. At the shipping 25s default that
+shows cleanly — all 8 turns took threads and `/healthz` waited **23.03s**,
+which is the read timeout, not the 20s run length.
+
+**The 10s comparison is not clean, and should not be quoted as one.** That
+sample recorded 18.07s, *higher* than one would expect from a 10s timeout,
+because only 4 of the 8 turns got threads in the first wave and a second wave
+followed — the same uneven-distribution effect as §3, not a property of the
+timeout. One sample each is enough to demonstrate the mechanism and not enough
+to size the improvement. What can be said: the read timeout does bound the
+thread hold when HealthClaw hangs, and this is a HealthClaw-outage scenario,
+not the concurrency one #219 describes.
+
+One defect visible here and not in the issue: `_stream_run` has no `try/except`
+around `hc.agent_run_events`, so a `HealthClawError` mid-stream kills the
+generator and the browser sees the connection drop with **no `error` event** —
+the chat just stops. Small, separate, worth its own issue.
+
+(The `ConnectionResetError` traceback in the (c) block above is the *fake*
+HealthClaw logging a client that disconnected mid-request when its gunicorn
+thread was torn down. Rig noise, not a finding — left in rather than stripped,
+so the transcript is what the script actually printed.)
+
+## 8. Finding not in the issue: `/healthz` fails its own probe budget at zero load
+
+`/healthz` calls `_worker_state()` (`careagents/app.py:1377` → `:814`), which
+makes an HTTP call to HealthClaw with the client's 25s timeout. With **no chat
+load at all**, a slow HealthClaw makes `/healthz` slow:
+
+```
+HealthClaw hangs, no chat load, client read timeout 25s (shipping default): /healthz took [25.01, 25.01] -> [503, 503]
+HealthClaw hangs, no chat load, client read timeout 10s (proposed):         /healthz took [10.01, 10.01] -> [503, 503]
+```
+
+It answers correctly (503, degraded) — it just takes 25 seconds to say so, and
+the Dockerfile's `--timeout=5s` cannot pass. The endpoint's own docstring
+already warns about this shape:
+
+> Callers that only need "is this process up" (a boot gate, a restart probe)
+> must not use this endpoint — it answers for the whole system, including
+> dependencies it does not control.
+
+Nothing currently acts on that failure (§5), so it is latent — but it is the
+part of #219 that a Docker-native host, or a future Railway that adds runtime
+probes, would actually trip. **It is triggered by HealthClaw being slow, not by
+concurrency**, which is the opposite of the issue's causal story.
+
+## 9. Finding not in the issue: the poll storm
+
+Each open chat turn polls HealthClaw's run-events endpoint every 0.25s. The
+tables' `HC req/s` column is measured against the fake: **~31 requests/second
+at N=8**, ~62 at N=16 with 16 threads. Those requests go to the HealthClaw
+instance that also serves the clinician. That is the more plausible way
+CareAgents concurrency causes harm outside itself, and the issue does not
+mention it. Not chased here — flagging only.
+
+## 10. What could NOT be measured locally
+
+Stated plainly, because a silent gap is how this gets re-litigated:
+
+1. **Whether Railway sets `CARE_WEB_WORKERS` for the CareAgents service, and to
+   what.** The Dockerfile defaults to 2; the actual value is a dashboard
+   variable. Both 2×4 and 1×8 were measured to cover it; a larger value was
+   not.
+2. **The CareAgents Railway service's own healthcheck settings.** The repo's
+   `railway.toml` is HealthClaw's (`healthcheckPath = "/r6/fhir/health"`).
+   CareAgents deploys by `railway up` from a staged directory, so its
+   `healthcheckPath` / `healthcheckTimeout` live in the dashboard and are not
+   in this repo. §5's conclusion rests on Railway's documented platform
+   behaviour, which is settings-independent — but the specific values were not
+   read.
+3. **Real HealthClaw latency under the poll storm.** The fake answers
+   instantly. What 31 req/s does to a real HealthClaw was not measured, and
+   measuring it properly needs a full local HealthClaw plus a run worker, or
+   production — which is out of bounds.
+4. **The real distribution of turn durations in production.** The hold was
+   controlled, not observed. Whether real turns cluster at 3s or at the 120s
+   deadline decides how often N=6 is even reached, and that number is only
+   available from production telemetry.
+5. **The "turns started" column is noisy, and was not diagnosed.** It counts
+   turns whose `accepted` event arrived inside a 2s settle window, and it moves
+   around in ways the thread count alone does not explain (4/8 at a 5s hold
+   versus 7/8 at a 20s hold, same N). SQLite is one likely contributor — the
+   rig uses it where production uses Postgres, and the `claim_daily_turn` write
+   at the start of every turn serialises — but that was not confirmed. Read the
+   column as indicative only. It does not touch the starvation numbers: the
+   thread hold is the SSE loop, which never reads the account store.
+6. **Railway's edge proxy behaviour on a 150s SSE stream.** If the edge cuts
+   the stream earlier than the app does, the reconnect path runs more often
+   than modelled here.
+7. **Whether any of this has happened.** This measures a mechanism, not an
+   incident rate. No production logs were consulted.
+
+## 11. Recommendation
+
+Not a fix — a re-scoping, for the CTO and founder to rule on:
+
+- **Close the restart-loop and data-wipe halves of #219 as not reproducible**
+  (§5, §6). They rest on a platform behaviour Railway does not have and on
+  state CareAgents does not hold.
+- **Keep the starvation half, re-titled**, with the corrected trigger: 6
+  concurrent turns on the shipping 2×4 config, up to 118s of every route
+  blocked, no restart. Its user-visible cost is a hung page for whoever is not
+  already in a turn, and a deploy that will not go live while it lasts.
+- **Of the three mitigations listed, only two move the measured number**, and
+  neither removes the failure: lowering `run_deadline_seconds` scales the
+  starvation window 1:1, and more threads raises the concurrency at which it
+  starts. Dropping the read timeout does not address the case the issue
+  describes. *(Observation, outside what was asked: the thread is held only to
+  poll on the browser's behalf, and the client already reconnects by design —
+  so the hold is structural rather than necessary. Sizing that is Dev's call,
+  not this probe's.)*
+- **File `/healthz`'s 25s dependency call separately** (§8). It is a one-line
+  shape, it is real today, and it has nothing to do with concurrency.
+
+## Appendix — full run transcript
+
+```
+==============================================================================
+probe #219 — /healthz under concurrent chat turns
+==============================================================================
+repo HEAD      : 89b42fb
+python         : 3.11.15
+fake HealthClaw: http://127.0.0.1:63715
+hold per turn  : 20.0s     concurrency levels: [0, 4, 6, 8, 10, 16]
+scratch        : /var/folders/tp/f0jrwq392932r3h4x6b95n9c0000gn/T/probe219-jxep821s
+seeded         : 16 accounts (1 per virtual user)
+
+### Item 1 — does /healthz starve? ###
+  [2w x 4t (8 threads)] N=0   started=0/0   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [2w x 4t (8 threads)] N=4   started=4/4   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 4t (8 threads)] N=6   started=6/6   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 4t (8 threads)] N=8   started=7/8   healthz(5s) 3/4 healthz(30s) 1/1 true wait 18.19s
+  [2w x 4t (8 threads)] N=10  started=8/10  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.13s
+  [2w x 4t (8 threads)] N=16  started=8/16  healthz(5s) 0/4 healthz(30s) 0/1 true wait 38.32s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  0    20s           0/0  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.01s       0.0
+  4    20s           4/4  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.00s     109.9
+  6    20s           6/6  4/4 ok, max 0.01s  1/1 ok, max 0.00s      0.00s     165.3
+  8    20s           7/8  3/4 ok, max 5.00s 1/1 ok, max 18.19s     18.19s      30.9
+ 10    20s          8/10  1/4 ok, max 5.00s 1/1 ok, max 18.12s     18.13s      38.4
+ 16    20s          8/16  0/4 ok, max 5.00s 0/1 ok, max 30.00s     38.32s      31.2
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+  [1w x 8t (8 threads)] N=0   started=0/0   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=4   started=4/4   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=6   started=6/6   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.01s
+  [1w x 8t (8 threads)] N=8   started=8/8   healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.18s
+  [1w x 8t (8 threads)] N=10  started=8/10  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.28s
+  [1w x 8t (8 threads)] N=16  started=8/16  healthz(5s) 0/4 healthz(30s) 0/1 true wait 38.49s
+
+/healthz under N concurrent chat turns — 1w x 8t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  0    20s           0/0  4/4 ok, max 0.01s  1/1 ok, max 0.01s      0.01s       0.0
+  4    20s           4/4  4/4 ok, max 0.00s  1/1 ok, max 0.00s      0.01s     110.3
+  6    20s           6/6  4/4 ok, max 0.00s  1/1 ok, max 0.01s      0.01s     165.5
+  8    20s           8/8  1/4 ok, max 5.00s 1/1 ok, max 18.18s     18.18s      31.0
+ 10    20s          8/10  1/4 ok, max 5.00s 1/1 ok, max 18.27s     18.28s      37.6
+ 16    20s          8/16  0/4 ok, max 5.00s 0/1 ok, max 30.00s     38.49s      30.8
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+### Item 2 — real per-turn thread hold ###
+
+Per-turn web-thread hold (one turn, 2w x 4t)
+--------------------------------------------
+ run duration   thread held   accepted after   poll reqs  events
+           2s         2.09s           0.018s           9  accepted,text,done
+          10s        10.13s           0.025s          40  accepted,text,done
+          30s        30.02s           0.007s         116  accepted,text,done
+
+### Worst case — 8 turns each holding 120s (the run deadline) ###
+  [2w x 4t (8 threads)] N=8   started=8/8   healthz(5s) 0/4 healthz(30s) 0/1 true wait 118.12s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8   120s           8/8  0/4 ok, max 5.00s 0/1 ok, max 30.00s    118.12s      30.7
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+### Why 2w x 4t starves below 8 — N=6, repeated ###
+  arrivals in the same millisecond (burst):
+  run 1/6: /healthz true wait 18.11s  (5s budget 3/4 ok)
+  run 2/6: /healthz true wait 18.13s  (5s budget 1/4 ok)
+  run 3/6: /healthz true wait 0.01s  (5s budget 1/4 ok)
+  run 4/6: /healthz true wait 18.27s  (5s budget 1/4 ok)
+  run 5/6: /healthz true wait 0.01s  (5s budget 4/4 ok)
+  run 6/6: /healthz true wait 18.21s  (5s budget 3/4 ok)
+
+  N=6 on 2w x 4t, 6 runs: /healthz stalled in 4/6. Waits: [18.11, 18.13, 0.01, 18.27, 0.01, 18.21]
+
+  arrivals spread 0.3s apart (closer to real traffic):
+  run 1/6: /healthz true wait 17.00s  (5s budget 1/4 ok)
+  run 2/6: /healthz true wait 0.01s  (5s budget 4/4 ok)
+  run 3/6: /healthz true wait 0.01s  (5s budget 1/4 ok)
+  run 4/6: /healthz true wait 16.99s  (5s budget 1/4 ok)
+  run 5/6: /healthz true wait 16.97s  (5s budget 2/4 ok)
+  run 6/6: /healthz true wait 16.97s  (5s budget 1/4 ok)
+
+  N=6 on 2w x 4t, 6 runs: /healthz stalled in 4/6. Waits: [17.0, 0.01, 0.01, 16.99, 16.97, 16.97]
+
+### Item 4 — what a restart actually loses ###
+DEV email — Verify your email for restart-probe-1788474575@example.invalid: 89021758
+  burst limiter (CARE_CHAT_TURNS=3), 4 turns before restart: [200, 200, 200, 429]
+  first turn AFTER restart: 200 data: {"type": "accepted", "run_id": "run-4", "next_cursor": 0}
+
+id: 1
+data: {"t
+  durable daily counter (UsageDay.turns) across the restart: [4]
+  login-code attempts read back through a new engine: 2
+  chat turns persisted to HealthClaw, not CareAgents memory: 3 POSTs to /command-center/api/conversations
+
+### Item 5 — measured effect of each mitigation ###
+
+(a) bound the turn: same N, shorter run
+  [2w x 4t (8 threads)] N=8   started=4/8   healthz(5s) 3/4 healthz(30s) 1/1 true wait 0.01s
+  [2w x 4t (8 threads)] N=16  started=8/16  healthz(5s) 3/4 healthz(30s) 1/1 true wait 13.73s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8     5s           4/8  3/4 ok, max 5.00s  1/1 ok, max 8.49s      0.01s      15.1
+ 16     5s          8/16  3/4 ok, max 5.00s  1/1 ok, max 3.24s     13.73s      21.1
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+(b) drop the HealthClaw read timeout 25s -> 10s
+  b1. /healthz's own call, no chat load:
+  HealthClaw hangs, no chat load, client read timeout 25s (shipping default): /healthz took [25.01, 25.01] -> [503, 503]
+----------------------------------------
+Exception occurred during processing of request from ('127.0.0.1', 51180)
+Traceback (most recent call last):
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 691, in process_request_thread
+    self.finish_request(request, client_address)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 361, in finish_request
+    self.RequestHandlerClass(request, client_address, self)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 755, in __init__
+    self.handle()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 440, in handle
+    self.handle_one_request()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 428, in handle_one_request
+    method()
+  File "/Users/<user>/Git/HealthClawGuardrails/.claude/worktrees/agent-a078e2964ba2642fb/scripts/probe_219_thread_saturation.py", line 155, in do_GET
+    return self._reply(200, {"available": True, "workers": 1})
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/<user>/Git/HealthClawGuardrails/.claude/worktrees/agent-a078e2964ba2642fb/scripts/probe_219_thread_saturation.py", line 115, in _reply
+    self.wfile.write(raw)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 834, in write
+    self._sock.sendall(b)
+BrokenPipeError: [Errno 32] Broken pipe
+----------------------------------------
+  HealthClaw hangs, no chat load, client read timeout 10s (proposed): /healthz took [10.01, 10.01] -> [503, 503]
+
+  b2. under load — HealthClaw hangs on run events, so the read timeout IS the thread hold (N=8):
+  [2w x 4t (8 threads)] N=8   started=8/8   healthz(5s) 0/4 healthz(30s) 1/1 true wait 23.03s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           8/8  0/4 ok, max 5.00s 1/1 ok, max 23.04s     23.03s       0.3
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+  [2w x 4t (8 threads)] N=8   started=4/8   healthz(5s) 2/4 healthz(30s) 1/1 true wait 18.07s
+
+/healthz under N concurrent chat turns — 2w x 4t (8 threads)
+------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           4/8  2/4 ok, max 5.00s  1/1 ok, max 0.01s     18.07s       0.4
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+(c) raise threads: 2w x 8t (16 threads)
+----------------------------------------
+Exception occurred during processing of request from ('127.0.0.1', 51824)
+Traceback (most recent call last):
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 691, in process_request_thread
+    self.finish_request(request, client_address)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 361, in finish_request
+    self.RequestHandlerClass(request, client_address, self)
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socketserver.py", line 755, in __init__
+    self.handle()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 442, in handle
+    self.handle_one_request()
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/http/server.py", line 408, in handle_one_request
+    self.raw_requestline = self.rfile.readline(65537)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/<user>/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/lib/python3.11/socket.py", line 718, in readinto
+    return self._sock.recv_into(b)
+           ^^^^^^^^^^^^^^^^^^^^^^^
+ConnectionResetError: [Errno 54] Connection reset by peer
+----------------------------------------
+  [2w x 8t (16 threads)] N=8   started=8/8   healthz(5s) 4/4 healthz(30s) 1/1 true wait 0.00s
+  [2w x 8t (16 threads)] N=16  started=16/16  healthz(5s) 1/4 healthz(30s) 1/1 true wait 18.23s
+
+/healthz under N concurrent chat turns — 2w x 8t (16 threads)
+-------------------------------------------------------------
+  N   hold turns started  healthz 5s budget healthz 30s budget  true wait  HC req/s
+-----------------------------------------------------------------------------------
+  8    20s           8/8  4/4 ok, max 0.00s  1/1 ok, max 0.00s      0.00s     222.3
+ 16    20s         16/16  1/4 ok, max 5.00s 1/1 ok, max 18.23s     18.23s      61.8
+  'turns started' = turns that got their `accepted` event within the 2s settle;
+  'true wait'     = /healthz latency measured with a budget large enough to record it.
+
+machine-readable report: /var/folders/tp/f0jrwq392932r3h4x6b95n9c0000gn/T/probe219-jxep821s/probe-219-report.json
+```

--- a/scripts/probe_219_thread_saturation.py
+++ b/scripts/probe_219_thread_saturation.py
@@ -1,0 +1,839 @@
+#!/usr/bin/env python3
+"""Measure what concurrent chat turns actually do to CareAgents' ``/healthz``.
+
+Run-once measurement for issue #219, which claims:
+
+    One worker, 8 threads. Each chat turn holds a thread for its whole
+    duration -- up to 6 tool rounds x 25s HealthClaw timeout, plus a 90s LLM
+    timeout. 8 concurrent turns block everything including ``/healthz``,
+    Railway marks the container unhealthy, restarts it, and every chat
+    history and rate-limit state is wiped.
+
+This probe measures the first half (does ``/healthz`` starve?) and reads the
+second half out of the code. It does NOT touch production: everything runs
+against a local gunicorn plus a fake HealthClaw on loopback.
+
+What is faked, and why
+----------------------
+* **HealthClaw** is a local ``ThreadingHTTPServer`` (:class:`FakeHealthClaw`).
+  ``HEALTHCLAW_BASE`` points at it, so the *real* ``HealthClawClient`` and its
+  *real* 25s timeout are exercised -- nothing is monkeypatched inside
+  gunicorn. The fake answers token-mint, message-claim, run-create and
+  worker-health instantly, and reports a run as ``running`` for a controlled
+  number of seconds before completing it. That controlled duration is the
+  independent variable: it is how long a chat turn holds a gunicorn thread.
+* **The LLM is not faked, because the web tier never calls it.** Since #257
+  (`careagents/wsgi.py`) inference runs in ``python -m careagents.worker``.
+  The web request enqueues a run and streams durable events back. No worker
+  process is started here; the fake supplies the run's lifecycle directly.
+
+Everything else is the shipping code: ``careagents.wsgi:app`` under the same
+gunicorn invocation as ``deploy/careagents/Dockerfile``.
+
+Usage
+-----
+    uv run python scripts/probe_219_thread_saturation.py
+    uv run python scripts/probe_219_thread_saturation.py --quick
+    uv run python scripts/probe_219_thread_saturation.py --only saturation
+
+Exits 0 when the measurement completed (whatever it found); non-zero only if
+the rig itself could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import secrets
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import defaultdict
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Generated per run, never written down. The rig needs a session signing key
+# and an internal-secret value that its own fake HealthClaw will accept; both
+# are throwaway and both processes receive them through the environment. They
+# are computed rather than hard-coded so this committed file contains no
+# credential-shaped literal for a scanner -- or a reader -- to mistake for one.
+SESSION_SECRET = secrets.token_urlsafe(32)
+MINT_SECRET = secrets.token_urlsafe(16)
+STEP_UP_STUB = secrets.token_urlsafe(16)
+
+# Docker HEALTHCHECK --timeout=5s (deploy/careagents/Dockerfile) and the
+# healthcheckTimeout used in this repo's railway.toml. Both are probed, so the
+# table says which budget a slow /healthz actually breaks.
+PROBE_TIMEOUTS = (5.0, 30.0)
+
+
+# --------------------------------------------------------------------------
+# Fake HealthClaw
+# --------------------------------------------------------------------------
+
+class FakeState:
+    """Knobs the scenarios turn, shared with the request handler."""
+
+    def __init__(self) -> None:
+        self.hold_seconds = 20.0        # how long a run stays "running"
+        self.worker_health_delay = 0.0  # stall /runs/workers/health this long
+        self.events_hang = 0.0          # stall /runs/<id>/events this long
+        self.first_seen: dict[str, float] = {}
+        self.counts: dict[str, int] = defaultdict(int)
+        self.lock = threading.Lock()
+
+    def reset_counts(self) -> None:
+        with self.lock:
+            self.counts = defaultdict(int)
+            self.first_seen = {}
+
+    def bump(self, key: str) -> None:
+        with self.lock:
+            self.counts[key] += 1
+
+    def run_elapsed(self, run_id: str) -> float:
+        with self.lock:
+            started = self.first_seen.setdefault(run_id, time.monotonic())
+        return time.monotonic() - started
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"      # keep-alive, like a real HealthClaw
+    state: FakeState = None            # set on the server class
+
+    def log_message(self, *_args) -> None:  # noqa: D102 - silence the fake
+        pass
+
+    def _reply(self, status: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw or b"{}")
+        except ValueError:
+            body = {}
+        path = urlparse(self.path).path
+        st = self.state
+
+        if path.endswith("/internal/step-up-token"):
+            st.bump("mint")
+            return self._reply(200, {"token": STEP_UP_STUB})
+
+        if path == "/command-center/api/conversations":
+            st.bump("message")
+            return self._reply(
+                201, {"id": f"msg-{st.counts['message']}",
+                      "role": body.get("role", "user")})
+
+        if path == "/command-center/api/runs":
+            st.bump("run_create")
+            run_id = f"run-{st.counts['run_create']}"
+            return self._reply(201, {
+                "id": run_id, "tenant_id": body.get("tenant_id"),
+                "agent_id": "careagents", "status": "queued"})
+
+        return self._reply(404, {"error": "probe fake: unhandled POST"})
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        parsed = urlparse(self.path)
+        path, query = parsed.path, parse_qs(parsed.query)
+        st = self.state
+
+        if path == "/command-center/api/runs/workers/health":
+            st.bump("worker_health")
+            if st.worker_health_delay:
+                time.sleep(st.worker_health_delay)
+            return self._reply(200, {"available": True, "workers": 1})
+
+        if path.startswith("/command-center/api/runs/") and \
+                path.endswith("/events"):
+            st.bump("run_events")
+            if st.events_hang:
+                # The hang the read timeout is supposed to bound. _stream_run
+                # has no try/except, so HealthClawError ends the generator.
+                time.sleep(st.events_hang)
+            run_id = path.split("/")[-2]
+            after = int((query.get("after") or ["0"])[0])
+            if st.run_elapsed(run_id) < st.hold_seconds:
+                return self._reply(200, {"events": [], "status": "running"})
+            events = []
+            if after < 1:
+                events.append({"id": 1, "type": "agent.text",
+                               "payload": {"text": "probe answer"}})
+            return self._reply(200, {"events": events, "status": "completed"})
+
+        if path.startswith("/command-center/api/runs/"):
+            st.bump("run_lookup")
+            run_id = path.rstrip("/").split("/")[-1]
+            return self._reply(200, {
+                "id": run_id, "tenant_id": self.headers.get("X-Tenant-Id"),
+                "agent_id": "careagents", "status": "running"})
+
+        return self._reply(404, {"error": "probe fake: unhandled GET"})
+
+
+def start_fake_healthclaw() -> tuple[ThreadingHTTPServer, FakeState, int]:
+    state = FakeState()
+    handler = type("ProbeHandler", (_Handler,), {"state": state})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, state, server.server_address[1]
+
+
+# --------------------------------------------------------------------------
+# Seeding + session cookies
+# --------------------------------------------------------------------------
+
+def base_env(db_path: Path, fake_port: int) -> dict[str, str]:
+    env = dict(os.environ)
+    env.update({
+        "CARE_ENV": "development",
+        "CARE_SESSION_SECRET": SESSION_SECRET,
+        "CARE_DATABASE_URL": f"sqlite:///{db_path}",
+        "HEALTHCLAW_BASE": f"http://127.0.0.1:{fake_port}",
+        "HEALTHCLAW_MINT_SECRET": MINT_SECRET,
+        # The burst limiter is 20 turns / 600s per account and the daily cap is
+        # 200. Both are raised here ONLY so a rate-limited turn (which returns
+        # 429 instantly and holds no thread) cannot masquerade as a held
+        # thread. Every scenario asserts its turns were accepted.
+        "CARE_CHAT_TURNS": "10000",
+        "CARE_CHAT_TURNS_PER_DAY": "100000",
+        "PYTHONUNBUFFERED": "1",
+        # macOS-only rig artifact: gunicorn's pre-fork master crashes its
+        # children with "+[NSCharacterSet initialize] may have been in
+        # progress ... Crashing instead". The container runs Linux, where this
+        # variable is inert. It changes nothing about Python's threading.
+        "OBJC_DISABLE_INITIALIZE_FORK_SAFETY": "YES",
+        # Import careagents from the repo without running gunicorn *in* it --
+        # gunicorn 25 drops a `gunicorn.ctl` control socket in its cwd.
+        "PYTHONPATH": str(REPO_ROOT),
+    })
+    for stale in ("PORT", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+        env.pop(stale, None)
+    return env
+
+
+def seed_accounts(env: dict[str, str], count: int,
+                  prefix: str = "probe") -> list[dict]:
+    """One account + connection + agent per virtual user, plus its cookie.
+
+    Distinct accounts on purpose: N concurrent turns from ONE account is a
+    different scenario (the per-account limiter), not the one #219 describes.
+    """
+    saved = dict(os.environ)
+    os.environ.update(env)
+    try:
+        from careagents.accounts import AccountService
+        from careagents.app import create_app
+        from careagents.config import Config
+        from careagents.models import Account, now
+
+        cfg = Config()
+        svc = AccountService(cfg)
+        app = create_app(cfg)
+        serializer = app.session_interface.get_signing_serializer(app)
+
+        users: list[dict] = []
+        for i in range(count):
+            with svc.session() as s:
+                acct = Account(email=f"{prefix}-{i}@example.invalid",
+                               email_verified_at=now())
+                s.add(acct)
+                s.flush()
+                account_id = acct.id
+            conn_id = svc.add_connection(
+                account_id, "sample", f"probe-tenant-{i}", "Probe records")
+            agent_id = svc.create_agent(account_id, "Probe", "calm", conn_id)
+            cookie = serializer.dumps({"account_id": account_id,
+                                       "_permanent": True})
+            users.append({"account_id": account_id, "agent_id": agent_id,
+                          "cookie": cookie})
+        return users
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+# --------------------------------------------------------------------------
+# Gunicorn, run the way the container runs it
+# --------------------------------------------------------------------------
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class Gunicorn:
+    """`deploy/careagents/Dockerfile`'s web command, minus the container."""
+
+    def __init__(self, env: dict[str, str], workers: int, threads: int,
+                 wsgi: str = "careagents.wsgi:app") -> None:
+        self.port = free_port()
+        self.workers, self.threads, self.wsgi = workers, threads, wsgi
+        self.env = dict(env)
+        self.env["PORT"] = str(self.port)
+        self.cwd = Path(tempfile.mkdtemp(prefix="probe219-cwd-"))
+        self.proc: subprocess.Popen | None = None
+        self.log = tempfile.NamedTemporaryFile(
+            prefix="probe219-gunicorn-", suffix=".log", delete=False)
+
+    @property
+    def label(self) -> str:
+        return (f"{self.workers}w x {self.threads}t "
+                f"({self.workers * self.threads} threads)")
+
+    def __enter__(self) -> "Gunicorn":
+        cmd = [sys.executable, "-m", "gunicorn", self.wsgi,
+               "--bind", f"127.0.0.1:{self.port}",
+               "--workers", str(self.workers),
+               "--threads", str(self.threads),
+               "--timeout", "180",
+               "--access-logfile", "-", "--error-logfile", "-"]
+        self.proc = subprocess.Popen(cmd, cwd=str(self.cwd), env=self.env,
+                                     stdout=self.log, stderr=subprocess.STDOUT)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError(
+                    f"gunicorn exited {self.proc.returncode}; log: "
+                    f"{self.log.name}\n{Path(self.log.name).read_text()[-2000:]}")
+            probe = health_probe(self.port, timeout=2.0)
+            if probe["status"] == 200:
+                return self
+            time.sleep(0.25)
+        raise RuntimeError(f"gunicorn never became ready; log: {self.log.name}")
+
+    def __exit__(self, *_exc) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self.log.close()
+
+
+# --------------------------------------------------------------------------
+# Load generation
+# --------------------------------------------------------------------------
+
+def health_probe(port: int, timeout: float) -> dict:
+    """One /healthz request on its own connection, like a container probe."""
+    started = time.monotonic()
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+    try:
+        conn.request("GET", "/healthz")
+        resp = conn.getresponse()
+        resp.read()
+        return {"status": resp.status,
+                "seconds": time.monotonic() - started, "error": None}
+    except Exception as exc:  # noqa: BLE001 - a probe records its failures
+        return {"status": None, "seconds": time.monotonic() - started,
+                "error": type(exc).__name__}
+    finally:
+        conn.close()
+
+
+class Holder(threading.Thread):
+    """One virtual user: POST /api/chat and consume the SSE to the end."""
+
+    def __init__(self, port: int, user: dict, stop: threading.Event) -> None:
+        super().__init__(daemon=True)
+        self.port, self.user, self.stop = port, user, stop
+        self.http_status: int | None = None
+        self.accepted_at: float | None = None
+        self.finished_at: float | None = None
+        self.events: list[str] = []
+        self.error: str | None = None
+        self.started_at = 0.0
+
+    def run(self) -> None:
+        self.started_at = time.monotonic()
+        body = json.dumps({"agent_id": self.user["agent_id"],
+                           "message": "probe turn"}).encode()
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=200)
+        try:
+            conn.request("POST", "/api/chat", body=body, headers={
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+                "Cookie": f"session={self.user['cookie']}"})
+            resp = conn.getresponse()
+            self.http_status = resp.status
+            if resp.status != 200:
+                self.error = resp.read()[:200].decode("utf-8", "replace")
+                return
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data: "):
+                    continue
+                event = json.loads(line[6:])
+                kind = event.get("type", "?")
+                self.events.append(kind)
+                if kind == "accepted" and self.accepted_at is None:
+                    self.accepted_at = time.monotonic()
+                if kind in ("done", "reconnect"):
+                    break
+                if self.stop.is_set():
+                    break
+        except Exception as exc:  # noqa: BLE001 - a probe records its failures
+            self.error = f"{type(exc).__name__}: {exc}"
+        finally:
+            self.finished_at = time.monotonic()
+            conn.close()
+
+
+def run_scenario(gun: Gunicorn, state: FakeState, users: list[dict],
+                 n: int, hold: float, settle: float = 2.0,
+                 stagger: float = 0.0) -> dict:
+    """N concurrent turns; probe /healthz while they hold threads."""
+    state.hold_seconds = hold
+    state.reset_counts()
+    stop = threading.Event()
+    holders = [Holder(gun.port, users[i], stop) for i in range(n)]
+    t0 = time.monotonic()
+    for h in holders:
+        h.start()
+        if stagger:
+            time.sleep(stagger)
+    time.sleep(settle)  # let the holds establish before probing
+
+    # Three sweeps in parallel. The 5s and 30s probes answer "does the
+    # configured budget hold?"; the patient one has enough budget to record
+    # what the latency actually WAS, so a timeout is never the only datum.
+    patience = hold + 60.0
+    results: dict[str, list[dict]] = {"p5": [], "p30": [], "patient": []}
+
+    def sweep(key: str, timeout: float, count: int) -> None:
+        for _ in range(count):
+            results[key].append(health_probe(gun.port, timeout))
+            time.sleep(0.2)
+
+    threads = [threading.Thread(target=sweep, args=("p5", 5.0, 4), daemon=True),
+               threading.Thread(target=sweep, args=("p30", 30.0, 1),
+                                daemon=True),
+               threading.Thread(target=sweep, args=("patient", patience, 1),
+                                daemon=True)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    probe_window = time.monotonic() - t0
+
+    stop.set()
+    for h in holders:
+        h.join(timeout=hold + 60)
+
+    accepted = [h for h in holders if h.accepted_at is not None]
+    rejected = [h for h in holders
+                if h.http_status not in (200, None) or
+                (h.http_status is None and h.error)]
+    with state.lock:
+        polls = state.counts.get("run_events", 0)
+
+    def summarise(rows: list[dict]) -> dict:
+        oks = [r for r in rows if r["status"] == 200]
+        return {
+            "n": len(rows),
+            "ok": len(oks),
+            "fail": len(rows) - len(oks),
+            "max_s": max((r["seconds"] for r in rows), default=0.0),
+            "each_s": [round(r["seconds"], 2) for r in rows],
+            "errors": sorted({r["error"] for r in rows if r["error"]}),
+        }
+
+    return {
+        "concurrency": n,
+        "hold": hold,
+        "accepted": len(accepted),
+        "accepted_within_settle": len(
+            [h for h in accepted if h.accepted_at - t0 <= settle]),
+        "rejected": len(rejected),
+        "reject_detail": sorted({(h.error or "")[:80] for h in rejected}),
+        "probe_window_s": probe_window,
+        "hold_seconds_observed": [
+            round((h.finished_at - h.started_at), 2) for h in holders
+            if h.finished_at],
+        "run_event_polls": polls,
+        "poll_rate_per_s": round(polls / probe_window, 1) if probe_window else 0,
+        "p5": summarise(results["p5"]),
+        "p30": summarise(results["p30"]),
+        "patient": summarise(results["patient"]),
+    }
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+def print_table(title: str, rows: list[dict]) -> None:
+    print()
+    print(title)
+    print("-" * len(title))
+    head = (f"{'N':>3} {'hold':>6} {'turns started':>13} "
+            f"{'healthz 5s budget':>18} {'healthz 30s budget':>18} "
+            f"{'true wait':>10} {'HC req/s':>9}")
+    print(head)
+    print("-" * len(head))
+    for r in rows:
+        started = f"{r['accepted_within_settle']}/{r['concurrency']}"
+        p5 = f"{r['p5']['ok']}/{r['p5']['n']} ok, max {r['p5']['max_s']:.2f}s"
+        p30 = (f"{r['p30']['ok']}/{r['p30']['n']} ok, "
+               f"max {r['p30']['max_s']:.2f}s")
+        true = f"{r['patient']['max_s']:.2f}s"
+        print(f"{r['concurrency']:>3} {r['hold']:>5.0f}s {started:>13} "
+              f"{p5:>18} {p30:>18} {true:>10} "
+              f"{r['poll_rate_per_s']:>9}")
+    print("  'turns started' = turns that got their `accepted` event within "
+          "the 2s settle;")
+    print("  'true wait'     = /healthz latency measured with a budget large "
+          "enough to record it.")
+
+
+def saturation_matrix(env: dict, state: FakeState, users: list[dict],
+                      configs: list[tuple[int, int]], levels: list[int],
+                      hold: float, wsgi: str = "careagents.wsgi:app",
+                      stagger: float = 0.0) -> dict:
+    out: dict[str, list[dict]] = {}
+    for workers, threads in configs:
+        with Gunicorn(env, workers, threads, wsgi=wsgi) as gun:
+            rows = []
+            for n in levels:
+                row = run_scenario(gun, state, users, n, hold,
+                                   stagger=stagger)
+                rows.append(row)
+                print(f"  [{gun.label}] N={n:<3} started="
+                      f"{row['accepted_within_settle']}/{n:<3} "
+                      f"healthz(5s) {row['p5']['ok']}/{row['p5']['n']} "
+                      f"healthz(30s) {row['p30']['ok']}/{row['p30']['n']} "
+                      f"true wait {row['patient']['max_s']:.2f}s")
+            out[gun.label] = rows
+            print_table(f"/healthz under N concurrent chat turns — {gun.label}",
+                        rows)
+    return out
+
+
+def turn_hold_measurement(env: dict, state: FakeState,
+                          users: list[dict]) -> list[dict]:
+    """Item 2: what one turn actually holds a web thread for."""
+    rows = []
+    with Gunicorn(env, 2, 4) as gun:
+        for hold in (2.0, 10.0, 30.0):
+            state.hold_seconds = hold
+            state.reset_counts()
+            stop = threading.Event()
+            h = Holder(gun.port, users[0], stop)
+            h.start()
+            h.join(timeout=hold + 60)
+            with state.lock:
+                polls = state.counts.get("run_events", 0)
+            rows.append({
+                "run_seconds": hold,
+                "thread_hold_s": round(h.finished_at - h.started_at, 2),
+                "accept_latency_s": round(h.accepted_at - h.started_at, 3)
+                if h.accepted_at else None,
+                "events": h.events,
+                "run_event_polls": polls,
+            })
+    print()
+    print("Per-turn web-thread hold (one turn, 2w x 4t)")
+    print("--------------------------------------------")
+    print(f"{'run duration':>13}  {'thread held':>12}  "
+          f"{'accepted after':>15}  {'poll reqs':>10}  events")
+    for r in rows:
+        print(f"{r['run_seconds']:>12.0f}s  {r['thread_hold_s']:>11.2f}s  "
+              f"{r['accept_latency_s']:>14.3f}s  "
+              f"{r['run_event_polls']:>10}  {','.join(r['events'])}")
+    return rows
+
+
+def distribution_variance(env: dict, state: FakeState, users: list[dict],
+                          n: int, hold: float, repeats: int,
+                          stagger: float = 0.0) -> list[dict]:
+    """Why 2 workers starve BELOW their thread count.
+
+    Gunicorn pre-fork workers accept from a shared socket, so N turns do not
+    spread evenly. With 2x4, six turns can land 5-and-1 and saturate one
+    worker while the other idles. /healthz is served by whichever worker
+    accepts it, so starvation below the total thread count is a coin flip --
+    which a single sample cannot show.
+    """
+    rows = []
+    with Gunicorn(env, 2, 4) as gun:
+        for i in range(repeats):
+            row = run_scenario(gun, state, users, n, hold,
+                               stagger=stagger)
+            rows.append(row)
+            print(f"  run {i + 1}/{repeats}: /healthz true wait "
+                  f"{row['patient']['max_s']:.2f}s  "
+                  f"(5s budget {row['p5']['ok']}/{row['p5']['n']} ok)")
+    stalled = [r for r in rows if r["patient"]["max_s"] > 1.0]
+    print(f"\n  N={n} on 2w x 4t, {repeats} runs: /healthz stalled in "
+          f"{len(stalled)}/{repeats}. "
+          f"Waits: {[round(r['patient']['max_s'], 2) for r in rows]}")
+    return rows
+
+
+def restart_and_state(env: dict, state: FakeState) -> dict:
+    """Item 4: which state a restart actually loses.
+
+    Drives the real endpoints, restarts gunicorn against the same database,
+    and reports what survived. Three stores are in play: the in-process burst
+    limiter (`app.py` `turns`), the durable daily counter (`UsageDay`), and
+    the login-code attempt counter (`EmailToken.attempts`).
+    """
+    env = dict(env)
+    env["CARE_CHAT_TURNS"] = "3"          # small window, so it is easy to trip
+    env["CARE_CHAT_TURNS_PER_DAY"] = "1000"
+    state.hold_seconds = 0.5
+    state.reset_counts()
+
+    user = seed_accounts(env, 1, prefix=f"restart-{int(time.time())}")[0]
+    result: dict = {}
+
+    def one_turn(port: int) -> tuple[int, str]:
+        body = json.dumps({"agent_id": user["agent_id"],
+                           "message": "restart probe"}).encode()
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=60)
+        try:
+            conn.request("POST", "/api/chat", body=body, headers={
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+                "Cookie": f"session={user['cookie']}"})
+            resp = conn.getresponse()
+            payload = resp.read()[:200].decode("utf-8", "replace")
+            return resp.status, payload
+        finally:
+            conn.close()
+
+    with Gunicorn(env, 1, 4) as gun:
+        before = [one_turn(gun.port) for _ in range(4)]
+    result["before_restart"] = [
+        {"status": s, "body": b[:80]} for s, b in before]
+
+    with state.lock:
+        result["messages_sent_to_healthclaw"] = state.counts.get("message", 0)
+
+    # Same database, brand new processes: this IS the restart.
+    with Gunicorn(env, 1, 4) as gun:
+        after = one_turn(gun.port)
+    result["after_restart"] = {"status": after[0], "body": after[1][:80]}
+
+    saved = dict(os.environ)
+    os.environ.update(env)
+    try:
+        from careagents.accounts import AccountService
+        from careagents.config import Config
+        from careagents.models import EmailToken, UsageDay
+
+        svc = AccountService(Config())
+        with svc.session() as s:
+            rows = s.query(UsageDay).filter_by(
+                account_id=user["account_id"]).all()
+            result["usage_day_turns_after_restart"] = [
+                int(r.turns or 0) for r in rows]
+        # Login-code attempts: two wrong guesses, then read the column back
+        # through a fresh engine -- the same thing a restart does.
+        email = f"restart-probe-{int(time.time())}@example.invalid"
+        svc.start_email_code(email)       # dev: logged, not sent (no API key)
+        for _ in range(2):
+            try:
+                svc.verify_email_code(email, "00000000")
+            except Exception:  # noqa: BLE001 - a wrong code is the point
+                pass
+        svc2 = AccountService(Config())   # new engine == new process
+        with svc2.session() as s:
+            tok = s.query(EmailToken).filter_by(email=email).first()
+            result["login_attempts_after_new_engine"] = (
+                int(tok.attempts or 0) if tok else None)
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+    print("  burst limiter (CARE_CHAT_TURNS=3), 4 turns before restart: "
+          f"{[s for s, _ in before]}")
+    print(f"  first turn AFTER restart: {result['after_restart']['status']} "
+          f"{result['after_restart']['body']}")
+    print("  durable daily counter (UsageDay.turns) across the restart: "
+          f"{result['usage_day_turns_after_restart']}")
+    print("  login-code attempts read back through a new engine: "
+          f"{result['login_attempts_after_new_engine']}")
+    print("  chat turns persisted to HealthClaw, not CareAgents memory: "
+          f"{result['messages_sent_to_healthclaw']} POSTs to "
+          "/command-center/api/conversations")
+    return result
+
+
+def hanging_dependency(env: dict, state: FakeState, users: list[dict],
+                       client_timeout_label: str,
+                       wsgi: str = "careagents.wsgi:app") -> dict:
+    """Item 5b: /healthz when HealthClaw hangs, at zero chat load.
+
+    /healthz calls hc.agent_worker_health(), so its latency floor is a network
+    call to HealthClaw with the client's read timeout -- independent of any
+    thread saturation.
+    """
+    with Gunicorn(env, 2, 4, wsgi=wsgi) as gun:
+        state.worker_health_delay = 40.0   # longer than either read timeout
+        try:
+            rows = [health_probe(gun.port, 60.0) for _ in range(2)]
+        finally:
+            state.worker_health_delay = 0.0
+    result = {"client_timeout": client_timeout_label,
+              "seconds": [round(r["seconds"], 2) for r in rows],
+              "status": [r["status"] for r in rows],
+              "error": [r["error"] for r in rows]}
+    print(f"  HealthClaw hangs, no chat load, client read timeout "
+          f"{client_timeout_label}: /healthz took "
+          f"{result['seconds']} -> {result['status']}")
+    return result
+
+
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quick", action="store_true",
+                    help="fewer concurrency levels and a shorter hold")
+    ap.add_argument("--hold", type=float, default=20.0,
+                    help="seconds a faked run stays 'running' (default 20)")
+    ap.add_argument("--only",
+                    choices=["saturation", "hold", "worstcase", "variance",
+                             "restart", "mitigations"],
+                    help="run one section instead of all of them")
+    args = ap.parse_args()
+
+    levels = [0, 4, 8, 16] if args.quick else [0, 4, 6, 8, 10, 16]
+    hold = 8.0 if args.quick else args.hold
+
+    tmp = Path(tempfile.mkdtemp(prefix="probe219-"))
+    server, state, fake_port = start_fake_healthclaw()
+    env = base_env(tmp / "careagents.db", fake_port)
+
+    print("=" * 78)
+    print("probe #219 — /healthz under concurrent chat turns")
+    print("=" * 78)
+    print(f"repo HEAD      : "
+          f"{subprocess.run(['git', 'rev-parse', '--short', 'HEAD'], cwd=REPO_ROOT, capture_output=True, text=True).stdout.strip()}")
+    print(f"python         : {sys.version.split()[0]}")
+    print(f"fake HealthClaw: http://127.0.0.1:{fake_port}")
+    print(f"hold per turn  : {hold}s     concurrency levels: {levels}")
+    print(f"scratch        : {tmp}")
+
+    users = seed_accounts(env, max(levels) or 1)
+    print(f"seeded         : {len(users)} accounts (1 per virtual user)")
+
+    report: dict = {"levels": levels, "hold": hold}
+    try:
+        if args.only in (None, "saturation"):
+            print("\n### Item 1 — does /healthz starve? ###")
+            report["saturation"] = saturation_matrix(
+                env, state, users,
+                configs=[(2, 4), (1, 8)], levels=levels, hold=hold)
+
+        if args.only in (None, "hold"):
+            print("\n### Item 2 — real per-turn thread hold ###")
+            report["turn_hold"] = turn_hold_measurement(env, state, users)
+
+        if args.only in (None, "worstcase"):
+            # The tables above use a short hold to keep the matrix fast. The
+            # number that matters is the one at the code's OWN worst case: a
+            # run that lives to `CARE_RUN_DEADLINE_SECONDS` (120s default).
+            worst = 20.0 if args.quick else 120.0
+            print(f"\n### Worst case — 8 turns each holding {worst:.0f}s "
+                  f"(the run deadline) ###")
+            report["worst_case"] = saturation_matrix(
+                env, state, users, configs=[(2, 4)], levels=[8],
+                hold=worst)
+
+        if args.only in (None, "variance"):
+            print("\n### Why 2w x 4t starves below 8 — N=6, repeated ###")
+            repeats = 3 if args.quick else 6
+            print("  arrivals in the same millisecond (burst):")
+            report["variance_burst"] = distribution_variance(
+                env, state, users, n=6, hold=hold, repeats=repeats)
+            print("\n  arrivals spread 0.3s apart (closer to real traffic):")
+            report["variance_staggered"] = distribution_variance(
+                env, state, users, n=6, hold=hold, repeats=repeats,
+                stagger=0.3)
+
+        if args.only in (None, "restart"):
+            print("\n### Item 4 — what a restart actually loses ###")
+            report["restart"] = restart_and_state(env, state)
+
+        if args.only in (None, "mitigations"):
+            print("\n### Item 5 — measured effect of each mitigation ###")
+            print("\n(a) bound the turn: same N, shorter run")
+            report["mitigation_bound_turn"] = saturation_matrix(
+                env, state, users, configs=[(2, 4)],
+                levels=[8, 16], hold=max(2.0, hold / 4))
+
+            print("\n(b) drop the HealthClaw read timeout 25s -> 10s")
+            shim_env = dict(env)
+            shim = tmp / "probe_wsgi_10s.py"
+            shim.write_text(
+                '"""Probe-only shim: 10s HealthClaw read timeout.\n\n'
+                'Rebinds the client default BEFORE create_app, so nothing in\n'
+                'careagents/ is edited to measure the mitigation.\n"""\n'
+                "import careagents.healthclaw as _hc\n"
+                "_orig = _hc.HealthClawClient.__init__\n"
+                "def _patched(self, base, mint_secret, timeout=10.0):\n"
+                "    _orig(self, base, mint_secret, timeout)\n"
+                "_hc.HealthClawClient.__init__ = _patched\n"
+                "from careagents.app import create_app\n"
+                "app = create_app()\n")
+            shim_env["PYTHONPATH"] = (
+                f"{tmp}{os.pathsep}{shim_env.get('PYTHONPATH', '')}")
+            shim_wsgi = "probe_wsgi_10s:app"
+
+            print("  b1. /healthz's own call, no chat load:")
+            report["mitigation_timeout_25"] = hanging_dependency(
+                env, state, users, "25s (shipping default)")
+            report["mitigation_timeout_10"] = hanging_dependency(
+                shim_env, state, users, "10s (proposed)", wsgi=shim_wsgi)
+
+            print("\n  b2. under load — HealthClaw hangs on run events, so "
+                  "the read timeout IS the thread hold (N=8):")
+            state.events_hang = 40.0
+            try:
+                report["mitigation_hang_25"] = saturation_matrix(
+                    env, state, users, configs=[(2, 4)], levels=[8],
+                    hold=hold)
+                report["mitigation_hang_10"] = saturation_matrix(
+                    shim_env, state, users, configs=[(2, 4)], levels=[8],
+                    hold=hold, wsgi=shim_wsgi)
+            finally:
+                state.events_hang = 0.0
+
+            print("\n(c) raise threads: 2w x 8t (16 threads)")
+            report["mitigation_threads"] = saturation_matrix(
+                env, state, users, configs=[(2, 8)],
+                levels=[8, 16], hold=hold)
+    finally:
+        server.shutdown()
+
+    out = tmp / "probe-219-report.json"
+    out.write_text(json.dumps(report, indent=2, default=str))
+    print(f"\nmachine-readable report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Council ruling D2 item 8 asked for a measurement, not a fix: *"#219 probe (10
concurrent). Build only if it fails."* This is the measurement. **No production
code is changed, and no load was sent to production** — `careagents.cloud`
serves a real clinician, so everything here runs against a local gunicorn and a
fake HealthClaw on loopback.

## Verdict: reproduces differently

The starvation half is real and starts earlier than the issue says. The restart
half does not happen at all, and most of the data-loss half was already false.

| # | Claim in #219 | Measured |
|---|---|---|
| 1 | "One worker, 8 threads" | **Wrong.** `--workers 2 --threads 4` (`deploy/careagents/Dockerfile:54`). Same 8 threads, but the split makes saturation start *earlier* and *non-deterministically* |
| 2 | "6 tool rounds × 25s + 90s LLM" holds the thread | **Wrong mechanism, right symptom.** The web tier runs no inference since #257. The hold is the SSE replay loop (`app.py:833`) |
| 3 | "8 concurrent turns block everything including `/healthz`" | **Confirmed at 8; intermittent from 6.** At the code's own worst case `/healthz` waits **118s** |
| 4 | "Railway marks the container unhealthy → restart" | **Does not happen.** Railway's healthcheck is deploy-time only |
| 5 | "All chat histories wiped" | **False.** Transcripts live in HealthClaw, per tenant |
| 6 | "Rate-limit state wiped" | **Half true.** The in-process *burst* limiter resets (by design); the durable daily cap and the login-code attempt counter both survive |

## Does `/healthz` starve? Yes

Shipping config, 8 threads as `2 × 4`, each turn holding for 20s:

| N | turns started | `/healthz` 5s budget | 30s budget | true wait |
|---|---|---|---|---|
| 0 | — | 4/4 ok | 1/1 ok | 0.01s |
| 4 | 4/4 | 4/4 ok | 1/1 ok | 0.00s |
| 6 | 6/6 | 4/4 ok | 1/1 ok | 0.00s |
| 8 | 7/8 | 3/4 ok | 1/1 ok | **18.19s** |
| 10 | 8/10 | 1/4 ok | 1/1 ok | **18.13s** |
| 16 | 8/16 | 0/4 ok | 0/1 ok | **38.32s** |

`/healthz` never refuses a connection — it connects instantly and waits for a
free thread, so the wait tracks the *turn duration*, not N. At the code's own
worst case (`run_deadline_seconds` = 120):

| N | hold | `/healthz` true wait |
|---|---|---|
| 8 | 120s | **118.12s** |

**N=6 is a coin flip.** The single sample above is clean at N=6; repeating it is
what shows the effect. Two gunicorn workers accept from a shared socket, so six
turns land unevenly and saturate one worker while the other idles. Across three
attempts of six runs each — bursty arrivals and arrivals staggered 0.3s apart —
**2, 4 and 4 of 6 stalled ~18s**, the rest ~0.01s. On six trials that spread is
ordinary noise, so read it as "intermittent", not as a rate. What is stable is
the shape: the wait is either ~0s or ~18s and never in between, because it
depends on which worker accepted the probe. Staggering arrivals does not remove
it. Full numbers in the evidence doc.

## Why there is no restart loop

<https://docs.railway.com/guides/healthchecks>:

> The healthcheck endpoint is currently **not used for continuous monitoring**
> as it is only called at the start of the deployment.

The Dockerfile's `HEALTHCHECK` (`--interval=30s --timeout=5s --retries=3`,
i.e. unhealthy after 90s of saturation) is not evaluated by Railway, and Docker
does not restart an unhealthy container by itself. The VPS alternative is
systemd with `Restart=on-failure` and no health check — it restarts on process
*exit*, which saturation does not cause.

**No mechanism, no restart, no wipe, no loop.** What saturation actually costs
on Railway is a *deploy* that fails its health check and does not go live.

## Why the data-loss half is mostly false

Measured by driving the real endpoints, restarting gunicorn against the same
database, and reading the stores back:

| State | Survives a restart? |
|---|---|
| Chat transcripts (HealthClaw `cc_conversation_messages`, per tenant) | **Yes** — not in CareAgents at all |
| Login-code attempts (`EmailToken.attempts`) | **Yes** — read back as 2 |
| Durable daily turn cap (`UsageDay`) | **Yes** — counted 4 across the restart |
| Chat *burst* limiter (in-process deque) | **No** — 429 before, 200 after |

Only the last is lost, and `careagents/config.py` already documents that as
deliberate, backed by the DB-backed daily cap.

## Mitigations, measured one at a time

| Mitigation | Measured effect |
|---|---|
| **Bound the turn** | Turn 20s → 5s dropped the wait **18.19s → 0.01s** at N=8 and **38.32s → 13.73s** at N=16. But the bound already exists (`run_deadline_seconds` = 120); the lever is lowering it, which trades a hung page for a cut-off answer |
| **Read timeout 25s → 10s** | **Nothing while HealthClaw is healthy** — those calls return in milliseconds. It binds only when HealthClaw *hangs*, and then it is the thread hold (measured 23.03s at the 25s default). The 10s comparison sample is not clean and is not quoted as one — see the evidence doc. Does not touch the case #219 describes |
| **Raise threads (2×8)** | **Fixes N=8 outright** (18.19s → **0.00s**). At N=16 it halves the wait (38.32s → **18.23s**) and starts all 16 turns, but `/healthz` still blows the 5s budget 3 times in 4. Buys about one doubling of headroom; the failure moves, it does not go away |

## Two findings not in the issue

1. **`/healthz` fails its own 5s probe budget at zero load.** It calls
   `hc.agent_worker_health()` with the client's 25s timeout, so a slow
   HealthClaw makes `/healthz` take 25s (measured: 25.01s → 503) with no chat
   traffic at all. Triggered by a HealthClaw outage, not by concurrency —
   the opposite of #219's causal story. Worth its own issue.
2. **Each open turn polls HealthClaw 4×/s** — ~31 req/s at N=8, aimed at the
   HealthClaw that also serves the clinician. Flagged, not chased.

Also: `_stream_run` has no `try/except` around `agent_run_events`, so a
`HealthClawError` mid-stream kills the generator and the browser sees the
connection drop with **no `error` event**. Small and separate.

## What is faked, and why

Real: `careagents.wsgi:app` under the Dockerfile's own gunicorn invocation, the
real `HealthClawClient` with its real 25s timeout, real sessions, real rate
limiters, real account store.

Faked: **HealthClaw only**, as a loopback `ThreadingHTTPServer` that
`HEALTHCLAW_BASE` points at — so the client and its timeouts run as shipped,
with nothing monkeypatched inside gunicorn. It holds a run in `running` for a
controlled number of seconds, and that duration is the independent variable.
The LLM is not faked because the web tier never calls it.

`CARE_CHAT_TURNS` / `CARE_CHAT_TURNS_PER_DAY` are raised in the rig so a
rate-limited turn (429, instant, holds no thread) cannot masquerade as a held
thread; every scenario reports how many turns actually got their `accepted`
event.

## What could NOT be measured locally

1. Which `CARE_WEB_WORKERS` Railway sets for CareAgents (both 2×4 and 1×8 were
   measured to cover it).
2. The CareAgents Railway service's own healthcheck settings — the repo's
   `railway.toml` is HealthClaw's; CareAgents deploys from a staged directory.
3. Real HealthClaw latency under the poll storm (the fake answers instantly).
4. The real distribution of turn durations in production — the hold was
   controlled, not observed. That number decides how often N=6 is even reached.
5. The account store is SQLite in the rig, Postgres in production. That
   inflates the "turns started" column (serialised writes at turn start); it
   does not touch the starvation numbers, since the SSE loop never reads it.
6. Railway's edge behaviour on a 150s SSE stream.
7. Whether any of this has happened. This measures a mechanism, not an
   incident rate.

## Deliverables

- `scripts/probe_219_thread_saturation.py` — the rig; a non-author can re-run
  it from `main` with `uv run python scripts/probe_219_thread_saturation.py`.
- `docs/evidence/2026-09-03-probe-219-thread-saturation.md` — full transcript,
  tables, and the recommendation.

Gates:

```
$ uv run ruff check .
All checks passed!

$ uv run python -m pytest tests/ -q -p no:cacheprovider
3157 passed, 13 skipped, 1 xfailed, 2 warnings in 112.44s (0:01:52)
```

**Note:** `dependency-audit` is red on every open PR from npm advisories fixed
in unmerged #544, not by anything here.

**Do not merge** — this is a measurement for the council to rule on. Auto-merge
is not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
