### PR TITLE
candidate: an unreadable 200 is not a saved review (review of #566)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -1038,6 +1038,17 @@ def create_app(config: Config | None = None,
                            "records. Nothing has been approved — please open "
                            "the form again to check before approving, because "
                            "approving twice could send it twice.")
+    #: Distinct from BOTH of the above, and the reason it is a third string
+    #: rather than a reuse of either: something answered the review POST and
+    #: nobody could read the answer. That POST is what records the approval
+    #: (#528), so "nothing has been approved" is a claim this path cannot
+    #: make — and neither is "your review was saved". Say the one thing that
+    #: is true, and leave the way back open: a second approval cannot send
+    #: the request twice, because the review route refuses a resubmit once a
+    #: confirmation exists (409) and the claim transition has a single winner.
+    _REVIEW_UNRESOLVED = ("We couldn't tell whether your review was saved. "
+                          "Reload this page to see where this request stands "
+                          "before approving again.")
 
     @app.get("/review/<agent_id>/<action_id>")
     @login_required
@@ -1090,6 +1101,20 @@ def create_app(config: Config | None = None,
         decisions = request.get_json(silent=True) or dict(request.form)
         try:
             status, body = hc.submit_review(tenant, action_id, decisions)
+        except HealthClawUnconfirmed:
+            # Something answered the review POST and the answer was not
+            # readable. Caught FIRST because it is a subclass: the arm below
+            # says nothing was approved, which this path cannot know — the
+            # review route mints the confirmation, so if the engine did
+            # receive this, the approval exists. `confirmed: null` is the
+            # answer the page already has a branch for (#220), and it is the
+            # honest one here: not saved, not unsaved.
+            logger.exception("review submit unreadable for %s", action_id)
+            return jsonify({
+                "error": "review_unavailable",
+                "confirmed": None,
+                "message": _REVIEW_UNRESOLVED,
+            }), 502
         except HealthClawError:
             # The decisions are gone and nobody told the patient. Ownership
             # was already confirmed, so this is not a permission answer.

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -1027,25 +1027,34 @@ def create_app(config: Config | None = None,
 
     # Both review routes deny with 404 and stall with 503. Saying "that form
     # isn't yours" because we could not reach the engine is a confident false
-    # statement about ownership; saying nothing was approved is true in every
-    # failure mode here, because nothing was.
+    # statement about ownership.
+    #
+    # "Nothing has been approved" survives here and ONLY here, because every
+    # site that uses this string failed BEFORE any review POST went out: the
+    # ownership pre-check on either route, and the review GET, which has no
+    # side effect at all. Nothing was submitted, so nothing could have been
+    # recorded. The paragraph this replaced said the claim was "true in every
+    # failure mode here" and the submit route used it too — see below.
     _REVIEW_UNCHECKABLE = ("We couldn't check this form right now. Nothing "
                            "has been approved — please try again in a moment.")
-    #: Distinct from the above: the review was SENT and the engine never
-    #: answered, so whether the decisions were recorded is unknown. What is
-    #: known is that the approval step below was never reached.
-    _REVIEW_UNSUBMITTED = ("We couldn't confirm your review reached your "
-                           "records. Nothing has been approved — please open "
-                           "the form again to check before approving, because "
-                           "approving twice could send it twice.")
-    #: Distinct from BOTH of the above, and the reason it is a third string
-    #: rather than a reuse of either: something answered the review POST and
-    #: nobody could read the answer. That POST is what records the approval
-    #: (#528), so "nothing has been approved" is a claim this path cannot
-    #: make — and neither is "your review was saved". Say the one thing that
-    #: is true, and leave the way back open: a second approval cannot send
-    #: the request twice, because the review route refuses a resubmit once a
-    #: confirmation exists (409) and the claim transition has a single winner.
+    #: Every way the review POST can fail to produce a readable answer, in one
+    #: sentence, because the patient is in the same position in all three:
+    #: transport loss, a gateway status the engine never wrote, and a 200
+    #: nobody could decode. This POST is what MINTS the ActionConfirmation
+    #: (#528) — the approval record — so none of the three can say whether an
+    #: approval now exists, in either direction.
+    #:
+    #: It replaces `_REVIEW_UNSUBMITTED`, which asserted "Nothing has been
+    #: approved" on the first two. That sentence answered a question the
+    #: `confirmed` field answers ("was it carried out": no, and knowably so —
+    #: `confirm_action` is reached only on a decodable 200) with words that
+    #: state a different one ("is your approval on file": unknown). One
+    #: control, two meanings, which is the shape docs/2026-08-02-retro.md is
+    #: about. It also warned that "approving twice could send it twice",
+    #: deterring the recovery with a claim that is false: once a confirmation
+    #: exists the review route answers 409, the payload seal refuses the
+    #: resubmit that races that pre-check, and the claim transition into
+    #: `executing` has a single winner. Verified against a running engine.
     _REVIEW_UNRESOLVED = ("We couldn't tell whether your review was saved. "
                           "Reload this page to see where this request stands "
                           "before approving again.")
@@ -1103,12 +1112,17 @@ def create_app(config: Config | None = None,
             status, body = hc.submit_review(tenant, action_id, decisions)
         except HealthClawUnconfirmed:
             # Something answered the review POST and the answer was not
-            # readable. Caught FIRST because it is a subclass: the arm below
-            # says nothing was approved, which this path cannot know — the
-            # review route mints the confirmation, so if the engine did
-            # receive this, the approval exists. `confirmed: null` is the
-            # answer the page already has a branch for (#220), and it is the
-            # honest one here: not saved, not unsaved.
+            # readable. Caught FIRST because it is a subclass.
+            #
+            # `null` rather than the `false` below, and the difference is not
+            # about what was executed — no confirm went out on any of these
+            # three paths. It is about which answer the page should act on: a
+            # 200 means the submit reached something that accepted it, so a
+            # status lookup describes the request the patient just acted on,
+            # and null is the value that routes to the branch which performs
+            # one (#220). The two below have no evidence anything was
+            # delivered; polling there would report on a request that may
+            # never have been made, so they keep Approve armed instead.
             logger.exception("review submit unreadable for %s", action_id)
             return jsonify({
                 "error": "review_unavailable",
@@ -1118,24 +1132,38 @@ def create_app(config: Config | None = None,
         except HealthClawError:
             # The decisions are gone and nobody told the patient. Ownership
             # was already confirmed, so this is not a permission answer.
+            #
+            # `confirmed: False` is right and stays: the confirm is only
+            # reached on a decodable 200, so the action was not carried out,
+            # and False is what leaves Approve armed — which on this path is
+            # the recovery, not a hazard. What was wrong was the SENTENCE:
+            # `_send` raises this for a read timeout as readily as for a
+            # refused connection, so the POST may have been delivered,
+            # recorded and minted before the answer was lost.
             logger.exception("review submit failed for %s", action_id)
             return jsonify({
                 "error": "review_unavailable",
                 "confirmed": False,
-                "message": _REVIEW_UNSUBMITTED,
+                "message": _REVIEW_UNRESOLVED,
             }), 503
         if status and not HealthClawClient._answered_about_data(status) \
                 and status != 200:
-            # The engine never answered, so we cannot say the review was
-            # saved. We CAN say nothing was approved: confirm_action is only
-            # reached on a 200 below, and that is the half that keeps a
-            # second approval from sending the request twice.
+            # A gateway spoke for an engine that said nothing. This arm used
+            # to reason: "we cannot say the review was saved, but we CAN say
+            # nothing was approved, because confirm_action is only reached on
+            # a 200 below". The first half of that is right and the second
+            # half is the same defect as the unreadable-200 one above, one
+            # branch over: what confirm_action reaches is EXECUTION. The
+            # approval record is minted by the review POST itself (#528), and
+            # a 5xx is delivered-or-not — so an approval may exist for a
+            # request this arm told the patient had none. `confirmed: False`
+            # still states the half that is known.
             logger.warning("review submit unanswered (%s) for %s",
                            status, action_id)
             return jsonify({
                 "error": "review_unavailable",
                 "confirmed": False,
-                "message": _REVIEW_UNSUBMITTED,
+                "message": _REVIEW_UNRESOLVED,
             }), 503
         if status == 200:
             try:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -547,10 +547,21 @@ def create_app(config: Config | None = None,
         try:
             purged = hc.purge_tenant(conn["tenant_id"])
         except HealthClawError:
-            # Never claim a deletion that did not happen.
+            # Never claim a deletion that did not happen — and this said more
+            # than that. "Nothing was changed" is the same claim the review
+            # arms above used to make, on the destructive route: `purge_tenant`
+            # raises on ANY non-200 and on a read timeout, so a gateway 5xx or
+            # a lost answer can follow a purge that ran. Found by inventorying
+            # this file for claims about what was sent, approved, recorded or
+            # retried rather than by another report about one arm.
+            #
+            # `deleted: False` stays and is not the same claim: it is what
+            # keeps the connection linked here, which is observed — the
+            # unlink below is not reached — and is the conservative half.
             return jsonify({"error": "deletion_failed", "deleted": False,
-                            "message": "Your records were not deleted. "
-                                       "Nothing was changed — please retry."}), 502
+                            "message": "We couldn't confirm your records were "
+                                       "deleted. Your connection is still "
+                                       "linked here — please try again."}), 502
         svc.delete_connection(acct.id, conn_id)
         return jsonify({
             "deleted": True,
@@ -1179,11 +1190,21 @@ def create_app(config: Config | None = None,
                 body = dict(body) if isinstance(body, dict) else {}
                 body.update({
                     "confirmed": None,
-                    "message": ("Your review was saved, but we couldn't "
-                                "confirm whether the approval went through. "
-                                "Don't approve again yet — check the request's "
-                                "status first, because approving twice could "
-                                "send it twice."),
+                    # "approving twice could send it twice" was the last false
+                    # deterrent in this file, and the third instance of one
+                    # shape: two rounds fixed the sentence in front of them
+                    # and left the twin one arm over. Since #550 a second
+                    # approval reaches the REVIEW route, which answers 409
+                    # while the action is still awaiting confirmation and 404
+                    # once it has moved on; `confirm_action` is called only on
+                    # a decodable 200, so it is never reached twice and there
+                    # is no second send to warn about. What is true is that we
+                    # did not retry it ourselves, and that the page is about
+                    # to look up where the request stands.
+                    "message": ("Your review was saved. We couldn't tell "
+                                "whether your approval went through, so we "
+                                "have not tried it again. We are checking "
+                                "where this request stands."),
                 })
                 return jsonify(body), 502
             except HealthClawError:

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -409,13 +409,34 @@ class HealthClawClient:
         r = self._send("POST", f"{self.actions}/{action_id}/review",
                        json=decisions, headers=self._headers(tenant),
                        what="review submit")
+        if r.ok:
+            # The rule the rest of this client follows, which this method was
+            # the one exemption from: a 200 carrying a proxy's interstitial is
+            # a failed call and not data (`_json_object`). Substituting a body
+            # and returning the status unchanged made the relay read it as the
+            # engine saying "saved" — it then confirmed, and told a patient
+            # their approval was recorded with no confirmation row anywhere
+            # (QA on #566, reproduced against a running engine).
+            #
+            # HealthClawUnconfirmed rather than a plain error, for the reason
+            # `confirm_action` raises it on its own unreadable 200: this POST
+            # MINTS the ActionConfirmation (#528), so something answered and
+            # whether an approval now exists is not knowable from here. Third
+            # answer (#220), and the relay routes it to `confirmed: null`.
+            try:
+                return r.status_code, self._json_object(r, "review submit")
+            except HealthClawError as exc:
+                raise HealthClawUnconfirmed(
+                    "review submit returned invalid data",
+                    r.status_code) from exc
         try:
             body = r.json()
         except ValueError:
             body = None
         if not isinstance(body, dict):
-            # The contract is (status, dict); a non-object body is a failed
-            # call, and handing it back would break the caller's `.get`.
+            # A non-2xx is somebody's refusal and nothing was minted by it.
+            # The contract is (status, dict); a non-object body would break
+            # the caller's `.get`.
             body = {"error": "unexpected response"}
         return r.status_code, body
 

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -424,8 +424,12 @@
       const d = await r.json().catch(() => ({}));
       if (!r.ok) {
         btn.disabled = false;
-        // Say plainly that nothing was deleted — never imply a partial wipe.
-        msg.textContent = d.message || "Your records were not deleted.";
+        // Never imply a partial wipe — and never assert a whole one either
+        // way. This fallback said "Your records were not deleted", which the
+        // server itself can no longer say: a purge that ran and lost its
+        // answer reaches here too.
+        msg.textContent = d.message ||
+          "We couldn't confirm your records were deleted.";
         return;
       }
       location.reload();

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -233,6 +233,14 @@
     }
     form.addEventListener('change', evaluate);
 
+    // The server-side rule, on this side of the relay: a 4xx other than 408
+    // or 429 is somebody's decision about this request, and nothing ran that
+    // was not meant to. Everything else — 5xx, 408, 429 — is a gateway
+    // speaking for a service that said nothing (#416).
+    function answeredAboutRequest(status) {
+      return status >= 400 && status < 500 && status !== 408 && status !== 429;
+    }
+
     form.addEventListener('submit', function (e) {
       e.preventDefault();
       if (!evaluate()) { return; }
@@ -372,6 +380,31 @@
             return;
           }
 
+          // Everything the relay itself answers on this route carries either
+          // `confirmed` (its two 502s) or the `review_unavailable` code (its
+          // 503s). A 5xx carrying neither was not written by it: a gateway
+          // spoke for a service that said nothing, and by this project's own
+          // rule (`_upstream_answered`, careagents/healthclaw.py) that is
+          // silence with a status code on it, not a refusal. It reached the
+          // red arm below with Approve armed — the #416 shape, one body
+          // shape over from the unreadable branch that handles it honestly.
+          //
+          // No checkStatus: nothing here establishes that the relay ran at
+          // all, let alone that a confirmation exists, and a poll from a
+          // branch that has established neither is what the guard on
+          // checkStatus's callers exists to forbid.
+          var relayAnswered = res.b.confirmed !== undefined
+            || res.b.error === 'review_unavailable';
+          if (!relayAnswered && !answeredAboutRequest(res.r.status)) {
+            btn.disabled = true;             // it may already have run
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent =
+              'We could not tell what happened to your approval, so we ' +
+              'cannot say whether it went through. We have not sent it ' +
+              'again. Reload this page to see where this request stands.';
+            return;
+          }
+
           gateMsg.className = 'alert alert-danger';
           // `message` first: it is the field the server uses when it has
           // something specific to say. `error` is a machine code.
@@ -405,57 +438,113 @@
             return { ok: r.ok, b: b }; }); })
           .then(function (res) {
             var status = res.ok ? (res.b.status || '') : '';
-            if (status === 'completed' || status === 'sent') {
+            // ONE SENTENCE PER STATE, saying only what that state
+            // establishes — read off `_TRANSITIONS` (r6/actions/models.py),
+            // not off who called this. The three arms that were here read
+            // 'sent', 'pending' and 'approved', which this system cannot
+            // produce, and none of the five it can, so a form-fill that
+            // really did run and fail arrived at the terminal "we cannot
+            // tell" while the status said otherwise. A test compares the two
+            // vocabularies so a new state cannot be added without an arm.
+            //
+            // What changed with them: the caller-conditioned clause. The
+            // previous `awaiting_confirmation` copy said "your approval is
+            // recorded", which that status does not carry — it is set at
+            // COMMIT, before any human approval — and was true only of the
+            // callers there were then. There is now a caller with no
+            // confirmation established (an unreadable answer to the review
+            // POST, QA #566), and a claim that depends on the caller is the
+            // shape docs/2026-08-02-retro.md is about. Every sentence below
+            // is true for every caller.
+            if (status === 'completed') {
               gateMsg.className = 'alert alert-success';
               // "and nothing was sent twice" was in this string. A status
               // of completed says the action completed; it says nothing
               // about how many times it ran. Claim only what was observed.
-              gateMsg.textContent = 'Confirmed. Your approval went through.';
+              gateMsg.textContent =
+                'Confirmed. Your approval went through and this request was ' +
+                'carried out.';
               return;
             }
-            if (status === 'pending' || status === 'approved') {
+            // executing, failed, needs_review and unknown are reachable only
+            // THROUGH executing, and the claim into executing spends an
+            // approval grant. So each of them does establish that the
+            // approval went through, on the status alone.
+            if (status === 'executing') {
               gateMsg.className = 'alert alert-success';
               gateMsg.textContent =
-                'Confirmed. Your approval was recorded and is being sent.';
+                'Confirmed. Your approval went through and this request is ' +
+                'being carried out now.';
               return;
             }
-            // The action is committed and not yet claimed. This used to fall
-            // through to the terminal "we cannot tell" below — which is
-            // weaker than what is on file, and is the loop this change
-            // closes: the copy sends the patient to check the status, and
-            // the status check then told them nothing was knowable.
-            //
-            // PRECONDITION, and it is load-bearing for the first clause:
-            // every caller of checkStatus has already established that a
-            // confirmation EXISTS — a 200 review mints one, and the 409
-            // fires only when one is present. The status alone does not
-            // carry that. `awaiting_confirmation` is set at COMMIT, before
-            // any human approval (r6/actions/models.py:35), so read off a
-            // caller that had not approved yet this sentence would be false.
-            // The unreachable-service branch deliberately does not call
-            // this, and a test pins that it does not.
+            if (status === 'needs_review') {
+              gateMsg.className = 'alert alert-warning';
+              gateMsg.textContent =
+                'Your approval went through. This request needs a person to ' +
+                'look at it before it can be completed.';
+              return;
+            }
+            if (status === 'failed') {
+              gateMsg.className = 'alert alert-danger';
+              // Red, and that is not the #416 shape: #416 is a definite
+              // failure printed for an outcome nobody observed. Here the
+              // engine observed it. Naming what failed matters — the
+              // approval landed, the work after it did not.
+              gateMsg.textContent =
+                'Your approval went through and this request could not be ' +
+                'completed. Approving again will not retry it.';
+              return;
+            }
+            if (status === 'unknown') {
+              gateMsg.className = 'alert alert-warning';
+              gateMsg.textContent =
+                'We cannot tell whether this request went out. We have not ' +
+                'sent it again, because it may already have gone.';
+              return;
+            }
+            // The action is committed and not yet claimed: nothing has run.
+            // The route back is a reload, because every branch that reaches
+            // here has disabled Approve — and it has to be offered, since on
+            // one of those branches the review may never have been saved and
+            // "do not approve again" would strand the patient mid-approval.
+            // Offering it is safe on all of them: once a confirmation exists
+            // the review route answers 409 (and the payload seal refuses the
+            // resubmit that races it), and the claim transition has a single
+            // winner, so a second approval cannot produce a second send.
             if (status === 'awaiting_confirmation') {
               gateMsg.className = 'alert alert-warning';
               gateMsg.textContent =
-                'Your approval is recorded and this request has not been ' +
-                'carried out yet. Approving again will not resend it.';
+                'This request has not been carried out yet. If you need to ' +
+                'approve it again, reload this page first — a second ' +
+                'approval cannot send it twice.';
+              return;
+            }
+            if (status === 'expired') {
+              gateMsg.className = 'alert alert-warning';
+              gateMsg.textContent =
+                'This request expired before it was carried out, and it ' +
+                'cannot be approved now.';
               return;
             }
             if (tries < 4) { setTimeout(poll, 2000 * tries); return; }
-            // Still unknown after four tries. Say that, and say what we will
-            // do about it. Do NOT invite a retry: the first one may have run.
+            // Still unknown after four tries. Say that, and point at the one
+            // thing that can still resolve it. This used to end "Please do
+            // not approve a second time", which is an instruction we cannot
+            // support: on the unreadable-answer path nothing may have been
+            // saved, and obeying it strands the patient mid-approval.
             gateMsg.className = 'alert alert-warning';
             gateMsg.textContent =
               'We still cannot tell whether your approval went through, so ' +
-              'we have not sent it again. Your care team will see this ' +
-              'request either way. Please do not approve a second time.';
+              'we have not sent it again. Reload this page to see where ' +
+              'this request stands.';
           })
           .catch(function () {
             if (tries < 4) { setTimeout(poll, 2000 * tries); return; }
             gateMsg.className = 'alert alert-warning';
             gateMsg.textContent =
               'We still cannot tell whether your approval went through, so ' +
-              'we have not sent it again. Please do not approve a second time.';
+              'we have not sent it again. Reload this page to see where ' +
+              'this request stands.';
           });
       })();
     }

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -313,6 +313,31 @@
             return;
           }
 
+          // The session expired while the form sat open, which on a phone in
+          // an in-app browser is the ordinary way this page is used. This
+          // route is not under /api/, so `login_required` answers a 302 to
+          // /auth rather than a 401; fetch follows it, and what arrives is
+          // the sign-in page as 200 text/html. That parses as unreadable, so
+          // it was reported as an approval whose outcome we could not
+          // determine, with Approve taken away — when nothing was submitted
+          // and nothing could have been: the request never passed the
+          // session gate. Say that instead, and leave the button alone,
+          // because signing in and tapping Approve is the whole recovery.
+          //
+          // Keyed on the redirect AND on where it landed. A redirect to
+          // somewhere that is not our sign-in page — a captive portal, an
+          // enterprise proxy — is not evidence about the session, so it
+          // falls through to the unreadable branch below, which claims
+          // nothing either way.
+          if (res.r.redirected && /\/auth(\?|$)/.test(res.r.url || '')) {
+            btn.disabled = false;            // sign in, then approve
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent =
+              'Your sign-in expired, so this approval was not submitted. ' +
+              'Sign in again in another tab, then approve here.';
+            return;
+          }
+
           // Say only that we could not read it. NOT what became of the
           // request: on an unreadable 200 the relay has already confirmed
           // the action, on an unreadable 502 it may or may not have, and
@@ -357,6 +382,34 @@
             return;
           }
 
+          // 404 from the ENGINE: the action is no longer awaiting review.
+          // `_load_form_fill_action` requires `awaiting_confirmation` and runs
+          // before the 409 pre-check, so once the confirm has claimed the
+          // action a second submit answers 404 {"error": "Unknown action"} —
+          // which is the ordinary two-tab and back-button outcome after an
+          // approval that WORKED. It rendered as a red machine string with
+          // Approve re-armed: the same shape the 409 branch exists to remove,
+          // one status code over.
+          //
+          // What this 404 establishes, and no more: the action has left
+          // `awaiting_confirmation`. That is claimed-and-run OR expired, and
+          // the status tells them apart — so state the one fact and let the
+          // poll finish the sentence. Ownership was verified before the
+          // submit went out, so "no such action" is not among the readings.
+          //
+          // The relay's OWN 404 is `{"error": "not yours"}` and is a different
+          // answer — a denial about this account, not about the action's
+          // state — so it is excluded here and keeps the failure arm below.
+          if (res.r.status === 404 && res.b.error !== 'not yours') {
+            btn.disabled = true;             // a further tap answers 404 too
+            gateMsg.className = 'alert alert-secondary';
+            gateMsg.textContent =
+              'This request is no longer waiting for your approval. We are ' +
+              'checking where it stands.';
+            checkStatus();
+            return;
+          }
+
           // THREE answers, not two (#220, #416). `confirmed === null` means
           // the engine never replied, so the approval MAY already have run.
           // This branch used to fall through to the else below and print
@@ -368,8 +421,12 @@
             btn.disabled = true;             // never invite a second send here
             gateMsg.className = 'alert alert-warning';
             gateMsg.textContent = res.b.message ||
-              'Your review was saved. We are checking whether the approval ' +
-              'went through.';
+              // NOT "your review was saved": this branch has two producers
+              // now, and on one of them — an answer to the review POST that
+              // nobody could read — it may not have been. The fallback fires
+              // only if the server sent no message at all, so it must be
+              // true for both.
+              'We are checking where this request stands.';
             checkStatus();
             return;
           }

