### PR TITLE
candidate: delete the unredacted subject append and stop logging caller expressions (CTO items on #562)

### DIFF
--- a/r6/sdc/expressions.py
+++ b/r6/sdc/expressions.py
@@ -151,19 +151,32 @@ def build_context(subject=None):
     return {'patient': projection, 'subject': projection}
 
 
-def evaluate(expression, resource, context=None):
+def evaluate(expression, resource, context=None, link_id=None):
     """Evaluate a FHIRPath expression, returning a scalar, list, or None.
 
     Returns the single value when the result has one element, the list when
     it has several, and None when empty or on any evaluation error.
+
+    `link_id` names the questionnaire item, for the failure log only — see
+    below for why it is what gets logged and the expression is not.
     """
     if not expression:
         return None
     try:
         result = fhirpathpy.evaluate(resource or {}, expression, context or {})
     except Exception as exc:  # noqa: BLE001 — never let one expr kill the run
-        logger.warning('FHIRPath evaluation failed for %r: %s',
-                       expression, type(exc).__name__)
+        # THE EXPRESSION IS NOT LOGGED. A Questionnaire is request body, so
+        # its expression text is the caller's: newlines that forge a log
+        # line, and literals the caller chose to park in a `where()`. Nor is
+        # `str(exc)` — fhirpathpy puts the offending token in the message
+        # ("Not implemented: notAFunction"), which is the same text arriving
+        # by the back door. The linkId identifies the item well enough to
+        # debug and is questionnaire structure rather than patient data; it
+        # is caller-supplied too, and %r is what escapes control characters
+        # in it. Pinned by tests/test_sdc_expressions.py::
+        # test_a_failing_expression_is_not_echoed_into_the_log.
+        logger.warning('FHIRPath evaluation failed for item %r: %s',
+                       link_id, type(exc).__name__)
         return None
     if not result:
         return None

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -182,8 +182,11 @@ def populate_questionnaire(questionnaire, subject, content_resources):
 
     questionnaire: Questionnaire dict.
     subject: Patient dict (or None).
-    content_resources: list of resource dicts available for population
-        (should include the subject and any Observations).
+    content_resources: list of resource dicts available for population —
+        Observations, and the MedicationRequest / AllergyIntolerance /
+        Condition rows the list groups match. NOT the subject: that arrives
+        as `subject` above, and putting it here as well left an unredacted
+        Patient reachable by anything walking this list (PR #562 review).
     issues: list of {'linkId', 'detail'} for items that errored (not for
         items that simply had no data).
     """
@@ -347,7 +350,8 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id):
         # The resource root is `context["patient"]` — the bounded projection,
         # not the stored Patient — so the allowlist applies to the
         # resource-root form (`Patient.name.family`) as well as to `%patient`.
-        value = evaluate(expr, context.get("patient"), context)
+        value = evaluate(expr, context.get("patient"), context,
+                         link_id=link_id)
         if value is not None:
             return _coerce(value, item_type), value_key
         _report_unpopulated(issues, link_id)

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -195,14 +195,23 @@ def register_sdc_routes(blueprint, deps):
         return None
 
     def _gather_content(params, subject, tenant_id):
+        # THE SUBJECT IS NOT IN THIS LIST. It reaches the engine as
+        # populate_questionnaire's `subject` argument, and it is NOT redacted
+        # there: an intake form exists to carry the patient's own name, DOB
+        # and address, and apply_redaction would truncate all three. What
+        # bounds it is the %patient projection in r6/sdc/expressions.py — an
+        # allowlist of exactly those elements — plus reference matching,
+        # which reads only the id.
+        #
+        # It used to be appended here as well. Nothing read it: the engine
+        # filters this list to Observations and to the three list-resource
+        # types, so a Patient passed no filter. But it was the second door to
+        # the identifier oracle QA walked an SSN through (PR #562 review) —
+        # `%resources.where(resourceType='Patient').identifier.value` — and
+        # it stayed reachable by anything that walks content. Pinned by
+        # tests/test_sdc_populate_bounded.py::
+        # test_the_content_list_handed_to_the_engine_carries_no_subject.
         content = []
-        if subject:
-            # The subject is NOT redacted: an intake form exists to carry the
-            # patient's own name, DOB and address, and apply_redaction would
-            # truncate all three. What bounds the subject is the %patient
-            # projection in r6/sdc/expressions.py, which is an allowlist of
-            # exactly those elements.
-            content.append(subject)
         if subject and subject.get("id"):
             for resource_type, subject_field in _AUTO_LOADED_RESOURCE_TYPES:
                 content.extend(_redacted_for_populate(

--- a/tests/test_populate_issue_property.py
+++ b/tests/test_populate_issue_property.py
@@ -172,7 +172,46 @@ def _expression_questionnaire(expressions):
 # The property, and the two halves it is built from
 # ---------------------------------------------------------------------------
 
-def _attempted_link_ids(questionnaire, parent_repeats=False):
+#: The resource types list-group population actually implements. This is a
+#: LITERAL, deliberately, not an import of r6/sdc/populate.py's
+#: `_LIST_RESOURCE_CONFIG` — the repo's two-file convention (cf.
+#: `_UNREDACTED_EXITS` and tests/test_unredacted_exits.py). Adding a fourth
+#: type to the engine goes red here until someone updates this set, which is
+#: the point of writing it twice.
+#:
+#: It is here because "a list-group leaf with a `definition`" turned out to
+#: mean two different things. The engine reads it as "a leaf of a group whose
+#: leaves name a type in that table" — `_list_group_resource_type` returns
+#: None for anything else, the group falls through to ordinary-group
+#: recursion, and its leaves are then not attempted at all. The first version
+#: of this helper read it as "any `definition` leaf under any repeating
+#: group", which is the CTO addendum's literal wording. The two disagree on
+#: exactly one shape, pinned below by
+#: test_a_repeating_group_of_an_unsupported_type_is_silent, and no fixture
+#: here exercised it, so the disagreement was invisible. QA review of #576.
+LIST_POPULATED_TYPES = {"MedicationRequest", "AllergyIntolerance", "Condition"}
+
+
+def _list_group_type(item):
+    """The resource type this repeating group's leaves populate from, or None.
+
+    Mirrors r6/sdc/populate.py:_list_group_resource_type — the FIRST child
+    definition naming a supported type wins, and a group naming none is not a
+    list group at all.
+    """
+    if not item.get("repeats"):
+        return None
+    for child in item.get("item", []):
+        definition = child.get("definition") or ""
+        if "#" not in definition:
+            continue
+        rtype = definition.split("#", 1)[1].split(".", 1)[0]
+        if rtype in LIST_POPULATED_TYPES:
+            return rtype
+    return None
+
+
+def _attempted_link_ids(questionnaire):
     """linkIds where the questionnaire asks populate to resolve something.
 
     Read from the Questionnaire, not from populate.py, so this test still
@@ -181,22 +220,27 @@ def _attempted_link_ids(questionnaire, parent_repeats=False):
 
       - an initialExpression (FHIRPath against the %patient projection),
       - an `item.code` (Observation matching),
-      - a `definition` on a leaf of a REPEATING group (list-resource
-        population).
+      - a `definition` on a leaf of a repeating group that names one of
+        LIST_POPULATED_TYPES (list-resource population).
 
     `definition` alone is deliberately not enough: every demographics leaf on
     the intake form carries one for `$extract`'s benefit and populates by
     expression. A definition-bearing leaf outside a repeating group is not an
-    attempted population.
+    attempted population — and neither, today, is one inside a repeating
+    group naming a type the engine does not implement. See
+    LIST_POPULATED_TYPES for why that second clause is stated out loud.
     """
     found = set()
     for item in questionnaire.get("item", []):
         if item.get("type") == "group":
-            found |= _attempted_link_ids(item, bool(item.get("repeats")))
+            if _list_group_type(item):
+                for child in item.get("item", []):
+                    if child.get("definition"):
+                        found.add(child["linkId"])
+            else:
+                found |= _attempted_link_ids(item)
             continue
         if _has_initial_expression(item) or item.get("code"):
-            found.add(item["linkId"])
-        elif parent_repeats and item.get("definition"):
             found.add(item["linkId"])
     return found
 
@@ -440,3 +484,177 @@ def test_one_absent_demographic_gives_exactly_one_issue():
     assert len(issues) == 4, [i["linkId"] for i in issues]
     assert [i["linkId"] for i in one_missing] == [
         "demographics.address-postal-code"]
+
+
+# ---------------------------------------------------------------------------
+# 5. The two mechanisms the matrix above never reached (QA review of #576)
+# ---------------------------------------------------------------------------
+
+LOINC = "http://loinc.org"
+
+UNSUPPORTED_LIST_DEF = ("http://hl7.org/fhir/StructureDefinition/Immunization"
+                        "#Immunization.vaccineCode.text")
+UNSUPPORTED_DATE_DEF = ("http://hl7.org/fhir/StructureDefinition/Immunization"
+                        "#Immunization.occurrenceDateTime")
+
+
+def _unsupported_list_questionnaire():
+    return {
+        "resourceType": "Questionnaire", "id": "unsupported-list",
+        "status": "active",
+        "item": [{
+            "linkId": "immunizations", "type": "group", "repeats": True,
+            "item": [
+                {"linkId": "immunizations.vaccine", "type": "string",
+                 "definition": UNSUPPORTED_LIST_DEF},
+                {"linkId": "immunizations.date", "type": "date",
+                 "definition": UNSUPPORTED_DATE_DEF},
+            ],
+        }],
+    }
+
+
+def test_a_repeating_group_of_an_unsupported_type_is_silent():
+    """THE ONE PLACE THE RULING AND THE ENGINE READ THE SAME WORDS DIFFERENTLY.
+
+    The CTO addendum states the exclusion predicate as: the issue attaches
+    where population was attempted — "an `initialExpression`, an `item.code`
+    Observation match, or a list-group leaf with a `definition`". A
+    `definition` leaf inside a `repeats: true` group satisfies that wording
+    whatever type it names.
+
+    The engine reads it narrower. `_list_group_resource_type` only recognises
+    a group whose leaves name MedicationRequest / AllergyIntolerance /
+    Condition; anything else is not a list group, falls through to
+    ordinary-group recursion, and its leaves reach `_resolve_answer` with no
+    expression and no code — the "NOTHING WAS ATTEMPTED" branch. So a
+    Questionnaire asking for immunizations gets unanswered leaves and NO
+    issue naming them: silence, which is the state the ruling set out to
+    remove ("a caller reads silence and concludes the patient has no such
+    value").
+
+    This test pins WHAT THE ENGINE DOES TODAY, not what it should do. It is
+    deliberately a plain assertion rather than a strict xfail — CLAUDE.md
+    records a strict-xfail row going red on the day someone fixed what it
+    pinned. If the reading is widened so these leaves report, this test is
+    one of the two places to update; LIST_POPULATED_TYPES is the other.
+
+    Not a leak: the silence is a function of the QUESTIONNAIRE's structure
+    only — same shape, same result, on every patient — which is what the loop
+    over PATIENT_MATRIX states.
+    """
+    q = _unsupported_list_questionnaire()
+
+    for label, patient in PATIENT_MATRIX.items():
+        qr, issues = populate_questionnaire(q, patient, [patient])
+
+        leaf_ids = [leaf["linkId"] for leaf in _leaf_occurrences(qr["item"])]
+        assert leaf_ids == ["immunizations.vaccine", "immunizations.date"], (
+            f"[{label}] {leaf_ids}")
+        assert not [leaf for leaf in _leaf_occurrences(qr["item"])
+                    if "answer" in leaf], label
+        # The divergence, stated as the number it is: two unanswered
+        # definition leaves, zero issues.
+        assert issues == [], (
+            f"[{label}] the engine now reports unsupported-type list leaves — "
+            f"good, but LIST_POPULATED_TYPES and this test have to be updated "
+            f"together: {issues}")
+
+
+def test_the_property_holds_on_the_unsupported_list_shape_too():
+    """The biconditional, evaluated on the shape above.
+
+    It passes because `_attempted_link_ids` now reads "attempted" the way the
+    engine does. Before the QA review of #576 the helper called those two
+    leaves attempted while the engine did not, so this assertion would have
+    failed — and no fixture in this file exercised the shape, so the helper's
+    "implementation-independent" claim went untested exactly where it was
+    wrong.
+    """
+    q = _unsupported_list_questionnaire()
+    for label, patient in PATIENT_MATRIX.items():
+        qr, issues = populate_questionnaire(q, patient, [patient])
+        _assert_zero_bits(q, qr, issues, f"unsupported-list / {label}")
+
+
+# --- the item.code Observation path -----------------------------------------
+
+def _observation(code, **value):
+    resource = {
+        "resourceType": "Observation", "id": f"o-{code}", "status": "final",
+        "subject": {"reference": "Patient/p1"},
+        "effectiveDateTime": "2026-01-01",
+        "code": {"coding": [{"system": LOINC, "code": code}]},
+    }
+    resource.update(value)
+    return resource
+
+
+#: Every shape `_observation_answer` can be handed, including the two that
+#: matter after `apply_redaction` has run: a valueCodeableConcept whose `text`
+#: was stripped and whose code r6/terminology.py has no label for, and a
+#: value[x] type the resolver does not read. Both resolve to nothing on a
+#: record that EXISTS, which is the case a record-driven classifier would
+#: treat differently from "no Observation at all".
+_OBSERVATION_CASES = {
+    "matched, valueQuantity": (True, [
+        _observation("29463-7", valueQuantity={"value": 70, "unit": "kg"})]),
+    "matched, valueString": (True, [
+        _observation("29463-7", valueString="70 kg")]),
+    "matched, valueCodeableConcept with text": (True, [
+        _observation("29463-7", valueCodeableConcept={"text": "Normal"})]),
+    "matched, valueCodeableConcept stripped of text": (False, [
+        _observation("29463-7", valueCodeableConcept={
+            "coding": [{"system": SNOMED, "code": "17621005"}]})]),
+    "matched, no value[x] at all": (False, [_observation("29463-7")]),
+    "matched, unsupported value[x] type": (False, [
+        _observation("29463-7", valueBoolean=True)]),
+    "a different code": (False, [
+        _observation("8302-2", valueString="170 cm")]),
+    "no observations at all": (False, []),
+}
+
+
+def test_the_item_code_path_holds_the_property():
+    """The third population mechanism, which nothing else in this file reaches.
+
+    The intake Questionnaire has no `item.code` items, so `_report_unpopulated`
+    on the Observation branch is invisible to every other fixture here — the
+    engine's own comment says so. A classifier re-introduced on that branch
+    alone would pass this whole file without these two tests.
+    """
+    q = {"resourceType": "Questionnaire", "id": "obs-q", "status": "active",
+         "item": [{"linkId": "weight", "type": "string",
+                   "code": [{"system": LOINC, "code": "29463-7"}]}]}
+
+    for label, (should_answer, content) in _OBSERVATION_CASES.items():
+        qr, issues = populate_questionnaire(q, FULL_PATIENT, content)
+        _assert_zero_bits(q, qr, issues, label)
+
+        leaf = qr["item"][0]
+        assert ("answer" in leaf) is should_answer, f"[{label}] {leaf}"
+        assert [i["linkId"] for i in issues] == ([] if should_answer
+                                                 else ["weight"]), label
+
+
+def test_the_item_code_issue_says_nothing_about_the_observation():
+    """Five different stored records, all unanswerable, one identical issue.
+
+    An Observation that exists but carries an unlabelled coded value has to be
+    indistinguishable from no Observation at all. Anything else is a read of
+    the record through the issue channel — the shape of the leak this file
+    exists to prevent, one mechanism over from where it was found.
+    """
+    q = {"resourceType": "Questionnaire", "id": "obs-q", "status": "active",
+         "item": [{"linkId": "weight", "type": "string",
+                   "code": [{"system": LOINC, "code": "29463-7"}]}]}
+
+    payloads = set()
+    for _label, (should_answer, content) in _OBSERVATION_CASES.items():
+        if should_answer:
+            continue
+        _qr, issues = populate_questionnaire(q, FULL_PATIENT, content)
+        payloads.add(repr(issues))
+
+    assert len(payloads) == 1, (
+        f"the issue payload varies with the stored Observation: {payloads}")

--- a/tests/test_sdc_expressions.py
+++ b/tests/test_sdc_expressions.py
@@ -1,5 +1,8 @@
+import logging
+
 from r6.sdc.expressions import (build_context, evaluate,
                                 patient_projection)
+from r6.sdc.populate import INITIAL_EXPRESSION_URL, populate_questionnaire
 
 
 def test_evaluate_simple_path():
@@ -112,6 +115,76 @@ def test_build_context_with_no_subject_is_empty():
 #   - the allowlist-membership list is what the projection tests above
 #     already assert directly, on the projection itself rather than through
 #     a function that guessed at it.
+
+
+# ---------------------------------------------------------------------------
+# What an evaluation failure is allowed to log
+# ---------------------------------------------------------------------------
+
+#: A Questionnaire an attacker can POST. `notAFunction()` makes fhirpathpy
+#: raise, and everything after the newline is a log line forged to look like
+#: the access kernel granting a step-up.
+FORGED = ("notAFunction()\n"
+          "2026-09-03 18:00:00 - r6.access - WARNING - step-up token "
+          "accepted for tenant admin")
+
+
+def test_a_failing_expression_is_not_echoed_into_the_log(caplog):
+    """The expression text is caller-supplied, so it does not get logged.
+
+    A Questionnaire is request body: its expressions carry whatever the
+    caller wrote, newlines and a forged WARNING line included, and on this
+    path they can also carry literals the caller chose. Logging them back
+    hands an attacker the log file's contents (CTO ruling on #562, "not
+    blocking, please file"). What is logged instead is the linkId — which is
+    questionnaire structure, not patient data — and the exception's CLASS
+    name. Not `str(exc)`: fhirpathpy puts the offending token in the message
+    ("Not implemented: notAFunction"), which is the caller's text arriving
+    by the back door.
+
+    Asserted on the LogRecord rather than on `caplog.text`, because the two
+    disagree in exactly the way that matters. `%r` escapes the newline when
+    the record is formatted, so a text assertion passes while the raw
+    expression still travels in `record.args` to every handler — and this
+    app installs a JSONFormatter in production (main.py), which serialises
+    args of its own accord.
+
+    Driven through `populate_questionnaire` rather than `evaluate` directly,
+    so the linkId plumbing is part of what is pinned: an item whose
+    expression fails must be identifiable from the log alone.
+    """
+    questionnaire = {
+        "resourceType": "Questionnaire", "status": "active",
+        "item": [{
+            "linkId": "demographics.phone", "type": "string",
+            "extension": [{
+                "url": INITIAL_EXPRESSION_URL,
+                "valueExpression": {"language": "text/fhirpath",
+                                    "expression": FORGED}}],
+        }],
+    }
+    with caplog.at_level(logging.WARNING, logger="r6.sdc.expressions"):
+        populate_questionnaire(questionnaire, {"resourceType": "Patient"}, [])
+
+    records = [r for r in caplog.records if r.name == "r6.sdc.expressions"]
+    assert len(records) == 1, "expected exactly one failure log record"
+    record = records[0]
+
+    parts = [str(record.msg), record.getMessage()]
+    parts += [str(arg) for arg in (record.args or ())]
+    for part in parts:
+        assert "notAFunction" not in part, (
+            "the caller's expression text reached the log record")
+        assert "step-up token accepted" not in part, (
+            "a caller forged a log line through an expression")
+        assert "\n" not in part
+
+    link_id, exc_type = record.args
+    assert link_id == "demographics.phone"
+    # A class name, not a message: `str(exc)` here is "Not implemented:
+    # notAFunction", which has spaces and a colon and would fail this.
+    assert exc_type.isidentifier(), (
+        f"{exc_type!r} is not a bare exception class name")
 
 
 def test_the_resource_root_form_still_evaluates_against_the_projection():

--- a/tests/test_sdc_expressions.py
+++ b/tests/test_sdc_expressions.py
@@ -144,10 +144,13 @@ def test_a_failing_expression_is_not_echoed_into_the_log(caplog):
 
     Asserted on the LogRecord rather than on `caplog.text`, because the two
     disagree in exactly the way that matters. `%r` escapes the newline when
-    the record is formatted, so a text assertion passes while the raw
-    expression still travels in `record.args` to every handler — and this
-    app installs a JSONFormatter in production (main.py), which serialises
-    args of its own accord.
+    the record is formatted, so a text assertion goes green on a forged log
+    line while the raw expression is still sitting in `record.args`, where
+    any handler or formatter that reads it — a structured one, a shipper —
+    gets the unescaped string. (This app's own JSONFormatter, main.py:36,
+    happens to use `getMessage()` and would not; the record is still where
+    the untrusted text is, and the assertion should not depend on which
+    formatter is installed.)
 
     Driven through `populate_questionnaire` rather than `evaluate` directly,
     so the linkId plumbing is part of what is pinned: an item whose

--- a/tests/test_sdc_populate_bounded.py
+++ b/tests/test_sdc_populate_bounded.py
@@ -34,6 +34,7 @@ filled in correctly is what stops that.
 import json
 
 from r6.models import R6Resource, db
+from r6.sdc import routes as sdc_routes
 
 INITIAL_EXPR_URL = (
     "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
@@ -708,3 +709,75 @@ def test_a_refused_item_still_names_itself_after_the_oracle_is_closed(
                      questionnaire_id="after-q").get_json()
 
     assert sorted(_issue_link_ids(body)) == sorted(WITHHELD)
+
+
+# ---------------------------------------------------------------------------
+# 6. What the engine is handed
+# ---------------------------------------------------------------------------
+
+def test_the_content_list_handed_to_the_engine_carries_no_subject(
+        client, app, tenant_id, tenant_headers, monkeypatch):
+    """The subject reaches the engine as the `subject` ARGUMENT, never inside
+    the content list.
+
+    `_gather_content` used to append the unredacted stored Patient to
+    `content` as well. Nothing read it — `populate_questionnaire` filters
+    that list to Observations and to the three list-resource types, and
+    `_references_subject` takes what it matches on from the `subject`
+    argument — but it was the second door to the identifier oracle QA walked
+    an SSN through during the review of PR #562
+    (`%resources.where(resourceType='Patient').identifier.value...`), and a
+    `%resources` environment variable is one context change away from
+    existing again.
+
+    So this asserts the LIST, not the response. A leak through that append
+    is invisible in the response today and would stop being invisible
+    without anything in this directory going red, which is why the boundary
+    is measured where it is rather than where its effects happen to show.
+
+    Every negative is paired with a positive on the same request: an empty
+    content list, or a 404, would satisfy all four "not present" assertions
+    while measuring nothing.
+
+    MUTATION: restore `content.append(subject)` in
+    r6/sdc/routes.py::_gather_content -> red on the first assertion.
+    """
+    _seed(app, tenant_id)
+    calls = []
+    real_populate = sdc_routes.populate_questionnaire
+
+    def spy(questionnaire, subject, content_resources):
+        calls.append((subject, content_resources))
+        return real_populate(questionnaire, subject, content_resources)
+
+    monkeypatch.setattr(sdc_routes, "populate_questionnaire", spy)
+
+    resp = _populate(client, tenant_headers)
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert len(calls) == 1
+    subject, content = calls[0]
+
+    for resource in content:
+        assert resource.get("resourceType") != "Patient", (
+            "the subject is in the content list: an unredacted Patient is "
+            "reachable by anything that walks content, which is what the "
+            "oracle did")
+        assert resource.get("id") != PATIENT_ID
+    withheld = _patient()["identifier"][0]["value"]
+    assert withheld not in json.dumps(content), (
+        f"{withheld} reached the engine's content list")
+
+    # The positives, same request. Auto-loaded content IS there and IS
+    # redacted, so "no Patient in the list" cannot pass by the list being
+    # empty...
+    assert [r for r in content if r.get("resourceType") == "Observation"], (
+        "no auto-loaded content at all — the negatives above measure nothing")
+    assert OBS_TEXT_NAME_MARKER not in json.dumps(content)
+    # ...the subject still reaches the engine whole, through the argument
+    # that carries it, which is what the reference matching and the %patient
+    # projection are both built from...
+    assert subject["id"] == PATIENT_ID
+    assert subject["identifier"] == _patient()["identifier"]
+    # ...and the form still fills in.
+    assert set(PERMITTED) <= set(_answers(_param(resp.get_json(), "response")))


### PR DESCRIPTION
## What

Two cleanups, both from the CTO ruling on #562. Neither changes behaviour, and
the live comparison below is the evidence for that rather than the claim.

- **The unredacted subject append is gone** (`r6/sdc/routes.py`, required item
  3). `_gather_content` appended the stored Patient — unredacted — to the
  content list handed to the populate engine. The subject still reaches the
  engine whole, through the `subject` argument, which is where reference
  matching and the `%patient` projection both read it from.
- **`evaluate()` no longer logs the caller's expression** (`r6/sdc/expressions.py`,
  the ruling's "not blocking, please file" list). The WARNING now names the
  item's linkId and the exception's class.
- One comment and two docstrings corrected where they described the deleted
  behaviour. The `_gather_content` comment explaining why the subject is *not*
  redacted stays — that is still true of where the subject travels — and the
  half describing the append is gone.

## Why

### Nothing read the append — here is the proof, four reads

`content_resources` is read in exactly two places, and neither can see a
Patient:

| read | filter | Patient |
| --- | --- | --- |
| `populate.py:200` `observations = [...]` | `resourceType == "Observation"` | excluded |
| `populate.py:306` `_populate_list_group` | `resourceType == resource_type`, over the three `_LIST_RESOURCE_CONFIG` keys (MedicationRequest / AllergyIntolerance / Condition) | excluded |

The other two paths the CTO named do not reach the list at all:

- **Code matching.** `_observation_answer` (`populate.py:410`) is handed
  `observations`, already filtered above — it never sees `content_resources`.
- **The reference-matching helper.** `_references_subject`
  (`populate.py:333`) only ever runs on resources that survived the list-group
  filter, and the thing it matches *against* is `subject_ref = _reference(subject)`
  — derived from the `subject` argument, not from the list. Removing the append
  cannot change what it compares.
- **Expressions.** `_resolve_answer` evaluates against `context["patient"]`, the
  projection. `build_context` puts nothing else in the environment, which
  `tests/test_sdc_expressions.py::test_the_environment_holds_the_projection_and_nothing_else`
  asserts as an exact set — there is no `%resources` for an expression to walk
  the list with.

Dynamic half: full suite green, and the live matrix below byte-identical.

It was still worth deleting rather than leaving. The append was the second door
to the identifier oracle in QA's review — `%resources.where(resourceType='Patient').identifier.value`
distinguished a right guess from a wrong one — and it stays reachable by
anything that walks `content`, so its safety is a property of today's consumers
rather than of the code. The sentence that would put it back was in
`populate_questionnaire`'s own parameter docstring: *"should include the subject
and any Observations"*. That is corrected here, as part of the same change; it
is the contract being changed, not scope creep.

### The expression text

A Questionnaire is request body, so the expression is the caller's: it can carry
newlines that forge a log line, and literals a caller chose to park in a
`where()`. `str(exc)` is out for the same reason — fhirpathpy puts the offending
token in the message (`Not implemented: notAFunction`), which is the same text
arriving by the back door. What is logged is the linkId and the exception class.

Nothing is bounded or sanitised beyond that, and one honest note: **the linkId is
caller-supplied too.** It is questionnaire structure rather than patient data,
which is the CTO's reason for accepting it, and `%r` is what escapes control
characters in it — that is the whole mitigation, and it is the same `%r` the old
line used. No new code.

Read off the two server logs, and stated exactly as measured — the same matrix
requests went to both, the forged request went only to the "after" server:

```
before (branch point, same request):
  r6.sdc.expressions - WARNING - FHIRPath evaluation failed for
  "%resources.where(resourceType='Observation').code.text": ValueError

after (same request):
  r6.sdc.expressions - WARNING - FHIRPath evaluation failed for item 'e02':
  ValueError

after, POSTed Questionnaire whose expression is
"notAFunction()\n2026-09-03 18:00:00 - r6.access - WARNING - step-up token
 accepted for tenant admin":
  r6.sdc.expressions - WARNING - FHIRPath evaluation failed for item
  'demographics.phone': Exception
  (grep for `notAFunction` and `step-up token accepted` in the log: no hits)
```

The "before" side is #576's head, not `main`; the forged shape was not sent to
it, so the first line is the echo demonstrated live and the forged line is an
"after"-only measurement.

## Base note

**This PR stacks on #576, which stacks on #562.** Merge order: **#562 → #576 →
this**. It targets `fix/populate-issue-unconditionally` (#576), not `main`. The
projection, the redaction, the `is_deleted` filters and the 7d→24h cut are
#562's; the unconditional issue and the probe deletion are #576's; neither is
touched here.

## Before and after, live

Against a running app on **port 5417** (5099, 5199, 5297 and 5311 were reported
taken today), synthetic seeded tenant matching #576's: 2 SNOMED allergies, 1
SNOMED condition, 1 RxNorm medication, 1 LOINC observation, an SSN-shaped
identifier, and `maritalStatus` / `contact` / `photo` / an `sms` telecom /
`name.text` / `name.period.start` for the withheld paths.

Method: one script, run against the branch point (byte-identical to #576's head)
and again against this commit, on the same seeded database. **`diff` of the two
outputs is empty.**

<details><summary>The run — condensed for reading, not the raw capture</summary>

Section 1 keeps its table verbatim; sections 2–5 are summarised (the answered
leaves are listed by group rather than one per line, and the parentheticals are
mine, not the script's). The load-bearing fact is the one above it: the two raw
captures `diff` to nothing.


```
=== 1. ruling matrix (status 200) ===
issue  answer  expression
True   False   %patient.identifier.value
True   False   %patient.photo.url
True   False   %resources.where(resourceType='Observation').code.text
True   False   %patient.maritalStatus.text
True   False   %patient.telecom.where(system='sms').value
True   False   %patient.identifier.first().value
True   False   %patient.identifier.value.where($this.startsWith('1'))
True   False   %patient.identifier.value.where($this.startsWith('9'))
False  True    %patient.identifier.value.combine(%patient.gender)
True   False   %patient.contact.gender
True   False   %patient.deceasedDateTime
True   False   %patient.name.period.start
severity: ['information']
code: ['incomplete']
issues: 11/12
issue text e00: e00: not populated: no value resolved. $populate reads only
the %patient projection (name, birthDate, gender, telecom phone/email,
address line/city/state/postalCode) and coded content this server
recognises; anything else is not read.      [wrapped for width]

=== 2. escape sweep (status 200) ===
answer  expression
True    %patient.descendants()
True    %patient.children()
False   %patient.repeat(item)
True    %patient.select($this)
False   %patient.ofType(Patient)
True    %patient.toString()
False   Patient.identifier.value
False   %resources
False   %context.identifier.value
False   %resource.identifier.value
False   %rootResource.identifier.value
False   %patient.extension.valueString
False   %patient.contact.telecom.value
False   %patient.name.text
False   %patient.address.country
False   %patient.photo.contentType
markers present in response: []
   (the four structural walkers that answer resolve to the PROJECTION; none
    of the six markers — SSN, maritalStatus, sms telecom, contact name,
    photo URL, name.text — appears anywhere in the response)

=== 3. intake form (status 200) ===
answered leaves (10): 9 demographics + medications.item.name
issues (6): allergies.item.allergen x2, allergies.item.reaction x2,
            conditions.item.name, medications.item.dose
row counts: allergen 2, condition 1, medication 1     (stored: 2, 1, 1)
no-known-allergies:     answered=False in-issue-list=False
no-current-medications: answered=False in-issue-list=False

=== 4. SSN walk (status 200) ===
guesses named: 10/10 — all of them, so no guess is distinguishable
RECOVERED: ''

=== 5. noise (status 200) ===
nine demographics -> answered 9, issues []
plus one absent element -> issues ['absent']
```

</details>

Every number matches #576's live matrix, including the `combine(...)` row that
correctly answers rather than being a silence.

## Tests

Both were written first and confirmed red against the branch point.

- `tests/test_sdc_populate_bounded.py::test_the_content_list_handed_to_the_engine_carries_no_subject`
  — spies on `populate_questionnaire` over the real HTTP route and asserts the
  **list**, not the response: no entry is a Patient, none carries the subject's
  id, and the withheld identifier is not in it. Asserted where it can be seen,
  because a leak through the append is invisible in the response — which is
  exactly why it survived this long. Paired with positives on the same request
  (the Observation *is* there and *is* redacted; the subject still arrives whole
  as the argument; the allowlisted items still populate) so an empty list cannot
  pass it. Re-adding `content.append(subject)` → red on the first assertion,
  measured.
- `tests/test_sdc_expressions.py::test_a_failing_expression_is_not_echoed_into_the_log`
  — drives a crafted expression through `populate_questionnaire` and asserts the
  **LogRecord**, not `caplog.text`. That distinction is load-bearing: `%r`
  escapes the newline when the record is formatted, so a text assertion passes
  while the raw expression still travels in `record.args` to every handler —
  and this app installs a `JSONFormatter` in production (`main.py`). It also
  pins `exc_type.isidentifier()`, which is what separates the class name from
  `str(exc)`, and the linkId, which is what makes the log useful. (This app's
  own `JSONFormatter`, `main.py:36`, uses `getMessage()` and would not have
  leaked the raw string — the second commit corrects a docstring that said
  otherwise. The record is still where the untrusted text is.)
  Mutation: drop `link_id=link_id` in `populate.py` → red
  (`assert None == 'demographics.phone'`); restored, green.

## Ran

```
uv run ruff check .
  All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
  3189 passed, 13 skipped, 1 xfailed, 2 warnings in 112.55s
  (baseline on #576's head: 3187 passed. +2, the two tests above.)

uv run python -m pytest tests/test_ratchets.py tests/test_guardrail_conformance.py \
    -q -p no:cacheprovider
  50 passed          (Grade A green; no ratchet pin moved — nothing here
                      changes an R6Resource.query site)
```

Plus, against the running app on `:5417`: the five sections above, twice, and a
POSTed Questionnaire carrying the forged log line, with the server log read back
both times.

The second commit is a docstring correction only. `ruff` and
`tests/test_sdc_expressions.py tests/test_sdc_populate_bounded.py` re-run on it
(`All checks passed!` / `24 passed in 0.95s`); the full suite and the live run
were not repeated, because no assertion and no production line changed.

`dependency-audit` will be red here. It is red on **every** open PR right now —
npm advisories fixed in unmerged **#544**, nothing from this branch.

## What was NOT run

- **Postgres CI lane.** SQLite only. Nothing here touches a query or an id.
- **`$extract`.** Unchanged by this diff, and nothing new enters the answer set,
  but not exercised.
- **`test_evaluate_returns_none_on_bad_expression`.** Noticed while crafting the
  new test: `"this is not fhirpath ((("` returns `[]` from fhirpathpy without
  raising, so that test has been exercising the empty-result path, not the
  `except` branch it reads as covering. The new test is currently the only one
  that reaches the log line at all. Left alone — it is not in the ruling and
  it does still pin something true.
- **The other `_gather_content`.** `r6/actions/review.py:208` does the same
  thing (`content = [patient]`) on the action rail's form-fill path. The same
  four-read proof says it is dead weight there too, but it is a different route
  and not in the ruling — **noticed, deliberately not touched.** Worth its own
  issue.
- **Load.** Deleting a list entry can only shorten two comprehensions; not
  measured.
- **Whether any renderer surfaces the issues** — still the real-patient gate the
  CTO flagged on #576, unchanged here.
- **The MCP `questionnaire_populate` caller.** Unchanged response shape, not
  re-exercised.

## Still open from the ruling, not in this PR

Required items 4 (D10 bullet 5 — the "from your records" marker or a written
deferral) and 5 (the PR-body correction on #562's labelling trade) are
**not** here. Neither is a code change to these files, and #576's body already
carries them forward; naming them again so they do not get lost between three
stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
