### PR TITLE
candidate: one doubling of thread headroom, and a health check that answers for itself (#219)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -45,6 +45,16 @@ logger = logging.getLogger(__name__)
 # strongest privacy control in the one place people read carefully.
 CONSENT_VERSION = "2026-08-01"
 
+# `/healthz` asks HealthClaw whether a run worker is present. That call gets
+# its own budget rather than the client's 25s chat timeout: as a
+# `(connect, read)` pair the worst case is 2.0s of network wait, which fits
+# inside the 4s the container probe allows (`careagents/healthcheck.py`) and
+# the Dockerfile's `HEALTHCHECK --timeout=5s`. The probe measured the old
+# shape taking 25.01s to answer at zero load, purely because it inherited the
+# chat timeout (docs/evidence/2026-09-03-probe-219-thread-saturation.md §8,
+# PR #573).
+_HEALTHZ_WORKER_TIMEOUT = (1.0, 1.0)
+
 # Local hard cap for the file-upload path (#227). The engine's
 # `internal/ingest-bundle` is the source of truth for the value; this
 # ceiling stops an oversized (or chunked / no-Content-Length) request
@@ -811,9 +821,10 @@ def create_app(config: Config | None = None,
     WORKERS_READY, WORKERS_NOT_READY, WORKERS_UNKNOWN = (
         "ready", "not_ready", "unknown")
 
-    def _worker_state() -> str:
+    def _worker_state(timeout=None) -> str:
         try:
-            status = hc.agent_worker_health(cfg.run_worker_stale_seconds)
+            status = hc.agent_worker_health(cfg.run_worker_stale_seconds,
+                                            timeout=timeout)
         except HealthClawError:
             return WORKERS_UNKNOWN
         return WORKERS_READY if status.get("available") else WORKERS_NOT_READY
@@ -838,7 +849,21 @@ def create_app(config: Config | None = None,
             "type": "accepted", "run_id": run_id,
             "next_cursor": cursor}) + "\n\n"
         while time.monotonic() - started < cfg.run_sse_timeout_seconds:
-            page = hc.agent_run_events(tenant, run_id, after=cursor, limit=100)
+            try:
+                page = hc.agent_run_events(tenant, run_id, after=cursor,
+                                           limit=100)
+            except HealthClawError:
+                # Without this the generator dies inside an open response and
+                # the browser is left with a stream that stopped for no stated
+                # reason (#219). Only this projection ends: the run is durable
+                # and keeps going, and a reconnect resumes at `cursor`. The
+                # text is the same generic sentence every other failure uses —
+                # an exception message here would be the first place engine
+                # internals reached a patient's screen.
+                logger.warning("run event stream failed for tenant %s", tenant)
+                yield "data: " + json.dumps({
+                    "type": "error", "text": GENERIC_FAILURE_TEXT}) + "\n\n"
+                return
             events = page.get("events") or []
             for event in events:
                 cursor = max(cursor, int(event.get("id") or 0))
@@ -1356,11 +1381,29 @@ def create_app(config: Config | None = None,
         load balancer would route real sign-ins straight into failure. It now
         round-trips a trivial query so the answer reflects reality.
 
-        Readiness has two inputs, and both gate the status code: the account
-        store must answer, and a fresh agent-run worker must be present. A
-        deployment with no worker can serve pages but cannot complete a chat
-        turn, so advertising it as ready would route people into failure the
-        same way the hard-coded accounts=True once did.
+        Readiness has two inputs and they are NOT symmetric (#219). The
+        account store is ours, so it gates the status code outright. The run
+        workers are HealthClaw's, so what gates the status code is their
+        ANSWER, not our ability to get one:
+
+        - Confirmed absent — HealthClaw answered, and no worker presence is
+          fresh. That deployment serves pages and cannot finish a chat turn.
+          It is the web-only deployment the durable-worker runbook tells
+          operators to expect a 503 for, and it stays a 503 deliberately: on
+          Railway the health check runs at the start of a deploy, and this is
+          a deploy that must not go live.
+        - Could not ask, inside `_HEALTHZ_WORKER_TIMEOUT` — that is a fact
+          about HealthClaw, not about this container. Reported as
+          `run_workers_state: "unknown"`; it does not fail the endpoint.
+          Failing it would block a CareAgents deploy on someone else's
+          outage, including the deploy that fixes it, while traffic stays on
+          a previous version with exactly the same dependency. The probe
+          measured the old shape taking 25.01s to answer 503 with nothing
+          running at all (evidence §8, PR #573).
+
+        Admission is unchanged, and it is the gate that protects people:
+        `POST /api/chat` still refuses a turn in BOTH states, so nothing
+        routes anyone into a turn no worker can run.
 
         It also reports which build is running (#258). That is telemetry, not
         a gate: an absent marker reports "unknown" and changes nothing about
@@ -1371,14 +1414,18 @@ def create_app(config: Config | None = None,
         including dependencies it does not control.
         """
         accounts_ok = svc.ping()
+        workers_state = _worker_state(timeout=_HEALTHZ_WORKER_TIMEOUT)
         # `run_workers` stays a boolean readiness VERDICT, not a claim about
         # the workers: false is correct when we could not confirm them, and
         # two runbooks plus the container-roles test read it as a bool.
-        workers_ok = _worker_state() == WORKERS_READY
-        ready = accounts_ok and workers_ok
+        # `run_workers_state` carries the claim the bool cannot make (#410) —
+        # and now also the difference the status code turns on.
+        workers_ok = workers_state == WORKERS_READY
+        ready = accounts_ok and workers_state != WORKERS_NOT_READY
         body = {"status": "ok" if ready else "degraded",
                 "provider": cfg.provider, "accounts": accounts_ok,
                 "run_workers": workers_ok,
+                "run_workers_state": workers_state,
                 "build": cfg.build_sha, "built_at": cfg.build_time}
         return jsonify(body), (200 if ready else 503)
 

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -55,6 +55,23 @@ CONSENT_VERSION = "2026-08-01"
 # PR #573).
 _HEALTHZ_WORKER_TIMEOUT = (1.0, 1.0)
 
+# The same call on the ADMISSION path (`POST /api/chat`, and the iMessage
+# relay ingress). It gets its own budget rather than sharing the readiness
+# probe's, because the stakes are opposite: `/healthz` must answer inside a
+# platform probe window and a wrong answer costs a deploy, while a turn
+# refused too eagerly costs a patient their question. A worker-health call
+# does two database round-trips on the engine that also serves clinicians, so
+# 1s of read is too tight to refuse a real user on.
+#
+# Left unbounded, this inherits the client's 25s CHAT timeout — measured at
+# 25.00s against a HealthClaw that accepts the connection and never answers.
+# That is a gunicorn thread held for 25 seconds *to refuse a turn*, in exactly
+# the dependency outage `/healthz` now reports as `unknown` and lets deploy,
+# and it eats the thread headroom this same change bought. 4s is a ceiling
+# chosen to end the 25s hold while leaving room for a loaded engine; it is not
+# a measured optimum, and a p99 from production should replace it.
+_ADMISSION_WORKER_TIMEOUT = (1.0, 3.0)
+
 # Local hard cap for the file-upload path (#227). The engine's
 # `internal/ingest-bundle` is the source of truth for the value; this
 # ceiling stops an oversized (or chunked / no-Content-Length) request
@@ -818,26 +835,57 @@ def create_app(config: Config | None = None,
     # below is unchanged. What changes is the claim: an incident used to be
     # filed as "the workers are down" when the workers were never reached
     # (#410).
-    WORKERS_READY, WORKERS_NOT_READY, WORKERS_UNKNOWN = (
-        "ready", "not_ready", "unknown")
+    WORKERS_READY, WORKERS_NOT_READY, WORKERS_UNKNOWN, WORKERS_REJECTED = (
+        "ready", "not_ready", "unknown", "rejected")
 
     def _worker_state(timeout=None) -> str:
         try:
             status = hc.agent_worker_health(cfg.run_worker_stale_seconds,
                                             timeout=timeout)
-        except HealthClawError:
+        except HealthClawError as exc:
+            # A 4xx is an ANSWER, not a failure to ask. HealthClaw understood
+            # the request and refused something about IT — the credential, the
+            # path, the query — so the fault is in THIS container's
+            # configuration and it gates the deploy exactly like a missing
+            # worker does. Measured: a wrong HEALTHCLAW_MINT_SECRET answers
+            # 403 and a wrong HEALTHCLAW_BASE path root answers 404, and both
+            # used to be filed as "we could not ask" and let a chat-dead
+            # deployment go live.
+            #
+            # Everything else stays `unknown`, deliberately: transport failure
+            # (status 0), a 5xx, and a 200 carrying a proxy interstitial are
+            # all statements about HealthClaw or the network to it, not about
+            # us. Blocking on those would re-block the deploy that fixes the
+            # outage, which is the ruling this endpoint exists to implement.
+            if 400 <= getattr(exc, "status", 0) < 500:
+                return WORKERS_REJECTED
             return WORKERS_UNKNOWN
         return WORKERS_READY if status.get("available") else WORKERS_NOT_READY
+
+    #: Which worker states mean "this deployment cannot finish a chat turn and
+    #: the fault is in the thing being deployed". These gate `/healthz`, and
+    #: through it the deploy. `unknown` is deliberately absent.
+    WORKERS_OUR_FAULT = (WORKERS_NOT_READY, WORKERS_REJECTED)
+
+    #: The machine-readable refusal code per state. Three states, three codes:
+    #: collapsing `rejected` into `run_workers_unavailable` would file "our
+    #: secret is wrong" as "the workers are down", which is the #410
+    #: mislabeling one layer along.
+    _REFUSAL_CODES = {
+        WORKERS_UNKNOWN: "run_workers_unknown",
+        WORKERS_REJECTED: "run_workers_rejected",
+        WORKERS_NOT_READY: "run_workers_unavailable",
+    }
 
     def _refuse_turn_without_workers(state: str):
         """The 503 body for a chat turn no worker can be promised to run.
 
-        The patient-facing sentence is the same in both failure states,
-        because it is true in both. Only the machine-readable code differs.
+        The patient-facing sentence is the same in every failure state,
+        because it is true in all of them. Only the machine-readable code
+        differs.
         """
         return jsonify({
-            "error": ("run_workers_unknown" if state == WORKERS_UNKNOWN
-                      else "run_workers_unavailable"),
+            "error": _REFUSAL_CODES.get(state, "run_workers_unavailable"),
             "message": "Chat is temporarily unavailable. Try again soon.",
         }), 503
 
@@ -907,7 +955,7 @@ def create_app(config: Config | None = None,
         text = (body.get("message") or "").strip()
         if not text or len(text) > 2000:
             return jsonify({"error": "message must be 1-2000 characters"}), 400
-        workers = _worker_state()
+        workers = _worker_state(timeout=_ADMISSION_WORKER_TIMEOUT)
         if workers != WORKERS_READY:
             return _refuse_turn_without_workers(workers)
         if not _allow_turn(acct.id):
@@ -1271,7 +1319,7 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "unknown agent"}), 404
         if not text or len(text) > 2000:
             return jsonify({"error": "message must be 1-2000 characters"}), 400
-        workers = _worker_state()
+        workers = _worker_state(timeout=_ADMISSION_WORKER_TIMEOUT)
         if workers != WORKERS_READY:
             return _refuse_turn_without_workers(workers)
         if not _allow_turn(surface["account_id"]):
@@ -1392,6 +1440,14 @@ def create_app(config: Config | None = None,
           operators to expect a 503 for, and it stays a 503 deliberately: on
           Railway the health check runs at the start of a deploy, and this is
           a deploy that must not go live.
+        - Refused — HealthClaw answered 4xx. It understood the request and
+          rejected something about it: this container's mint secret, or the
+          base URL it was pointed at. That is a fault in the artifact being
+          deployed, exactly like a missing worker, so it gates the deploy the
+          same way. Reported as `run_workers_state: "rejected"`. Splitting
+          this out of "unknown" is the difference between a deploy that is
+          blocked and a chat-dead deployment that goes live: measured, a
+          wrong mint secret answers 403 and a wrong base path answers 404.
         - Could not ask, inside `_HEALTHZ_WORKER_TIMEOUT` — that is a fact
           about HealthClaw, not about this container. Reported as
           `run_workers_state: "unknown"`; it does not fail the endpoint.
@@ -1399,11 +1455,13 @@ def create_app(config: Config | None = None,
           outage, including the deploy that fixes it, while traffic stays on
           a previous version with exactly the same dependency. The probe
           measured the old shape taking 25.01s to answer 503 with nothing
-          running at all (evidence §8, PR #573).
+          running at all (evidence §8, PR #573). A transport failure, a 5xx
+          and a proxy interstitial all land here, because none of them is
+          HealthClaw telling us something about ourselves.
 
         Admission is unchanged, and it is the gate that protects people:
-        `POST /api/chat` still refuses a turn in BOTH states, so nothing
-        routes anyone into a turn no worker can run.
+        `POST /api/chat` still refuses a turn in ALL THREE failure states, so
+        nothing routes anyone into a turn no worker can run.
 
         It also reports which build is running (#258). That is telemetry, not
         a gate: an absent marker reports "unknown" and changes nothing about
@@ -1421,7 +1479,7 @@ def create_app(config: Config | None = None,
         # `run_workers_state` carries the claim the bool cannot make (#410) —
         # and now also the difference the status code turns on.
         workers_ok = workers_state == WORKERS_READY
-        ready = accounts_ok and workers_state != WORKERS_NOT_READY
+        ready = accounts_ok and workers_state not in WORKERS_OUR_FAULT
         body = {"status": "ok" if ready else "degraded",
                 "provider": cfg.provider, "accounts": accounts_ok,
                 "run_workers": workers_ok,

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -74,7 +74,8 @@ class HealthClawClient:
     # `ingest_bundle` alone rather than for the boundary.
 
     def _send(self, method: str, url: str, *, what: str,
-              error: type[HealthClawError] = HealthClawError, **kwargs):
+              error: type[HealthClawError] = HealthClawError,
+              timeout=None, **kwargs):
         """Issue one request; a transport failure becomes `error`.
 
         Dispatches to `Session.get`/`Session.post` rather than
@@ -82,6 +83,11 @@ class HealthClawClient:
         here used before, and the relay doubles the cross-layer tests
         substitute for a Session keep working. Resolved lazily for the same
         reason: some of those doubles define only the verb they relay.
+
+        `timeout` bounds a single call instead of inheriting the
+        client-wide one. It exists for callers that have a budget of their
+        own: a probe answering inside a platform's health-check window cannot
+        wait the 25s a chat turn is allowed to (#219). `None` inherits.
 
         `error` exists for one caller and one reason (#220). Losing the answer
         to a *retryable* call means it did not happen, which is an ordinary
@@ -92,7 +98,7 @@ class HealthClawClient:
         """
         send = self.http.get if method == "GET" else self.http.post
         try:
-            return send(url, timeout=self.timeout, **kwargs)
+            return send(url, timeout=timeout or self.timeout, **kwargs)
         except requests.RequestException as exc:
             raise error(f"{what} failed", 0) from exc
 
@@ -701,12 +707,19 @@ class HealthClawClient:
                 f"run claim failed ({r.status_code})", r.status_code)
         return self._json_object(r, "run claim")
 
-    def agent_worker_health(self, max_age_seconds: int = 30) -> dict:
-        """Return queue-backed worker readiness, including unavailable/503."""
+    def agent_worker_health(self, max_age_seconds: int = 30, *,
+                            timeout=None) -> dict:
+        """Return queue-backed worker readiness, including unavailable/503.
+
+        `timeout` bounds this one call; `None` inherits the client's. The
+        readiness probe passes its own, because the answer is only useful
+        inside the window the platform gives it (#219).
+        """
         r = self._send(
             "GET", f"{self.base}/command-center/api/runs/workers/health",
             params={"max_age_seconds": max_age_seconds},
-            headers=self._internal_headers(), what="run worker health")
+            headers=self._internal_headers(), what="run worker health",
+            timeout=timeout)
         if r.status_code not in (200, 503):
             raise HealthClawError(
                 f"run worker health failed ({r.status_code})", r.status_code)

--- a/careagents/static/chat.js
+++ b/careagents/static/chat.js
@@ -259,7 +259,15 @@
         else if (ev.type === "text") {
           typing.remove(); addAgentText(ev.text);
         } else if (ev.type === "error") {
-          typing.remove(); addAgentText("⚠️ " + ev.text);
+          // Terminal, exactly like `done`. Every producer of an error frame
+          // ends the run on it: agent.py returns after each one, and the SSE
+          // replay loop returns after the stream-failure frame. Without
+          // `done` here the outer loop reconnects — and because that stream
+          // now ends CLEANLY it also resets `reconnectFailures`, so a
+          // persistent event-poll failure becomes an unbounded ~2.5 req/s
+          // retry loop that prints a fresh ⚠️ on every pass, aimed at the
+          // engine that also serves clinicians.
+          typing.remove(); addAgentText("⚠️ " + ev.text); state.done = true;
         } else if (ev.type === "done") {
           state.done = true;
         }

--- a/deploy/careagents/Dockerfile
+++ b/deploy/careagents/Dockerfile
@@ -49,9 +49,22 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 # only an unset variable means "default" — an empty one is a broken config.
 # `printf`, not `echo`: dash's echo expands backslash escapes, so a role value
 # containing one would truncate its own error message.
+#
+# `--threads 8` is a measurement, not a preference. Every open chat turn holds
+# one thread for the whole life of its run (the SSE replay loop), so this pool
+# is the concurrency ceiling for EVERY route, /healthz included. Measured
+# 2026-09-03 against this exact invocation: at 2x4, eight concurrent turns made
+# /healthz wait 18.19s and sixteen made it wait 38.32s; at 2x8, eight waited
+# 0.00s and sixteen waited 18.23s
+# (docs/evidence/2026-09-03-probe-219-thread-saturation.md §7, PR #573).
+# One doubling is all the evidence supports: it moves the failure from 8
+# concurrent turns to 16 rather than removing it, and each thread also polls
+# HealthClaw ~4x/s on a browser's behalf — so more threads is not free, it is
+# more load on the engine that also serves clinicians. Change this with a new
+# measurement. Pinned by tests/test_careagents_container_roles.py.
 CMD ["sh", "-c", "case \"${CARE_ROLE-web}\" in \
   web) exec gunicorn careagents.wsgi:app \
-  --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 4 --timeout 180 \
+  --bind 0.0.0.0:${PORT:-8600} --workers ${CARE_WEB_WORKERS:-2} --threads 8 --timeout 180 \
   --access-logfile - --error-logfile - \
   --access-logformat '%(h)s \"%(r)s\" %(s)s %(M)sms' ;; \
   worker) exec python -m careagents.worker ;; \

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -322,7 +322,14 @@ fails the endpoint:
 | --- | --- | --- | --- |
 | `ready` | `true` | 200 | A worker's presence is fresh. The finish line above. |
 | `not_ready` | `false` | **503** | HealthClaw answered: nothing is draining the queue. The section above — fix the deployment. |
+| `rejected` | `false` | **503** | HealthClaw answered **4xx**: it refused this deployment's request. `HEALTHCLAW_MINT_SECRET` or `HEALTHCLAW_BASE` on the *CareAgents* service is wrong. |
 | `unknown` | `false` | 200 | We could not reach HealthClaw's worker-health endpoint within 2s. |
+
+`rejected` gates the deploy for the same reason `not_ready` does: HealthClaw
+answered, and what it said is that this container is wired wrong. A 403 from a
+stale mint secret and a 404 from a mistyped base URL both land here, and both
+produce a CareAgents that serves pages and cannot finish a single chat turn.
+Only a transport failure, a 5xx or a proxy interstitial is `unknown`.
 
 `unknown` is a statement about HealthClaw, not about this container, so it does
 not fail readiness: Railway probes only at the start of a deploy, and blocking

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -303,7 +303,7 @@ everywhere that matters:
 ```text
 GET /healthz -> 503
 {"accounts": true, "provider": "openai", "run_workers": false,
- "status": "degraded"}
+ "run_workers_state": "not_ready", "status": "degraded"}
 
 POST /api/chat -> run_workers_unavailable
 ```
@@ -312,6 +312,25 @@ That is readiness failing closed because no durable worker presence is fresh,
 not a regression. The fix is to add the worker service. Never relax the check:
 a green `/healthz` with nothing draining the queue is the state the fail-closed
 design exists to make visible.
+
+### Telling that apart from "we could not ask" (#219)
+
+`run_workers_state` names which of three things happened, and only one of them
+fails the endpoint:
+
+| `run_workers_state` | `run_workers` | `/healthz` | Means |
+| --- | --- | --- | --- |
+| `ready` | `true` | 200 | A worker's presence is fresh. The finish line above. |
+| `not_ready` | `false` | **503** | HealthClaw answered: nothing is draining the queue. The section above — fix the deployment. |
+| `unknown` | `false` | 200 | We could not reach HealthClaw's worker-health endpoint within 2s. |
+
+`unknown` is a statement about HealthClaw, not about this container, so it does
+not fail readiness: Railway probes only at the start of a deploy, and blocking
+a CareAgents deploy on a HealthClaw outage blocks the deploy that would fix it
+while traffic stays on a previous version with the same dependency. Chat still
+refuses (`run_workers_unknown`), so nobody is routed into a turn no worker can
+run. **The finish-line check is therefore `200` *and* `"run_workers": true`,
+not `200` alone.**
 
 ## Compose
 

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -108,6 +108,21 @@ build_info: dict = {"deployed": None, "built_at": None, "built": None,
                     "asserted": False, "ok": None}
 
 
+#: What each `/healthz` `run_workers_state` means to whoever reads the alarm
+#: at 03:00. The two failures have different owners, so a line that said only
+#: "run_workers=False" would send the wrong person to the wrong dashboard.
+_WORKER_STATE_MEANING = {
+    "ready": "a fresh worker is claiming runs",
+    "not_ready": ("HealthClaw answered: nothing is draining the queue — the "
+                  "careagents-worker service is down or was never deployed"),
+    "unknown": ("CareAgents could not reach HealthClaw's worker health inside "
+                "its budget — the engine or the network to it, not this app; "
+                "chat is refusing turns"),
+    "unreported": ("this deployment does not publish run_workers_state, so it "
+                   "predates #219 — check which build is running"),
+}
+
+
 def check(name: str, ok: bool, detail: str = "") -> bool:
     results.append((name, ok, detail))
     mark = f"{G} OK {X}" if ok else f"{R}FAIL{X}"
@@ -278,6 +293,40 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     check("careagents: ready (db reachable)",
           getattr(r, "status_code", None) == 200 and body.get("accounts") is True,
           f"status={getattr(r, 'status_code', r)} accounts={body.get('accounts')}")
+
+    # A SECOND check, not an extra clause on the one above (#219). The line
+    # above means one thing — the app reached its own database — and the retro
+    # (`docs/2026-08-02-retro.md`) names a control that quietly does two as
+    # this codebase's own defect shape.
+    #
+    # It exists because the status code stopped carrying this. `/healthz` used
+    # to answer 503 when it could not reach HealthClaw's worker health, and
+    # that 503 blocked the deploy that would have fixed the outage, so #219
+    # made "we could not ask" a 200 with the state in the body. That moved the
+    # signal; without this line it would have REMOVED it. On 2026-08-06 the
+    # edge to HealthClaw was blocked from CareAgents while HealthClaw itself
+    # answered this script perfectly — "healthclaw: alive" passed, and the only
+    # thing that went red was this deployment's readiness. That run must still
+    # go red, so this reads the field rather than the status code.
+    #
+    # The detail names WHICH state, because the two failures have different
+    # owners and different remedies: `not_ready` is our worker service, and
+    # `unknown` is the engine or the network between us and it.
+    workers_state = str(body.get("run_workers_state") or "unreported")
+    meaning = _WORKER_STATE_MEANING.get(
+        workers_state, f"unrecognised state {workers_state!r}")
+    if healthz_read:
+        check("careagents: a run worker is draining the queue",
+              body.get("run_workers") is True,
+              f"{workers_state} — {meaning}")
+    else:
+        # #272's rule, applied to this field too: a verdict about a field the
+        # run never read is how an outage got filed as a stale build. The
+        # readiness check above already reports the outage, and its remedy is
+        # the right one.
+        report("careagents: a run worker is draining the queue",
+               f"not asserted — /healthz was not readable "
+               f"({getattr(r, 'status_code', r)})")
 
     # Same body, no second request. Every other check on this deployment is
     # satisfied just as well by a months-old build — in #258 both CareAgents

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -115,6 +115,10 @@ _WORKER_STATE_MEANING = {
     "ready": "a fresh worker is claiming runs",
     "not_ready": ("HealthClaw answered: nothing is draining the queue — the "
                   "careagents-worker service is down or was never deployed"),
+    "rejected": ("HealthClaw REFUSED this deployment's worker-health request "
+                 "(4xx) — CareAgents' own HEALTHCLAW_MINT_SECRET or "
+                 "HEALTHCLAW_BASE is wrong; fix the CareAgents service "
+                 "variables, not the engine"),
     "unknown": ("CareAgents could not reach HealthClaw's worker health inside "
                 "its budget — the engine or the network to it, not this app; "
                 "chat is refusing turns"),

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -250,10 +250,13 @@ def _read_text(tmp_path, text):
 
 # --- the monitor: open defects ----------------------------------------------
 
-def _prod_watch_with(payload, expect, demo_handshake=None):
+def _prod_watch_with(payload, expect, demo_handshake=None,
+                     healthz_status=200):
     """Run prod_watch against a fully-healthy fake, varying only /healthz.
 
     `demo_handshake` overrides the public demo's keyless `initialize` reply.
+    `healthz_status` is the code `/healthz` answers with, which since #219 no
+    longer moves in lockstep with what its body says about the run workers.
     Both `get` and `post` are stubbed: leaving `post` real let the demo
     handshake check reach the live server from inside a unit test, which is
     exactly the kind of green-for-the-wrong-reason this file exists to stop.
@@ -284,7 +287,7 @@ def _prod_watch_with(payload, expect, demo_handshake=None):
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
         if url.endswith("/healthz"):
-            return _Resp(200, payload)
+            return _Resp(healthz_status, payload)
         if url.endswith("/auth"):
             return _Resp(200, text='<input maxlength="8">')
         if url.endswith("/mcp"):
@@ -311,31 +314,75 @@ def _prod_watch_with(payload, expect, demo_handshake=None):
         prod_watch.results.clear()
 
 
-HEALTHY = {"status": "ok", "provider": "openai", "accounts": True}
+HEALTHY = {"status": "ok", "provider": "openai", "accounts": True,
+           # #219 split readiness in two: the status code answers for this
+           # container, and the worker state is published as a field. A
+           # deployment is only healthy when both say so.
+           "run_workers": True, "run_workers_state": "ready"}
 TIP = "4f2a91cbeef1a9d3c05e7b21fd8460ac9e13d7f5"
 
 
 def test_a_current_build_is_counted_as_a_real_check():
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [TIP])
-    # MOVED PIN 11 -> 12: prod_watch gained the demo-tenant shape check
-    # (#457, catalogue §10). The number is the point of this test — it
-    # asserts the script counts an asserted build as a real check rather
-    # than inflating the total — so it moves by exactly one here and the
-    # property is unchanged.
-    assert code == 0 and "all 12 checks passing" in out
+    # MOVED PIN 12 -> 13: prod_watch gained the run-worker check (#219),
+    # because /healthz stopped folding that state into its status code and
+    # the readiness check above never read the field. Previously 11 -> 12 for
+    # the demo-tenant shape check (#457, catalogue §10). The number is the
+    # point of this test — it asserts the script counts an asserted build as
+    # a real check rather than inflating the total — so it moves by exactly
+    # one here and the property is unchanged.
+    assert code == 0 and "all 13 checks passing" in out
+
+
+def test_a_deployment_with_no_run_worker_is_an_outage_at_either_status_code():
+    """The blind spot #219 would have opened, closed (#410, 2026-08-06).
+
+    `/healthz` used to fail closed on both worker failures, so the readiness
+    check's `status_code == 200` caught them for free. #219 stopped that for
+    the unreachable case — a 503 there blocked the deploy that would fix the
+    outage — which left a 200 whose body says no worker is claiming runs. The
+    readiness check never reads that field, and the "healthclaw: alive" check
+    cannot cover it: on 2026-08-06 the edge was blocked from CareAgents while
+    HealthClaw itself answered this script perfectly.
+
+    So both states must still be an outage, and the line must say WHICH one,
+    because `not_ready` sends an operator to the worker service and `unknown`
+    sends them to the engine.
+
+    MUTATION: delete the `check("careagents: a run worker ...")` call in
+    scripts/prod_watch.py and both halves of this test fail — exit 0 instead
+    of 1, and the state never appears in the output.
+    """
+    absent = {**HEALTHY, "status": "degraded", "run_workers": False,
+              "run_workers_state": "not_ready",
+              "build": "4f2a91cbeef1", "built_at": 1754056800}
+    code, out = _prod_watch_with(absent, [TIP], healthz_status=503)
+    assert code == 1, "no worker draining the queue is an outage"
+    assert "careagents: a run worker is draining the queue" in out
+    assert "not_ready" in out and "careagents-worker service" in out
+
+    # The case the status code no longer carries: 200, and still an outage.
+    unreachable = {**HEALTHY, "run_workers": False,
+                   "run_workers_state": "unknown",
+                   "build": "4f2a91cbeef1", "built_at": 1754056800}
+    code, out = _prod_watch_with(unreachable, [TIP])
+    assert code == 1, (
+        "a 200 whose body says no worker was confirmed must not read green")
+    assert "unknown" in out and "could not reach HealthClaw" in out
+    assert "all 13 checks passing" not in out
 
 
 def test_an_unasserted_build_never_inflates_the_count():
-    # The script's honesty property. "all 11 checks passing" must stay
+    # The script's honesty property. "all 12 checks passing" must stay
     # literally true when nothing pinned the build.
     #
-    # MOVED PIN 10 -> 11, same reason as above: one new check, and the gap
+    # MOVED PIN 11 -> 12, same reason as above: one new check, and the gap
     # between this number and the one above is still exactly one, which is
     # the property being pinned.
     code, out = _prod_watch_with({**HEALTHY, "build": "4f2a91cbeef1",
                                   "built_at": 1754056800}, [])
-    assert code == 0 and "all 11 checks passing" in out
+    assert code == 0 and "all 12 checks passing" in out
 
 
 class _Refused:
@@ -360,7 +407,7 @@ def test_a_demo_server_that_stops_serving_keyless_callers_is_an_outage():
                                  demo_handshake=_Refused())
     assert code == 1, "a demo server refusing keyless callers must be an outage"
     assert "serves an unauthenticated handshake" in out
-    assert "all 12 checks passing" not in out
+    assert "all 13 checks passing" not in out
 
 
 @pytest.mark.parametrize("supplied", ["", ",", " ", ",,"])

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -373,6 +373,49 @@ def test_a_deployment_with_no_run_worker_is_an_outage_at_either_status_code():
     assert "all 13 checks passing" not in out
 
 
+def test_a_deployment_healthclaw_refuses_names_its_own_variables():
+    """`rejected` sends the operator somewhere different from `not_ready`.
+
+    HealthClaw answered 4xx: it refused THIS deployment's request, so the
+    remedy is CareAgents' own service variables, not the worker service and
+    not the engine. A line that said only "run_workers=False" would send the
+    3am reader to the wrong dashboard — the thing this second check exists to
+    prevent.
+
+    MUTATION: drop the "rejected" entry from `_WORKER_STATE_MEANING` and the
+    line falls back to "unrecognised state", failing the last two asserts.
+    """
+    refused = {**HEALTHY, "status": "degraded", "run_workers": False,
+               "run_workers_state": "rejected",
+               "build": "4f2a91cbeef1", "built_at": 1754056800}
+    code, out = _prod_watch_with(refused, [TIP], healthz_status=503)
+    assert code == 1, "a deployment HealthClaw refuses is an outage"
+    assert "careagents: a run worker is draining the queue" in out
+    assert "rejected" in out
+    assert "HEALTHCLAW_MINT_SECRET" in out and "HEALTHCLAW_BASE" in out
+
+
+def test_the_run_worker_line_stays_silent_when_healthz_was_never_read():
+    """#272's rule, applied to the field this check reads.
+
+    When `/healthz` is unreadable there is no `run_workers_state` to have a
+    verdict about, and `body.get(...)` would return this script's own default
+    — indistinguishable from a deployment that genuinely published nothing.
+    Asserting on it tells whoever reads the alarm to go fix the worker service
+    when the deployment is simply DOWN. The readiness check above already
+    reports that outage with the right remedy.
+
+    MUTATION: replace the `if healthz_read:` guard with an unconditional
+    `check(...)` and the "not asserted" assert goes red.
+    """
+    code, out = _prod_watch_with({}, [TIP], healthz_status=500)
+    assert code == 1, "an unreadable /healthz is an outage"
+    assert "careagents: a run worker is draining the queue" in out
+    assert "not asserted" in out
+    # It must not claim a verdict it never had the field for.
+    assert "not_ready" not in out and "unreported" not in out
+
+
 def test_an_unasserted_build_never_inflates_the_count():
     # The script's honesty property. "all 12 checks passing" must stay
     # literally true when nothing pinned the build.

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1582,6 +1582,113 @@ def test_unreachable_worker_control_plane_stops_admission_not_the_deploy(
     assert "temporarily unavailable" in response.get_json()["message"]
 
 
+@pytest.mark.parametrize("status,why", [
+    (403, "a stale or wrong HEALTHCLAW_MINT_SECRET"),
+    (404, "a HEALTHCLAW_BASE pointed at the wrong path root"),
+    (400, "a request HealthClaw understood and rejected"),
+])
+def test_a_deployment_healthclaw_refuses_must_not_pass_the_deploy_gate(
+        cfg, svc, monkeypatch, status, why):
+    """A 4xx is an ANSWER about US, and it must gate the deploy.
+
+    `/healthz` gates a Railway deploy: 503 keeps traffic on the previous
+    version. #219 correctly stopped gating on "we could not reach HealthClaw",
+    because that blocks the deploy that would fix someone else's outage. But
+    it routed EVERY `HealthClawError` there, and the client raises one for any
+    status outside (200, 503) as well as for a dead socket. So a CareAgents
+    container carrying the wrong mint secret — which HealthClaw answers 403 —
+    was filed as "we could not ask" and admitted.
+
+    Measured against a running pair before this test existed: wrong mint
+    secret -> `/healthz` 200 `"status":"ok"`, and every chat turn refused. The
+    fault is in the artifact being deployed, which is precisely the case the
+    PR's own ruling says must stay blocked.
+
+    MUTATION: return WORKERS_UNKNOWN for every HealthClawError in
+    `careagents/app.py:_worker_state` and this goes red on the 503.
+    """
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    fake.worker_health_error = True
+    fake.worker_health_error_status = status
+
+    health = client.get("/healthz")
+    assert health.status_code == 503, (
+        f"{why} left a chat-dead deployment passing the deploy gate")
+    body = health.get_json()
+    assert body["run_workers_state"] == "rejected"
+    assert body["run_workers"] is False
+    assert body["status"] == "degraded"
+    # The account store is fine; this is not a claim about our database.
+    assert body["accounts"] is True
+
+    # The state is named separately from "the workers are down", because the
+    # remedy is different: this sends an operator to the CareAgents service
+    # variables, not to the worker service (#410's lesson, one layer along).
+    refused = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "hello", "request_id": "rejected-1"})
+    assert refused.status_code == 503
+    assert refused.get_json()["error"] == "run_workers_rejected"
+
+
+@pytest.mark.parametrize("status", [0, 500, 502, 503, 504])
+def test_an_outage_that_is_not_ours_still_lets_the_fixing_deploy_through(
+        cfg, svc, monkeypatch, status):
+    """The other half of the same carve, pinned so it cannot be over-tightened.
+
+    A dead socket (status 0), a 5xx, and a gateway error are statements about
+    HealthClaw or the network to it. Gating on those blocks a CareAgents
+    deploy on someone else's outage — including the deploy that fixes it —
+    which is the ruling #219 made and this must not undo.
+
+    MUTATION: widen the 4xx test in `_worker_state` to any non-zero status and
+    this goes red.
+    """
+    app, client, fake, agent_id, *_ = _chat_app(cfg, svc, monkeypatch)
+    fake.worker_health_error = True
+    fake.worker_health_error_status = status
+
+    health = client.get("/healthz")
+    assert health.status_code == 200, (
+        "a HealthClaw outage must not block the CareAgents deploy that fixes it")
+    assert health.get_json()["run_workers_state"] == "unknown"
+
+    # Admission still refuses — that is the gate that protects people.
+    refused = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "hello", "request_id": "unknown-1"})
+    assert refused.status_code == 503
+    assert refused.get_json()["error"] == "run_workers_unknown"
+
+
+def test_admission_bounds_its_dependency_call_too(cfg, svc, monkeypatch):
+    """The refusal path must not hold a thread for 25 seconds (#219).
+
+    `/healthz` got a bounded budget; `POST /api/chat` did not, so it inherited
+    the client's 25s CHAT timeout. Measured at 25.00s against a HealthClaw
+    that accepts the connection and never answers, versus 1.01s for the
+    bounded call. That is a gunicorn thread held for 25 seconds *to refuse a
+    turn*, during exactly the dependency outage `/healthz` now lets deploy —
+    and it spends the thread headroom the same change bought.
+
+    MUTATION: drop the `timeout=` argument at `careagents/app.py:958` and this
+    goes red.
+    """
+    app, client, fake, agent_id, *_ = _chat_app(cfg, svc, monkeypatch)
+
+    client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "hello", "request_id": "budget-1"})
+
+    asked = fake.worker_health_timeout
+    assert asked != "never called", "admission never asked about the workers"
+    assert asked is not None, (
+        "admission inherited the client-wide 25s chat timeout; a turn that is "
+        "about to be REFUSED must not hold a web thread that long")
+    connect, read = asked
+    assert connect + read <= 5.0, (
+        f"admission's worst-case wait is {connect + read}s, which is more "
+        "than a person waiting on a refusal should hold a thread for")
+
+
 def test_healthz_bounds_the_dependency_call_to_its_own_probe_budget(
         cfg, svc, monkeypatch):
     """The endpoint's answer about itself cannot wait on a dependency.
@@ -1726,6 +1833,12 @@ class FakeClient:
         self._event_id = 0
         self.worker_available = True
         self.worker_health_error = False
+        # The HTTP status the raised HealthClawError carries. 0 is a transport
+        # failure ("we could not ask"); a 4xx is HealthClaw ANSWERING that it
+        # refused this deployment's request, which is a different incident
+        # with a different owner. The client raises with `r.status_code`, so a
+        # fake that only ever raises 0 cannot tell the two apart.
+        self.worker_health_error_status = 0
         # The timeout the caller asked for on the last worker-health call, so
         # a test can pin that the readiness probe bounds it (#219).
         self.worker_health_timeout = "never called"
@@ -1843,7 +1956,8 @@ class FakeClient:
     def agent_worker_health(self, max_age_seconds=30, *, timeout=None):
         self.worker_health_timeout = timeout
         if self.worker_health_error:
-            raise HealthClawError("worker health unavailable", 0)
+            raise HealthClawError("worker health unavailable",
+                                  self.worker_health_error_status)
         return {"available": self.worker_available,
                 "active_workers": 1 if self.worker_available else 0,
                 "max_age_seconds": max_age_seconds}

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -615,6 +615,43 @@ def test_worker_health_client_accepts_fail_closed_503_projection():
     }
 
 
+def test_worker_health_uses_the_callers_timeout_and_otherwise_the_clients():
+    """The per-call budget reaches the wire, not just the signature (#219).
+
+    The app-level test pins that `/healthz` ASKS for a short timeout. This
+    pins that asking does anything: `_send` used to hard-code `self.timeout`
+    for every call, so a caller-supplied budget would have been accepted and
+    silently dropped — a fake would never have noticed.
+    """
+    import careagents.healthclaw as hcmod
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"available": True, "active_workers": 1}
+
+    class _HTTP:
+        @staticmethod
+        def get(url, params=None, headers=None, timeout=None):
+            captured["timeout"] = timeout
+            return _Resp()
+
+    client = hcmod.HealthClawClient("http://local", "mint-secret",
+                                    timeout=25.0)
+    client.http = _HTTP()
+
+    client.agent_worker_health(30, timeout=(1.0, 1.0))
+    assert captured["timeout"] == (1.0, 1.0)
+
+    # Every other caller keeps the client-wide timeout it has always had.
+    client.agent_worker_health(30)
+    assert captured["timeout"] == 25.0
+
+
 def test_worker_container_probe_uses_authenticated_queue_readiness(monkeypatch):
     from careagents import healthcheck
 
@@ -1370,6 +1407,41 @@ def test_tool_loop_stops_at_the_budget_instead_of_spending_forever(
     assert events[-1] == {"type": "text", "text": "final answer"}
 
 
+def test_a_stream_that_fails_mid_run_says_so_instead_of_going_quiet(
+        cfg, svc, monkeypatch):
+    """A dead stream must state that it died (#219).
+
+    `_stream_run` had no `except` around the run-event poll, so a
+    HealthClawError killed the generator inside an open response: the
+    connection dropped with no `error` frame and the page just stopped, with
+    nothing to tell the person whether their question was lost.
+
+    What the terminal frame may say is bounded by the same rule as every
+    other failure surface — the generic sentence, never the exception. Real
+    engine errors carry connection strings and correlation ids.
+    """
+    from careagents.agent import GENERIC_FAILURE_TEXT
+
+    app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
+        cfg, svc, monkeypatch)
+    fake.run_events_error = "OperationalError: could not connect to db-7"
+
+    response = client.post("/api/chat", json={
+        "agent_id": agent_id, "message": "what did my results say",
+        "request_id": "stream-dies-midway"}, buffered=False)
+    # An SSE body is a generator: without reading it the stream never runs.
+    body = response.get_data().decode()
+
+    frames = [json.loads(line[len("data: "):])
+              for line in body.splitlines() if line.startswith("data: ")]
+    assert response.status_code == 200
+    assert frames[0]["type"] == "accepted"
+    assert frames[-1] == {"type": "error", "text": GENERIC_FAILURE_TEXT}
+    assert len(frames) == 2, (
+        f"the error frame must be terminal, got {frames}")
+    assert "OperationalError" not in body and "db-7" not in body
+
+
 def test_healthz_reports_ok_when_the_account_store_answers(app):
     r = app.test_client().get("/healthz")
     assert r.status_code == 200
@@ -1423,6 +1495,16 @@ def test_an_unstamped_build_is_still_ready(app, cfg, monkeypatch):
 
 def test_healthz_and_chat_fail_fast_when_worker_presence_is_stale(
         cfg, svc, monkeypatch):
+    """The deploy gate that is KEPT, and deliberately (#219).
+
+    HealthClaw answered: there is no fresh worker. That is a CareAgents
+    deployment which serves pages and cannot finish a chat turn — the
+    web-only deployment `docs/runbooks/careagents-durable-worker.md`
+    documents a 503 for. Railway only probes at the start of a deploy, so
+    503 here means that deploy does not go live, which is the wanted
+    outcome: the fault is in the thing being deployed. Contrast the
+    unreachable case below, where the fault is not ours.
+    """
     app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
         cfg, svc, monkeypatch)
     fake.worker_available = False
@@ -1436,6 +1518,7 @@ def test_healthz_and_chat_fail_fast_when_worker_presence_is_stale(
 
     assert health.status_code == 503
     assert health.get_json()["run_workers"] is False
+    assert health.get_json()["run_workers_state"] == "not_ready"
     assert refused.status_code == 503
     assert refused.get_json()["error"] == "run_workers_unavailable"
     assert fake.runs == {}
@@ -1460,23 +1543,36 @@ def test_chat_recovers_after_worker_queue_access_returns(
     assert len(fake.runs) == 1
 
 
-def test_unreachable_worker_control_plane_degrades_readiness_and_admission(
+def test_unreachable_worker_control_plane_stops_admission_not_the_deploy(
         cfg, svc, monkeypatch):
-    """Both states still fail closed. The code says which one happened.
+    """Admission still fails closed. Readiness no longer does (#219).
 
-    Readiness and admission must refuse whether the workers reported
-    themselves absent or we could not reach the health endpoint at all — the
-    turn cannot be promised either way, and that half is unchanged. What
-    changed with #410 is the claim: this used to answer
-    `run_workers_unavailable`, filing "we could not ask" as "the workers are
-    down". The two are different incidents.
+    Admission is the gate that protects people, and it is unchanged: a turn
+    nobody can promise is refused whether the workers reported themselves
+    absent or we could not reach the health endpoint at all. #410 fixed the
+    *claim* — "we could not ask" stopped being filed as "the workers are
+    down" — and this changes what that claim is allowed to decide.
+
+    Readiness used to answer 503 here too. On Railway the health check runs
+    only at the start of a deploy, so that 503 blocked a CareAgents deploy
+    on a HealthClaw outage — including the deploy that would fix it — while
+    traffic stayed on a previous version with exactly the same dependency.
+    The state is still published, as `run_workers: false` with
+    `run_workers_state: "unknown"`; it just does not gate the status code.
+
+    MUTATION: restore `ready = accounts_ok and workers_ok` in
+    `careagents/app.py` and this fails on the 200.
     """
     app, client, fake, agent_id, _tenant, _conn_id = _chat_app(
         cfg, svc, monkeypatch)
     fake.worker_health_error = True
 
-    assert client.get("/healthz").status_code == 503
-    assert client.get("/healthz").get_json()["run_workers"] is False
+    health = client.get("/healthz")
+    assert health.status_code == 200
+    assert health.get_json()["run_workers"] is False
+    assert health.get_json()["run_workers_state"] == "unknown"
+    assert health.get_json()["accounts"] is True
+
     response = client.post("/api/chat", json={
         "agent_id": agent_id, "message": "upstream is unreachable"})
     assert response.status_code == 503
@@ -1484,6 +1580,32 @@ def test_unreachable_worker_control_plane_degrades_readiness_and_admission(
     # The sentence the patient reads is true in both states, so it does not
     # change with the code.
     assert "temporarily unavailable" in response.get_json()["message"]
+
+
+def test_healthz_bounds_the_dependency_call_to_its_own_probe_budget(
+        cfg, svc, monkeypatch):
+    """The endpoint's answer about itself cannot wait on a dependency.
+
+    The probe measured `/healthz` taking 25.01s and returning 503 with
+    nothing running at all, because its worker-health call inherited the
+    client's 25s chat timeout
+    (`docs/evidence/2026-09-03-probe-219-thread-saturation.md` §8, PR #573).
+    The container probe gives it 4s (`careagents/healthcheck.py`) and the
+    Dockerfile's HEALTHCHECK 5s, so the dependency call gets a budget that
+    fits inside both.
+
+    Asserted rather than waited on: a test that actually hangs a socket for
+    25s to prove this would be the slowest test in the suite and would still
+    only prove it once.
+    """
+    app, client, fake, *_ = _chat_app(cfg, svc, monkeypatch)
+
+    assert client.get("/healthz").status_code == 200
+
+    connect, read = fake.worker_health_timeout
+    assert connect + read <= 2.0, (
+        "the readiness probe's dependency call must answer inside a couple "
+        f"of seconds; worst case here is {connect + read}s")
 
 
 def test_ping_returns_false_instead_of_raising(svc, monkeypatch):
@@ -1604,6 +1726,12 @@ class FakeClient:
         self._event_id = 0
         self.worker_available = True
         self.worker_health_error = False
+        # The timeout the caller asked for on the last worker-health call, so
+        # a test can pin that the readiness probe bounds it (#219).
+        self.worker_health_timeout = "never called"
+        # Set to a message to make the run-event poll raise, which is the
+        # mid-stream failure a browser used to see as a silent dead stream.
+        self.run_events_error = ""
         # Instance state, NOT a class attribute. `purged = []` at class scope
         # was mutated through `self.purged.append(...)`, so every FakeClient
         # in the session shared one list and a test's assertion on
@@ -1695,6 +1823,8 @@ class FakeClient:
         return dict(run)
 
     def agent_run_events(self, tenant, run_id, after=0, limit=100):
+        if self.run_events_error:
+            raise HealthClawError(self.run_events_error, 0)
         run = self.get_agent_run(tenant, run_id)
         if run["status"] == "queued":
             from datetime import datetime, timezone
@@ -1710,7 +1840,8 @@ class FakeClient:
                 "events": events,
                 "next_cursor": events[-1]["id"] if events else after}
 
-    def agent_worker_health(self, max_age_seconds=30):
+    def agent_worker_health(self, max_age_seconds=30, *, timeout=None):
+        self.worker_health_timeout = timeout
         if self.worker_health_error:
             raise HealthClawError("worker health unavailable", 0)
         return {"available": self.worker_available,

--- a/tests/test_careagents_container_roles.py
+++ b/tests/test_careagents_container_roles.py
@@ -40,15 +40,16 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent
 DOCKERFILE = REPO / "deploy" / "careagents" / "Dockerfile"
 
-# The command the web role ran before #273, split as the shell splits it. Any
-# edit to a flag, a default, or the access-log format has to be made here too —
-# which is the point: the durable-run split must not quietly re-tune the web
-# process while it is adding a second role.
+# The command the web role runs, split as the shell splits it. Any edit to a
+# flag, a default, or the access-log format has to be made here too — which is
+# the point: the durable-run split must not quietly re-tune the web process
+# while it is adding a second role. `--threads` moved 4 -> 8 in #219; the test
+# below says why, so the number is never re-tuned from an estimate.
 WEB_ARGV = [
     "gunicorn", "careagents.wsgi:app",
     "--bind", "0.0.0.0:8600",
     "--workers", "2",
-    "--threads", "4",
+    "--threads", "8",
     "--timeout", "180",
     "--access-logfile", "-",
     "--error-logfile", "-",
@@ -111,6 +112,36 @@ def test_the_default_role_still_starts_the_web_server_unchanged(stubs, role):
     code, argv, stderr = _start(stubs, role)
     assert code == 0, stderr
     assert argv == WEB_ARGV
+
+
+def test_the_web_thread_pool_is_the_size_the_probe_measured(stubs):
+    """2 workers x 8 threads, because that is what was measured (#219).
+
+    Every open chat turn holds one gunicorn thread for the whole life of its
+    run — the SSE replay loop, not inference, which has run outside this
+    process since #257. The pool is therefore the concurrency ceiling for
+    every route, `/healthz` included. Measured 2026-09-03 against this exact
+    invocation, 20s turns:
+
+        2 x 4 :  N=8 -> /healthz waited 18.19s;  N=16 -> 38.32s
+        2 x 8 :  N=8 -> /healthz waited  0.00s;  N=16 -> 18.23s
+
+    (`docs/evidence/2026-09-03-probe-219-thread-saturation.md` §7, PR #573.)
+
+    One doubling is all that evidence supports. It moves the failure from 8
+    concurrent turns to 16; it does not remove it, and each thread also polls
+    HealthClaw ~4x/s on a browser's behalf, so the next doubling doubles that
+    load on the engine that also serves clinicians. This pin exists so the
+    next edit is a decision with a measurement behind it rather than drift.
+    """
+    _, argv, _ = _start(stubs, "web")
+    assert argv[argv.index("--threads") + 1] == "8", (
+        "the web thread count is pinned to the 2x8 the #219 probe measured; "
+        "changing it needs a new measurement, not an estimate")
+    assert argv[argv.index("--workers") + 1] == "2", (
+        "the probe measured 2 workers x 8 threads; CARE_WEB_WORKERS can "
+        "override the worker half on the platform, which multiplies a thread "
+        "count nobody measured")
 
 
 def test_the_web_role_still_honours_its_port_and_worker_overrides(stubs):

--- a/tests/test_careagents_container_roles_qa.py
+++ b/tests/test_careagents_container_roles_qa.py
@@ -42,7 +42,9 @@ WEB_ARGV = [
     "gunicorn", "careagents.wsgi:app",
     "--bind", "0.0.0.0:8600",
     "--workers", "2",
-    "--threads", "4",
+    # 4 -> 8 in #219, the one deliberate retune of this command since the role
+    # split. tests/test_careagents_container_roles.py carries the measurement.
+    "--threads", "8",
     "--timeout", "180",
     "--access-logfile", "-",
     "--error-logfile", "-",
@@ -216,10 +218,17 @@ def test_port_and_web_worker_overrides_reach_gunicorn(sandbox, shell):
     assert argv[argv.index("--workers") + 1] == "7"
 
 
-def test_the_web_command_is_unchanged_from_before_the_role_split():
+def test_the_web_command_changed_only_where_a_measurement_changed_it():
     # Byte-for-byte, not token-for-token: the durable-run split must not retune
     # the web process while it adds a second role. The doubled internal spaces
     # come from the line continuations and are part of the comparison.
+    #
+    # One difference is authorised, and it is written out here rather than
+    # loosened away: #219 measured the thread pool starving `/healthz` and
+    # raised it 4 -> 8. Anything else still fails, including a second edit to
+    # the same flag — this comparison would then be against 8, not against 4.
+    RETUNES = [("--threads 4", "--threads 8", "#219, measured")]
+
     previous = subprocess.run(
         ["git", "-C", str(REPO), "show",
          "f71d46e:deploy/careagents/Dockerfile"],
@@ -229,6 +238,11 @@ def test_the_web_command_is_unchanged_from_before_the_role_split():
     before = json.loads(re.search(
         r"^CMD (\[.*\])\s*$",
         previous.stdout.replace("\\\n", ""), re.M).group(1))[2]
+    for old, new, why in RETUNES:
+        assert old in before, (
+            f"the authorised retune ({why}) no longer applies: {old!r} is not "
+            "in the pre-split command, so this test is comparing to nothing")
+        before = before.replace(old, new)
     script = _script()
     opening = 'case "${CARE_ROLE-web}" in   web) exec '
     assert script.startswith(opening)

--- a/tests/test_prod_watch_build.py
+++ b/tests/test_prod_watch_build.py
@@ -59,7 +59,8 @@ def _fake_get(build="4f2a91cbeef1", built_at=1754056800, grade="A",
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
         if url.endswith("/healthz"):
             return _Resp(200, {"status": "ok", "provider": "openai",
-                               "accounts": True, "build": build,
+                               "accounts": True, "run_workers": True,
+                               "run_workers_state": "ready", "build": build,
                                "built_at": built_at})
         if url.endswith("/auth"):
             return _Resp(200, text='<input maxlength="8">')


### PR DESCRIPTION
Candidate, not a merge request. Three changes, each sized by what the #219
probe measured (`docs/evidence/2026-09-03-probe-219-thread-saturation.md` on
`probe/219-thread-saturation`, PR #573) rather than by the issue's estimate.
Nothing was run against production.

## What

1. **`deploy/careagents/Dockerfile:67`** — gunicorn `--threads 4` → `--threads 8`.
2. **`careagents/app.py:1374` (`/healthz`)** — the worker-health call gets its
   own bounded budget, and the endpoint stops failing on a dependency it
   cannot reach. `careagents/healthclaw.py` gains a per-call `timeout` so it
   can.
3. **`careagents/app.py:851` (`_stream_run`)** — a mid-stream failure now emits
   a terminal `error` frame instead of dropping the connection silently.
4. **`scripts/prod_watch.py`** — a second named check that reads the run-worker
   state, because change 2 stopped the status code carrying it and the
   readiness check never read the field. Without this, change 2 would have
   traded a loud failure for a quiet one.

## Why

### 1. One doubling of thread headroom

Every open chat turn holds one web thread for the whole life of its run — the
SSE replay loop, not inference, which has run outside this process since #257.
The pool is therefore the concurrency ceiling for **every** route, `/healthz`
included. Measured against this exact gunicorn invocation, 20s turns
(evidence §3, §7):

| config | N=8 | N=16 |
| --- | --- | --- |
| 2 workers × 4 threads (shipping) | `/healthz` waited **18.19s** | **38.32s** |
| 2 workers × 8 threads | **0.00s** | **18.23s** |

At the code's own worst case — `run_deadline_seconds` = 120 — 8 concurrent
turns made `/healthz` wait **118.12s** on the shipping config (§4). The 2×4
split also starves *intermittently from 6*, because two pre-fork workers share
an accept socket and six turns land unevenly (§3).

**One doubling is all the evidence supports.** It moves the failure from 8
concurrent turns to 16; it does not remove it, and at N=16 the 5s budget is
still blown 3 times in 4. Each thread also polls HealthClaw ~4×/s on a
browser's behalf (§9), so more threads is more load on the engine that also
serves clinicians. The comment at the setting and the new pin test both say so.

**Can the platform override this?** Half of it, and this is the trap the repo
already hit with `PORT`:

- `--workers` **is** overridable — `${CARE_WEB_WORKERS:-2}`, a Railway
  dashboard variable. Its actual production value was not readable from this
  repo (evidence §10.1); the probe covered both 2×4 and 1×8 and they behave
  the same at 8 threads total.
- `--threads` is **not** env-settable. The Dockerfile value is authoritative
  unless a service overrides the whole start command.
- So a dashboard `CARE_WEB_WORKERS` other than 2 multiplies a thread count
  nobody measured. I did **not** add a `CARE_WEB_THREADS` flag — unrequested —
  but someone should read the CareAgents service's variables before deploying.

### 2. A health check that answers for itself

The probe measured `/healthz` taking **25.01s** and returning **503 at zero
load**, because its worker-health call inherited the client's 25s chat timeout
(§8). That blows every budget it has: the container probe allows 4s
(`careagents/healthcheck.py`), the Dockerfile's `HEALTHCHECK` 5s.

The call now takes a `(connect, read)` pair of 1s + 1s — 2.0s of network wait,
worst case — and the three worker states stop being collapsed into one bool:

| `run_workers_state` | `/healthz` | Why |
| --- | --- | --- |
| `ready` | 200 | Fresh worker presence. |
| `not_ready` | **503** | HealthClaw answered: nothing is draining the queue. |
| `unknown` | 200 | We could not ask inside the budget. |

**The deploy-gating question, ruled.** Railway probes only at the start of a
deploy, so a 503 here means the deploy does not go live and traffic stays on
the previous version. My ruling is that this is wanted for `not_ready` and
wrong for `unknown`:

- **`not_ready` keeps gating the deploy — deliberately.** HealthClaw answered
  and there is no worker. That is a CareAgents deployment which serves pages
  and cannot finish a chat turn — exactly the web-only deployment
  `docs/runbooks/careagents-durable-worker.md` documents a 503 for. The fault
  is in the thing being deployed, so blocking it is the right outcome, and
  "never relax the check" is honoured: that scenario produces the same 503 it
  always did, and a test pins it.
- **`unknown` no longer gates it.** Being unable to reach HealthClaw is a fact
  about HealthClaw, not about this container. Failing there blocks a CareAgents
  deploy on someone else's outage — including the deploy that would fix it —
  while traffic stays on a previous version with exactly the same dependency.
  It is also the mislabeling #410 named: "we could not ask" filed as "the
  workers are down".

This changes one previously-pinned behaviour, deliberately and in the open:
`test_unreachable_worker_control_plane_degrades_readiness_and_admission`
asserted 503 on the unreachable path. It is rewritten (and renamed) with the
reasoning above. **Admission is untouched** — `POST /api/chat` still refuses a
turn in both failure states, so nobody is routed into a turn no worker can run.
That is the gate that protects people; `/healthz` is the gate that gates
deploys.

`run_workers` stays a bool (two runbooks and a test read it as one); the new
`run_workers_state` field carries the claim the bool cannot make. The runbook
gained the table above.

### 2b. The monitor that would have gone quiet

Change 2 moved a signal, and `scripts/prod_watch.py` was reading the old one.
Its "careagents: ready" check asserts `status_code == 200 and accounts is True`
and never reads `run_workers` — free coverage while `/healthz` failed closed on
both worker failures, and a blind spot the moment one of them became a 200.

That blind spot is not hypothetical: it is the 2026-08-06 shape exactly. The
edge to HealthClaw was blocked *from CareAgents* while HealthClaw itself
answered prod_watch perfectly, so `healthclaw: alive` passed and the only red
line was CareAgents readiness. After change 2 alone, nothing would have been
red. So this PR adds the check rather than filing it:

```
 OK  careagents: a run worker is draining the queue — ready — a fresh worker is claiming runs
FAIL careagents: a run worker is draining the queue — not_ready — HealthClaw answered: nothing is draining the queue — the careagents-worker service is down or was never deployed
FAIL careagents: a run worker is draining the queue — unknown — CareAgents could not reach HealthClaw's worker health inside its budget — the engine or the network to it, not this app; chat is refusing turns
```

Both failures exit 1. It is a **second named check**, not another clause on the
readiness line, because that line means one thing — the app reached its own
database — and a control that quietly does two is this codebase's own defect
shape (`docs/2026-08-02-retro.md`). The detail names the state because the two
failures have different owners: `not_ready` sends an operator to the worker
service, `unknown` sends them to the engine. When `/healthz` is not readable at
all the check does not run — a verdict about a field the run never read is the
#272 defect, and the readiness check already reports that outage with the right
remedy.

Check-count pins in the build-marker tests move 12 → 13 and 11 → 12; the gap
between them, which is the honesty property those two tests exist for, is
unchanged.

> **Merge-order warning — this collides with PR #549.** Both PRs branch from
> `89b42fb`, where the pins are **12** and **11**, and both move them. #549
> adds two checks (careagents.cloud and the Telegram tile) and sets **14** and
> **13**; this PR adds one and sets **13** and **12**. Whichever merges second
> gets a conflict on those `assert` lines, and **the answer is neither side —
> it is 15 and 14.** Taking one branch's number wholesale silently under-counts
> the other's checks, which is the failure these two tests exist to catch. The
> `MOVED PIN` comments above each assertion state each delta so the resolution
> is arithmetic rather than a guess.

### 3. A stream error that said nothing

`_stream_run` had no `except` around `agent_run_events`, so a HealthClawError
killed the generator inside an open response: the connection dropped with no
`error` frame and the page just stopped (evidence §7b, "one defect visible here
and not in the issue"). It now emits `{"type": "error", "text": …}` carrying
the same generic sentence every other failure surface uses — never the
exception, which in production carries connection strings and correlation ids —
and closes. The run itself is durable and unaffected.

**Known edge, disclosed rather than fixed:** after the error frame the stream
ends *cleanly*, so `chat.js` resets its failure counter and reconnects. If
`get_agent_run` succeeds while `agent_run_events` keeps failing, the browser
will loop and print a new ⚠️ each time. On a full HealthClaw outage the GET
503s and the existing 5-failure cap stops it. Fixing `chat.js` is out of scope
here; flagging for a reviewer to rule on.

## Ran

- `uv run python -m pytest tests/ -q -p no:cacheprovider` →
  **3162 passed, 13 skipped, 1 xfailed** (ratchets and conformance included).
- `uv run ruff check .` → **All checks passed!**
- Mutation-checked each new pin by reverting the production change and watching
  the test go red: the readiness gate, the timeout budget, the stream `except`,
  the Dockerfile thread count, and the new prod_watch assertion.

New/changed tests: the 2×8 pin with its measurement
(`tests/test_careagents_container_roles.py`), `/healthz` answering 200 with
`run_workers_state: "unknown"` against a dead downstream and asking for a
bounded timeout, the client actually forwarding that timeout to the wire (a
fake would not have caught it being dropped — CareAgents fakes prove a call is
made, not accepted), `not_ready` still gating the deploy, a stream that raises
mid-run emitting a terminal error frame with nothing after it, and both worker
failure states exiting 1 from prod_watch with the state named in the line.

## Deploy note

**This changes a container setting, so it takes effect only on a deploy — and
deploying CareAgents is owner-only.** It is a manual `railway up` from a staged
directory for *both* the web and worker services
(`docs/runbooks/careagents-durable-worker.md`); pushing `main` does not deploy
CareAgents. Merging this changes nothing in production until someone does that.

**Read `CARE_WEB_WORKERS` on the deployed CareAgents service BEFORE deploying,
not after.** Nobody has read it. It is a Railway dashboard variable that is not
in this repo, and it was not readable from the probe either (evidence §10.1).
The Dockerfile defaults it to 2 and every measurement in this PR assumed 2, so
2 × 8 = 16 threads. If the dashboard sets anything else, this change ships a
thread count that was never measured at that width: 4 workers would be 32
threads, each of which holds a chat turn and polls HealthClaw ~4×/s at the
engine that also serves clinicians. The `--threads` half is not env-settable,
so the two cannot be reconciled after the fact from the dashboard alone — it
would take another image. This is the same shape as the `PORT` trap this repo
already hit: a Dockerfile value the platform overrides. If the variable is not
2, do not deploy this until the number has been re-measured or the variable
has been set to 2.

## What was NOT run

- **No load against production.** Nothing was sent to `careagents.cloud` or
  `app.healthclaw.io`. The probe's rig is committed on
  `probe/219-thread-saturation` for anyone re-measuring locally.
- **The 2×8 config was not re-measured here.** These numbers are the probe's,
  taken on its branch.
- **No container was built or run**, so the new thread count is proven only
  through the Dockerfile's own `CMD` dispatch, as the existing container-roles
  tests do.
- **The `/healthz` timeout was asserted, not waited on** — no test hangs a real
  socket for 25s.
- Nothing was measured about how often 6 concurrent turns actually happen; that
  needs production telemetry the probe also could not get (evidence §10.4).

`dependency-audit` is red on every open PR from npm advisories already fixed in
unmerged PR #544; it is unrelated to this change.