--- a/templates/action_review.html
+++ b/templates/action_review.html
@@ -273,6 +273,19 @@
           // may have run. Resolve into a shape the renderer can branch on.
           return r.json()
             .then(function (b) {
+              // A body that PARSES but is not an object is not an answer
+              // either, and it is worse than one that does not parse: the
+              // renderer below reads `.confirmed` and `.next_step` off it,
+              // and on `null` — valid JSON — that THROWS. Nothing catches
+              // after the renderer, deliberately, so the screen never moves
+              // and Approve stays armed: the silent failure this branch
+              // exists to remove, one body shape over. Verified in a
+              // browser at 390x844 — a 502 carrying the body `null` left
+              // the page still reading "Ready to generate" with Approve
+              // enabled, which is an invitation to tap it again.
+              if (b === null || typeof b !== 'object' || Array.isArray(b)) {
+                return { r: r, b: {}, reached: true, readable: false };
+              }
               return { r: r, b: b, reached: true, readable: true }; })
             .catch(function () {
               return { r: r, b: {}, reached: true, readable: false }; });
@@ -281,12 +294,15 @@
           // Nothing was reached, so nothing about the request is known here
           // — including whether it arrived at all.
           //
-          // RULED: leave Approve ENABLED, alone among these branches. A
-          // dropped connection most often means the request never left the
-          // device, and a disabled button with no way forward strands a
-          // patient mid-approval. Name the uncertainty, point at the check,
-          // and let them act on it. The option ruled out is the silent
-          // failure this branch used to be.
+          // RULED: leave Approve ENABLED. A dropped connection most often
+          // means the request never left the device, and a disabled button
+          // with no way forward strands a patient mid-approval. Name the
+          // uncertainty, point at the check, and let them act on it. The
+          // option ruled out is the silent failure this branch used to be.
+          //
+          // It is not alone in that any more — the relay's own 503s below
+          // stay armed too, for the same reason. It was, when this was
+          // written, and the sentence saying so outlived the fact.
           if (!res.reached) {
             btn.disabled = false;
             gateMsg.className = 'alert alert-warning';
@@ -402,6 +418,32 @@
               'We could not tell what happened to your approval, so we ' +
               'cannot say whether it went through. We have not sent it ' +
               'again. Reload this page to see where this request stands.';
+            return;
+          }
+
+          // A 503 the relay wrote is a STALL, not a decision about this
+          // request. All three of its 503 sites answer `review_unavailable`
+          // — the ownership pre-check could not be run, the review POST was
+          // lost in transport, or a gateway answered for an engine that said
+          // nothing — and each carries an honest sentence: we could not tell,
+          // we could not check. The failure style around it was not honest.
+          // Red states a refusal, and it was paired with an armed Approve:
+          // the style told the patient to stop while the control told them to
+          // continue, and on these paths continuing is the recovery (nothing
+          // ran, and if the POST did land the review route now answers 409).
+          // Ruled by QA on the finished stack; found in a browser, where all
+          // three painted `alert-danger` with Approve enabled.
+          //
+          // PRESENTATION ONLY. The sentence is still the server's, the
+          // button is left where these branches already left it — enabled,
+          // explicitly, so the next tidy-up cannot quietly disable it — and
+          // nothing polls, because a 503 has established nothing to poll for.
+          if (res.r.status === 503 && res.b.error === 'review_unavailable') {
+            btn.disabled = false;            // the recovery, not a hazard
+            gateMsg.className = 'alert alert-warning';
+            gateMsg.textContent = res.b.message ||
+              'We could not tell whether your review was saved. Reload ' +
+              'this page to see where this request stands.';
             return;
           }
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3917,6 +3917,72 @@ def test_no_review_submit_failure_claims_an_approval_does_not_exist(
         assert posted.get_json().get("confirmed") is not True
 
 
+@pytest.mark.xfail(strict=True, reason=(
+    "QA on the finished stack (#550 -> #566 -> #579). The identical false "
+    "deterrent the stack removed from the review-submit arms survives on the "
+    "CONFIRM arm, careagents/app.py:1182-1186, and nothing guarded it. "
+    "Fix is one sentence and belongs to Dev/Product, not QA."))
+def test_the_confirm_arm_does_not_deter_a_recovery_the_seal_makes_safe(
+        cfg, svc, monkeypatch):
+    """The review POST landed; the CONFIRM answer was lost.
+
+    The relay says: "Don't approve again yet - check the request's status
+    first, because approving twice could send it twice."
+
+    Both halves of that last clause are false since #550. What a second
+    approval reaches is the engine's review route, and that route now
+    answers 409 while the action is still awaiting_confirmation (a
+    confirmation exists) and 404 once it has moved on. `confirm_action` is
+    called only on a decodable 200, so it is never reached again and nothing
+    can be sent a second time. The stack's own PR body argues exactly this
+    to justify rewriting `_REVIEW_UNSUBMITTED`, and then leaves the same
+    sentence standing one arm over.
+
+    Not hypothetical, and not rare: driven against a running HealthClaw on
+    :5601 through the real relay and a real socket, an ordinary form-fill
+    approval on a deployment with no provider configured takes this path —
+
+        relay -> HTTP 502 confirmed=null
+        message: "... Don't approve again yet ... approving twice could
+                  send it twice."
+        engine status: failed        (2 confirmations, both consumed)
+        second approval -> HTTP 404 {"error": "Unknown action"}
+
+    The wording standard is the sibling guard's, so a fix has a shape to
+    aim at: it may say the outcome is unknown and it may say we have not
+    sent it again; it may not tell the patient that approving again could
+    send it twice.
+    """
+    from careagents.app import create_app
+    from careagents.healthclaw import HealthClawUnconfirmed
+
+    fake = FakeClient()
+
+    def _unconfirmed(*_a, **_kw):
+        raise HealthClawUnconfirmed("confirm unanswered (502)", 502)
+
+    fake.confirm_action = _unconfirmed
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    posted = c.post(f"/review/{agent}/act-1/submit",
+                    json={"med-0": "yes", "nka": "true"})
+    assert posted.status_code == 502
+    payload = posted.get_json()
+    assert payload["confirmed"] is None, "unknown is not false, and not true"
+    msg = payload["message"].lower()
+    assert "twice" not in msg or "cannot" in msg, (
+        "the copy warns that approving twice could send it twice. Since #550 "
+        "a second approval answers 409 while the action is awaiting "
+        "confirmation and 404 once it has moved on; confirm_action is "
+        "unreachable either way, so nothing can be sent a second time")
+
+
 def test_an_unreachable_engine_is_never_reported_as_an_unknown_run(
         cfg, svc, monkeypatch):
     """"Unknown run" and "unknown form" are claims about what exists (#410).

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -264,6 +264,16 @@ def test_review_submit_does_not_claim_nothing_was_sent_when_it_cannot_tell(
     why #416 survived a suite that looked like it covered this. The other half
     is in tests/test_healthclaw_transport.py, where the real client meets a
     real 504 over a real socket.
+
+    The assertion below used to require `"twice" in msg`, which froze the
+    deterrent "approving twice could send it twice" into place as though it
+    were the fix. It was true of #220's world and false since #550: a second
+    approval reaches the review route, which answers 409 while the action is
+    awaiting confirmation and 404 once it has moved on, so `confirm_action`
+    is never reached twice. A guard that pins a sentence rather than the
+    property behind it keeps the sentence after the property has gone —
+    which is how this survived two rounds of fixing its siblings. Pin the
+    property: the uncertainty is stated, and no false deterrent rides along.
     """
     from careagents.app import create_app
     from careagents.healthclaw import HealthClawUnconfirmed
@@ -293,7 +303,13 @@ def test_review_submit_does_not_claim_nothing_was_sent_when_it_cannot_tell(
     assert body["confirmed"] is None, "unknown is not false"
     msg = body["message"].lower()
     assert "nothing has been sent" not in msg
-    assert "couldn't confirm" in msg and "twice" in msg
+    assert "couldn't tell" in msg or "could not tell" in msg, (
+        "the message no longer states the uncertainty, which is the whole "
+        "of #220's third answer")
+    assert "twice" not in msg or "cannot" in msg, (
+        "the message warns that approving twice could send it twice; since "
+        "#550 a second approval answers 409 or 404 and never reaches the "
+        "confirm")
 
 
 def test_confirm_action_separates_a_refusal_from_an_unanswered_confirm():
@@ -3009,6 +3025,23 @@ def test_delete_does_not_unlink_when_the_purge_fails(cfg, svc, monkeypatch):
     # connection survives, so the patient can retry
     assert c.post(f"/api/connections/{conn}/disconnect").status_code == 200
 
+    # ...and the sentence may not say more than that. "Nothing was changed"
+    # was here, which is the same claim the review arms made, on the
+    # destructive route: `purge_tenant` raises on ANY non-200 and on a read
+    # timeout, so a gateway 5xx or a lost answer can follow a purge that ran.
+    # Found by inventorying this file for claims about what was sent,
+    # approved, recorded or retried, not by a report about this route.
+    #
+    # MUTATION: restore "Your records were not deleted. Nothing was changed"
+    # -> red. Ran it, saw red.
+    msg = r.get_json()["message"].lower()
+    assert "nothing was changed" not in msg, (
+        "the purge may have run and lost its answer; nothing observed here "
+        "says the records are still there")
+    assert "were not deleted" not in msg, (
+        "same claim, shorter: this path cannot tell whether they were")
+    assert "couldn't confirm" in msg or "could not confirm" in msg
+
 
 def test_delete_and_disconnect_reject_other_peoples_connections(app, svc,
                                                                 monkeypatch):
@@ -3917,11 +3950,15 @@ def test_no_review_submit_failure_claims_an_approval_does_not_exist(
         assert posted.get_json().get("confirmed") is not True
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "QA on the finished stack (#550 -> #566 -> #579). The identical false "
-    "deterrent the stack removed from the review-submit arms survives on the "
-    "CONFIRM arm, careagents/app.py:1182-1186, and nothing guarded it. "
-    "Fix is one sentence and belongs to Dev/Product, not QA."))
+# QA on the finished stack (#550 -> #566 -> #579), filed as a strict xfail and
+# fixed here, so the marker is gone and the reason is kept as the record:
+#
+#   The identical false deterrent the stack removed from the review-submit
+#   arms survived on the CONFIRM arm, careagents/app.py:1182-1186, and nothing
+#   guarded it. Two rounds fixed the sentence in front of them and left the
+#   twin. It is what an ordinary form-fill approval reaches on any deployment
+#   with no provider configured, which is every deployment today.
+
 def test_the_confirm_arm_does_not_deter_a_recovery_the_seal_makes_safe(
         cfg, svc, monkeypatch):
     """The review POST landed; the CONFIRM answer was lost.

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -4435,6 +4435,46 @@ def test_delete_confirmation_is_not_a_form_or_native_dialog():
     assert "showModal" not in _HOME_JS
 
 
+def test_the_delete_failure_fallback_cannot_reassert_what_the_server_dropped():
+    """The claim was removed from the server AND from here; only one is fenced.
+
+    `careagents/app.py`'s purge arm no longer says "Your records were not
+    deleted. Nothing was changed", because `purge_tenant` raises on a read
+    timeout, on a gateway 5xx, and on a 200 whose body nobody could decode —
+    and that last one is a purge that SUCCEEDED. Measured with the real
+    client over real sockets:
+
+        ok              -> success path
+        refused (403)   -> 502 arm   records really are still there
+        gateway (504)   -> 502 arm   the purge may have run
+        200, unreadable -> 502 arm   the purge DID run
+
+    `test_delete_does_not_unlink_when_the_purge_fails` fences the server
+    string. This fallback is the other place the sentence lived, it fires
+    when the server sends no message at all, and nothing stopped the old
+    wording from being restored here alone — on the destructive route, which
+    is the worst place in the product to be wrong about what happened.
+
+    MUTATION: restore `"Your records were not deleted."` as the fallback
+    -> red. Ran it, saw red.
+    """
+    anchor = '.conn-delete'
+    assert anchor in _HOME_JS, "the delete handler moved; this guard reads it"
+    block = _HOME_JS.split(anchor, 1)[1].split("location.reload();", 1)[0]
+    # Comments quote the old wording to record why it went. Scan what runs.
+    stripped = "\n".join(re.sub(r"//.*$", "", ln) for ln in block.splitlines())
+    assert "d.message" in stripped, (
+        "the block this guard reads is not the delete handler any more")
+    for claim in ("were not deleted", "nothing was changed",
+                  "nothing was deleted"):
+        assert claim not in stripped.lower(), (
+            f"the delete fallback can print {claim!r}. A purge that ran and "
+            f"lost its answer reaches this branch, so nothing here observed "
+            f"that the records are still present")
+    assert "confirm your records were deleted" in stripped.lower(), (
+        "the fallback no longer states the uncertainty it is there for")
+
+
 def test_hub_dialog_selector_contract():
     """home.js addresses these by id; a template rename would break the flow at
     runtime only, with no server-side signal."""

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3768,6 +3768,73 @@ def test_a_gateway_504_on_review_submit_does_not_claim_the_review_was_saved(
     assert refused.status_code == 422
 
 
+def test_an_unreadable_answer_to_the_review_is_neither_saved_nor_unsaved(
+        cfg, svc, monkeypatch):
+    """QA #566 (HIGH), the route half.
+
+    Something answered the review POST and nobody could read the answer. The
+    client now raises `HealthClawUnconfirmed` there (the transport half is in
+    tests/test_healthclaw_transport.py, over a real socket). This route must
+    catch it BEFORE `HealthClawError`, because that arm says "Nothing has
+    been approved" — and this POST is what mints the confirmation (#528), so
+    if the engine received it an approval exists. Neither half is knowable,
+    which is what `confirmed: null` is for (#220).
+
+    What must NOT happen is what shipped: the status passed through as 200,
+    `confirm_action` called on the strength of it, and the patient told
+    "your review was saved and your approval is recorded" with no
+    confirmation row anywhere.
+
+    MUTATION: delete the `except HealthClawUnconfirmed` arm -> red, the
+    subclass falls into the HealthClawError arm and answers 503 with
+    "Nothing has been approved". Ran it, saw red.
+    """
+    from careagents.app import create_app
+    from careagents.healthclaw import HealthClawUnconfirmed
+
+    def _unreadable(*_a, **_kw):
+        raise HealthClawUnconfirmed("review submit returned invalid data", 200)
+
+    confirms = []
+
+    fake = FakeClient()
+    fake.submit_review = _unreadable
+    fake.confirm_action = lambda t, a: confirms.append(a)
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    _login(c, svc, monkeypatch)
+    conn = c.post("/api/connections/sample").get_json()["id"]
+    agent = c.post("/api/agents", json={"name": "A", "persona": "calm",
+                                        "connection_id": conn}).get_json()["id"]
+
+    posted = c.post(f"/review/{agent}/act-1/submit",
+                    json={"med-0": "yes", "nka": "true"})
+    assert posted.status_code == 502
+    payload = posted.get_json()
+    assert payload["confirmed"] is None, "unknown is not false, and not true"
+    assert not confirms, "an unreadable answer must not be confirmed on"
+    msg = payload["message"].lower()
+    # Both directions. Each of these is false on one of the two ways this
+    # path can have happened, so neither of the two neighbouring messages
+    # can be reused here — which is why this is a third string.
+    assert "nothing has been approved" not in msg, \
+        "the review may have been saved, and this POST is what records it"
+    # The other direction, and a substring test alone cannot see it: this
+    # message contains "your review was saved" — inside "whether". What is
+    # forbidden is ASSERTING it, so require the qualifier rather than the
+    # absence of the words.
+    for claim in ("your review was saved", "your approval is recorded"):
+        at = msg.find(claim)
+        assert at == -1 or msg[:at].rstrip().endswith("whether"), (
+            f"{claim!r} is stated here as a fact; nothing on this path "
+            f"observed it")
+    # What it may say, and does: that we could not tell.
+    assert "couldn't tell" in msg or "could not tell" in msg
+    # And the way back stays open: no instruction not to approve again.
+    assert "approving again" in msg or "before approving" in msg
+
+
 def test_an_unreachable_engine_is_never_reported_as_an_unknown_run(
         cfg, svc, monkeypatch):
     """"Unknown run" and "unknown form" are claims about what exists (#410).

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3726,7 +3726,13 @@ def test_a_dead_socket_on_the_review_path_is_not_a_bare_500(
                     json={"med-0": "yes", "nka": "true"})
     assert posted.status_code == 503
     assert posted.get_json().get("confirmed") is not True
-    assert "Nothing has been approved" in posted.get_json()["message"]
+    # This assertion used to require "Nothing has been approved" here too,
+    # and the GET above still does — correctly, because a GET has no side
+    # effect. The submit does: `_send` raises this same HealthClawError for a
+    # read timeout as readily as for a refused connection, so the POST may
+    # have been delivered and minted the confirmation (#528) before the
+    # answer was lost. Nothing observed on this path can say it did not.
+    assert "Nothing has been approved" not in posted.get_json()["message"]
 
 
 def test_a_gateway_504_on_review_submit_does_not_claim_the_review_was_saved(
@@ -3735,9 +3741,17 @@ def test_a_gateway_504_on_review_submit_does_not_claim_the_review_was_saved(
 
     A 5xx here was passed straight through as the response status with the
     engine's body, which tells the patient nothing about whether their
-    decisions were recorded. What we DO know is that `confirm_action` is
-    only reached on a 200, so nothing was approved — that half is sayable,
-    and it is the half that stops a second approval sending twice.
+    decisions were recorded.
+
+    This test used to also require the message to say "Nothing has been
+    approved", on the reasoning that `confirm_action` is only reached on a
+    200. That reasoning holds for EXECUTION and was written as if it held for
+    the approval: the review POST itself mints the ActionConfirmation (#528),
+    and a gateway 5xx is delivered-or-not, so an approval may exist for the
+    request the patient was told had none. Same defect as the unreadable-200
+    one, one branch over. `confirmed: False` still carries the half that is
+    known — nothing was carried out — which is the half that keeps Approve
+    armed for the retry that is this path's recovery.
 
     MUTATION: return `jsonify(body), status` unconditionally -> red.
     Ran it, saw red.
@@ -3759,7 +3773,9 @@ def test_a_gateway_504_on_review_submit_does_not_claim_the_review_was_saved(
     assert posted.status_code == 503
     payload = posted.get_json()
     assert payload.get("confirmed") is not True
-    assert "Nothing has been approved" in payload["message"]
+    assert "Nothing has been approved" not in payload["message"]
+    assert "could send it twice" not in payload["message"], (
+        "the old copy deterred the retry with a claim the seal makes false")
 
     # A 422 is the engine's own answer — attestation missing — and must
     # still reach the patient as the engine's answer, unchanged.
@@ -3833,6 +3849,72 @@ def test_an_unreadable_answer_to_the_review_is_neither_saved_nor_unsaved(
     assert "couldn't tell" in msg or "could not tell" in msg
     # And the way back stays open: no instruction not to approve again.
     assert "approving again" in msg or "before approving" in msg
+
+
+def test_no_review_submit_failure_claims_an_approval_does_not_exist(
+        cfg, svc, monkeypatch):
+    """The property, over every way the submit can fail, in one place.
+
+    Each of these was fixed one at a time and each time the sibling survived:
+    the unreadable 200 was found by review while the gateway 5xx and the
+    transport loss went on asserting the same thing next to it. The three
+    share a cause — the review POST is what mints the ActionConfirmation
+    (#528), so none of them can say whether an approval exists — so pin them
+    together rather than as three unrelated strings.
+
+    What each MAY still say, and does, is that nothing was carried out:
+    `confirm_action` is reached only on a decodable 200, and `confirmed`
+    carries that. This guard is about the words the patient reads.
+
+    MUTATION: put "Nothing has been approved" back in `_REVIEW_UNRESOLVED`
+    -> red on all three. Ran it, saw red.
+    """
+    from careagents.app import create_app
+    from careagents.healthclaw import HealthClawUnconfirmed
+
+    def _timeout(*_a, **_kw):
+        # What `_send` raises for a read timeout — which is delivered, then
+        # lost — and for a refused connection alike. Indistinguishable here.
+        raise HealthClawError("review submit failed", 0)
+
+    def _unreadable(*_a, **_kw):
+        raise HealthClawUnconfirmed("review submit returned invalid data", 200)
+
+    modes = {
+        "transport lost after possible delivery": _timeout,
+        "gateway 502, engine silent": lambda t, a, d: (502, {"error": "bad"}),
+        "gateway 504, engine silent": lambda t, a, d: (504, {"error": "bad"}),
+        "200 nobody could decode": _unreadable,
+    }
+
+    for name, impl in modes.items():
+        fake = FakeClient()
+        fake.submit_review = impl
+        app = create_app(config=cfg, client=fake, accounts=svc)
+        app.config["TESTING"] = True
+        c = app.test_client()
+        _login(c, svc, monkeypatch, email=f"gene+{len(name)}@example.com")
+        conn = c.post("/api/connections/sample").get_json()["id"]
+        agent = c.post("/api/agents",
+                       json={"name": "A", "persona": "calm",
+                             "connection_id": conn}).get_json()["id"]
+        posted = c.post(f"/review/{agent}/act-1/submit",
+                        json={"med-0": "yes", "nka": "true"})
+        msg = (posted.get_json() or {}).get("message", "").lower()
+        assert msg, f"{name}: no message at all"
+        assert "nothing has been approved" not in msg, (
+            f"{name}: the patient is told no approval exists. The review POST "
+            f"mints the confirmation, so on this path one may")
+        # The opposite claim, allowed only as the thing we could not tell —
+        # the message contains these words, inside "whether".
+        for claim in ("your review was saved", "your approval is recorded"):
+            at = msg.find(claim)
+            assert at == -1 or msg[:at].rstrip().endswith("whether"), (
+                f"{name}: {claim!r} is stated as a fact")
+        assert "twice" not in msg or "cannot" in msg, (
+            f"{name}: the copy warns that approving twice could send twice. "
+            f"Once a confirmation exists the review route answers 409")
+        assert posted.get_json().get("confirmed") is not True
 
 
 def test_an_unreachable_engine_is_never_reported_as_an_unknown_run(

--- a/tests/test_healthclaw_transport.py
+++ b/tests/test_healthclaw_transport.py
@@ -455,19 +455,20 @@ def test_a_confirm_answered_200_but_unreadable_is_not_a_refusal(stub_base,
         _client(stub_base).confirm_action("t", "a1")
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "QA #566 (HIGH). `submit_review` is the one method that opts out of the "
-    "rule `_json_object` exists to state: it substitutes "
-    "{'error': 'unexpected response'} for an unreadable body and returns the "
-    "status unchanged. On a 200 that means the relay believes the engine "
-    "saved the review and minted a confirmation when nothing reached the "
-    "engine at all. careagents/app.py:1116 then calls confirm_action, and a "
-    "mint refusal lands in the HealthClawError branch, which since this PR "
-    "tells the patient 'your review was saved and your approval is recorded' "
-    "and disables Approve. Reproduced against a running HealthClaw: "
-    "ActionConfirmation rows [] and QuestionnaireResponse rows 0 for the "
-    "action the patient was told carried their approval. Fixing this reddens "
-    "the pin: update it in the same PR."))
+# QA #566 (HIGH), filed as a strict xfail and fixed here, so the marker is
+# gone and the reason is kept as the record of what it caught:
+#
+#   `submit_review` was the one method that opted out of the rule
+#   `_json_object` exists to state. It substituted {'error': 'unexpected
+#   response'} for an unreadable body and returned the status unchanged, so on
+#   a 200 the relay believed the engine had saved the review and minted a
+#   confirmation when nothing reached the engine at all. careagents/app.py
+#   then called confirm_action, and the mint refusal landed in the
+#   HealthClawError branch, which told the patient "your review was saved and
+#   your approval is recorded" and disabled Approve. Reproduced against a
+#   running HealthClaw: ActionConfirmation rows [] and QuestionnaireResponse
+#   rows 0 for the action the patient was told carried their approval.
+
 def test_an_unreadable_200_review_is_not_a_saved_review(stub_base,
                                                         reset_mode):
     """A 200 nobody can decode is not the engine saying "saved".
@@ -480,10 +481,48 @@ def test_an_unreadable_200_review_is_not_a_saved_review(stub_base,
     The engine's real answer here always carries `reviewed_qr_id` and
     `approved_via: 'review-page'` — verified against a running instance — so
     there is evidence available to require rather than a shape to guess at.
+
+    MUTATION: return `(r.status_code, {"error": "unexpected response"})` on
+    the ok path again -> red. Ran it, saw red.
     """
     _set(status=200, body=NON_JSON_BODY, ctype="text/html")
     with pytest.raises(HealthClawError):
         _client(stub_base).submit_review("t", "a1", {"nka": "true"})
+
+
+def test_an_unreadable_200_review_is_the_third_answer_not_a_failure(
+        stub_base, reset_mode):
+    """And it is `HealthClawUnconfirmed` specifically, which is what routes it.
+
+    The type is the whole fix. Plain `HealthClawError` reaches the relay arm
+    that answers "Nothing has been approved" — false in the other direction,
+    because this POST is what MINTS the confirmation (#528): if the engine
+    did receive it, an approval exists. Neither answer is knowable, which is
+    what `confirmed: null` means.
+
+    MUTATION: raise plain `HealthClawError` from the ok path -> red.
+    Ran it, saw red.
+    """
+    _set(status=200, body=NON_JSON_BODY, ctype="text/html")
+    with pytest.raises(HealthClawUnconfirmed):
+        _client(stub_base).submit_review("t", "a1", {"nka": "true"})
+
+
+def test_an_unreadable_refusal_still_reaches_the_page_as_a_refusal(
+        stub_base, reset_mode):
+    """The scope of the raise, pinned from the other side.
+
+    A 4xx is somebody's decision and nothing was minted by it, so it keeps
+    the (status, dict) contract and renders as the engine's answer. Raising
+    on every unreadable body instead would convert the engine's own refusal
+    — a 422 behind an edge that rewrites error bodies — into an unknown
+    outcome, which is #416 run backwards.
+
+    MUTATION: hoist the raise above the `r.ok` test -> red.
+    """
+    _set(status=422, body=NON_JSON_BODY, ctype="text/html")
+    status, body = _client(stub_base).submit_review("t", "a1", {})
+    assert status == 422 and isinstance(body, dict)
 
 
 def test_a_confirm_answered_by_nobody_stays_unconfirmed(stub_base,

--- a/tests/test_review_says_what_it_knows.py
+++ b/tests/test_review_says_what_it_knows.py
@@ -67,6 +67,34 @@ def _code_only(js: str) -> str:
     return "\n".join(re.sub(r"//.*$", "", line) for line in js.splitlines())
 
 
+def _as_printed(js: str) -> str:
+    """Comment-stripped code with JS string concatenation joined up.
+
+    The forbidden-claims guards below compare banned sentences against the
+    source with `in`. Every message in this page is built the same way —
+
+        gateMsg.textContent =
+          'We could not tell what happened to your approval, so we ' +
+          'cannot say whether it went through.';
+
+    — so a banned sentence written in the page's own idiom is never a
+    substring of the source, and both guards were green against every
+    mutation that split one. Measured (QA, final stack review): a literal
+    `'nothing was sent'` was caught; `'Nothing was ' + 'sent.'` and a
+    three-line `'Your approval is ' + 'recorded and it did not ' + 'go
+    through.'` were both MISSED, by the case-sensitive guard and the
+    case-insensitive one alike. That is a control whose only enforcement was
+    its own description, which is what docs/2026-08-02-retro.md is about.
+
+    Collapsing `' + '` is exactly and only string concatenation, so this
+    joins nothing a reader would not read as one sentence. Whitespace is
+    normalised afterwards so a claim broken across lines inside one literal
+    is caught too.
+    """
+    joined = re.sub(r"['\"]\s*\+\s*['\"]", "", _code_only(js))
+    return re.sub(r"\s+", " ", joined)
+
+
 def test_there_is_a_submit_handler_to_examine(page):
     """A pass over a handler that no longer exists is not a pass."""
     body = _submit_handler(page)
@@ -97,8 +125,12 @@ def test_no_branch_can_call_an_unknown_outcome_a_rejection(page):
 
     A fallback string is fine. A fallback string that asserts an OUTCOME is
     not, because it fires exactly when the server declined to assert one.
+
+    Scans `_as_printed`, not the raw source: every sentence on this page is
+    assembled from concatenated fragments, so `in` against the source read
+    as coverage while catching only a claim nobody would write that way.
     """
-    body = _code_only(_submit_handler(page))
+    body = _as_printed(_submit_handler(page))
     for claim in ("Submission rejected", "was rejected", "did not go through",
                   "nothing was sent"):
         assert claim not in body, (
@@ -555,8 +587,12 @@ def test_the_forbidden_claims_guard_is_not_defeated_by_capitalisation(page):
 
     MUTATION: set any branch's text to 'Nothing was sent.' -> red here,
     green on the original guard.
+
+    Also scans `_as_printed`: capitalisation was the first way past this
+    list and concatenation was the second, and the second is the one the
+    page's own house style produces by default.
     """
-    body = _code_only(_submit_handler(page)).lower()
+    body = _as_printed(_submit_handler(page)).lower()
     for claim in ("submission rejected", "was rejected", "did not go through",
                   "nothing was sent",
                   # Added with the QA #566 fix. This is the HIGH's own
@@ -568,6 +604,139 @@ def test_the_forbidden_claims_guard_is_not_defeated_by_capitalisation(page):
                   "approval is recorded"):
         assert claim not in body, (
             f"the page can print {claim!r} without knowing it")
+
+
+def test_the_forbidden_claims_guard_is_not_defeated_by_concatenation():
+    """The guard's own mutation test, run over a synthetic page.
+
+    Both guards above compare with `in`. The page writes every sentence as
+    `'half a ' + 'sentence'` across lines, so before `_as_printed` a banned
+    claim written the way this file writes claims was invisible to both.
+    Measured on the real page (QA, final stack review):
+
+        CAUGHT  'nothing was sent'                 (one literal)
+        CAUGHT  'Nothing Was Sent'                 (capitalisation guard)
+        MISSED  'Nothing was ' + 'sent.'
+        MISSED  'Your approval is ' + 'recorded and it did not ' +
+                'go through.'
+        MISSED  'Submission ' + 'rejected.'
+
+    This runs those same shapes through the normaliser rather than trusting
+    that it works. MUTATION: revert `_as_printed` to `_code_only` -> red.
+    """
+    prologue = "form.addEventListener('submit', function (e) {\n"
+    epilogue = "\n});\nevaluate();"
+    shapes = {
+        "one literal": "  gateMsg.textContent = 'nothing was sent';",
+        "capitalised": "  gateMsg.textContent = 'Nothing Was Sent';",
+        "joined by a +": "  gateMsg.textContent = 'Nothing was ' + 'sent.';",
+        "the page's own idiom":
+            "  gateMsg.textContent =\n"
+            "    'Your approval is ' +\n"
+            "    'recorded and it did not ' +\n"
+            "    'go through.';",
+        "split mid-word-boundary":
+            "  gateMsg.textContent = 'Submission ' + 'rejected.';",
+        "mixed quote styles":
+            "  gateMsg.textContent = 'nothing was ' + \"sent\";",
+    }
+    banned = ("submission rejected", "was rejected", "did not go through",
+              "nothing was sent", "approval is recorded")
+    for name, snippet in shapes.items():
+        fake = prologue + snippet + epilogue
+        printed = _as_printed(_submit_handler(fake)).lower()
+        assert any(claim in printed for claim in banned), (
+            f"a false claim written as {name} walks past the forbidden-"
+            f"claims list. The page builds every sentence this way, so a "
+            f"guard that misses it reads as coverage and is not.")
+
+
+def test_a_relay_stall_is_not_painted_as_a_refusal(page):
+    """QA ruling on the finished stack: red style, armed button, honest text.
+
+    All three of the relay's 503 sites answer `review_unavailable` and say
+    some version of "we could not tell" or "we could not check". Driven in a
+    browser at 390x844 they all painted `alert-danger` with Approve still
+    enabled — the style saying the request was refused, the control saying
+    carry on. Nothing was refused on any of them, and on all three a second
+    approval is the recovery.
+
+    MUTATION: delete this branch, or set its class to `alert-danger` -> red.
+    """
+    body = _code_only(_submit_handler(page))
+    anchor = "res.r.status === 503"
+    assert anchor in body, (
+        "no branch separates the relay's own stall from a refusal, so an "
+        "honest 'we could not tell' renders in the failure style")
+    block = _block(body, anchor)
+    assert "alert-warning" in block, (
+        "the relay's 503 renders in the failure style. Red states a refusal "
+        "the relay never made")
+    assert "alert-danger" not in block
+    assert "btn.disabled = false" in block, (
+        "the stall branch does not leave Approve enabled. A second approval "
+        "is the recovery here: nothing ran, and if the POST did land the "
+        "review route answers 409 rather than sending anything twice")
+    assert "checkStatus()" not in block, (
+        "the stall branch polls. A 503 establishes nothing to poll for — "
+        "the request may never have reached the relay at all")
+
+
+def test_a_body_that_parses_but_is_not_an_object_is_unreadable(page):
+    """`null` is valid JSON, and the renderer reads fields off the body.
+
+    Driven in a browser: a 502 carrying the body `null` threw inside the
+    renderer — where nothing catches, by design — so the page still read
+    "Ready to generate. The server will re-verify every item on submit."
+    with Approve ENABLED, after the patient had tapped it. That is the exact
+    silent failure the parse `.catch` was added to remove, reached through a
+    body shape that parses.
+
+    MUTATION: delete the type check in the parse `.then` -> red.
+    """
+    body = _code_only(_submit_handler(page))
+    parse = body[body.index("r.json()"):body.index(".then(function (res)")]
+    assert "typeof b !== 'object'" in parse and "b === null" in parse, (
+        "a JSON body that is not an object is treated as readable, so the "
+        "renderer dereferences it and throws with nothing to catch: the "
+        "screen does not move and Approve stays armed")
+    assert "readable: false" in parse
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "QA on the finished stack (#550 -> #566 -> #579). The 409 branch removed "
+    "the #416 shape for a request still awaiting confirmation; the same shape "
+    "survives one status code over, for a request that was approved AND ran. "
+    "Fix needs a sentence about state, which is Dev's call, not QA's."))
+def test_an_action_that_moved_on_is_not_rendered_as_a_bare_failure(page):
+    """Second tab, or the back button, after the approval went through.
+
+    `_load_form_fill_action` requires `awaiting_confirmation` and runs before
+    the 409 pre-check, so once the confirm has claimed the action a second
+    submit answers 404 `{"error": "Unknown action"}` — the relay passes it
+    through untouched. Driven end to end against a running HealthClaw on
+    :5601 through the real relay, an ordinary form-fill approval reached
+
+        first approval  -> 502, engine status: failed  (approval consumed)
+        second approval -> 404 {"error": "Unknown action"}
+
+    and in a browser at 390x844 that painted:
+
+        alert alert-danger / "Unknown action" / Approve ENABLED
+
+    A machine string, in the failure style, for a request the patient really
+    did approve and that really did run — with the button re-armed. That is
+    the shape the 409 branch exists to remove. The 404 also cannot be told
+    apart here from the relay's own `{"error": "not yours"}`, so a fix has to
+    read the body, not just the status; that is the part that is a claim
+    about state rather than presentation, which is why QA pinned it instead
+    of writing it.
+    """
+    body = _code_only(_submit_handler(page))
+    assert re.search(r"res\.r\.status\s*===\s*404", body), (
+        "no branch handles the 404 a second approval gets once the action "
+        "has moved on, so an approved-and-executed request renders as a red "
+        "'Unknown action' with Approve re-armed")
 
 
 # QA #566 (MEDIUM), filed as a strict xfail and fixed here, so the marker is

--- a/tests/test_review_says_what_it_knows.py
+++ b/tests/test_review_says_what_it_knows.py
@@ -402,20 +402,40 @@ def test_awaiting_confirmation_is_not_reported_as_an_unknown_outcome(page):
         "recorded approval as an outcome nobody can determine")
 
 
-def test_the_awaiting_confirmation_arm_never_invites_a_second_approval(page):
-    """MUTATION: drop the "will not resend" clause -> red.
+def test_the_awaiting_confirmation_arm_says_only_what_the_status_carries(page):
+    """Rewritten from `..._never_invites_a_second_approval`, which pinned
+    "recorded" and "will not resend" — the copy #566 shipped.
 
-    The state is reachable precisely when a patient has been sent to check on
-    an approval they already gave. Saying it is not finished, without saying
-    that re-approving cannot help, is what produced the double-tap.
+    Both clauses were true of the callers that existed when it was written
+    and false of the caller added since (an unreadable answer to the review
+    POST, where nothing may have been saved). `awaiting_confirmation` is set
+    at COMMIT, before any human approval (r6/actions/models.py), so the
+    status does not carry a recorded approval, and `/api/form/` returns the
+    status alone — the poll cannot recover what the status does not say.
+    Telling that patient their approval is on file is the HIGH of QA #566;
+    telling them re-approving cannot help strands them mid-approval.
+
+    So: the arm states the state, and leaves the way back open.
+
+    MUTATION: restore either clause -> red.
     """
     block = _block(_code_only(_submit_handler(page)), "'awaiting_confirmation'")
-    assert "will not resend" in block, (
-        "the awaiting_confirmation arm says the request is unfinished but "
-        "not that approving again cannot resend it")
-    assert "recorded" in block, (
-        "the awaiting_confirmation arm does not say the approval is on file, "
-        "which is the whole reason it is not an unknown outcome")
+    assert "recorded" not in block, (
+        "the awaiting_confirmation arm claims an approval is on file. The "
+        "status does not establish that, and one caller reaches here with no "
+        "confirmation anywhere")
+    assert "will not resend" not in block and "not resend" not in block, (
+        "the arm tells the patient re-approving cannot help. On the "
+        "unreadable-answer path nothing may have been saved, and that "
+        "instruction is the one thing standing between them and a request "
+        "that never gets made")
+    assert "carried out yet" in block, (
+        "the arm no longer says the thing the status DOES establish: this "
+        "request has not run")
+    assert "reload" in block.lower(), (
+        "every branch that reaches this arm has disabled Approve, so an arm "
+        "that leaves re-approval open must say how (#419: an instruction "
+        "needs a destination)")
 
 
 def test_the_relay_confirm_failure_gets_the_destination_it_points_at(page):
@@ -480,15 +500,28 @@ def _checkstatus_call_sites(body: str) -> list[int]:
             if not body[:m.start()].rstrip().endswith("function")]
 
 
-def test_check_status_is_only_called_where_an_approval_is_established(page):
-    """The comment's invariant, made a check.
+def test_check_status_is_only_called_where_the_relay_answered(page):
+    """The comment's invariant, made a check. Renamed, and the invariant
+    restated, because the copy it protected has changed.
+
+    As written (QA #566) this guard protected the sentence "Your approval is
+    recorded" in the `awaiting_confirmation` arm: every caller had
+    established that a confirmation EXISTS. That is no longer true of the
+    `confirmed: null` branch — the relay now also answers null when nobody
+    could read the engine's answer to the review POST, where no confirmation
+    may exist. Rather than keep a caller-conditioned claim alive by passing
+    the fact into the poll, the fix removed the claim: every arm of
+    checkStatus now says only what the status itself carries, so the poll is
+    honest for any caller.
+
+    What the call-site restriction still protects, and why it stays: the
+    three branches below are the ones where SOMETHING answered the submit, so
+    a status lookup describes the same request the patient just acted on. The
+    two branches deliberately outside it — the unreachable service, and a
+    gateway 5xx that is not the relay's — have no evidence the submit reached
+    CareAgents at all, and both send the patient to a reload instead.
 
     MUTATION: add `checkStatus();` to the `!res.reached` branch -> red.
-
-    Every caller must sit inside one of the three answers that establish a
-    confirmation EXISTS: the 409 (fires only when one is present), the
-    relay's 502 confirm-failure, and the 502 `confirmed: null`. All three
-    follow a review the engine answered 200, which is what mints it.
     """
     body = _code_only(_submit_handler(page))
     anchors = ("res.r.status === 409",
@@ -525,20 +558,29 @@ def test_the_forbidden_claims_guard_is_not_defeated_by_capitalisation(page):
     """
     body = _code_only(_submit_handler(page)).lower()
     for claim in ("submission rejected", "was rejected", "did not go through",
-                  "nothing was sent"):
+                  "nothing was sent",
+                  # Added with the QA #566 fix. This is the HIGH's own
+                  # sentence: it was printed from the page's own text, off a
+                  # status that is set at commit, for a caller that may have
+                  # no confirmation anywhere. The relay may still send it in
+                  # `message` on the one branch that observed the mint; the
+                  # page may never assert it on its own authority.
+                  "approval is recorded"):
         assert claim not in body, (
             f"the page can print {claim!r} without knowing it")
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "QA #566: checkStatus handles 'sent', 'pending' and 'approved', none of "
-    "which _TRANSITIONS can produce, and handles none of 'executing', "
-    "'failed', 'needs_review', 'expired' or 'unknown', all of which it can. "
-    "A form-fill confirm reaches 'failed' on a deployment with no provider "
-    "configured — verified against a running engine — so the #220 third "
-    "answer, the case checkStatus exists for, terminates at 'we still cannot "
-    "tell whether your approval went through' while the status says it ran. "
-    "Fixing this reddens the pin: update it in the same PR."))
+# QA #566 (MEDIUM), filed as a strict xfail and fixed here, so the marker is
+# gone and the reason is kept as the record of what it caught:
+#
+#   checkStatus handled 'sent', 'pending' and 'approved', none of which
+#   _TRANSITIONS can produce, and none of 'executing', 'failed',
+#   'needs_review', 'expired' or 'unknown', all of which it can. A form-fill
+#   confirm reaches 'failed' on a deployment with no provider configured —
+#   verified against a running engine — so the #220 third answer, the case
+#   checkStatus exists for, terminated at "we still cannot tell whether your
+#   approval went through" while the status said it ran.
+
 def test_the_poll_reads_statuses_the_state_machine_can_actually_produce(page):
     """The poll's vocabulary against the state machine's, both read from source.
 
@@ -570,3 +612,140 @@ def test_the_poll_reads_statuses_the_state_machine_can_actually_produce(page):
         f"checkStatus has no arm for {unhandled}, so each falls through to "
         f"the terminal 'we still cannot tell whether your approval went "
         f"through' — an unknown outcome reported for a status that is known.")
+
+
+# --- QA #566 MEDIUM 2: a gateway that spoke for a service that said nothing --
+#
+# `_upstream_answered` (careagents/healthclaw.py) is the project's rule for
+# this on the server side: a 4xx other than 408/429 is somebody's decision
+# about the request; a 5xx is a gateway speaking for an upstream that may
+# already have run the thing. The page had no such rule. It keyed its honest
+# arms on bodies the RELAY writes, so a gateway 502 carrying JSON — no
+# `confirmed` key, nothing the relay would ever send — fell to the red arm
+# with a machine string as the message and Approve still armed. That is the
+# #416 shape, one body shape over from the unreadable branch that handles it.
+
+
+def _poll_body(page: str) -> str:
+    """checkStatus only, comment-stripped."""
+    body = _code_only(_submit_handler(page))
+    return body[body.index("function checkStatus"):]
+
+
+def _answered_predicate(page: str) -> str:
+    """The body of the page's own `answeredAboutRequest`.
+
+    It is defined outside the submit handler, so `_submit_handler` does not
+    reach it.
+    """
+    m = re.search(r"function answeredAboutRequest\(status\) \{(.*?)\n    \}",
+                  page, re.S)
+    assert m, "the page's status predicate moved or was renamed"
+    return m.group(1)
+
+
+def test_the_page_classifies_a_status_exactly_as_the_relay_does(page):
+    """Equivalence, not resemblance.
+
+    The page now answers the same question `_upstream_answered` answers — did
+    anyone actually decide about this request — and two implementations of one
+    rule drift. So evaluate the page's expression and the relay's predicate
+    over the statuses that reach this handler and require the same answer,
+    rather than checking that the JS looks about right.
+
+    MUTATION: drop `status !== 408` from the page's predicate -> red.
+    """
+    from careagents.healthclaw import HealthClawClient
+
+    src = _answered_predicate(page).strip()
+    expr = src.removeprefix("return").rstrip(";").strip()
+    py = expr.replace("&&", "and").replace("!==", "!=")
+    assert "||" not in py and "===" not in py, (
+        "the predicate was re-expressed in a form this guard cannot "
+        "translate; re-express the guard with it rather than deleting it")
+
+    for status in (200, 400, 401, 403, 404, 408, 409, 422, 429,
+                   500, 502, 503, 504):
+        assert eval(py, {"status": status}) is \
+            HealthClawClient._upstream_answered(status), (
+            f"the page and the relay disagree about {status}: one calls it "
+            f"an answer about the request and the other calls it silence")
+
+
+def test_a_5xx_the_relay_did_not_write_is_not_rendered_as_a_refusal(page):
+    """MUTATION: delete the `!relayAnswered` branch -> red.
+
+    Every answer the relay writes on this route carries `confirmed` (its two
+    502s) or the `review_unavailable` code (its 503s). A 5xx with neither is
+    a gateway's, and nothing about it says the relay did not run the whole
+    submit — so it must not be painted as a definite failure, and Approve
+    must not be left armed under it.
+    """
+    body = _code_only(_submit_handler(page))
+    assert "relayAnswered" in body, (
+        "nothing distinguishes an answer the relay wrote from one a gateway "
+        "wrote, so a gateway 5xx renders as a refusal of the approval")
+    block = _block(body, "!relayAnswered")
+    assert "alert-danger" not in block, (
+        "a gateway 5xx is silence with a status code on it; painting it red "
+        "tells the patient their approval was refused, which nobody observed")
+    assert re.search(r"btn\.disabled\s*=\s*true", block), (
+        "the branch leaves Approve armed on a request that may already have "
+        "been submitted and confirmed")
+    assert "reload" in block.lower(), (
+        "the branch states an uncertainty and offers nothing to resolve it "
+        "(#419); it cannot poll, because it has not established that the "
+        "relay ran at all")
+    assert body.index("!relayAnswered") < body.index("alert alert-danger"), (
+        "the branch sits below the generic failure arm and can never run")
+
+
+def test_the_branch_that_cannot_poll_does_not_poll(page):
+    """The other half of the call-site guard, from the new branch's side.
+
+    MUTATION: add `checkStatus();` to the `!relayAnswered` branch -> red here
+    AND in the call-site guard above.
+    """
+    assert "checkStatus()" not in _block(_code_only(_submit_handler(page)),
+                                         "!relayAnswered"), (
+        "a branch with no evidence the relay ran polls for the status of the "
+        "request it may never have made")
+
+
+# --- the instruction that strands a patient mid-approval --------------------
+
+
+def test_the_poll_never_tells_the_patient_not_to_approve_again(page):
+    """The terminus ended "Please do not approve a second time."
+
+    Reachable now from a caller whose review may never have been saved (the
+    unreadable answer to the review POST, QA #566 HIGH). Obeyed there, the
+    request is never made at all. The page may say a second approval cannot
+    send it twice — the review route answers 409 once a confirmation exists —
+    but it may not forbid one, because on that path re-approving is the whole
+    recovery.
+
+    MUTATION: restore the clause in either terminal arm -> red.
+    """
+    body = _poll_body(page).lower()
+    for instruction in ("do not approve", "don't approve", "not approve a"):
+        assert instruction not in body, (
+            f"the poll tells the patient {instruction!r}. On the "
+            f"unreadable-answer path that instruction is the difference "
+            f"between a request that gets made and one that does not")
+
+
+def test_every_terminal_arm_of_the_poll_offers_a_way_forward(page):
+    """A terminus that says "we cannot tell" and stops is where #419 started.
+
+    MUTATION: drop the reload sentence from either terminal arm -> red.
+    """
+    body = _poll_body(page)
+    ends = [m.start() for m in re.finditer("still cannot tell", body)]
+    assert len(ends) == 2, (
+        f"expected the two terminal arms (the poll's own and its .catch), "
+        f"found {len(ends)}")
+    for at in ends:
+        assert "Reload this page" in body[at:at + 400], (
+            "a terminal arm reports an unknown outcome and offers nothing "
+            "the patient can do about it")

--- a/tests/test_review_says_what_it_knows.py
+++ b/tests/test_review_says_what_it_knows.py
@@ -268,6 +268,17 @@ def _block(js: str, anchor: str) -> str:
     raise AssertionError(f"unbalanced block after {anchor!r}")
 
 
+def _condition(js: str, anchor: str) -> str:
+    """The text from `anchor` to the `{` that opens its branch.
+
+    `_block` returns the branch BODY, so a guard about what a branch is keyed
+    ON has to read this instead — two of these guards were written against
+    `_block` first and passed nothing, because the condition is not in it.
+    """
+    start = js.index(anchor)
+    return js[start:js.index("{", start)]
+
+
 def test_the_json_parse_has_a_catch(page):
     """MUTATION: delete the `.catch` after `r.json()` -> red.
 
@@ -473,6 +484,25 @@ def test_the_awaiting_confirmation_arm_says_only_what_the_status_carries(page):
         "needs a destination)")
 
 
+def test_the_unknown_branchs_own_fallback_is_true_for_both_its_producers(page):
+    """A fallback is a sentence too, and this one gained a second producer.
+
+    `confirmed: null` was written for one case — the confirm went out and was
+    never answered, where the review HAD been saved. It now also carries the
+    answer to a review POST that nobody could read, where it may not have
+    been. The server sends a message on both, so the fallback fires only if
+    one is missing; it still may not assert what only one producer knows.
+
+    MUTATION: restore "Your review was saved." as the fallback -> red.
+    """
+    block = _block(_code_only(_submit_handler(page)),
+                   "res.b.confirmed === null")
+    assert "review was saved" not in block, (
+        "the unknown branch's fallback claims the review was saved. One of "
+        "its two producers is an answer nobody could read, where nothing "
+        "observed says it was")
+
+
 def test_the_relay_confirm_failure_gets_the_destination_it_points_at(page):
     """The other half of the loop.
 
@@ -559,9 +589,14 @@ def test_check_status_is_only_called_where_the_relay_answered(page):
     MUTATION: add `checkStatus();` to the `!res.reached` branch -> red.
     """
     body = _code_only(_submit_handler(page))
+    # The 404 was added to this list, not around it: it is the engine's own
+    # answer about this action — ownership was verified before the submit, so
+    # the action exists and is this tenant's — which is exactly the property
+    # the list encodes. The two branches deliberately outside it still are.
     anchors = ("res.r.status === 409",
                "res.b.confirmed === null",
-               "res.r.status === 502 &&")
+               "res.r.status === 502 &&",
+               "res.r.status === 404 &&")
     allowed = []
     for anchor in anchors:
         block = _block(body, anchor)
@@ -706,11 +741,6 @@ def test_a_body_that_parses_but_is_not_an_object_is_unreadable(page):
     assert "readable: false" in parse
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "QA on the finished stack (#550 -> #566 -> #579). The 409 branch removed "
-    "the #416 shape for a request still awaiting confirmation; the same shape "
-    "survives one status code over, for a request that was approved AND ran. "
-    "Fix needs a sentence about state, which is Dev's call, not QA's."))
 def test_an_action_that_moved_on_is_not_rendered_as_a_bare_failure(page):
     """Second tab, or the back button, after the approval went through.
 
@@ -734,19 +764,40 @@ def test_an_action_that_moved_on_is_not_rendered_as_a_bare_failure(page):
     read the body, not just the status; that is the part that is a claim
     about state rather than presentation, which is why QA pinned it instead
     of writing it.
+
+    Fixed here, and the pin's marker removed with it. The properties below
+    are the ones the browser walk measured as wrong, so the guard checks each
+    rather than only that a branch exists — a 404 arm that still painted red,
+    or still re-armed Approve, would have satisfied the original assertion.
+
+    MUTATION: delete the branch; render it `alert-danger`; leave the button
+    enabled; drop the `not yours` exclusion; drop `checkStatus()` -> red, one
+    at a time.
     """
     body = _code_only(_submit_handler(page))
     assert re.search(r"res\.r\.status\s*===\s*404", body), (
         "no branch handles the 404 a second approval gets once the action "
         "has moved on, so an approved-and-executed request renders as a red "
         "'Unknown action' with Approve re-armed")
+    block = _block(body, "res.r.status === 404")
+    assert "alert-danger" not in block, (
+        "the action was approved and ran; painting that as a failure is the "
+        "shape the 409 branch exists to remove")
+    assert re.search(r"btn\.disabled\s*=\s*true", block), (
+        "Approve is re-armed for an action that no longer accepts one — a "
+        "further tap answers 404 again")
+    assert "not yours" in _condition(body, "res.r.status === 404"), (
+        "the relay's own 404 is `{'error': 'not yours'}`, a denial about the "
+        "account rather than about the action's state; without excluding it "
+        "this branch tells someone else's form it merely moved on")
+    assert "checkStatus()" in block, (
+        "the branch says the request is no longer waiting and then abandons "
+        "it (#419). Claimed-and-ran and expired both reach this 404, and "
+        "only the status tells them apart")
+    assert body.index("res.r.status === 404") < body.index("alert alert-danger"), (
+        "the 404 branch sits below the generic failure arm and can never run")
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "QA on the finished stack (#550 -> #566 -> #579). A session that expires "
-    "while the form is open is reported as an unknown approval outcome, on a "
-    "page whose primary device is a phone in an in-app browser. The page has "
-    "the evidence and does not read it. Fix names a state, so Dev's call."))
 def test_a_signed_out_submit_is_not_reported_as_an_unknown_outcome(page):
     """The patient left the form open and the cookie expired.
 
@@ -771,12 +822,39 @@ def test_a_signed_out_submit_is_not_reported_as_an_unknown_outcome(page):
     template, with the submit answered `200 text/html`. The 302 mechanics
     are read from `login_required`, not driven through a genuinely expired
     session.
+
+    Fixed here, and the pin's marker removed with it. Three properties, not
+    one: the redirect has to be READ, the branch has to run before the
+    unreadable arm that used to swallow it, and it has to leave Approve
+    alone — signing in and tapping Approve is the whole recovery, so a
+    branch that reads the redirect and still disables the button fixes only
+    the sentence.
+
+    Keyed on the destination too. A redirect somewhere that is not our
+    sign-in page is not evidence about the session, and must keep falling
+    through to the unreadable branch.
+
+    MUTATION: delete the branch; move it below `!res.readable`; disable the
+    button in it; drop the URL test -> red, one at a time.
     """
     body = _code_only(_submit_handler(page))
     assert "res.r.redirected" in body, (
         "the page cannot tell a signed-out submit from an unreadable answer, "
         "so an expired session is reported as an approval whose outcome is "
         "unknown, with Approve disabled")
+    assert body.index("res.r.redirected") < body.index("!res.readable"), (
+        "the redirect is read after the unreadable branch, which returns "
+        "first — the sign-in page parses as unreadable, so the new branch "
+        "can never run")
+    block = _block(body, "res.r.redirected")
+    assert "auth" in _condition(body, "res.r.redirected"), (
+        "the branch treats ANY redirect as a sign-out. A captive portal or "
+        "an enterprise proxy says nothing about the session, and claiming it "
+        "does is the same shape one layer out")
+    assert re.search(r"btn\.disabled\s*=\s*false", block), (
+        "Approve is taken away from a patient whose only problem is an "
+        "expired cookie, on the one branch where nothing was submitted and "
+        "a second tap is the recovery")
 
 
 # QA #566 (MEDIUM), filed as a strict xfail and fixed here, so the marker is

--- a/tests/test_review_says_what_it_knows.py
+++ b/tests/test_review_says_what_it_knows.py
@@ -373,9 +373,12 @@ def test_the_fetch_itself_has_a_catch(page):
 def test_an_unreachable_service_leaves_the_button_enabled(page):
     """The ruling, pinned. MUTATION: set `btn.disabled = true` here -> red.
 
-    Deliberately the opposite of every sibling branch, which is exactly why
-    it needs a guard: the next person to tidy these into one shape would
-    disable it for consistency and strand the patient.
+    The opposite of most sibling branches, which is exactly why it needs a
+    guard: the next person to tidy these into one shape would disable it for
+    consistency and strand the patient. It read "every sibling branch" until
+    the relay's own 503s were ruled the same way for the same reason; the
+    sentence had outlived the fact, which is the thing this file exists to
+    catch, so it is stated as it is rather than as it was.
     """
     block = _block(_code_only(_submit_handler(page)), "!res.reached")
     assert "btn.disabled = false" in block, (
@@ -737,6 +740,43 @@ def test_an_action_that_moved_on_is_not_rendered_as_a_bare_failure(page):
         "no branch handles the 404 a second approval gets once the action "
         "has moved on, so an approved-and-executed request renders as a red "
         "'Unknown action' with Approve re-armed")
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "QA on the finished stack (#550 -> #566 -> #579). A session that expires "
+    "while the form is open is reported as an unknown approval outcome, on a "
+    "page whose primary device is a phone in an in-app browser. The page has "
+    "the evidence and does not read it. Fix names a state, so Dev's call."))
+def test_a_signed_out_submit_is_not_reported_as_an_unknown_outcome(page):
+    """The patient left the form open and the cookie expired.
+
+    `/review/<agent>/<action>/submit` is not under `/api/`, so
+    `login_required` answers a 302 to the sign-in page rather than a 401
+    (careagents/app.py:189-192). `fetch` follows redirects by default, so
+    what arrives is `200 text/html` — the login page. That parses as
+    unreadable, and the page says, verbatim in a browser at 390x844:
+
+        alert alert-warning / Approve DISABLED
+        "We could not read the answer to your approval, so we cannot tell
+         you whether it went through. We have not sent it again. Reload
+         this page to see where this request stands."
+
+    Nothing was submitted and nothing could have been: the request never
+    passed the session gate. The screen reports an unknown approval
+    outcome, takes the only control away, and points at a reload that lands
+    on a sign-in page saying nothing about the request. `res.r.redirected`
+    and `res.r.url` are both on the response and neither is read.
+
+    Scope: the rendering above was executed in a browser against the real
+    template, with the submit answered `200 text/html`. The 302 mechanics
+    are read from `login_required`, not driven through a genuinely expired
+    session.
+    """
+    body = _code_only(_submit_handler(page))
+    assert "res.r.redirected" in body, (
+        "the page cannot tell a signed-out submit from an unreadable answer, "
+        "so an expired session is reported as an approval whose outcome is "
+        "unknown, with Approve disabled")
 
 
 # QA #566 (MEDIUM), filed as a strict xfail and fixed here, so the marker is


### PR DESCRIPTION
Answers the QA reviews of #566 and of the finished stack. Three rounds on one
shape — a sentence that claims an outcome nobody observed — so the third round
started with an inventory instead of a fix.

## The inventory

Every patient-facing string in `careagents/app.py` and
`templates/action_review.html` that claims something was **sent, approved,
recorded, or can be retried**, with a verdict against *every* path that reaches
it. Two rounds of this stack fixed the sentence in front of them and left the
twin; this is the list that stops that.

### `careagents/app.py`

| # | Where | Claim | Verdict |
|---|---|---|---|
| A1 | `_REVIEW_UNCHECKABLE` — 4 sites: review GET ownership, review GET unanswered, submit ownership | "Nothing has been approved — please try again in a moment." | **TRUE on every path.** Every site fails *before* any review POST goes out: the ownership pre-check, or the GET, which has no side effect. |
| A2 | `_REVIEW_UNRESOLVED` — 3 sites: submit transport loss, submit gateway 5xx, submit unreadable 200 | "We couldn't tell whether your review was saved. Reload… before approving again." | **FIXED this PR** (round 2). Was "Nothing has been approved… approving twice could send it twice" — false in both halves. |
| A3 | confirm-unanswered arm | was: "Don't approve again yet… **because approving twice could send it twice**" | **FIXED this round.** The reviewer's headline. See below. |
| A4 | confirm-failed arm | "Your review was saved and your approval is recorded, but we could not complete it just now. Approving again here will not resend it." | **TRUE.** Reached only after a decodable 200 (review saved, confirmation minted) and a refused mint or an engine 4xx on confirm, so the action is still `awaiting_confirmation` and a second submit answers 409. |
| A5 | review GET, engine's own 4xx | "This form is no longer awaiting review." | **TRUE** — guarded by `_answered_about_data`, so only the engine's own answer reaches it. |
| A6 | connection delete, purge failed | was: "Your records were not deleted. **Nothing was changed** — please retry." | **FIXED this round.** `purge_tenant` raises on any non-200 *and* on a read timeout, so a gateway 5xx can follow a purge that ran. Same claim, same shape, on the destructive route. Found by this inventory, not by a report. |
| A7 | `home.js` fallback for A6 | was: "Your records were not deleted." | **FIXED this round** — it would have reintroduced the claim the server stopped making. |
| A8 | refresh unavailable | "We couldn't reach your records right now… we'll keep checking." | **TRUE** — a stall, no outcome claimed. |
| A9 | chat unavailable | "Chat is temporarily unavailable. Try again soon." | **TRUE** — no outcome claimed. |

### `templates/action_review.html`

| # | Branch | Claim | Verdict |
|---|---|---|---|
| P1 | gate | "Ready to generate. The server will re-verify every item on submit." | **TRUE** — the review route re-populates from FHIR and re-checks every row. |
| P2 | fetch rejected | "We could not reach the service, so we cannot tell you whether your approval was sent." | **TRUE.** |
| P3 | signed out | was: routed to P4 and reported as an unknown approval outcome | **FIXED this round.** |
| P4 | unreadable body | "We could not read the answer… We have not sent it again." | **TRUE** for what still reaches it, once the signed-out case is split out ahead of it. |
| P5 | `r.ok` | "Review recorded. " + `next_step` | **TRUE** — a decodable 200 from the engine. |
| P6 | 409 | "You have already approved this request." | **TRUE** — the 409 fires only where a confirmation exists. |
| P7 | **404, engine** | was: red + "Unknown action" + Approve re-armed | **FIXED this round.** |
| P8 | 404, relay's `not yours` | "not yours" | **TRUE** — a denial about the account, reached only when the engine says the action is absent for this tenant. Presented as a machine string; noted below, not fixed. |
| P9 | `confirmed === null` fallback | was: "Your review was saved. We are checking whether the approval went through." | **FIXED this round.** The branch gained a second producer in round 1 (an unreadable answer to the review POST) and the fallback was not true for it. |
| P10 | `502 && confirmed === false` fallback | "Your review was saved, but we could not complete your approval." | **TRUE** — single producer, always after a decodable 200. |
| P11 | 5xx the relay did not write | "We could not tell what happened to your approval… We have not sent it again." | **TRUE.** |
| P12 | relay 503 stall fallback | "We could not tell whether your review was saved." | **TRUE.** |
| P13 | danger fallback | "We could not record your review. Please try again." | **TRUE** once P7 is split out: what remains are answered 4xx refusals, where nothing was recorded. It was **false for the 404** before this round — that is P7. |
| P14 | poll `completed` | "Your approval went through and this request was carried out." | **TRUE.** |
| P15 | poll `executing` | "…being carried out now." | **TRUE** — reachable only through a spent approval grant. |
| P16 | poll `needs_review` | "Your approval went through. This request needs a person to look at it…" | **TRUE.** |
| P17 | poll `failed` | "Your approval went through and this request could not be completed. Approving again will not retry it." | **TRUE** — measured: a submit on a `failed` action answers 404. |
| P18 | poll `unknown` | "We cannot tell whether this request went out. We have not sent it again…" | **TRUE.** |
| P19 | poll `awaiting_confirmation` | "…If you need to approve it again, reload this page first — a second approval cannot send it twice." | **TRUE** — measured: 409 where a confirmation exists, one ordinary send where none does. (The reviewer's LOW about the reload→409 loop stands: true, but it cannot unstick a lost confirm.) |
| P20 | poll `expired` | "This request expired before it was carried out, and it cannot be approved now." | **TRUE.** |
| P21 | poll terminal ×2 | "We still cannot tell… so we have not sent it again." | **TRUE.** |
| P22 | **NEW** signed out | "Your sign-in expired, so this approval was not submitted." | **TRUE** — `login_required` returns before the handler, so nothing was submitted; keyed on the redirect landing on `/auth`. |
| P23 | **NEW** 404, engine | "This request is no longer waiting for your approval. We are checking where it stands." | **TRUE** — ownership was verified before the submit, so the only reading left is that the action left `awaiting_confirmation`. |

## The three fixes

### The confirm arm — `careagents/app.py`

> was: "Don't approve again yet — check the request's status first, **because approving twice could send it twice**."

False since #550. A second approval reaches the **review** route, which answers
409 while the action is awaiting confirmation and 404 once it has moved on;
`confirm_action` is called only on a decodable 200, so it is never reached
twice. This PR's own body argued that to justify rewriting `_REVIEW_UNSUBMITTED`
and then left the identical sentence one arm over. It is not rare: it is what an
ordinary form-fill approval reaches on any deployment with no provider
configured.

> now: "Your review was saved. We couldn't tell whether your approval went
> through, so we have not tried it again. We are checking where this request
> stands."

Nothing guarded it, and one thing actively held it in place:
`test_review_submit_does_not_claim_nothing_was_sent_when_it_cannot_tell`
asserted `"twice" in msg`. It pinned the sentence rather than the property, so
it kept the sentence after the property had gone — which is how this survived
two rounds of its siblings being corrected. It now pins the property.

### A 404 after the action moved on — `templates/action_review.html`

`_load_form_fill_action` requires `awaiting_confirmation` and runs before the
409 pre-check, so once the confirm has claimed the action a second submit
answers 404 `{"error": "Unknown action"}`. That rendered **red, a machine
string, Approve re-armed** — for a request that was approved and did run. The
ordinary two-tab and back-button outcome.

It now states the one thing the 404 establishes — the action has left
`awaiting_confirmation` — and polls, because *claimed-and-ran* and *expired*
both land here and only the status separates them. Driven: `failed` →
"Your approval went through and this request could not be completed";
`completed` → "Confirmed…"; `expired` → "This request expired…". The relay's
own `{"error": "not yours"}` is excluded and keeps the failure arm.

The checkStatus call-site allowlist gained this anchor rather than being worked
around: the 404 is the engine's own answer about this action — ownership was
verified before the submit went out — which is exactly the property that list
encodes. The two branches deliberately outside it still are.

### A session expiring mid-approval — both files

The route is not under `/api/`, so `login_required` answers a 302 to `/auth`;
`fetch` follows it and the sign-in page arrives as `200 text/html`, which parses
as unreadable. The page reported an approval whose outcome it could not
determine and **took Approve away** — when nothing was submitted and nothing
could have been.

> now: "Your sign-in expired, so this approval was not submitted. Sign in again
> in another tab, then approve here."

Approve stays armed: signing in and tapping it is the whole recovery, and the
other-tab route keeps the decisions already entered. Keyed on the destination as
well as the redirect — a captive portal or an enterprise proxy says nothing
about the session and still falls through to the unreadable branch.

## The lesson from the guard normalisation

Taken as given, but worth recording next to the inventory: the forbidden-claims
guard was defeated by the page's own house style, because every message here is
built as `'half a ' + 'sentence'` and the guard compared literals. A guard that
the codebase's ordinary idiom evades is not a guard. Two of *my* new guards in
this round had the same defect from the other end — they read `_block`, which
returns a branch's body, while asserting things about what the branch is keyed
**on**, so they passed against nothing. A `_condition` helper now reads the
`if (…)` and both were re-pointed at it.

## Base note

Stacks on **#566** (`fix/approve-page-handles-409`), which stacks on **#550**
(`fix/528-payload-immutable-after-confirmation`). Read the diff against #566.
Merge order: #550, then #566, then this.

## Earlier rounds, kept for the reviewer

### The worst thing found in this stack

Pre-fix, with a working token mint, an unreadable answer to the review POST did
not merely produce a false sentence. **The relay spent the approval grant on a
review the engine never received.** Against a real engine through a proxy that
answers the review POST `200 text/html` without forwarding it:

```text
engine status at commit: awaiting_confirmation
relay -> HTTP 502
engine status now:       failed
```

The one-time grant was minted, the confirm issued, the action claimed, and it
died terminal — with the patient's decisions never recorded, and the patient
told their approval was recorded. Post-fix the action stays
`awaiting_confirmation` and no confirm is issued. **Bound, tested: not a breach
of the human gate** — `form_fill.py` refuses without a `reviewed_qr_id` and
returns `needs_review`; no form is produced.

### Round 1 — an unreadable 200 is not a saved review

`submit_review` was the one method that opted out of the rule `_json_object`
states four lines above it. Its success path now decodes through `_json_object`
and raises `HealthClawUnconfirmed`; the relay answers `confirmed: null`, the
third answer (#220), because both neighbouring sentences are false in opposite
directions. A non-2xx keeps the `(status, dict)` contract, so the engine's own
refusal still reaches the page as a refusal.

### Round 1 — the poll ignored the states that actually happen

`sent`, `pending` and `approved` dropped (`_TRANSITIONS` cannot produce them);
arms added for `executing`, `failed`, `needs_review`, `expired` and `unknown`.
The `awaiting_confirmation` arm no longer claims a recorded approval — that
status is set at COMMIT, and `/api/form/` returns the status alone.

### Round 1 — a gateway 5xx the relay did not write

Routed to the unknown copy rather than the failure arm, disabled, pointing at a
reload, and it does not poll. The page classifies statuses with the same rule as
`_upstream_answered`, checked by evaluating both over the same statuses.

### Round 2 — the same claim on the two sibling submit arms

`_REVIEW_UNSUBMITTED` said "Nothing has been approved" on a gateway 5xx and on a
transport loss, where the POST may have been delivered and minted. Measured, on
the same engine:

```text
BEFORE  "…Nothing has been approved — …because approving twice could send it twice."
        second approval -> HTTP 409          # a confirmation was on file
AFTER   "We couldn't tell whether your review was saved. Reload this page…"
        second approval -> HTTP 409          # unchanged, and now not deterred
```

## Ran

```text
uv run python -m pytest tests/ -q -p no:cacheprovider
3201 passed, 13 skipped, 1 xfailed, 2 warnings in 118.75s

uv run ruff check .
All checks passed!

uv run python -m pytest tests/test_ratchets.py tests/test_guardrail_conformance.py \
  tests/test_conformance_endpoint.py tests/test_conformance_report_never_contradicts_itself.py -q
65 passed in 3.20s          # conformance grade A intact
```

Baseline on #566 was `3183 passed, 13 skipped, 3 xfailed`. All five strict
xfails filed against this stack — two on #566, three on the finished stack —
now pass as ordinary tests, markers removed, reasons kept as comments.

**Twenty-six mutations across the three rounds, each red at its named test.**
This round: restore the deterrent on the confirm arm; delete the 404 branch;
paint it red; let it swallow `not yours`; drop its `checkStatus()`; delete the
signed-out branch; disable Approve in it; ignore the redirect destination;
restore "your review was saved" in the unknown fallback; restore "Nothing was
changed" on the delete route.

**The page's real submit handler driven through eleven answer shapes** under a
stub DOM in node, including all three new branches and every branch they sit
between, so branch selection is executed rather than read.

## What was NOT run

- **No browser this round.** The reviewer's walk was in Chromium at 390×844; the
  node drive executes branch logic only and says nothing about CSS or layout.
- The 302 mechanics are read from `login_required`, not driven through a
  genuinely expired session (same scope note the reviewer recorded).
- No genuinely concurrent double submit inside the mint→confirm window.
- Telegram and dashboard approve surfaces untouched.
- `dependency-audit` is red on every open PR from npm advisories already fixed
  in unmerged **#544**.

## Noticed, deliberately not touched

- **P8**: the relay's `not yours` 404 renders as the bare machine string in the
  failure style with Approve armed. The claim is true; the presentation is poor.
  Out of the reviewed scope.
- The reviewer's LOW: where a confirmation exists but the confirm never landed,
  reload → 409 → poll → the same sentence, until `expires_at`. Every sentence in
  that loop is true; `/api/form/` cannot separate the sub-states.
- Nothing retries a failed confirm; such an action expires.

## Note on the scratchpad

It is shared between agents — the first round's mutation script was overwritten
mid-task by another agent's script targeting `r6/routes.py`. Nothing reached
this worktree; everything since is under uniquely named files.
