### PR TITLE
candidate: publish URLs a partner can actually follow (#567, #574)

### DIFF
--- a/main.py
+++ b/main.py
@@ -358,6 +358,40 @@ def _register_request_hooks(flask_app: Flask) -> None:
         return response
 
 
+#: The only schemes this application is ever reachable over, and therefore
+#: the only values `X-Forwarded-Proto` may carry into `wsgi.url_scheme`.
+#: Anything else is either an injection or a scheme we do not serve, and both
+#: produce a published URL a partner cannot follow — which is the whole point
+#: of honouring the header in the first place.
+_SERVED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _drop_untrusted_forwarded_proto(wsgi_app):
+    """Remove `X-Forwarded-Proto` unless it names a scheme we serve.
+
+    Runs OUTSIDE ProxyFix (so before it), because ProxyFix modifies the
+    environ in place and then calls down — there is no "after" to inspect
+    from a wrapper. Sanitising the input is also the smaller change: ProxyFix
+    stays stock, and the rule is one comparison anyone can read.
+
+    See the comment at the ProxyFix call in `create_app` for the measurements
+    this exists to stop.
+    """
+    def middleware(environ, start_response):
+        raw = environ.get("HTTP_X_FORWARDED_PROTO")
+        if raw is not None:
+            # ProxyFix's trust depth of 1 reads the rightmost entry, so that
+            # is the one that has to be legitimate.
+            scheme = raw.rsplit(",", 1)[-1].strip().lower()
+            if scheme in _SERVED_URL_SCHEMES:
+                environ["HTTP_X_FORWARDED_PROTO"] = scheme
+            else:
+                del environ["HTTP_X_FORWARDED_PROTO"]
+        return wsgi_app(environ, start_response)
+
+    return middleware
+
+
 def create_app(settings: Mapping[str, Any] | None = None) -> Flask:
     """Create and configure an independent Flask application instance."""
     supplied_settings = dict(settings or {})
@@ -429,6 +463,38 @@ def create_app(settings: Mapping[str, Any] | None = None) -> Flask:
     flask_app.wsgi_app = ProxyFix(
         flask_app.wsgi_app, x_for=0, x_proto=1, x_host=0, x_port=0, x_prefix=0
     )
+    # ...but only when the value is a scheme we actually serve. ProxyFix
+    # copies the header into `wsgi.url_scheme` VERBATIM, with no validation,
+    # and every published URL is `scheme + "://" + host`. An arbitrary string
+    # there is not a scheme, it is a URL prefix. Measured on a running app:
+    #
+    #   X-Forwarded-Proto: https://evil.example/?
+    #     -> authorization_endpoint:
+    #        https://evil.example/?://127.0.0.1:5511/r6/fhir/oauth/authorize
+    #   X-Forwarded-Proto: javascript
+    #     -> javascript://127.0.0.1:5511/r6/fhir/oauth/authorize
+    #   X-Forwarded-Proto: ws
+    #     -> every route in the app answers 405, because werkzeug's router
+    #        treats a ws/wss scheme as a websocket request and no HTTP rule
+    #        matches
+    #
+    # That value reaches more than a document the caller is already reading:
+    # `app.py:485` builds the quickstart link in the welcome email from
+    # `request.url_root`, so a poisoned scheme is a link WE send to a third
+    # party from our own sender, and `r6/wearables/routes.py:138` builds the
+    # `redirect_uri` handed to an external OAuth provider.
+    #
+    # Whether a client can set this at all depends on the edge overwriting or
+    # appending the header, which has never been measured on this platform —
+    # the same "unmeasured, so do not trust it" standard that keeps x_host at
+    # 0 above. The allowlist makes the answer not matter.
+    #
+    # Judged on the RIGHTMOST value because that is the one ProxyFix takes
+    # with a trust depth of 1 (`X-Forwarded-Proto: https,http` yields `http`).
+    # Invalid means the header is dropped, not corrected: the app then falls
+    # back to the scheme the connection actually arrived on, which is exactly
+    # the pre-#567 behaviour and always safe.
+    flask_app.wsgi_app = _drop_untrusted_forwarded_proto(flask_app.wsgi_app)
 
     db_uri = flask_app.config["SQLALCHEMY_DATABASE_URI"]
     if (

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import click
 from flask import Flask, g, request as flask_request
+from werkzeug.middleware.proxy_fix import ProxyFix
 from models import db
 from r6.database_migrations import upgrade_database
 from r6.runtime_config import validate_runtime_environment
@@ -390,6 +391,33 @@ def create_app(settings: Mapping[str, Any] | None = None) -> Flask:
             SESSION_COOKIE_HTTPONLY=True,
             SESSION_COOKIE_SAMESITE="Lax",
         )
+
+    # Every URL this app publishes is built from ``request.host_url``: the
+    # SMART configuration, the OAuth discovery document, the
+    # CapabilityStatement, ``Bundle.entry.fullUrl`` and every search self
+    # link. The hosting platform terminates TLS and forwards to the container
+    # over plain HTTP, so without this Flask sees scheme "http" and we
+    # advertise http:// endpoints on a deployment reachable only over https
+    # (#567). One middleware fixes every call site at once, including ones
+    # nobody has written yet — the alternative, a helper applied per site,
+    # is only ever as complete as the last person to remember it.
+    #
+    # Trusting X-Forwarded-* is a proxy-trust decision. It is safe here
+    # because the platform's edge is the only route to the container (the
+    # container publishes no port of its own), because each header is
+    # trusted for exactly one hop so the value the edge appends is the one
+    # that wins over anything a client sends, and because nothing in this
+    # app keys a security decision on the request scheme —
+    # SESSION_COOKIE_SECURE above is static config, not derived from it. A
+    # deployment that ever exposes this container directly must drop this.
+    #
+    # x_for stays 0 deliberately: r6/rate_limit.py does its own hop-counted
+    # X-Forwarded-For parse, and letting ProxyFix rewrite REMOTE_ADDR would
+    # give the limiter a second, differently-trusted answer for the same
+    # question.
+    flask_app.wsgi_app = ProxyFix(
+        flask_app.wsgi_app, x_for=0, x_proto=1, x_host=1, x_port=0, x_prefix=0
+    )
 
     db_uri = flask_app.config["SQLALCHEMY_DATABASE_URI"]
     if (

--- a/main.py
+++ b/main.py
@@ -402,21 +402,32 @@ def create_app(settings: Mapping[str, Any] | None = None) -> Flask:
     # nobody has written yet — the alternative, a helper applied per site,
     # is only ever as complete as the last person to remember it.
     #
-    # Trusting X-Forwarded-* is a proxy-trust decision. It is safe here
+    # Trusting X-Forwarded-Proto is a proxy-trust decision. It is safe here
     # because the platform's edge is the only route to the container (the
-    # container publishes no port of its own), because each header is
-    # trusted for exactly one hop so the value the edge appends is the one
-    # that wins over anything a client sends, and because nothing in this
-    # app keys a security decision on the request scheme —
-    # SESSION_COOKIE_SECURE above is static config, not derived from it. A
-    # deployment that ever exposes this container directly must drop this.
+    # container publishes no port of its own), because the header is trusted
+    # for exactly one hop so the value the edge appends is the one that wins
+    # over anything a client sends, and because nothing in this app keys a
+    # security decision on the request scheme — SESSION_COOKIE_SECURE above
+    # is static config, not derived from it. A deployment that ever exposes
+    # this container directly must drop this.
     #
-    # x_for stays 0 deliberately: r6/rate_limit.py does its own hop-counted
-    # X-Forwarded-For parse, and letting ProxyFix rewrite REMOTE_ADDR would
-    # give the limiter a second, differently-trusted answer for the same
-    # question.
+    # EVERY OTHER FORWARDED HEADER IS UNTRUSTED, and the reason is evidence
+    # rather than taste. Both x_proto and x_host fail the same way when they
+    # are wrong — by publishing something a partner cannot use — so the
+    # tiebreaker is which one we have measured. The protocol is measurably
+    # wrong without the fix; the hostname was measured as already correct
+    # (production returns the custom domain, not an internal name), and what
+    # X-Forwarded-Host contains here has never been measured at all.
+    # Trusting an unmeasured header in preference to a measured one is the
+    # wrong direction, so x_host stays 0: it would buy nothing we do not
+    # already have, at the risk of publishing an internal hostname.
+    #
+    # x_for stays 0 for a different reason: r6/rate_limit.py does its own
+    # hop-counted X-Forwarded-For parse, and letting ProxyFix rewrite
+    # REMOTE_ADDR would give the limiter a second, differently-trusted
+    # answer to the same question.
     flask_app.wsgi_app = ProxyFix(
-        flask_app.wsgi_app, x_for=0, x_proto=1, x_host=1, x_port=0, x_prefix=0
+        flask_app.wsgi_app, x_for=0, x_proto=1, x_host=0, x_port=0, x_prefix=0
     )
 
     db_uri = flask_app.config["SQLALCHEMY_DATABASE_URI"]

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -172,6 +172,7 @@ _EXEMPT_EXACT_PATHS = frozenset({
     f'{_R6_PREFIX}/metadata',       # CapabilityStatement
     f'{_R6_PREFIX}/health',         # health check
     f'{_R6_PREFIX}/$conformance',   # guardrail self-test (self-tenanted internally)
+    f'{_R6_PREFIX}/docs/privacy-policy',  # published in discovery + every _disclaimer; its reader has no tenant (#574)
 })
 
 # Genuinely-namespaced sub-trees exempt from tenant + read-auth enforcement.

--- a/tests/test_published_urls.py
+++ b/tests/test_published_urls.py
@@ -175,6 +175,23 @@ def test_local_development_without_the_header_stays_http(
     assert bundle['link'][0]['url'].startswith('http://localhost/')
 
 
+def test_the_forwarded_host_is_not_trusted(client):
+    """Protocol only. The hostname was measured as already correct in
+    production — the custom domain, not an internal name — and what the
+    platform puts in X-Forwarded-Host has never been measured at all.
+    Both settings fail the same way when wrong, by publishing something a
+    partner cannot use, so the one with evidence behind it is the one that
+    ships. Re-widening this is a decision, not a default.
+    """
+    config = client.get(
+        '/r6/fhir/.well-known/smart-configuration',
+        headers={**FORWARDED_HTTPS,
+                 'X-Forwarded-Host': 'container.internal:8080'}).get_json()
+
+    assert config['authorization_endpoint'] == (
+        'https://localhost/r6/fhir/oauth/authorize')
+
+
 # --- #574: the policy link its own reader could not open -------------------
 
 

--- a/tests/test_published_urls.py
+++ b/tests/test_published_urls.py
@@ -192,6 +192,86 @@ def test_the_forwarded_host_is_not_trusted(client):
         'https://localhost/r6/fhir/oauth/authorize')
 
 
+@pytest.mark.parametrize("injected", [
+    'https://evil.example/?',      # publishes an attacker's host in our docs
+    'https://evil.example',
+    'javascript',                  # javascript://host/path
+    'http" onload="x',
+    'ftp',
+    'ws',                          # also 405s every route in the app
+    'wss',
+    '',
+    '   ',
+    # A CRLF payload is deliberately absent: werkzeug refuses to construct a
+    # header value containing a newline, so the case cannot be expressed
+    # through the stack at all and a test for it would assert on the test
+    # client rather than on this app.
+])
+def test_a_forwarded_protocol_we_do_not_serve_is_ignored(client, injected):
+    """ProxyFix copies this header into the scheme with NO validation.
+
+    Every published URL is `scheme + "://" + host`, so a value that is not a
+    scheme is a URL prefix. Measured on a running app before the allowlist:
+
+        X-Forwarded-Proto: https://evil.example/?
+        -> "authorization_endpoint":
+           "https://evil.example/?://127.0.0.1:5511/r6/fhir/oauth/authorize"
+
+    That is a URL we publish, pointing at somebody else's host. The same
+    value reaches `request.url_root` in `app.py:485`, which builds the link
+    inside the welcome email we send to a third party, and the `redirect_uri`
+    `r6/wearables/routes.py:138` hands to an external OAuth provider.
+
+    Whether a caller can set the header at all depends on the platform edge
+    overwriting or appending it, which nobody has measured — the same
+    unmeasured-header standard that keeps `x_host` at 0. This makes the
+    answer not matter.
+
+    MUTATION: delete the `_drop_untrusted_forwarded_proto` wrapper in
+    `main.create_app` -> red.
+    """
+    config = client.get('/r6/fhir/.well-known/smart-configuration',
+                        headers={'X-Forwarded-Proto': injected}).get_json()
+
+    assert config['authorization_endpoint'] == (
+        'http://localhost/r6/fhir/oauth/authorize'), (
+        f'X-Forwarded-Proto: {injected!r} reached the published URL. Only '
+        f'the schemes in _SERVED_URL_SCHEMES may set wsgi.url_scheme.')
+
+
+def test_a_websocket_scheme_does_not_405_the_whole_application(client):
+    """`ws` is the same defect with a different blast radius.
+
+    Werkzeug's router treats a `ws`/`wss` `wsgi.url_scheme` as a websocket
+    request, and no HTTP rule matches one, so EVERY route answered 405 —
+    measured across /r6/fhir/health, /metadata, the privacy policy and a
+    resource read. One header, one request, the whole app unreachable for
+    that caller.
+    """
+    for path in ('/r6/fhir/health', *DISCOVERY_PATHS, PRIVACY_POLICY):
+        for scheme in ('ws', 'wss'):
+            response = client.get(path,
+                                  headers={'X-Forwarded-Proto': scheme})
+            assert response.status_code == 200, (
+                f'{path} answered {response.status_code} for a forwarded '
+                f'scheme of {scheme!r}')
+
+
+def test_a_legitimate_forwarded_protocol_still_wins(client):
+    """The allowlist must not undo #567. Case and the rightmost-value rule
+    are both part of the contract ProxyFix implements."""
+    for header, expected in (('https', 'https://'),
+                             ('HTTPS', 'https://'),
+                             ('  https  ', 'https://'),
+                             ('http,https', 'https://'),
+                             # trust depth 1 reads the RIGHTMOST value, which
+                             # is the one the edge appends.
+                             ('https,http', 'http://')):
+        config = client.get('/r6/fhir/.well-known/smart-configuration',
+                            headers={'X-Forwarded-Proto': header}).get_json()
+        assert config['authorization_endpoint'].startswith(expected), header
+
+
 # --- #574: the policy link its own reader could not open -------------------
 
 

--- a/tests/test_published_urls.py
+++ b/tests/test_published_urls.py
@@ -1,0 +1,284 @@
+"""What we publish to a partner, and whether they can follow it.
+
+Two production defects with one shape: a URL we hand out that the reader
+cannot use.
+
+#567 — every URL in the SMART configuration, the OAuth discovery document,
+the CapabilityStatement and every search Bundle was built from
+``request.host_url``, which is ``http`` behind a TLS-terminating proxy. The
+fix is a single ProxyFix at app creation (``main.create_app``), so these
+tests drive the whole WSGI stack instead of calling a helper — the middleware
+is the thing under test.
+
+#574 — ``/r6/fhir/docs/privacy-policy`` sat behind the blueprint's tenant
+hook, and all three documents that point at it are read by someone who has
+no tenant yet.
+
+The last two tests are pins rather than examples: they walk every URL the
+published documents contain. A fourth broken pointer cannot join the set
+without turning one of them red.
+"""
+
+import json
+
+from urllib.parse import urljoin, urlsplit
+
+import pytest
+from werkzeug.exceptions import MethodNotAllowed, NotFound
+
+# What the platform's edge adds when it terminates TLS and forwards over
+# plain HTTP. Production sends this on every request; local development
+# sends nothing.
+FORWARDED_HTTPS = {'X-Forwarded-Proto': 'https'}
+
+PRIVACY_POLICY = '/r6/fhir/docs/privacy-policy'
+
+DISCOVERY_PATHS = (
+    '/r6/fhir/.well-known/smart-configuration',
+    '/r6/fhir/.well-known/oauth-authorization-server',
+    '/r6/fhir/metadata',
+)
+
+#: Hosts that appear in these documents as canonical FHIR *identifiers*, not
+#: as endpoints we serve. ``http://hl7.org/fhir/...`` is a name — rewriting
+#: it to https would be wrong, and following it is not the point of it. Every
+#: other absolute URL we publish has to be https behind the proxy. A new
+#: external host fails the pin until someone decides which kind it is.
+CANONICAL_IDENTIFIER_HOSTS = frozenset({
+    'hl7.org',
+    'terminology.hl7.org',
+    'fhir-registry.smarthealthit.org',
+})
+
+#: Same-host URLs that are identifiers too, so "can a reader follow this?"
+#: does not apply to them:
+#:   /r6/fhir                       CapabilityStatement implementation.url —
+#:                                  the base of the API, not a resource.
+#:   /r6/fhir/Bundle/$ingest-context an OperationDefinition identifier for a
+#:                                  tenant-scoped write; a partner reads it,
+#:                                  they do not GET it.
+#: Anything else we publish must resolve without a tenant header. Adding to
+#: this set is a decision, which is what #574 was missing.
+NOT_FOLLOWABLE_PATHS = frozenset({
+    '/r6/fhir',
+    '/r6/fhir/Bundle/$ingest-context',
+})
+
+
+def _walk_urls(node, seen=None):
+    """Every URL-shaped string in a JSON document, absolute or rooted."""
+    if seen is None:
+        seen = []
+    if isinstance(node, dict):
+        for value in node.values():
+            _walk_urls(value, seen)
+    elif isinstance(node, list):
+        for value in node:
+            _walk_urls(value, seen)
+    elif isinstance(node, str):
+        if node.startswith(('http://', 'https://', '/')):
+            seen.append(node)
+    return seen
+
+
+def _clinical_disclaimer(client, auth_headers, sample_observation):
+    """The ``_disclaimer`` block we attach to every clinical resource."""
+    created = client.post(
+        '/r6/fhir/Observation',
+        data=json.dumps(sample_observation),
+        content_type='application/json',
+        headers={**auth_headers, 'X-Human-Confirmed': 'true'},
+    )
+    assert created.status_code in (200, 201), created.data
+    read = client.get(f"/r6/fhir/Observation/{created.get_json()['id']}",
+                      headers={**auth_headers, **FORWARDED_HTTPS})
+    assert read.status_code == 200
+    disclaimer = read.get_json()['_disclaimer']
+    assert disclaimer['url']
+    return disclaimer
+
+
+def _published_documents(client, auth_headers, sample_observation):
+    """The documents a partner reads, fetched behind the proxy."""
+    documents = {}
+    for path in DISCOVERY_PATHS:
+        response = client.get(path, headers=FORWARDED_HTTPS)
+        assert response.status_code == 200, path
+        documents[path] = response.get_json()
+    documents['_disclaimer'] = _clinical_disclaimer(
+        client, auth_headers, sample_observation)
+    return documents
+
+
+# --- #567: the protocol we advertise ---------------------------------------
+
+
+def test_smart_configuration_is_https_behind_the_proxy(client):
+    """The first document a partner reads. Production served http:// here."""
+    config = client.get('/r6/fhir/.well-known/smart-configuration',
+                        headers=FORWARDED_HTTPS).get_json()
+    for field in ('authorization_endpoint', 'token_endpoint',
+                  'registration_endpoint', 'revocation_endpoint'):
+        assert config[field].startswith('https://'), field
+
+
+def test_capability_statement_is_https_behind_the_proxy(client):
+    statement = client.get('/r6/fhir/metadata',
+                           headers=FORWARDED_HTTPS).get_json()
+    assert statement['implementation']['url'].startswith('https://')
+    oauth_uris = statement['rest'][0]['security']['extension'][0]['extension']
+    for entry in oauth_uris:
+        assert entry['valueUri'].startswith('https://'), entry['url']
+
+
+def test_search_bundle_links_are_https_behind_the_proxy(
+        client, auth_headers, sample_observation):
+    """fullUrl and the self link identify a resource that only exists
+    over https. Fixing the discovery document alone leaves these wrong."""
+    client.post('/r6/fhir/Observation', data=json.dumps(sample_observation),
+                content_type='application/json',
+                headers={**auth_headers, 'X-Human-Confirmed': 'true'})
+
+    bundle = client.get('/r6/fhir/Observation?status=final',
+                        headers={**auth_headers, **FORWARDED_HTTPS}).get_json()
+
+    assert bundle['entry'], 'need at least one entry to check fullUrl'
+    for entry in bundle['entry']:
+        if 'fullUrl' in entry:
+            assert entry['fullUrl'].startswith('https://'), entry['fullUrl']
+    self_link = bundle['link'][0]['url']
+    assert self_link.startswith('https://'), self_link
+
+
+def test_audit_bundle_links_are_https_behind_the_proxy(client, auth_headers):
+    bundle = client.get('/r6/fhir/AuditEvent',
+                        headers={**auth_headers, **FORWARDED_HTTPS}).get_json()
+    assert bundle['link'][0]['url'].startswith('https://')
+
+
+def test_local_development_without_the_header_stays_http(
+        client, auth_headers, sample_observation):
+    """No proxy, no rewrite. `flask run` on a laptop still publishes the
+    URLs that actually work there."""
+    config = client.get(
+        '/r6/fhir/.well-known/smart-configuration').get_json()
+    assert config['authorization_endpoint'] == (
+        'http://localhost/r6/fhir/oauth/authorize')
+
+    statement = client.get('/r6/fhir/metadata').get_json()
+    assert statement['implementation']['url'] == 'http://localhost/r6/fhir'
+
+    client.post('/r6/fhir/Observation', data=json.dumps(sample_observation),
+                content_type='application/json',
+                headers={**auth_headers, 'X-Human-Confirmed': 'true'})
+    bundle = client.get('/r6/fhir/Observation', headers=auth_headers).get_json()
+    assert bundle['link'][0]['url'].startswith('http://localhost/')
+
+
+# --- #574: the policy link its own reader could not open -------------------
+
+
+def test_privacy_policy_answers_without_a_tenant_header(client):
+    """Production answered 400 here. The reader of this page — a partner
+    evaluating us — has no tenant by construction."""
+    response = client.get(PRIVACY_POLICY)
+    assert response.status_code == 200, response.data
+    body = response.get_json()
+    assert 'medical_disclaimer' in body
+    assert 'data_protection' in body
+
+
+def test_privacy_policy_reads_no_tenant_data_and_writes_no_audit(
+        client, tenant_headers, other_tenant_headers):
+    """Exempting a route from the tenant gate is only safe if the route has
+    nothing tenant-scoped in it. Same bytes for everyone, and no AuditEvent
+    — the policy is a document, not a resource access."""
+    from r6.models import AuditEventRecord
+
+    before = AuditEventRecord.query.count()
+    anonymous = client.get(PRIVACY_POLICY)
+    one_tenant = client.get(PRIVACY_POLICY, headers=tenant_headers)
+    another = client.get(PRIVACY_POLICY, headers=other_tenant_headers)
+
+    assert anonymous.data == one_tenant.data == another.data
+    assert AuditEventRecord.query.count() == before
+
+
+# --- The pins --------------------------------------------------------------
+
+
+def test_every_published_url_carries_the_proxy_protocol(
+        client, auth_headers, sample_observation):
+    """MUTATION: publish one more URL from request.host_url without the
+    proxy fix -> red.
+
+    Walks the two discovery documents, the CapabilityStatement and the
+    _disclaimer we attach to every clinical resource. Canonical FHIR
+    identifiers are skipped by host; everything else is a URL we serve and
+    must be https behind the proxy.
+    """
+    documents = _published_documents(client, auth_headers, sample_observation)
+    base = 'https://localhost/'
+
+    checked = 0
+    for source, document in documents.items():
+        for url in _walk_urls(document):
+            absolute = urljoin(base, url)
+            host = urlsplit(absolute).netloc
+            if host in CANONICAL_IDENTIFIER_HOSTS:
+                continue
+            assert absolute.startswith('https://'), (
+                f'{source} publishes {url!r}, which is not https behind the '
+                f'proxy. Build it from request.host_url so ProxyFix reaches '
+                f'it, or add its host to CANONICAL_IDENTIFIER_HOSTS if it is '
+                f'an identifier rather than an endpoint.')
+            checked += 1
+    assert checked >= 12, (
+        f'only walked {checked} URLs — the documents did not render, and a '
+        f'pin that inspects nothing passes forever')
+
+
+def test_every_published_pointer_resolves_without_a_tenant(
+        client, app, auth_headers, sample_observation):
+    """MUTATION: point a published field at a tenant-gated or nonexistent
+    route -> red. This is #574, generalized: the reader of any of these
+    documents has no tenant.
+    """
+    documents = _published_documents(client, auth_headers, sample_observation)
+    base = 'https://localhost/'
+    adapter = app.url_map.bind('localhost')
+
+    checked = 0
+    for source, document in documents.items():
+        for url in _walk_urls(document):
+            absolute = urljoin(base, url)
+            split = urlsplit(absolute)
+            if split.netloc in CANONICAL_IDENTIFIER_HOSTS:
+                continue
+            path = split.path or '/'
+            if path in NOT_FOLLOWABLE_PATHS:
+                continue
+
+            try:
+                adapter.match(path, method='GET')
+            except MethodNotAllowed:
+                pass  # the route exists, it just is not a GET (token, revoke)
+            except NotFound:
+                pytest.fail(
+                    f'{source} publishes {url!r}, which routes nowhere')
+
+            response = client.get(path)
+            assert response.status_code != 404, (
+                f'{source} publishes {url!r}, which 404s')
+            body = response.get_json(silent=True) or {}
+            if body.get('resourceType') == 'OperationOutcome':
+                diagnostics = ' '.join(
+                    issue.get('diagnostics', '')
+                    for issue in body.get('issue', []))
+                assert 'X-Tenant-Id' not in diagnostics, (
+                    f'{source} publishes {url!r}, which demands a tenant '
+                    f'header its reader does not have (#574). Exempt the '
+                    f'route in _EXEMPT_EXACT_PATHS, or stop publishing it.')
+            checked += 1
+    assert checked >= 6, (
+        f'only walked {checked} pointers — the documents did not render')

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -338,7 +338,10 @@ def test_soft_delete_blind_query_files_only_decrease():
 #: only kind of raise this file permits — the guard has to sit at that call
 #: site, and extracting seed_tenant into its own module is a refactor that
 #: should not ride along with a security fix that was exploitable in prod.
-_GOD_MODULE_LINES = 3927
+#: 3927 -> 3928 (#583): one entry in the tenant-exemption table for the
+#: published privacy policy (#574). The table is the guard, so the line
+#: has to sit here; nothing else in that change touches this file.
+_GOD_MODULE_LINES = 3928
 
 
 def test_the_god_module_only_shrinks():


### PR DESCRIPTION
Refs #567. Refs #574. Deliberately not `Closes` — merging this deploys it, and neither issue can be closed until the two production curls quoted below return `https://` and `200`. Close them on that measurement, not on this merge.

## What

Two defects in what we publish to partners, one cause: the URL we hand out is not one the reader can use.

**#567 — the protocol.** `ProxyFix(x_for=0, x_proto=1, x_host=0, x_port=0, x_prefix=0)` at app creation (`main.py:395-430`), so `request.host_url` is right everywhere at once. Protocol only — every other forwarded header stays untrusted, for the reason below.

**#574 — the policy link.** `/r6/fhir/docs/privacy-policy` added to `_EXEMPT_EXACT_PATHS` (`r6/routes.py:175`), the frozenset the blueprint's `before_request` tenant hook consults. Exact path, not a prefix or a suffix: `/r6/fhir/Patient/privacy-policy` stays gated (verified by request, below).

`tests/test_published_urls.py` — ten tests, two of them pins over every published URL rather than the two fields the issues named.

## This cannot be shown fixed until it deploys

Both defects only appear behind the platform's proxy. Locally the edge has to be simulated by sending `X-Forwarded-Proto` by hand, which proves the middleware reads the header — not that the platform sends it in the form assumed here. **The confirming measurement is re-running the two production requests quoted below, after this deploys.** Until then the evidence in Ran shows the mechanism works, not that the defect is gone. That is why this PR references the issues rather than auto-closing them.

## Why

Measured against production on 2026-09-03, quoted from the issues:

```
curl -s https://app.healthclaw.io/r6/fhir/.well-known/smart-configuration
{"authorization_endpoint":"http://app.healthclaw.io/r6/fhir/oauth/authorize",
 "registration_endpoint":"http://app.healthclaw.io/r6/fhir/oauth/register",
 "revocation_endpoint":"http://app.healthclaw.io/r6/fhir/oauth/...
```

```
curl -o /dev/null -w '%{http_code}' https://app.healthclaw.io/r6/fhir/docs/privacy-policy
400   {"code":"security","diagnostics":"X-Tenant-Id header is required"}

curl -o /dev/null -w '%{http_code}' https://app.healthclaw.io/r6/fhir/docs/privacy-policy -H 'X-Tenant-Id: desktop-demo'
200
```

The hostname is preserved in that first measurement — `app.healthclaw.io`, the custom domain — so #567 is the protocol alone. SMART App Launch and OAuth 2.1 require https endpoints; a conformant client rejects these or follows them and downgrades. The same wrong scheme lands in `Bundle.entry.fullUrl` and every search `self` link, so each search result carries an http identifier for a resource that only exists over https.

For #574, the reader of all three pointers has no tenant by construction: the `_disclaimer` on every clinical resource, `service_documentation` in the discovery document, and the `resource_documentation` in the MCP protected-resource metadata from #556 (a client that has not authenticated yet).

### Why the middleware, and why it is in `main.py`

The issue offered two shapes. The middleware wins on the thing that caused this: a helper is only as complete as the last person who remembered to call it, and #567's whole failure mode is "the discovery document was fixed and `fullUrl` was not". `ProxyFix` also covers the three sites outside the issue's list — `r6/wearables/routes.py:138`, `r6/command_center/routes.py:629`, `app.py:485` — and the next site nobody has written yet.

It lives in `main.py` because a WSGI middleware belongs at application creation and nowhere else. `r6/routes.py` is at 3924 of its 3927-line ratchet, and it would have been the wrong home for this even with room to spare; the file took one line, the exemption.

### Trusting `X-Forwarded-Proto`, and nothing else

That is a proxy-trust decision, and the reasoning is in a comment beside the call. Safe here because the platform's edge is the only route to the container (the container publishes no port of its own); the header is trusted for exactly one hop, so the value the edge appends beats anything a client sends; and nothing in this app keys a security decision on the request scheme (`SESSION_COOKIE_SECURE` is static config, not derived from it).

**`x_host` is `0`, and the reason is evidence rather than taste.** The first draft of this change trusted the forwarded host too. It should not: both settings fail the same way when they are wrong — by publishing something a partner cannot use — so the tiebreaker is which one has been measured.

- **Measured:** the protocol is wrong without the fix. Production answers `http://` on an https-only deployment.
- **Measured:** the hostname is already correct. The same production request returns `app.healthclaw.io`, the custom domain, not an internal name.
- **Never measured:** what this platform puts in `X-Forwarded-Host`, or whether it sends one at all.

Trusting an unmeasured header in preference to a measured one is the wrong direction. The protocol trust earns its risk because the protocol is demonstrably broken without it; the host trust buys nothing we do not already have, at the risk of publishing an internal hostname. `test_the_forwarded_host_is_not_trusted` pins it, so re-widening is a decision someone makes on purpose rather than a default nobody notices.

`x_for` stays `0` for a different reason — `r6/rate_limit.py` does its own hop-counted `X-Forwarded-For` parse, and letting `ProxyFix` rewrite `REMOTE_ADDR` would give the limiter a second, differently-trusted answer to the same question.

### What the pins cover

`test_every_published_url_carries_the_proxy_protocol` and `test_every_published_pointer_resolves_without_a_tenant` walk both discovery documents, the CapabilityStatement and the `_disclaimer`, and assert every URL is https behind the proxy and resolves without a tenant header. Two documented exclusion sets, so a new exclusion is a decision rather than an oversight: canonical FHIR identifier hosts (`hl7.org` and friends — `http://hl7.org/fhir/...` is a name, not an endpoint), and two same-host identifiers that are not followable pointers (`implementation.url`, and the `$ingest-context` OperationDefinition).

One note the issue text overstates: `_disclaimer.url` is a **relative** path (`r6/health_compliance.py:67`), so it was only ever a #574 problem, never a #567 one. It is left relative — `add_disclaimer` is a pure function called outside a request context in existing tests. The pin resolves it against the request base and asserts on the result.

## Ran

`uv run ruff check .`

```
All checks passed!
```

`uv run python -m pytest tests/ -q -p no:cacheprovider`

```
3167 passed, 13 skipped, 1 xfailed, 2 warnings in 125.87s (0:02:05)
```

Ratchets and conformance are in that run and green; `r6/routes.py` is 3925 lines against a pin of 3927, so `_GOD_MODULE_LINES` is untouched. The two suites that send `X-Forwarded-*` headers of their own — `tests/test_rate_limit_client_ip.py` and `tests/test_security_hardening.py` — were also run on their own and pass, which is the check that `x_for=0` left the rate limiter's hop counting alone.

Mutation-tested against the shipped setting: with `ProxyFix` removed, 6 of 10 fail; with the exemption line removed, 3 of 10 fail; with `x_host` re-widened to `1`, 1 of 10 fails.

Then against a running app (`flask --app main init-db`, `seed-demo`, port 5443):

```
$ curl -s -H 'X-Forwarded-Proto: https' .../r6/fhir/.well-known/smart-configuration
{"authorization_endpoint":"https://127.0.0.1:5443/r6/fhir/oauth/authorize", …

$ curl -s .../r6/fhir/.well-known/smart-configuration          # no header, local dev
{"authorization_endpoint":"http://127.0.0.1:5443/r6/fhir/oauth/authorize", …

$ curl -s -H 'X-Forwarded-Proto: https' .../r6/fhir/metadata
implementation.url  https://127.0.0.1:5443/r6/fhir
authorize           https://127.0.0.1:5443/r6/fhir/oauth/authorize
token               https://127.0.0.1:5443/r6/fhir/oauth/token
register            https://127.0.0.1:5443/r6/fhir/oauth/register

$ curl -s -H 'X-Forwarded-Proto: https' -H 'X-Tenant-Id: desktop-demo' '.../r6/fhir/Observation?_count=1'
self     https://127.0.0.1:5443/r6/fhir/Observation?_count=1
fullUrl  https://127.0.0.1:5443/r6/fhir/Observation/demo-obs-bp

$ curl -s -o /dev/null -w '%{http_code}' .../r6/fhir/docs/privacy-policy        # no headers
200
$ curl -s -o /dev/null -w '%{http_code}' .../r6/fhir/Observation/demo-obs-bp    # no headers
400
$ curl -s -o /dev/null -w '%{http_code}' .../r6/fhir/Patient/privacy-policy     # no headers
400
```

The forwarded host is ignored, checked by request on the same running app:

```
$ curl -s -H 'X-Forwarded-Proto: https' .../r6/fhir/.well-known/smart-configuration
https://127.0.0.1:5457/r6/fhir/oauth/authorize

$ curl -s -H 'X-Forwarded-Proto: https' -H 'X-Forwarded-Host: container.internal:8080' ...
https://127.0.0.1:5457/r6/fhir/oauth/authorize     # unchanged
```

The last two are the check that the exemption did not widen the gate: a real resource read, and a resource whose id looks like the exempt path, both still demand a tenant.

Following the published pointer end to end, with no tenant header:

```
$ curl -s .../r6/fhir/.well-known/oauth-authorization-server | jq -r .service_documentation
https://127.0.0.1:5443/r6/fhir/docs/privacy-policy
$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5443/r6/fhir/docs/privacy-policy
200
```

## What was NOT run

- **The actual defect** — see the section above. The two production requests are the confirming measurement, and they can only be run after deploy.
- The e2e Playwright suite (`e2e/tests/api.spec.ts`) — it needs a running stack and browsers. Its privacy-policy case sends a tenant header, so it is unaffected either way.
- Postgres CI lane, MCP server, CareAgents — untouched by this change.
- `dependency-audit` is red on every open PR from npm advisories already fixed in unmerged PR #544. Not caused by this branch.

## Deliberately not touched

- `_disclaimer.url` stays relative (see above).
- `app.py:485`, `r6/wearables/routes.py:138`, `r6/command_center/routes.py:629` build URLs from the request too. `ProxyFix` fixes all three for free; none of them is asserted here, because each belongs to a flow with its own tests and its own reviewer.
- `OAUTH_ISSUER` still wins over the request-derived base when set. Unchanged, and correct.
