### PR TITLE
candidate: report every unpopulated leaf, delete the probe (CTO ruling on #562)

### DIFF
--- a/r6/sdc/expressions.py
+++ b/r6/sdc/expressions.py
@@ -30,14 +30,23 @@ own structure.
 
 AND NOTHING IN THIS MODULE MAY EVALUATE A CALLER'S EXPRESSION AGAINST THE
 REAL RECORD. Not to answer a yes/no question, not to decide whether to warn.
-`resolves_outside_projection` reads a constant probe for exactly that reason
-— its docstring has the reproduction. A bool derived from a patient's data
-and handed to the caller is a read of that data; repeat it once per
-questionnaire item and it is a fast one.
+A bool derived from a patient's data and handed to the caller is a read of
+that data; repeat it once per questionnaire item and it is a fast one. That
+is not a hypothetical: a `resolves_outside_projection` classifier lived here
+and decided whether to report an unpopulated item by evaluating the caller's
+own expression against the unbounded record, and eleven HTTP requests walked
+a stored identifier out through the issue list one character at a time (QA
+review of PR #562).
+
+There is no classifier here now, in any shape. `r6/sdc/populate.py` reports
+every leaf that resolved no value, which depends on nothing but whether an
+answer was produced — a fact the caller already holds, because the response
+carries `answer` only on the leaves that got one. Nothing to leak, by
+construction, and nobody has to re-verify that the next time this file is
+touched.
 """
 
 import logging
-from functools import lru_cache
 
 import fhirpathpy
 
@@ -140,139 +149,6 @@ def build_context(subject=None):
     if projection is None:
         return {}
     return {'patient': projection, 'subject': projection}
-
-
-#: The record `resolves_outside_projection` probes. It is a CONSTANT, and it
-#: has to stay one — see that function's docstring. Every element the
-#: projection withholds is populated here with a placeholder, so an
-#: expression reaching for one resolves against this and not against a
-#: patient. Nothing here is anybody's data.
-_PROBE_PATIENT = {
-    'resourceType': 'Patient',
-    'id': 'projection-probe',
-    'name': [{'given': ['Probe'], 'family': 'Probe', 'text': 'Probe Probe',
-              'prefix': ['Probe'], 'suffix': ['Probe'], 'use': 'official'}],
-    'birthDate': '2000-01-01',
-    'gender': 'unknown',
-    'deceasedBoolean': False,
-    'multipleBirthInteger': 1,
-    'active': True,
-    'telecom': [{'system': s, 'value': 'probe', 'use': 'home'}
-                for s in ('phone', 'email', 'sms', 'fax', 'pager', 'url',
-                          'other')],
-    'address': [{'line': ['probe'], 'city': 'probe', 'state': 'probe',
-                 'postalCode': 'probe', 'district': 'probe',
-                 'country': 'probe', 'text': 'probe', 'use': 'home'}],
-    'identifier': [{'system': 'urn:probe', 'value': 'probe', 'use': 'usual',
-                    'type': {'text': 'probe'}}],
-    'photo': [{'url': 'probe', 'contentType': 'image/png', 'title': 'probe',
-               'data': 'cHJvYmU='}],
-    'contact': [{'name': {'given': ['Probe'], 'family': 'Probe'},
-                 'telecom': [{'system': 'phone', 'value': 'probe'}],
-                 'address': {'line': ['probe'], 'city': 'probe'},
-                 'relationship': [{'text': 'probe'}]}],
-    'communication': [{'language': {'text': 'probe'}, 'preferred': True}],
-    'maritalStatus': {'text': 'probe', 'coding': [{'code': 'probe'}]},
-    'generalPractitioner': [{'reference': 'Practitioner/probe',
-                             'display': 'probe'}],
-    'managingOrganization': {'reference': 'Organization/probe',
-                             'display': 'probe'},
-    'link': [{'other': {'reference': 'Patient/probe'}, 'type': 'seealso'}],
-    'extension': [{'url': 'urn:probe', 'valueString': 'probe'}],
-    'modifierExtension': [{'url': 'urn:probe', 'valueString': 'probe'}],
-    'meta': {'tag': [{'code': 'probe'}], 'security': [{'code': 'probe'}],
-             'profile': ['urn:probe'], 'source': 'probe'},
-    'text': {'status': 'generated', 'div': 'probe'},
-    'implicitRules': 'urn:probe',
-    'language': 'en',
-}
-
-#: One placeholder per resource type $populate auto-loads, so an expression
-#: reaching for `%resources` is reported rather than silently empty. Constant,
-#: for the same reason as _PROBE_PATIENT.
-_PROBE_RESOURCES = [
-    {'resourceType': 'Observation', 'id': 'probe', 'status': 'final',
-     'subject': {'reference': 'Patient/probe', 'display': 'probe'},
-     'code': {'text': 'probe', 'coding': [{'code': 'probe',
-                                           'display': 'probe'}]},
-     'valueString': 'probe',
-     'valueCodeableConcept': {'text': 'probe'},
-     'note': [{'text': 'probe'}],
-     'performer': [{'reference': 'Practitioner/probe', 'display': 'probe'}]},
-    {'resourceType': 'MedicationRequest', 'id': 'probe', 'status': 'active',
-     'subject': {'reference': 'Patient/probe', 'display': 'probe'},
-     'medicationCodeableConcept': {'text': 'probe'},
-     'dosageInstruction': [{'text': 'probe'}]},
-    {'resourceType': 'AllergyIntolerance', 'id': 'probe',
-     'patient': {'reference': 'Patient/probe', 'display': 'probe'},
-     'code': {'text': 'probe'},
-     'reaction': [{'manifestation': [{'text': 'probe'}]}]},
-    {'resourceType': 'Condition', 'id': 'probe',
-     'subject': {'reference': 'Patient/probe', 'display': 'probe'},
-     'code': {'text': 'probe'}},
-]
-
-
-@lru_cache(maxsize=512)
-def resolves_outside_projection(expression):
-    """Does `expression` reach for something the projection does not carry?
-
-    THE ONE PROPERTY: **this is a pure function of the expression text.** It
-    never sees a patient. It evaluates `expression` twice against the
-    CONSTANT `_PROBE_PATIENT` — once through the projection and once around
-    it — and reports "outside" when the unbounded form resolves and the
-    bounded form does not.
-
-    It reads a constant because the obvious implementation does not, and the
-    obvious implementation is a PHI exfiltration channel. Evaluating the
-    caller's expression against the REAL record and returning whether it was
-    non-empty makes the issue list a one-bit oracle over exactly the data the
-    projection withholds: a caller sends
-
-        %patient.identifier.value.where($this.startsWith('123'))
-
-    on one item, reads whether an issue named that linkId, and walks the
-    withheld SSN out one character at a time — measured at eleven HTTP
-    requests, with the value never once appearing in an answer (QA review of
-    PR #562, council ruling D10). A bool is a value. Any function of the
-    record whose output reaches the caller is a read of the record, however
-    narrow the output looks.
-
-    Answering from a constant keeps what the ruling asked for — an item that
-    was refused says so, naming its linkId, instead of looking like a patient
-    with no phone number — while telling the caller nothing whatsoever about
-    this patient. `%patient.identifier` is outside the projection for
-    everyone; that is a property of the allowlist, not of a record.
-
-    The bounded half of the comparison is what keeps an ALLOWLISTED path that
-    the real patient simply lacks (`%patient.telecom.where(system='email')`
-    on a patient with no email) from being reported as withheld: it resolves
-    against the probe on both sides, so it is not "outside".
-
-    WHAT THIS IS NOT: exhaustive. A withheld path `_PROBE_PATIENT` happens
-    not to populate — `%patient.deceasedDateTime`, `%patient.name.period`,
-    `%patient.telecom.rank` today — answers False, so that item comes back
-    silently empty instead of naming itself. That is a gap in the REPORTING,
-    never in the bound: the projection still withholds it, and nothing about
-    the patient reaches the caller either way. Widen the probe to close one;
-    do not widen it with anything but placeholders.
-
-    Cached because the answer depends only on `expression`, which also caps
-    the work a caller can buy per request.
-    """
-    if not expression:
-        return False
-    projected = patient_projection(_PROBE_PATIENT)
-    bounded = {'patient': projected, 'subject': projected}
-    unbounded = {
-        'patient': _PROBE_PATIENT,
-        'subject': _PROBE_PATIENT,
-        # The name the projection withholds entirely.
-        'resources': _PROBE_RESOURCES,
-    }
-    if evaluate(expression, _PROBE_PATIENT, unbounded) is None:
-        return False
-    return evaluate(expression, projected, bounded) is None
 
 
 def evaluate(expression, resource, context=None):

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -27,16 +27,29 @@ test_zero_allergies_never_infers_no_known_allergies (the load-bearing one)
 and test_zero_medications_never_infers_no_current_medications.
 """
 
-from r6.sdc.expressions import (build_context, evaluate,
-                                resolves_outside_projection)
+from r6.sdc.expressions import build_context, evaluate
 
-#: What an item's issue says when the %patient projection is the reason it has
-#: no answer. Fixed text: a Questionnaire author controls the expression, and
-#: echoing it back would put an author-supplied literal (`where(value='...')`)
-#: into an OperationOutcome that leaves the boundary.
-WITHHELD_BY_PROJECTION = (
-    'not populated: the expression resolves outside the %patient projection '
-    'this operation permits (name, birthDate, gender, telecom, address)'
+#: What an attempted-but-unresolved leaf reports. ONE sentence for both
+#: causes, because the server does not tell the two apart and must not appear
+#: to: "the projection withheld it" and "the patient has no email address"
+#: read identically here on purpose. `questionnaire_populate` is in the
+#: model-facing read tier, and text naming a refusal would have a model tell
+#: a patient their record was held back when it is simply empty.
+#:
+#: What the caller gets instead is the allowlist, which is public — they can
+#: compare it against their own expression without the server answering a
+#: question about a patient to do it. (The constant this replaced was called
+#: WITHHELD_BY_PROJECTION and said so; it was true for only some of the
+#: leaves it was attached to, which is retro pattern 1 living in a name.)
+#:
+#: The expression is deliberately NOT echoed: a Questionnaire author controls
+#: it, and a `where(value='...')` clause is a place to park a literal that
+#: would then ride out on an OperationOutcome.
+NOT_POPULATED = (
+    'not populated: no value resolved. $populate reads only the %patient '
+    'projection (name, birthDate, gender, telecom phone/email, address '
+    'line/city/state/postalCode) and coded content this server recognises; '
+    'anything else is not read.'
 )
 
 INITIAL_EXPRESSION_URL = (
@@ -213,7 +226,7 @@ def _populate_item(item, subject, context, observations, issues, content_resourc
         list_resource_type = _list_group_resource_type(item)
         if item.get("repeats") and list_resource_type:
             return _populate_list_group(item, list_resource_type, subject,
-                                        content_resources)
+                                        content_resources, issues)
         # Ordinary group: recurse, keep the group only if it produced
         # child answers.
         children = []
@@ -260,11 +273,29 @@ def _parse_definition(definition):
     return parts[0], parts[1]
 
 
-def _populate_list_group(item, resource_type, subject, content_resources):
+def _populate_list_group(item, resource_type, subject, content_resources,
+                         issues):
     """Emit one repeat of `item` per matching, currently-relevant resource of
     `resource_type` for `subject`. Returns [] when there are none — an empty
     repeating group, never a default answer for a sibling item (see module
     docstring's safety invariant).
+
+    ROW COUNT EQUALS RECORD COUNT, always. A repeat is emitted for every
+    matching resource even when not one of its leaves resolves — an
+    unlabelled allergen is a row with no answer and an issue, never a
+    dropped row. A patient with three allergies seeing two is a false
+    negative on an allergy list, and an allergy section that renders empty
+    is one click from someone ticking "no known allergies". Pinned by
+    tests/test_populate_lists.py::
+    test_three_unlabelled_allergies_still_produce_three_repeats.
+
+    Leaves report through the same mechanism as everything else: a leaf
+    carrying a `definition` is an attempted population, so one that resolves
+    nothing gets an issue naming its linkId. A leaf with no `definition` is
+    not attempted and is left alone — that is the same exclusion
+    `_resolve_answer` applies to the attestation booleans, and it is why a
+    future patient-entered leaf inside a repeating group will not be
+    reported as something the server failed to fill.
     """
     config = _LIST_RESOURCE_CONFIG[resource_type]
     subject_ref = _reference(subject)
@@ -289,6 +320,8 @@ def _populate_list_group(item, resource_type, subject, content_resources):
             if value is not None:
                 value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
                 child_item["answer"] = [{value_key: value}]
+            elif child.get("definition"):
+                _report_unpopulated(issues, child.get("linkId"))
             children.append(child_item)
         repeats.append({"linkId": item.get("linkId"), "item": children})
     return repeats
@@ -317,24 +350,56 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id):
         value = evaluate(expr, context.get("patient"), context)
         if value is not None:
             return _coerce(value, item_type), value_key
-        # An empty answer has two very different causes and a caller cannot
-        # tell them apart from the response, so say which one it was.
-        #
-        # This asks about the EXPRESSION, not about this patient, and it must
-        # keep doing so. resolves_outside_projection takes no record for that
-        # reason: answering it from the real one turns this issue list into a
-        # one-bit oracle a caller walks the withheld data out through, one
-        # `where($this.startsWith(...))` per item. See its docstring.
-        if resolves_outside_projection(expr):
-            issues.append({"linkId": link_id, "detail": WITHHELD_BY_PROJECTION})
+        _report_unpopulated(issues, link_id)
         return None, value_key
 
     codes = item.get("code") or []
     if codes:
+        # A code-matched item that found no Observation is an attempted
+        # population that resolved nothing, exactly like the expression above.
+        # The intake Questionnaire has no item.code items, so this is
+        # invisible today — another Questionnaire will have them.
         value = _observation_answer(codes, observations)
         if value is not None:
             return value, value_key
+        _report_unpopulated(issues, link_id)
+
+    # No initialExpression and no code: NOTHING WAS ATTEMPTED, so nothing is
+    # reported. THIS IS THE EXCLUSION AND IT IS LOAD-BEARING —
+    # `allergies.no-known-allergies` and `medications.no-current-medications`
+    # reach exactly here. They carry no code and no expression precisely so
+    # that no mechanism ever touches them (r6/sdc/intake.py). An issue
+    # reading "not populated: no value resolved" against `no-known-allergies`
+    # tells a model-facing reader that the system tried to determine NKA and
+    # could not — which is a hair from inferring it, and inferring it is the
+    # non-negotiable. Pinned by tests/test_populate_lists.py::
+    # test_the_attestation_items_never_appear_in_the_issue_list.
     return None, value_key
+
+
+def _report_unpopulated(issues, link_id):
+    """Record that `link_id` was attempted and resolved nothing.
+
+    UNCONDITIONAL, and that is the design rather than an omission. The
+    response already says which leaves have no answer — `_populate_item`
+    attaches `answer` only on success — so an issue per unanswered attempted
+    leaf is a redundant encoding of what the caller is holding, and carries
+    no information about the patient BY CONSTRUCTION. There is nothing here
+    to verify does not leak.
+
+    Do not add a condition. Every predicate that has stood here was a
+    question about the record or about the expression, and both shapes have
+    already failed in this file: one evaluated the caller's expression
+    against the unbounded Patient (a one-bit oracle — eleven HTTP requests
+    recovered a stored identifier), and its replacement asked a constant
+    probe instead, which was safe but reported only six of twelve withheld
+    expressions, so the other six came back silent and a caller reads silence
+    as "this patient has no such value". Both are `docs/2026-08-02-retro.md`
+    pattern 1. Pinned by tests/test_populate_issue_property.py, which asserts
+    the biconditional per item; any classifier reddens on the first leaf it
+    silences.
+    """
+    issues.append({"linkId": link_id, "detail": NOT_POPULATED})
 
 
 def _observation_answer(item_codes, observations):

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -363,6 +363,7 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id):
         if value is not None:
             return value, value_key
         _report_unpopulated(issues, link_id)
+        return None, value_key
 
     # No initialExpression and no code: NOTHING WAS ATTEMPTED, so nothing is
     # reported. THIS IS THE EXCLUSION AND IT IS LOAD-BEARING —

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -323,9 +323,15 @@ def _commit_bundle(bundle, tenant_id):
 
 
 def _issues_outcome(issues):
+    # severity=information, NOT warning. Under unconditional emission
+    # (r6/sdc/populate.py:_report_unpopulated) an ordinary form with one
+    # empty optional field carries an issue, and a conformant client reading
+    # `warning` treats that as a failed operation. Nothing here is a
+    # failure — every issue says "this leaf resolved no value", which is a
+    # restatement of the response's own missing `answer`.
     return {
         "resourceType": "OperationOutcome",
-        "issue": [{"severity": "warning", "code": "incomplete",
+        "issue": [{"severity": "information", "code": "incomplete",
                    "diagnostics": f"{i['linkId']}: {i['detail']}"}
                   for i in issues],
     }

--- a/tests/test_populate_issue_property.py
+++ b/tests/test_populate_issue_property.py
@@ -1,0 +1,442 @@
+"""The $populate issue list carries zero bits about the patient.
+
+THE PROPERTY, stated once: for every leaf where population was ATTEMPTED,
+
+    an answer is present  <=>  no issue names that occurrence
+
+so the issue list is a redundant re-encoding of something the caller is
+already holding — `_populate_item` attaches `answer` only when a value
+resolved, so *which* leaves came back empty is in the response either way.
+Nothing about the record can reach the caller through a channel that says
+only what the caller can already count. That is the whole reason the issue
+is emitted unconditionally rather than classified.
+
+It replaces a classifier that decided whether to report by asking a question
+*about the record*. The first cut evaluated the caller's own expression
+against the unbounded Patient and reported whether it came back non-empty —
+a one-bit oracle that walked a stored identifier out over eleven HTTP
+requests (QA review of PR #562). The second cut asked the same question of a
+constant probe, which closed the leak but answered "no issue" for six of the
+ruling's twelve withheld expressions, because it fired only when the
+caller's `where()` filter happened to match the probe's placeholder text.
+Both are `docs/2026-08-02-retro.md` pattern 1: a control that looks like "we
+tell you when we refused" and does something else. Neither shape can pass
+this file — a classifier that silences any attempted leaf changes a count
+here, and a classifier driven by the record changes it *per patient*, which
+is what `test_the_issue_set_is_identical_for_every_patient` measures.
+
+REPEATS: the biconditional is stated as counts, not booleans. One allergy
+row labelled and one not is one answered occurrence and one issue on the
+SAME linkId, so `answer present <=> no issue` only reads correctly per
+occurrence. Counter equality says exactly that.
+
+ATTEMPTED, and why the predicate is read from the QUESTIONNAIRE here rather
+than imported from the engine: a leaf with no population mechanism at all
+must never be reported. `allergies.no-known-allergies` and
+`medications.no-current-medications` carry no `code` and no
+initialExpression precisely so nothing ever touches them, and an issue
+reading "not populated: no value resolved" against them tells a
+model-facing reader that the system tried to determine "no known allergies"
+and failed — one step from inferring it. Deriving the predicate from the
+questionnaire's own structure keeps this test independent of how populate.py
+decides.
+"""
+
+from collections import Counter
+
+from r6.sdc.intake import intake_questionnaire
+from r6.sdc.populate import NOT_POPULATED, populate_questionnaire
+
+INITIAL_EXPR_URL = (
+    "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
+    "sdc-questionnaire-initialExpression"
+)
+
+SNOMED = "http://snomed.info/sct"
+
+
+# ---------------------------------------------------------------------------
+# The matrix: patients x expressions
+# ---------------------------------------------------------------------------
+
+#: Full demographics — every allowlisted path resolves.
+FULL_PATIENT = {
+    "resourceType": "Patient",
+    "id": "p1",
+    "name": [{"given": ["Ada"], "family": "Lovelace"}],
+    "birthDate": "1815-12-10",
+    "gender": "female",
+    "identifier": [{"system": "http://hl7.org/fhir/sid/us-ssn",
+                    "value": "123-45-6789"}],
+    "photo": [{"url": "https://example.org/ada.jpg"}],
+    "maritalStatus": {"text": "Married"},
+    "contact": [{"name": {"family": "Byron"}, "gender": "male"}],
+    "deceasedDateTime": "2026-01-01",
+    "telecom": [{"system": "phone", "value": "617-555-0198"},
+                {"system": "email", "value": "ada@example.org"},
+                {"system": "sms", "value": "617-555-0199"}],
+    "address": [{"line": ["123 Clinical Ave"], "city": "Boston",
+                 "state": "MA", "postalCode": "02101"}],
+}
+
+#: One given name and nothing else. Every other allowlisted path is genuinely
+#: absent rather than withheld — the case the old text got wrong out loud.
+SPARSE_PATIENT = {
+    "resourceType": "Patient",
+    "id": "p1",
+    "name": [{"given": ["Ada"]}],
+}
+
+#: No demographics at all, and a different withheld identifier, so a
+#: record-driven classifier would answer differently here than on FULL.
+BARE_PATIENT = {
+    "resourceType": "Patient",
+    "id": "p1",
+    "identifier": [{"system": "http://hl7.org/fhir/sid/us-ssn",
+                    "value": "999-99-9999"}],
+}
+
+PATIENT_MATRIX = {
+    "full": FULL_PATIENT,
+    "sparse": SPARSE_PATIENT,
+    "bare": BARE_PATIENT,
+}
+
+#: linkId -> expression. The CTO ruling's own twelve-row live matrix, which
+#: is where the probe was measured and found to report six of them. The
+#: `oracle-*` rows are the `where()` shapes that walked an identifier out;
+#: they are the ordinary way an author writes a filter, which is why the
+#: probe's placeholder-matching gap was not an edge case.
+WITHHELD_EXPRESSIONS = {
+    # D10's three named negatives.
+    "mrn": "%patient.identifier.value",
+    "photo": "%patient.photo.url",
+    "obs-text": "%resources.where(resourceType='Observation').code.text",
+    # Withheld, and reported by the probe.
+    "marital": "%patient.maritalStatus.text",
+    "sms": "%patient.telecom.where(system='sms').value",
+    "mrn-first": "%patient.identifier.first().value",
+    # Withheld, and SILENT under the probe. Each of these is a row the
+    # classifier answered False for while the projection withheld the value.
+    "oracle-1": "%patient.identifier.value.where($this.startsWith('1'))",
+    "oracle-9": "%patient.identifier.value.where($this.startsWith('9'))",
+    "contact-gender": "%patient.contact.gender",
+    "deceased": "%patient.deceasedDateTime",
+    "name-period": "%patient.name.period.start",
+}
+
+#: The ruling's twelfth row, held apart because it is not a silence at all.
+#: `combine` unions a withheld path with an ALLOWLISTED one, so on a patient
+#: who has a gender it resolves — to the gender, and to nothing else. The
+#: item is ANSWERED, which is why it reported no issue under the probe and
+#: reports none now. It varies with the record exactly as far as the answer
+#: does, which is the allowlist working, so it cannot ride in the invariance
+#: test below.
+COMBINE_EXPRESSION = {
+    "oracle-combine": "%patient.identifier.value.combine(%patient.gender)",
+}
+
+#: An ALLOWLISTED path the sparse fixture patient genuinely lacks. It is not
+#: withheld and never was; under the ruling it is reported in exactly the
+#: same words, which is the point — the text claims nothing about why.
+ABSENT_BUT_ALLOWLISTED = {
+    "email": "%patient.telecom.where(system='email').value",
+}
+
+ALLOWLISTED = {
+    "given": "%patient.name.given.first()",
+    "family": "%patient.name.family",
+    "dob": "%patient.birthDate",
+}
+
+
+def _expr_item(link_id, expression, item_type="string"):
+    return {
+        "linkId": link_id, "type": item_type,
+        "extension": [{
+            "url": INITIAL_EXPR_URL,
+            "valueExpression": {"language": "text/fhirpath",
+                                "expression": expression},
+        }],
+    }
+
+
+def _expression_questionnaire(expressions):
+    return {"resourceType": "Questionnaire", "id": "property-q",
+            "status": "active",
+            "item": [_expr_item(link_id, expr)
+                     for link_id, expr in expressions.items()]}
+
+
+# ---------------------------------------------------------------------------
+# The property, and the two halves it is built from
+# ---------------------------------------------------------------------------
+
+def _attempted_link_ids(questionnaire, parent_repeats=False):
+    """linkIds where the questionnaire asks populate to resolve something.
+
+    Read from the Questionnaire, not from populate.py, so this test still
+    means something if the engine's own predicate changes. Three mechanisms,
+    matching the module docstring of r6/sdc/populate.py:
+
+      - an initialExpression (FHIRPath against the %patient projection),
+      - an `item.code` (Observation matching),
+      - a `definition` on a leaf of a REPEATING group (list-resource
+        population).
+
+    `definition` alone is deliberately not enough: every demographics leaf on
+    the intake form carries one for `$extract`'s benefit and populates by
+    expression. A definition-bearing leaf outside a repeating group is not an
+    attempted population.
+    """
+    found = set()
+    for item in questionnaire.get("item", []):
+        if item.get("type") == "group":
+            found |= _attempted_link_ids(item, bool(item.get("repeats")))
+            continue
+        if _has_initial_expression(item) or item.get("code"):
+            found.add(item["linkId"])
+        elif parent_repeats and item.get("definition"):
+            found.add(item["linkId"])
+    return found
+
+
+def _has_initial_expression(item):
+    return any(ext.get("url") == INITIAL_EXPR_URL
+               for ext in item.get("extension", []))
+
+
+def _leaf_occurrences(items):
+    """Every leaf item in the QUESTIONNAIRERESPONSE, repeats included.
+
+    One entry per occurrence, not per linkId: two allergy rows are two
+    occurrences of `allergies.item.allergen`.
+    """
+    for item in items:
+        if "item" in item:
+            yield from _leaf_occurrences(item["item"])
+        else:
+            yield item
+
+
+def _assert_zero_bits(questionnaire, qr, issues, label):
+    """THE PROPERTY. Per linkId: unanswered attempted occurrences == issues.
+
+    MUTATION: silence any attempted leaf (re-add a classifier, of any shape)
+    -> the expected count exceeds the actual and this goes red naming the
+    linkId. Emit for an unattempted leaf -> the second assertion goes red.
+    """
+    attempted = _attempted_link_ids(questionnaire)
+    expected = Counter()
+    unattempted_answered = []
+    for leaf in _leaf_occurrences(qr.get("item", [])):
+        link_id = leaf.get("linkId")
+        if link_id in attempted:
+            if "answer" not in leaf:
+                expected[link_id] += 1
+        elif "answer" in leaf:
+            unattempted_answered.append(link_id)
+
+    actual = Counter(issue["linkId"] for issue in issues)
+    assert actual == expected, (
+        f"[{label}] the issue list is not the unanswered-leaf list: "
+        f"only-in-issues={actual - expected}, only-unanswered={expected - actual}")
+
+    # The other half of "attempted": nothing without a population mechanism
+    # may be answered OR reported. This is the NKA guard restated as a
+    # property rather than a spot check.
+    unattempted_named = set(actual) - attempted
+    assert not unattempted_named, (
+        f"[{label}] issues name leaves with no population mechanism: "
+        f"{sorted(unattempted_named)}")
+    assert not unattempted_answered, (
+        f"[{label}] leaves with no population mechanism were answered: "
+        f"{sorted(unattempted_answered)}")
+
+    # Every issue says the same thing, and it is the neutral sentence.
+    for issue in issues:
+        assert issue["detail"] == NOT_POPULATED, issue
+
+
+# ---------------------------------------------------------------------------
+# 1. The property over the matrix
+# ---------------------------------------------------------------------------
+
+def test_answer_present_iff_no_issue_across_patients_and_expressions():
+    """Every patient x every expression class, per item.
+
+    This is the assertion the ruling asked for. It is implementation-
+    independent: it never imports the engine's own notion of "withheld", only
+    the questionnaire's structure and the response's own answers.
+    """
+    expressions = dict(WITHHELD_EXPRESSIONS)
+    expressions.update(COMBINE_EXPRESSION)
+    expressions.update(ABSENT_BUT_ALLOWLISTED)
+    expressions.update(ALLOWLISTED)
+    q = _expression_questionnaire(expressions)
+
+    for label, patient in PATIENT_MATRIX.items():
+        qr, issues = populate_questionnaire(q, patient, [patient])
+        _assert_zero_bits(q, qr, issues, label)
+
+
+def test_the_intake_form_holds_the_property_on_every_patient():
+    """The real Questionnaire, including its list groups and its two
+    attestation booleans, over the same patient matrix."""
+    q = intake_questionnaire()
+    content_shapes = {
+        "no clinical content": [],
+        "one unlabelled allergy": [{
+            "resourceType": "AllergyIntolerance", "id": "a1",
+            "patient": {"reference": "Patient/p1"},
+            "code": {"coding": [{"system": SNOMED, "code": "91936005"}]},
+        }],
+    }
+    for label, patient in PATIENT_MATRIX.items():
+        for shape, extra in content_shapes.items():
+            qr, issues = populate_questionnaire(
+                q, patient, [patient] + extra)
+            _assert_zero_bits(q, qr, issues, f"{label} / {shape}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Zero bits, stated as invariance rather than as a count
+# ---------------------------------------------------------------------------
+
+def test_the_issue_set_is_identical_for_every_patient():
+    """A questionnaire of withheld expressions reports the SAME linkIds for
+    every patient. Nothing in the record can move this list.
+
+    The count property above is the general statement; this is the one that
+    reads as a security claim. Any classifier that consults the record —
+    however narrow its output — differs between FULL (which HAS an
+    identifier, a photo, a maritalStatus and an sms telecom) and BARE (which
+    has only the identifier), and lands here first.
+
+    MUTATION: report only when the expression resolves against the real
+    subject -> FULL names all eleven and SPARSE names none.
+    """
+    q = _expression_questionnaire(WITHHELD_EXPRESSIONS)
+
+    named = {}
+    for label, patient in PATIENT_MATRIX.items():
+        qr, issues = populate_questionnaire(q, patient, [patient])
+        named[label] = sorted(issue["linkId"] for issue in issues)
+        assert not [leaf for leaf in _leaf_occurrences(qr["item"])
+                    if "answer" in leaf], "a withheld path produced an answer"
+
+    assert named["full"] == sorted(WITHHELD_EXPRESSIONS), (
+        "a withheld expression came back silent: the caller reads that as "
+        "'this patient has no such value'")
+    assert len(set(map(tuple, named.values()))) == 1, (
+        f"the issue list varies with the record: {named}")
+
+
+def test_a_right_guess_and_a_wrong_guess_are_indistinguishable():
+    """The oracle, restated at the engine.
+
+    `test_the_withheld_issue_cannot_be_used_to_guess_the_withheld_value` in
+    tests/test_sdc_populate_bounded.py walks this over HTTP, which is where
+    it matters; this is the same property one layer down, where it is cheap
+    enough to run over the whole alphabet.
+    """
+    secret = FULL_PATIENT["identifier"][0]["value"]
+    alphabet = sorted(set(secret))
+    q = _expression_questionnaire({
+        f"guess-{n}": ("%patient.identifier.value.where($this.startsWith('"
+                       + ch + "'))")
+        for n, ch in enumerate(alphabet)
+    })
+
+    _qr, issues = populate_questionnaire(q, FULL_PATIENT, [FULL_PATIENT])
+
+    named = sorted(issue["linkId"] for issue in issues)
+    assert named == sorted(f"guess-{n}" for n in range(len(alphabet))), (
+        f"the issue list singled out a guess: {named}")
+
+
+# ---------------------------------------------------------------------------
+# 3. What the issue says
+# ---------------------------------------------------------------------------
+
+def test_the_issue_text_is_true_whether_the_value_was_withheld_or_absent():
+    """One sentence for both causes, claiming nothing about the patient.
+
+    `questionnaire_populate` is in the model-facing read tier. Text saying
+    the record was withheld would have a model tell a patient their data was
+    held back when they simply have no email address — so the text states
+    what did not happen (no value resolved) and hands over the allowlist for
+    the caller to compare against their own expression.
+    """
+    withheld_q = _expression_questionnaire({"mrn": WITHHELD_EXPRESSIONS["mrn"]})
+    absent_q = _expression_questionnaire(ABSENT_BUT_ALLOWLISTED)
+
+    _qr, withheld_issues = populate_questionnaire(
+        withheld_q, SPARSE_PATIENT, [SPARSE_PATIENT])
+    _qr, absent_issues = populate_questionnaire(
+        absent_q, SPARSE_PATIENT, [SPARSE_PATIENT])
+
+    assert len(withheld_issues) == len(absent_issues) == 1
+    assert withheld_issues[0]["detail"] == absent_issues[0]["detail"]
+
+    detail = withheld_issues[0]["detail"]
+    # The allowlist is public and is the actionable half.
+    for element in ("name", "birthDate", "gender", "telecom", "address"):
+        assert element in detail, element
+    # Nothing that reads as a claim about this patient or this request.
+    for forbidden in ("withheld", "refused", "denied", "not permitted",
+                      "does not have", "no such"):
+        assert forbidden not in detail.lower(), forbidden
+
+
+def test_the_expression_text_is_never_echoed_back():
+    """A `where()` clause is a place a questionnaire author parks a literal;
+    the OperationOutcome leaves the boundary. Pre-existing property of the
+    fixed sentence, pinned here because the retext could have lost it."""
+    expression = "%patient.identifier.value.where($this='a-planted-literal')"
+    q = _expression_questionnaire({"planted": expression})
+
+    _qr, issues = populate_questionnaire(q, FULL_PATIENT, [FULL_PATIENT])
+
+    assert len(issues) == 1
+    assert "planted" not in issues[0]["detail"]
+    assert expression not in issues[0]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 4. The counts the ruling states out loud
+# ---------------------------------------------------------------------------
+
+def test_full_demographics_populate_the_intake_form_with_zero_issues():
+    """The ruling's noise measurement: nine initialExpression items, all
+    nine answer, no issues. Unconditional emission is only tolerable if an
+    ordinary form on an ordinary patient is quiet."""
+    q = intake_questionnaire()
+
+    qr, issues = populate_questionnaire(q, FULL_PATIENT, [FULL_PATIENT])
+
+    answered = [leaf["linkId"] for leaf in _leaf_occurrences(qr["item"])
+                if "answer" in leaf]
+    assert len(answered) == 9, answered
+    assert issues == []
+
+
+def test_one_absent_demographic_gives_exactly_one_issue():
+    """And the other half of the measurement, which is what makes the first
+    half mean something."""
+    patient = {k: v for k, v in FULL_PATIENT.items() if k != "address"}
+    q = intake_questionnaire()
+
+    _qr, issues = populate_questionnaire(
+        q, patient, [patient])
+
+    # Four address leaves lose their answer, so pull one back to isolate it.
+    patient_with_city = dict(patient, address=[{"city": "Boston",
+                                                "line": ["123 Clinical Ave"],
+                                                "state": "MA"}])
+    _qr, one_missing = populate_questionnaire(
+        q, patient_with_city, [patient_with_city])
+
+    assert len(issues) == 4, [i["linkId"] for i in issues]
+    assert [i["linkId"] for i in one_missing] == [
+        "demographics.address-postal-code"]

--- a/tests/test_populate_lists.py
+++ b/tests/test_populate_lists.py
@@ -11,6 +11,19 @@ of whether the patient has any allergies/medications on file. Absent data is
 not consent to a "no known allergies" attestation; only a human can make
 that call (Task 6). See test_zero_allergies_never_infers_no_known_allergies
 below, which is the point of this whole file.
+
+THE SECOND INVARIANT, added with the CTO ruling on PR #562: ROW COUNT EQUALS
+RECORD COUNT. A stored resource always produces a repeat, even when not one
+of its leaves resolves a label — an unlabelled allergen is a row with no
+answer plus an issue naming it, never a dropped row. A patient with three
+allergies shown two is a false negative on an allergy list, and an allergy
+section that renders empty is one click from someone ticking "no known
+allergies", which walks straight into the invariant above.
+
+Under that ruling every ATTEMPTED leaf that resolves nothing reports an
+issue, so the `issues` assertions here are exact lists rather than `[]`.
+`PATIENT` below carries no telecom and no address, which is why five
+demographics leaves appear in nearly all of them.
 """
 
 from r6.sdc.intake import intake_questionnaire
@@ -43,6 +56,45 @@ def _by_link_id(qr, link_id):
 
 def _all_by_link_id(qr, link_id):
     return [item for item in _walk(qr.get("item", [])) if item.get("linkId") == link_id]
+
+
+def _issue_ids(issues):
+    """Every linkId reported, WITH duplicates — one allergy row per repeat."""
+    return sorted(issue["linkId"] for issue in issues)
+
+
+#: `PATIENT` has name/birthDate/gender and neither telecom nor address, so
+#: these five intake demographics leaves resolve nothing on every populate in
+#: this file. Spelled out rather than filtered away: an assertion that says
+#: "and nothing else" is what stops a real regression hiding in the list.
+ABSENT_DEMOGRAPHICS = [
+    "demographics.address-city",
+    "demographics.address-line",
+    "demographics.address-postal-code",
+    "demographics.address-state",
+    "demographics.phone",
+]
+
+
+def _snomed_allergy(rid, code, reaction_code=None):
+    """An allergy as the engine actually sees it after apply_redaction.
+
+    r6/terminology.py holds zero SNOMED entries and TERMINOLOGY_LOOKUP_ENABLED
+    is unset in every deploy config, so on a real import the upstream `text`
+    and `display` are stripped and nothing replaces them — this is the shape
+    that reaches populate.py, not a hypothetical.
+    """
+    resource = {
+        "resourceType": "AllergyIntolerance",
+        "id": rid,
+        "patient": {"reference": "Patient/p1"},
+        "code": {"coding": [{"system": "http://snomed.info/sct", "code": code}]},
+    }
+    if reaction_code:
+        resource["reaction"] = [{"manifestation": [
+            {"coding": [{"system": "http://snomed.info/sct",
+                         "code": reaction_code}]}]}]
+    return resource
 
 
 def _med_request(rid, display, status="active", dose=None):
@@ -118,7 +170,11 @@ def test_two_active_medications_populate_two_repeats():
                         for c in r["item"]))
     dose_item = next(c for c in dosed["item"] if c["linkId"] == "medications.item.dose")
     assert dose_item["answer"][0]["valueString"] == "Twice daily"
-    assert issues == []
+
+    # m2 carries no dosageInstruction, so its dose leaf resolves nothing and
+    # says so. One issue for one unresolved row, not one for the linkId.
+    assert _issue_ids(issues) == sorted(
+        ABSENT_DEMOGRAPHICS + ["medications.item.dose"])
 
 
 def test_inactive_medications_excluded():
@@ -157,7 +213,8 @@ def test_one_allergy_populates_and_nka_stays_unanswered():
 
     nka = _by_link_id(qr, "allergies.no-known-allergies")
     assert "answer" not in nka
-    assert issues == []
+    # Both allergy leaves resolved, so only the absent demographics report.
+    assert _issue_ids(issues) == ABSENT_DEMOGRAPHICS
 
 
 def test_zero_allergies_never_infers_no_known_allergies():
@@ -183,7 +240,12 @@ def test_zero_allergies_never_infers_no_known_allergies():
     # The allergies repeating group produced zero repeats — it's empty, not
     # defaulted to anything.
     assert _all_by_link_id(qr, "allergies.item") == []
-    assert issues == []
+
+    # And zero allergies produces zero ALLERGY issues too. The issue channel
+    # must not become the back door the answer set is not: "we tried to work
+    # out your allergies and could not" is the same inference wearing a
+    # different hat.
+    assert _issue_ids(issues) == ABSENT_DEMOGRAPHICS
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +263,7 @@ def test_zero_medications_never_infers_no_current_medications():
     assert "answer" not in no_current
 
     assert _all_by_link_id(qr, "medications.item") == []
-    assert issues == []
+    assert _issue_ids(issues) == ABSENT_DEMOGRAPHICS
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +290,7 @@ def test_three_conditions_populate_three_repeats():
     }
     assert names == {"Type 2 diabetes mellitus", "Essential hypertension",
                       "Hyperlipidemia"}
-    assert issues == []
+    assert _issue_ids(issues) == ABSENT_DEMOGRAPHICS
 
 
 # ---------------------------------------------------------------------------
@@ -269,4 +331,98 @@ def test_all_three_lists_populate_together_and_nka_still_unanswered():
     assert len(_all_by_link_id(qr, "conditions.item")) == 1
     nka = _by_link_id(qr, "allergies.no-known-allergies")
     assert "answer" not in nka
-    assert issues == []
+
+    # m1 has no dose and a1 has no reaction; both say so, and nothing else
+    # does.
+    assert _issue_ids(issues) == sorted(
+        ABSENT_DEMOGRAPHICS
+        + ["allergies.item.reaction", "medications.item.dose"])
+
+
+# ---------------------------------------------------------------------------
+# 7. Row count equals record count, and the attestation exclusion
+#    (CTO ruling on PR #562)
+# ---------------------------------------------------------------------------
+
+def test_three_unlabelled_allergies_still_produce_three_repeats():
+    """THE ROW-COUNT INVARIANT.
+
+    Three stored allergies, none of which the server can label — SNOMED
+    codes, and r6/terminology.py has no SNOMED entries, so apply_redaction
+    strips the upstream text and nothing replaces it. That is today's real
+    behaviour on a MEDENT-shaped import, not an edge case.
+
+    Three rows must still come back. Omitting an unlabelled row would show a
+    patient with three allergies only the ones we happened to recognise,
+    which is a false negative on an allergy list, and it would leave the
+    section empty for a patient whose allergies are all SNOMED-coded.
+
+    The blanks are REPORTED rather than answered: six issues, one per
+    unresolved leaf, so the renderer knows the row exists and its label does
+    not. Nothing goes into the answer set — a marker string there becomes
+    fabricated clinical text the moment $extract writes it back.
+
+    MUTATION: skip a repeat whose leaves all resolve None -> len(repeats)
+    drops and this goes red before anything renders.
+    """
+    q = intake_questionnaire()
+    allergies = [
+        _snomed_allergy("a1", "91936005"),    # penicillin allergy
+        _snomed_allergy("a2", "300916003"),   # latex allergy
+        _snomed_allergy("a3", "425525006"),   # dairy allergy
+    ]
+    content = [PATIENT] + allergies
+
+    qr, issues = populate_questionnaire(q, PATIENT, content)
+
+    repeats = _all_by_link_id(qr, "allergies.item")
+    assert len(repeats) == 3, "row count must equal record count"
+    for repeat in repeats:
+        assert [c["linkId"] for c in repeat["item"]] == [
+            "allergies.item.allergen", "allergies.item.reaction"]
+        for child in repeat["item"]:
+            assert "answer" not in child, (
+                "an unresolvable label must not be invented into the answer "
+                "set — $extract writes answers back as clinical text")
+
+    assert _issue_ids(issues) == sorted(
+        ABSENT_DEMOGRAPHICS
+        + ["allergies.item.allergen"] * 3
+        + ["allergies.item.reaction"] * 3)
+
+
+def test_the_attestation_items_never_appear_in_the_issue_list():
+    """THE EXCLUSION, pinned as its own row.
+
+    `allergies.no-known-allergies` and `medications.no-current-medications`
+    carry no `code` and no initialExpression precisely so that no population
+    mechanism ever touches them (r6/sdc/intake.py). Under unconditional issue
+    emission they are the two linkIds it must still never name.
+
+    An issue reading "not populated: no value resolved" against
+    `no-known-allergies` tells a model-facing reader that the server TRIED to
+    determine whether this patient has no known allergies and failed. That is
+    one step from something inferring the attestation, and "no known
+    allergies is never inferred" is a non-negotiable (CLAUDE.md). The
+    attestation is a thing a human affirms; it is not a value that can be
+    absent.
+
+    Asserted across every content shape, because "with no allergies on file"
+    is exactly the case where a helpful-sounding issue would be tempting.
+    """
+    q = intake_questionnaire()
+    shapes = {
+        "nothing on file": [PATIENT],
+        "allergies on file": [PATIENT, _allergy("a1", "Penicillin", "Hives")],
+        "unlabelled allergies on file": [PATIENT, _snomed_allergy("a1", "91936005")],
+        "medications on file": [PATIENT, _med_request("m1", "Metformin")],
+    }
+
+    for label, content in shapes.items():
+        qr, issues = populate_questionnaire(q, PATIENT, content)
+        named = _issue_ids(issues)
+        for attestation in ("allergies.no-known-allergies",
+                            "medications.no-current-medications"):
+            assert attestation not in named, f"{label}: {attestation} reported"
+            item = _by_link_id(qr, attestation)
+            assert item is not None and "answer" not in item, label

--- a/tests/test_sdc_expressions.py
+++ b/tests/test_sdc_expressions.py
@@ -1,5 +1,5 @@
-from r6.sdc.expressions import (build_context, evaluate, patient_projection,
-                                resolves_outside_projection)
+from r6.sdc.expressions import (build_context, evaluate,
+                                patient_projection)
 
 
 def test_evaluate_simple_path():
@@ -92,94 +92,26 @@ def test_build_context_with_no_subject_is_empty():
     assert patient_projection("not a resource") is None
 
 
-def test_resolves_outside_projection_names_the_paths_the_allowlist_withholds():
-    """Withheld -> True; allowlisted -> False. A property of the ALLOWLIST.
-
-    `identifier` and `name.text` are on a Patient and off the allowlist, so
-    an item asking for either is refused and says so. The allowlisted paths
-    are not, or every intake form would warn about its own demographics.
-    """
-    for withheld in ("%patient.identifier.value", "%patient.name.text",
-                     "%patient.photo.url", "%patient.contact.name.family",
-                     "%patient.maritalStatus.text",
-                     "%patient.telecom.where(system='sms').value",
-                     "%subject.identifier.value", "Patient.identifier.value",
-                     "%resources.where(resourceType='Observation').code.text"):
-        assert resolves_outside_projection(withheld) is True, withheld
-    for allowed in ("%patient.name.family", "%patient.name.given.first()",
-                    "%patient.birthDate", "%patient.gender",
-                    "%patient.telecom.where(system='phone').value",
-                    "%patient.telecom.where(system='email').value",
-                    "%patient.address.line.first()",
-                    "%patient.address.city.first()",
-                    "%patient.address.state.first()",
-                    "%patient.address.postalCode.first()",
-                    "Patient.name.family"):
-        assert resolves_outside_projection(allowed) is False, allowed
-    assert resolves_outside_projection("") is False
-    assert resolves_outside_projection(None) is False
-
-
-def test_resolves_outside_projection_never_looks_at_a_patient():
-    """THE ONE PROPERTY, and the reason the signature takes no record.
-
-    The answer is a pure function of the expression text. It has to be: the
-    version that evaluated the caller's expression against the REAL record
-    and reported whether it was non-empty made the issue list a one-bit
-    oracle over exactly the data the projection withholds — eleven HTTP
-    requests recovered a withheld SSN through it, character by character,
-    with the value never appearing in an answer.
-
-    MUTATION: pass the real subject back into the probe -> `walked` becomes
-    the SSN and this goes red on the first character.
-    """
-    victim = dict(_FULL_PATIENT)
-    victim["identifier"] = [{"system": "http://hl7.org/fhir/sid/us-ssn",
-                             "value": "123-45-6789"}]
-
-    walked = ""
-    for _ in range(len("123-45-6789")):
-        for ch in "0123456789-":
-            probe = ("%patient.identifier.value.where($this.startsWith('"
-                     + walked + ch + "'))")
-            # The signature admits no record, so nothing about `victim` can
-            # steer this. Both a right and a wrong guess answer the same way.
-            if resolves_outside_projection(probe):
-                walked += ch
-                break
-        else:
-            break
-    assert walked == "", (
-        f"the withheld identifier leaked through the issue channel: {walked!r}")
-
-    # And the two halves of the guess are indistinguishable, which is what
-    # "no oracle" means.
-    right = "%patient.identifier.value.where($this='123-45-6789')"
-    wrong = "%patient.identifier.value.where($this='999-99-9999')"
-    assert resolves_outside_projection(right) == \
-        resolves_outside_projection(wrong)
-
-
-def test_resolves_outside_projection_admits_no_record_to_evaluate_against():
-    """The signature IS the guard, so pin the signature.
-
-    Everything else in this file can be satisfied by an implementation that
-    still takes a patient and merely happens not to leak today. A function
-    that cannot be handed the record cannot evaluate against it, and it
-    cannot be handed the tenant's content either — which is also what stops
-    a caller buying work with `%resources.descendants().descendants()`
-    (measured at 32s for 50 items over 500 stored resources before this
-    changed, against 0.01s after).
-
-    MUTATION: add `subject` back to the signature -> red here, and red in
-    both oracle tests, before anyone has to notice the leak.
-    """
-    import inspect
-    params = inspect.signature(
-        resolves_outside_projection.__wrapped__).parameters
-    assert list(params) == ["expression"], (
-        "resolves_outside_projection grew a parameter. If it is a record, "
-        "the withheld-item issue is an oracle again — see its docstring.")
+# The three `resolves_outside_projection` tests that stood here are gone with
+# the function (CTO ruling on PR #562). They pinned real properties and those
+# properties still hold — they moved rather than lapsed:
+#
+#   - the oracle test (a right guess and a wrong guess must be
+#     indistinguishable) is now
+#     tests/test_populate_issue_property.py::
+#     test_a_right_guess_and_a_wrong_guess_are_indistinguishable, and over
+#     HTTP in tests/test_sdc_populate_bounded.py::
+#     test_the_withheld_issue_cannot_be_used_to_guess_the_withheld_value;
+#   - the signature pin (the classifier must not be able to see a record)
+#     is subsumed by there being no classifier: the issue is emitted for
+#     every attempted leaf that resolved nothing, which is a fact the
+#     response already carries. tests/test_populate_issue_property.py states
+#     that as `answer present <=> no issue`, per item, so a reintroduced
+#     classifier of ANY shape — record-driven or probe-driven — reddens on
+#     the first leaf it silences, which the signature pin could not catch;
+#   - the allowlist-membership list is what the projection tests above
+#     already assert directly, on the projection itself rather than through
+#     a function that guessed at it.
 
 
 def test_the_resource_root_form_still_evaluates_against_the_projection():

--- a/tests/test_sdc_populate.py
+++ b/tests/test_sdc_populate.py
@@ -1,4 +1,4 @@
-from r6.sdc.populate import populate_questionnaire
+from r6.sdc.populate import NOT_POPULATED, populate_questionnaire
 
 INITIAL_EXPR_URL = (
     "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
@@ -58,6 +58,17 @@ def test_populate_observation_based_by_code():
 
 
 def test_populate_records_issue_for_unresolved_item():
+    """An item.code that matched no Observation is an ATTEMPTED population.
+
+    It reports for the same reason an initialExpression does: the caller
+    asked the server to resolve something and it did not. The issue is
+    `information`, not an error — "absence of data is not an error" still
+    holds, and the text says only that no value resolved.
+
+    The intake Questionnaire carries no item.code items, so this path is
+    invisible on today's form; another Questionnaire will have them, which
+    is why it is pinned here rather than left to the integration tests.
+    """
     q = {"resourceType": "Questionnaire", "status": "active",
          "item": [{"linkId": "missing", "type": "string",
                    "code": [{"system": "http://loinc.org", "code": "0000-0"}]}]}
@@ -67,7 +78,8 @@ def test_populate_records_issue_for_unresolved_item():
 
     # No answer produced, and no spurious answer array on the item.
     assert "answer" not in qr["item"][0]
-    assert issues == []  # absence of data is not an error, just no answer
+    assert [i["linkId"] for i in issues] == ["missing"]
+    assert issues[0]["detail"] == NOT_POPULATED
 
 
 def test_populate_nested_group_items():

--- a/tests/test_sdc_populate_bounded.py
+++ b/tests/test_sdc_populate_bounded.py
@@ -11,8 +11,13 @@ route with real store rows — not against the pure engine, because the engine
 cannot tell you what left the boundary:
 
   1. An expression outside the %patient allowlist yields NO answer, and an
-     OperationOutcome issue naming the linkId, so the refusal is visible
-     rather than indistinguishable from "the patient has no phone number".
+     OperationOutcome issue naming the linkId, so an item that was not
+     filled says so rather than looking like a completed form. The issue
+     does NOT say which of the two causes applied — "the projection
+     withheld it" and "the patient has no phone number" report identically,
+     because telling them apart means answering a question about the
+     patient, and the first version of that was a working exfiltration
+     channel (CTO ruling on PR #562; see §5 below).
   2. The allowlisted expressions still populate. A bound that also breaks the
      intake form is not a fix.
   3. A tombstoned row is not read.
@@ -279,10 +284,15 @@ def test_a_withheld_expression_is_reported_as_an_issue_naming_its_link_id(
     body = _populate(client, tenant_headers).get_json()
 
     assert sorted(_issue_link_ids(body)) == sorted(WITHHELD)
-    diagnostics = _param(body, "issues")["issue"][0]["diagnostics"]
+    outcome = _param(body, "issues")
+    diagnostics = outcome["issue"][0]["diagnostics"]
     assert "%patient projection" in diagnostics
     for expression in WITHHELD.values():
         assert expression not in diagnostics
+    # One sentence for every leaf, at `information` severity — see
+    # test_an_allowlisted_element_the_patient_lacks_reports_in_the_same_words
+    # for why the wording may not distinguish withheld from absent.
+    assert {i["severity"] for i in outcome["issue"]} == {"information"}
 
 
 def test_allowlisted_expressions_still_populate(
@@ -304,14 +314,25 @@ def test_allowlisted_expressions_still_populate(
     }
 
 
-def test_no_issue_is_raised_when_the_record_simply_has_no_value(
+def test_an_allowlisted_element_the_patient_lacks_reports_in_the_same_words(
         client, app, tenant_id, tenant_headers):
-    """An allowlisted element the patient does not have is NOT a refusal.
+    """The ruling's one-absent-demographic row, over the wire.
 
-    This is the line between the two causes above. A patient with no telecom
-    gets an empty item and no issue; conflating that with a withheld path
-    would put an OperationOutcome on every sparse record and make the issue
-    list meaningless.
+    This test used to assert the OPPOSITE — that a merely-absent value is
+    silent while a withheld one is reported. That distinction is what the
+    CTO ruling on PR #562 removed, and removed deliberately: drawing it
+    requires the server to answer a question about the patient, and however
+    narrow the answer looks it is still a read (eleven HTTP requests walked
+    an identifier out through the first version of it).
+
+    So both causes report, in one sentence that is true of both, and the
+    caller compares the published allowlist against their own expression to
+    tell them apart. That matters most in the model-facing tier: the old
+    text would have a model tell a patient their record was withheld when
+    they simply have no email address.
+
+    MUTATION: reintroduce any classifier -> `email` goes silent and this
+    goes red on the issue list.
     """
     bare = {"resourceType": "Patient", "id": PATIENT_ID,
             "name": [{"given": ["Ada"]}]}
@@ -324,7 +345,18 @@ def test_no_issue_is_raised_when_the_record_simply_has_no_value(
     body = _populate(client, tenant_headers, "sparse-q").get_json()
 
     assert _answers(_param(body, "response")) == {"given": "Ada"}
-    assert _param(body, "issues") is None
+    # Exactly one issue: the one leaf that got no answer. Not two.
+    assert _issue_link_ids(body) == ["email"]
+
+    issue = _param(body, "issues")["issue"][0]
+    # information, not warning: a form with one empty optional field is an
+    # ordinary result, and a conformant client reading `warning` would treat
+    # it as a failed operation.
+    assert issue["severity"] == "information"
+    diagnostics = issue["diagnostics"]
+    assert "%patient projection" in diagnostics
+    for claim in ("withheld", "refused", "denied"):
+        assert claim not in diagnostics.lower(), claim
 
 
 # ---------------------------------------------------------------------------
@@ -607,12 +639,17 @@ def test_the_withheld_issue_cannot_be_used_to_guess_the_withheld_value(
     identifier that way during the review of PR #562, and the value never
     once appeared in an answer.
 
-    So the issue has to depend on the EXPRESSION and nothing else: a right
-    guess and a wrong guess must be indistinguishable from outside.
+    So the issue must depend on neither: EVERY attempted leaf that resolved
+    nothing is reported, so a right guess and a wrong guess are named alike
+    and the list carries no bits at all. The classifier that replaced the
+    oracle answered from a constant probe, which was safe but silenced six
+    of the ruling's twelve withheld expressions — including this very walk's
+    `where($this.startsWith(...))` shape, which came back with no issue at
+    all. There is no classifier now.
 
-    MUTATION: pass the real subject back into resolves_outside_projection ->
-    `recovered` becomes the stored MRN and this goes red on the first
-    character.
+    MUTATION: gate the issue on anything — the real subject, a probe, the
+    expression text — and `named` stops being the whole alphabet on the
+    first round.
     """
     _seed(app, tenant_id)
     secret = _patient()["identifier"][0]["value"]
@@ -631,13 +668,18 @@ def test_the_withheld_issue_cannot_be_used_to_guess_the_withheld_value(
         body = _populate(client, tenant_headers,
                          questionnaire_id="oracle-q").get_json()
         named = set(_issue_link_ids(body))
+        # Every guess is named. Not "all or none" — ALL, which is the
+        # stronger statement and the one unconditional emission makes: the
+        # issue list is the unanswered-leaf list, and every guess in this
+        # questionnaire is unanswered whatever the identifier says.
+        assert named == {f"guess-{n}" for n in range(len(alphabet))}, (
+            f"the issue list singled out {sorted(named)} out of {alphabet}: "
+            f"the report is a function of the patient's data, not of what "
+            f"the response already shows")
         hits = [ch for n, ch in enumerate(alphabet) if f"guess-{n}" in named]
-        # All refused or none refused. Anything between is the oracle.
-        assert len(hits) in (0, len(alphabet)), (
-            f"the issue list singled out {hits} out of {alphabet}: the "
-            f"refusal is a function of the patient's data, not of the "
-            f"expression")
-        if not hits:
+        # Every character answers the same, so no guess is distinguishable
+        # and there is nothing to walk. (An oracle picks out exactly one.)
+        if len(hits) != 1:
             break
         recovered += hits[0]
 
@@ -652,9 +694,10 @@ def test_a_refused_item_still_names_itself_after_the_oracle_is_closed(
 
     D10 asks for an OperationOutcome issue naming the linkId on
     `%patient.identifier`, `%patient.photo` and `%resources...code.text`.
-    Answering from a constant probe keeps all of them — those paths are
-    outside the allowlist for every patient, which is a fact about the
-    allowlist and not about anyone's record.
+    Reporting every unresolved leaf keeps all of them, and keeps the six the
+    constant probe silently dropped as well — completeness is the half the
+    probe could not deliver, since its inventory of placeholder paths was
+    never going to cover the expression classes an author actually writes.
     """
     _seed(app, tenant_id)
     items = [_expr_item(link_id, expr) for link_id, expr in WITHHELD.items()]


### PR DESCRIPTION
## What

Implements ruling 1 and ruling 2 of the CTO ruling on #562.

- **The issue is emitted unconditionally, and the probe is deleted.**
  `resolves_outside_projection`, `_PROBE_PATIENT`, `_PROBE_RESOURCES` and the
  `lru_cache` are gone — 124 lines out of `r6/sdc/expressions.py`.
  `patient_projection` and `build_context` are untouched.
- **One mechanism for both paths.** `_report_unpopulated` is reached from the
  expression path, the `item.code` Observation path, and list-group leaves
  carrying a `definition`, so allergies, conditions and medication doses report
  too.
- **Retext.** One sentence that is true whether the value was withheld or
  simply absent, claiming nothing about the patient, handing over the public
  allowlist. The old constant was named `WITHHELD_BY_PROJECTION` and said so;
  it was true of only some of the leaves it was attached to.
- **Severity `warning` → `information`** (`r6/sdc/routes.py`). The `code` stays
  `incomplete`.
- **Row count equals record count**, pinned. Three unlabelled SNOMED allergies
  produce three repeats and six issues, not fewer rows.
- **The exclusion**, pinned as its own named test:
  `allergies.no-known-allergies` and `medications.no-current-medications` never
  appear in the issue list, on any patient, with any content.

## Why

The probe closed QA's leak but was the wrong control, and the ruling's own live
numbers said so: six of twelve withheld expressions produced no issue at all,
because the classifier fired only when the caller's filter happened to match the
placeholder text. `where($this.startsWith('1'))` — the ordinary way an author
writes a filter, and the exact shape QA used to walk an SSN out — came back
silent, and a caller reads silence as "this patient has no such value". That is
`docs/2026-08-02-retro.md` pattern 1: a control that looks like "we tell you
when we refused" and does "we tell you when your expression matches our
placeholder".

The zero-bits argument is what makes unconditional emission safe rather than
merely safer. `_populate_item` attaches `answer` only when a value resolved, so
**which linkIds have no answer is already in the response**. An issue per
unanswered attempted leaf is a redundant encoding of what the caller is already
holding, and therefore carries no information about the patient *by
construction* — not "we checked it doesn't leak", but "there is nothing to
leak", which nobody has to re-verify the next time the file is touched. It is
also complete, which the probe was not: every withheld path names itself, not
just the ones an inventory of placeholders happened to cover.

## Base note

**This PR stacks on #562** (`fix/sdc-populate-bounded-reads`) and targets that
branch, not `main`. It is the "required before merge" work from the ruling, not
a replacement for #562 — the projection, the redaction, the `is_deleted`
filters and the 7d→24h cut all live in #562 and are unchanged here.

## The live matrix

Against a running app on **port 5311** (5099, 5199 and 5297 were reported taken
by other agents today), synthetic seeded tenant: 2 SNOMED allergies, 1 SNOMED
condition, 1 RxNorm medication, 1 LOINC observation, an SSN-shaped identifier.
All twelve expressions in one request. `probe` is what the deleted classifier
reported, measured by the CTO on `:5199`.

```
issue  answer  probe  expression
------------------------------------------------------------------------------
True   False   True   %patient.identifier.value
True   False   True   %patient.photo.url
True   False   True   %resources.where(resourceType='Observation').code.text
True   False   True   %patient.maritalStatus.text
True   False   True   %patient.telecom.where(system='sms').value
True   False   True   %patient.identifier.first().value
True   False   False  %patient.identifier.value.where($this.startsWith('1'))
True   False   False  %patient.identifier.value.where($this.startsWith('9'))
False  True    False  %patient.identifier.value.combine(%patient.gender)
True   False   False  %patient.contact.gender
True   False   False  %patient.deceasedDateTime
True   False   False  %patient.name.period.start

severity: ['information']   code: ['incomplete']   issues: 11/12
```

**One correction to the ruling's matrix.** Row 9 is not a silence.
`combine` unions a withheld path with an allowlisted one, so on a patient who
has a gender it **resolves — to the gender**, and the item is *answered*. It
reported no issue under the probe and reports none now, correctly, and the
biconditional holds for it. Eleven of the twelve were silences; that one was
not. It is held out of the invariance test for that reason, with the reasoning
written down at `tests/test_populate_issue_property.py`.

Issue text, verbatim:

```
e00: not populated: no value resolved. $populate reads only the %patient
projection (name, birthDate, gender, telecom phone/email, address
line/city/state/postalCode) and coded content this server recognises; anything
else is not read.
```

No expression text is echoed into the OperationOutcome (checked against all
twelve).

**The intake form**, same seeded patient — the addendum's predicted **six**:

```
answered leaves (10): 9 demographics + medications.item.name
issues (6): allergies.item.allergen x2, allergies.item.reaction x2,
            conditions.item.name, medications.item.dose
row counts: allergen 2, condition 1, medication 1   (stored: 2, 1, 1)
no-known-allergies: answered=False   in-issue-list=False
```

**The noise measurement**, both halves:

```
nine intake expressions, full demographics -> 9/9 answered, issues []
postalCode removed                         -> issues ['postal']
restored                                   -> issues []
```

**The SSN walk over HTTP**, 10 guesses in one request:

```
guesses named: 10/10 — all of them, so no guess is distinguishable
RECOVERED: ''
```

**The severity change does not hide the issues from the model.** Checked
because it would have been the quiet way to undo the retext:
`populateQuestionnaire` in `services/agent-orchestrator/src/tools.ts:1487-1510`
returns the whole `Parameters` body verbatim and filters nothing on
`severity` — the `information` issues reach the model exactly as `warning`
ones did. (The `severity`-filtering code at `tools.ts:1317-1319` belongs to
`validate_resource`, a different tool.) Neither the tool description at
`tools.ts:423` nor `adapters/tools.manifest.json:198` claims anything about
withheld data, so no stale copy needed correcting there.

**Audit and PHI sweep:** 7 `$populate` audit rows, details
`populate; issues=0|1|6|10|11`, no PHI marker in any of them; none of the six
withheld markers (identifier, maritalStatus, sms telecom, contact name, photo
URL, `name.text`) appears anywhere in a `$populate` response.

## Ran

```
uv run ruff check .
  All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
  3187 passed, 13 skipped, 1 xfailed, 2 warnings in 102.44s
  (baseline on da16068: 3180 passed. +8 property tests, +2 list tests,
   -3 resolves_outside_projection tests.)

uv run python -m pytest tests/test_ratchets.py tests/test_guardrail_conformance.py \
    -q -p no:cacheprovider
  50 passed          (Grade A green; no ratchet pin was moved)
```

**Mutation-tested — four breaks, all red before restore** (retro rule 1; the
point is that the property test is load-bearing rather than decoration):

| mutation | red |
| --- | --- |
| M1 report only when the expression resolves against the unbounded record (the original oracle) | 18 |
| M2 report only for expressions without a `where(` (the probe's silencing shape) | 17 |
| M3 omit a list repeat whose leaves all resolved nothing | 3 |
| M4 report leaves with no population mechanism (the attestations) | 13 |

Restored, 35 passed. M4 was re-run on its own to confirm by name that
`test_the_attestation_items_never_appear_in_the_issue_list` is one of the
reds — the exclusion pin the addendum asked for is load-bearing, not
incidentally green.

The property test is `answer present ⟺ no issue for that linkId`, per item,
over three patients × the ruling's twelve expressions. Stated as **counts**, so
a repeating group with one labelled and one unlabelled row reads correctly, and
the "was population attempted" predicate is derived from the **Questionnaire**
rather than from the engine — so it stays honest if `populate.py`'s own
predicate changes. The three deleted `resolves_outside_projection` tests are
replaced by it and it catches strictly more: the signature pin could not see a
probe-driven classifier, and M2 is exactly that.

`dependency-audit` is red on this PR. It is red on **every** open PR right now —
npm advisories fixed in unmerged **#544**, nothing from this branch.

## What was NOT run

- **Postgres CI lane.** SQLite only here. Nothing in this change touches a
  query or an id.
- **`$extract` against the changed response.** The ruling establishes that
  nothing new enters the answer set, which is what would round-trip, but I did
  not exercise `$extract` on a form populated by this code.
- **Whether any renderer surfaces the issues.** The CTO flagged this as
  unverified and as a real-patient gate rather than a merge gate; it still is.
  A blank allergen row that is *reported* in the response and still *renders*
  blank on a patient's phone is not fixed where it matters
  (`r6/sdc/documents.py`, the intake form UI).
- **The MCP `questionnaire_populate` caller** against the new issue count and
  the `information` severity.
- **Load.** Emission is now one list append per unanswered leaf; the probe's
  ~800× amplification is gone with it, but I did not re-measure.

## Deliberately not touched — the ruling's other three required items

These are in the ruling and **not** in this PR, so they do not get lost:

3. **`r6/sdc/routes.py:205`** — the unredacted subject append. Still there.
   Nothing reads it, and after this change there is no `%resources` consumer at
   all, so it is dead weight rather than a live door — but it is the ruling's
   item 3 and wants its own diff.
4. **D10 bullet 5** — `questionnaire_populate` in the model-facing read tier
   (`adapters/tools.manifest.json:198`,
   `services/agent-orchestrator/src/tools.ts:423`). No "from your records"
   marker was added. **The written deferral is #570**, which records the
   decision to be made and why the reason the council gave for pulling the
   tool no longer holds. An earlier version of this line said no deferral
   was written; that was wrong, and the ruling's requirement is met by the
   link. Note this change *strengthens* the case for leaving the tool in:
   the text a model now sees claims nothing about the patient.
5. **The PR-body correction on #562** about the scope of the labelling trade.

Also unfiled, from the ruling's "not blocking, please file" list: `$extract`'s
duplicate-Patient and wrong-element write; the SNOMED label additions needing
clinician initials; `r6/sdc/expressions.py` logging caller-supplied expression
text at WARNING (now line 165 — log injection, newlines included, pre-existing);
`_coerce` returning dicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

