### PR TITLE
candidate: every unanswered leaf reports, and the explanation is said once (review of #576)

### DIFF
--- a/r6/sdc/expressions.py
+++ b/r6/sdc/expressions.py
@@ -151,7 +151,7 @@ def build_context(subject=None):
     return {'patient': projection, 'subject': projection}
 
 
-def evaluate(expression, resource, context=None, link_id=None):
+def evaluate(expression, resource, context=None, link_id=None, warned=None):
     """Evaluate a FHIRPath expression, returning a scalar, list, or None.
 
     Returns the single value when the result has one element, the list when
@@ -159,6 +159,16 @@ def evaluate(expression, resource, context=None, link_id=None):
 
     `link_id` names the questionnaire item, for the failure log only — see
     below for why it is what gets logged and the expression is not.
+
+    `warned` is an optional set of linkIds already logged, owned by the
+    caller and scoped to ONE REQUEST — populate_questionnaire builds it per
+    call. It exists because the same leaf is evaluated once per repeat
+    inside a list group, and a malformed expression would otherwise log a
+    line per row: the caller supplies the records through the inline
+    `content` Bundle, so log volume would scale with attacker-controlled
+    input. The evaluation itself is unchanged and still happens per row —
+    this is a logging concern only, and every line after the first says the
+    same thing about the same linkId.
     """
     if not expression:
         return None
@@ -175,6 +185,13 @@ def evaluate(expression, resource, context=None, link_id=None):
         # is caller-supplied too, and %r is what escapes control characters
         # in it. Pinned by tests/test_sdc_expressions.py::
         # test_a_failing_expression_is_not_echoed_into_the_log.
+        #
+        # ONCE PER REQUEST PER LINKID. `warned` is None for callers with no
+        # request scope (the direct unit tests), and those log every time.
+        if warned is not None:
+            if link_id in warned:
+                return None
+            warned.add(link_id)
         logger.warning('FHIRPath evaluation failed for item %r: %s',
                        link_id, type(exc).__name__)
         return None

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -10,7 +10,16 @@ Pure function (no DB, no Flask). Supports three SDC population mechanisms:
   - List-resource-based: a `repeats: true` group whose leaves carry a
     `definition` naming a supported resource type (MedicationRequest /
     AllergyIntolerance / Condition) emits one repeat of the group per
-    matching resource for the subject (see _populate_list_group).
+    matching resource for the subject, resolving leaves at every nesting
+    depth inside the group (see _populate_list_group).
+
+WHAT COUNTS AS ATTEMPTED, since it is one rule and it is read in two places:
+an initialExpression, an `item.code`, or a `definition` on a leaf anywhere
+under a `repeats: true` group. The third clause does NOT depend on the type
+the definition names — a repeating group of Immunizations is an attempted
+population this file has no resolver for, so it answers nothing and reports
+every leaf, rather than going silent and letting a caller read the silence
+as "this patient has no immunizations".
 
 Out of scope (v1): StructureMap-based and CQL populate.
 
@@ -29,12 +38,23 @@ and test_zero_medications_never_infers_no_current_medications.
 
 from r6.sdc.expressions import build_context, evaluate
 
-#: What an attempted-but-unresolved leaf reports. ONE sentence for both
-#: causes, because the server does not tell the two apart and must not appear
-#: to: "the projection withheld it" and "the patient has no email address"
-#: read identically here on purpose. `questionnaire_populate` is in the
-#: model-facing read tier, and text naming a refusal would have a model tell
-#: a patient their record was held back when it is simply empty.
+#: Why attempted-but-unresolved leaves report, said ONCE PER RESPONSE. ONE
+#: sentence for both causes, because the server does not tell the two apart
+#: and must not appear to: "the projection withheld it" and "the patient has
+#: no email address" read identically here on purpose.
+#: `questionnaire_populate` is in the model-facing read tier, and text naming
+#: a refusal would have a model tell a patient their record was held back
+#: when it is simply empty.
+#:
+#: ONCE, not once per leaf. This constant is identical for every leaf of
+#: every response, so a copy on each issue was pure repetition: it made the
+#: response grow with the number of unanswered leaves TIMES a fixed
+#: paragraph, and a 29.3KB request came back 3519.6KB over HTTP. The issues
+#: now carry the only thing that varies — the linkId — and this sentence is
+#: emitted once beside them (r6/sdc/routes.py:_issues_outcome). The CTO
+#: ruling on the QA review of #576 chose this over a cap: a cap is a second
+#: control to reason about and would silently truncate a legitimate long
+#: form, while the amplification was entirely the repetition of a constant.
 #:
 #: What the caller gets instead is the allowlist, which is public — they can
 #: compare it against their own expression without the server answering a
@@ -46,8 +66,9 @@ from r6.sdc.expressions import build_context, evaluate
 #: it, and a `where(value='...')` clause is a place to park a literal that
 #: would then ride out on an OperationOutcome.
 NOT_POPULATED = (
-    'not populated: no value resolved. $populate reads only the %patient '
-    'projection (name, birthDate, gender, telecom phone/email, address '
+    'not populated: no value resolved. Each accompanying issue names one '
+    'such item by linkId. $populate reads only the %patient projection '
+    '(name, birthDate, gender, telecom phone/email, address '
     'line/city/state/postalCode) and coded content this server recognises; '
     'anything else is not read.'
 )
@@ -187,8 +208,11 @@ def populate_questionnaire(questionnaire, subject, content_resources):
         Condition rows the list groups match. NOT the subject: that arrives
         as `subject` above, and putting it here as well left an unredacted
         Patient reachable by anything walking this list (PR #562 review).
-    issues: list of {'linkId', 'detail'} for items that errored (not for
-        items that simply had no data).
+    issues: list of {'linkId'} — one entry per leaf OCCURRENCE where
+        population was attempted and no value resolved. The reason is the
+        same for all of them and is the module constant NOT_POPULATED, said
+        once per response by r6/sdc/routes.py:_issues_outcome rather than
+        copied onto each entry.
     """
     issues = []
     # The context carries a BOUNDED projection of `subject`, never the stored
@@ -203,7 +227,8 @@ def populate_questionnaire(questionnaire, subject, content_resources):
     answer_items = []
     for item in questionnaire.get("item", []):
         answer_items.extend(_populate_item(
-            item, subject, context, observations, issues, content_resources))
+            item, subject, context, observations, issues, content_resources,
+            in_repeating_group=False))
 
     qr = {
         "resourceType": "QuestionnaireResponse",
@@ -217,10 +242,16 @@ def populate_questionnaire(questionnaire, subject, content_resources):
     return qr, issues
 
 
-def _populate_item(item, subject, context, observations, issues, content_resources):
+def _populate_item(item, subject, context, observations, issues,
+                   content_resources, in_repeating_group):
     """Populate one questionnaire item. Always returns a list of zero or more
     QuestionnaireResponse items (zero or one for ordinary items; zero or many
     for a repeating list-resource group — one per matching resource).
+
+    `in_repeating_group` is True once ANY ancestor group carries
+    `repeats: true`. It is what makes a `definition` leaf an attempted
+    population — see _resolve_answer's last branch, which is where the rule
+    is written down.
     """
     link_id = item.get("linkId")
     item_type = item.get("type")
@@ -231,18 +262,22 @@ def _populate_item(item, subject, context, observations, issues, content_resourc
             return _populate_list_group(item, list_resource_type, subject,
                                         content_resources, issues)
         # Ordinary group: recurse, keep the group only if it produced
-        # child answers.
+        # child answers. A `repeats: true` group whose leaves name a type
+        # with no resolver lands here too — that is what the flag carries
+        # down, so its leaves still count as attempted.
+        nested = in_repeating_group or bool(item.get("repeats"))
         children = []
         for child in item.get("item", []):
             children.extend(_populate_item(
                 child, subject, context, observations, issues,
-                content_resources))
+                content_resources, nested))
         if not children:
             return []
         return [{"linkId": link_id, "item": children}]
 
     answer_value, value_key = _resolve_answer(
-        item, item_type, context, observations, issues, link_id)
+        item, item_type, context, observations, issues, link_id,
+        in_repeating_group)
     # Leaf items are always emitted so the response mirrors the questionnaire's
     # structure; the answer array is attached only when a value resolved.
     answer_item = {"linkId": link_id}
@@ -309,25 +344,57 @@ def _populate_list_group(item, resource_type, subject, content_resources,
         and config["included"](r)
     ]
 
-    repeats = []
-    for resource in resources:
-        children = []
-        for child in item.get("item", []):
-            child_resource_type, element_path = _parse_definition(
-                child.get("definition"))
-            resolver = None
-            if child_resource_type == resource_type:
-                resolver = config["resolvers"].get(element_path)
-            value = resolver(resource) if resolver else None
-            child_item = {"linkId": child.get("linkId")}
-            if value is not None:
-                value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
-                child_item["answer"] = [{value_key: value}]
-            elif child.get("definition"):
-                _report_unpopulated(issues, child.get("linkId"))
-            children.append(child_item)
-        repeats.append({"linkId": item.get("linkId"), "item": children})
-    return repeats
+    return [{"linkId": item.get("linkId"),
+             "item": _populate_list_children(item.get("item", []),
+                                             resource_type, config, resource,
+                                             issues)}
+            for resource in resources]
+
+
+def _populate_list_children(items, resource_type, config, resource, issues):
+    """Resolve one row's leaves, AT EVERY DEPTH, and report the ones that
+    resolve nothing.
+
+    NESTED GROUPS ARE WALKED, and that is the fix rather than an
+    embellishment. This loop used to visit the repeating group's DIRECT
+    children only and test `child.get("definition")`; a child that is itself
+    a group carries none, so it was emitted as a bare item and its own
+    leaves were never visited at all — no answer, no issue, and no item in
+    the response. A stored `reaction.manifestation.text` and the leaf asking
+    for it both simply vanished (QA addendum to the review of #576).
+
+    The response mirrors the questionnaire's structure at every depth now,
+    which is what makes "every leaf that could carry an answer and does not
+    gets an issue" a checkable claim instead of a vacuous one: a leaf that
+    is missing from the response is neither answered nor unanswered, so
+    dropping it satisfies the biconditional while defeating its purpose.
+    Pinned by tests/test_populate_issue_property.py's structural mirror.
+    """
+    children = []
+    for child in items:
+        if child.get("type") == "group":
+            nested = _populate_list_children(child.get("item", []),
+                                             resource_type, config, resource,
+                                             issues)
+            group_item = {"linkId": child.get("linkId")}
+            if nested:
+                group_item["item"] = nested
+            children.append(group_item)
+            continue
+        child_resource_type, element_path = _parse_definition(
+            child.get("definition"))
+        resolver = None
+        if child_resource_type == resource_type:
+            resolver = config["resolvers"].get(element_path)
+        value = resolver(resource) if resolver else None
+        child_item = {"linkId": child.get("linkId")}
+        if value is not None:
+            value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
+            child_item["answer"] = [{value_key: value}]
+        elif child.get("definition"):
+            _report_unpopulated(issues, child.get("linkId"))
+        children.append(child_item)
+    return children
 
 
 def _references_subject(resource, subject_field, subject_ref):
@@ -342,7 +409,8 @@ def _references_subject(resource, subject_field, subject_ref):
     return ref == subject_ref.get("reference")
 
 
-def _resolve_answer(item, item_type, context, observations, issues, link_id):
+def _resolve_answer(item, item_type, context, observations, issues, link_id,
+                    in_repeating_group):
     value_key = _ANSWER_KEY_BY_TYPE.get(item_type, "valueString")
 
     expr = _initial_expression(item)
@@ -369,21 +437,52 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id):
         _report_unpopulated(issues, link_id)
         return None, value_key
 
-    # No initialExpression and no code: NOTHING WAS ATTEMPTED, so nothing is
-    # reported. THIS IS THE EXCLUSION AND IT IS LOAD-BEARING —
+    # No initialExpression and no code. Two cases, and the difference between
+    # them is finding 1 of the QA review of #576.
+    #
+    # (a) A `definition` leaf inside a repeating group IS an attempted list
+    # population — the questionnaire asked for one element of one record per
+    # row. When the group's leaves name a type _LIST_RESOURCE_CONFIG
+    # implements, _populate_list_group resolved and reported them and this
+    # branch is never reached. When they name anything else there is no
+    # resolver, _list_group_resource_type returns None, the group falls
+    # through to ordinary recursion, and the leaves arrive HERE. They used to
+    # return silently: unanswered leaves and ZERO issues — no `issues`
+    # parameter on the response at all — which is exactly the state the
+    # ruling set out to remove, a caller reading silence as "this patient has
+    # no such value". The predicate is deliberately about the
+    # QUESTIONNAIRE's structure and nothing else: not the record, and not
+    # which resource types this file happens to implement, so adding a
+    # fourth type cannot change who reports.
+    if in_repeating_group and item.get("definition"):
+        _report_unpopulated(issues, link_id)
+        return None, value_key
+
+    # (b) NOTHING WAS ATTEMPTED, so nothing is reported. THIS IS THE
+    # EXCLUSION AND IT IS LOAD-BEARING —
     # `allergies.no-known-allergies` and `medications.no-current-medications`
     # reach exactly here. They carry no code and no expression precisely so
     # that no mechanism ever touches them (r6/sdc/intake.py). An issue
     # reading "not populated: no value resolved" against `no-known-allergies`
     # tells a model-facing reader that the system tried to determine NKA and
     # could not — which is a hair from inferring it, and inferring it is the
-    # non-negotiable. Pinned by tests/test_populate_lists.py::
+    # non-negotiable. Clause (a) cannot reach them for two independent
+    # reasons: they carry no `definition`, and they are siblings of the
+    # repeating `<section>.item` group rather than children of it. Pinned by
+    # tests/test_populate_lists.py::
     # test_the_attestation_items_never_appear_in_the_issue_list.
     return None, value_key
 
 
 def _report_unpopulated(issues, link_id):
     """Record that `link_id` was attempted and resolved nothing.
+
+    ONE FIELD, and it is the only thing that varies between two of these.
+    The reason is NOT_POPULATED — the same constant for every leaf of every
+    response — so a copy per issue made the response grow with the number of
+    unanswered leaves TIMES a fixed paragraph, measured at 3519.6KB back from
+    a 29.3KB request. r6/sdc/routes.py:_issues_outcome says the sentence once
+    and gives each issue its linkId.
 
     UNCONDITIONAL, and that is the design rather than an omission. The
     response already says which leaves have no answer — `_populate_item`
@@ -404,7 +503,7 @@ def _report_unpopulated(issues, link_id):
     the biconditional per item; any classifier reddens on the first leaf it
     silences.
     """
-    issues.append({"linkId": link_id, "detail": NOT_POPULATED})
+    issues.append({"linkId": link_id})
 
 
 def _observation_answer(item_codes, observations):

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -13,10 +13,20 @@ Pure function (no DB, no Flask). Supports three SDC population mechanisms:
     matching resource for the subject, resolving leaves at every nesting
     depth inside the group (see _populate_list_group).
 
+THE THREE ARE NOT EXCLUSIVE AND NONE OF THEM DEPENDS ON WHERE THE LEAF SITS.
+A leaf inside a list row that carries an initialExpression or an `item.code`
+populates by that mechanism, exactly as it would outside one; the row's own
+record is tried first and the rest is _resolve_answer's, which is the single
+place this rule is implemented.
+
 WHAT COUNTS AS ATTEMPTED, since it is one rule and it is read in two places:
 an initialExpression, an `item.code`, or a `definition` on a leaf anywhere
-under a `repeats: true` group. The third clause does NOT depend on the type
-the definition names — a repeating group of Immunizations is an attempted
+under a `repeats: true` group. ALL THREE CLAUSES, INSIDE A LIST ROW AS WELL —
+the engine used to implement the third alone there, so an expression leaf in
+an AllergyIntolerance group was neither evaluated nor reported while the same
+leaf in an Immunization group was both, which put _LIST_RESOURCE_CONFIG back
+into the predicate by the back door (QA review of #584). The third clause
+does NOT depend on the type the definition names — a repeating group of Immunizations is an attempted
 population this file has no resolver for, so it answers nothing and reports
 every leaf, rather than going silent and letting a caller read the silence
 as "this patient has no immunizations".
@@ -260,6 +270,7 @@ def _populate_item(item, subject, context, observations, issues,
         list_resource_type = _list_group_resource_type(item)
         if item.get("repeats") and list_resource_type:
             return _populate_list_group(item, list_resource_type, subject,
+                                        context, observations,
                                         content_resources, issues)
         # Ordinary group: recurse, keep the group only if it produced
         # child answers. A `repeats: true` group whose leaves name a type
@@ -311,8 +322,8 @@ def _parse_definition(definition):
     return parts[0], parts[1]
 
 
-def _populate_list_group(item, resource_type, subject, content_resources,
-                         issues):
+def _populate_list_group(item, resource_type, subject, context, observations,
+                         content_resources, issues):
     """Emit one repeat of `item` per matching, currently-relevant resource of
     `resource_type` for `subject`. Returns [] when there are none — an empty
     repeating group, never a default answer for a sibling item (see module
@@ -327,13 +338,14 @@ def _populate_list_group(item, resource_type, subject, content_resources,
     tests/test_populate_lists.py::
     test_three_unlabelled_allergies_still_produce_three_repeats.
 
-    Leaves report through the same mechanism as everything else: a leaf
-    carrying a `definition` is an attempted population, so one that resolves
-    nothing gets an issue naming its linkId. A leaf with no `definition` is
-    not attempted and is left alone — that is the same exclusion
-    `_resolve_answer` applies to the attestation booleans, and it is why a
-    future patient-entered leaf inside a repeating group will not be
-    reported as something the server failed to fill.
+    Leaves report through the same mechanism as everything else, and that
+    is now literally true rather than nearly: a row's leaves end at
+    `_resolve_answer`, the one function that decides what was attempted. A
+    leaf with NO mechanism at all — no definition, no expression, no code —
+    is left alone there, which is the same exclusion that keeps the
+    attestation booleans out of the issue list, and it is why a future
+    patient-entered leaf inside a repeating group will not be reported as
+    something the server failed to fill.
     """
     config = _LIST_RESOURCE_CONFIG[resource_type]
     subject_ref = _reference(subject)
@@ -347,13 +359,36 @@ def _populate_list_group(item, resource_type, subject, content_resources,
     return [{"linkId": item.get("linkId"),
              "item": _populate_list_children(item.get("item", []),
                                              resource_type, config, resource,
-                                             issues)}
+                                             context, observations, issues)}
             for resource in resources]
 
 
-def _populate_list_children(items, resource_type, config, resource, issues):
-    """Resolve one row's leaves, AT EVERY DEPTH, and report the ones that
-    resolve nothing.
+def _populate_list_children(items, resource_type, config, resource, context,
+                            observations, issues):
+    """Resolve one row's leaves, AT EVERY DEPTH AND BY EVERY MECHANISM, and
+    report the ones that resolve nothing.
+
+    THE ROW'S RECORD FIRST, THEN `_resolve_answer` FOR EVERYTHING ELSE. This
+    loop used to resolve a leaf by `definition` and by nothing else, and to
+    carry its own copy of the reporting decision (`elif
+    child.get("definition")`). A leaf carrying an initialExpression or an
+    `item.code` inside a MedicationRequest / AllergyIntolerance / Condition
+    group was therefore neither evaluated nor reported — an unanswered leaf
+    and no issue, which is the silence a caller reads as "this patient has
+    no such value". The same leaf inside a repeating group naming a type
+    with no resolver WAS evaluated and reported, because that group falls
+    through to ordinary recursion: which mechanisms applied depended on
+    whether `_LIST_RESOURCE_CONFIG` happened to contain the group's type,
+    so deleting the type table from the predicate had moved it here rather
+    than removed it (QA review of #584).
+
+    Handing the leaf to `_resolve_answer` leaves ONE implementation of
+    "attempted" in this file. A leaf whose definition names an element of
+    this row's resource takes the record value; anything else — including a
+    definition with no resolver — falls through to the shared predicate,
+    which evaluates the other two mechanisms and makes the one reporting
+    decision. Adding a fourth resource type still changes only which leaves
+    ANSWER.
 
     NESTED GROUPS ARE WALKED, and that is the fix rather than an
     embellishment. This loop used to visit the repeating group's DIRECT
@@ -375,24 +410,34 @@ def _populate_list_children(items, resource_type, config, resource, issues):
         if child.get("type") == "group":
             nested = _populate_list_children(child.get("item", []),
                                              resource_type, config, resource,
-                                             issues)
+                                             context, observations, issues)
             group_item = {"linkId": child.get("linkId")}
             if nested:
                 group_item["item"] = nested
             children.append(group_item)
             continue
+        link_id = child.get("linkId")
         child_resource_type, element_path = _parse_definition(
             child.get("definition"))
         resolver = None
         if child_resource_type == resource_type:
             resolver = config["resolvers"].get(element_path)
         value = resolver(resource) if resolver else None
-        child_item = {"linkId": child.get("linkId")}
+        value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
+        if value is None:
+            # This row's record held nothing for the leaf — or the leaf does
+            # not name an element of it at all. The other two mechanisms and
+            # the whole reporting decision are _resolve_answer's, including
+            # the "nothing was attempted" exclusion the attestation booleans
+            # depend on. A leaf carrying both a matching definition and an
+            # expression is author-pathological and resolves record-first;
+            # nothing in the intake form or the fixtures has one.
+            value, value_key = _resolve_answer(
+                child, child.get("type"), context, observations, issues,
+                link_id, in_repeating_group=True)
+        child_item = {"linkId": link_id}
         if value is not None:
-            value_key = _ANSWER_KEY_BY_TYPE.get(child.get("type"), "valueString")
             child_item["answer"] = [{value_key: value}]
-        elif child.get("definition"):
-            _report_unpopulated(issues, child.get("linkId"))
         children.append(child_item)
     return children
 
@@ -442,11 +487,11 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id,
     #
     # (a) A `definition` leaf inside a repeating group IS an attempted list
     # population — the questionnaire asked for one element of one record per
-    # row. When the group's leaves name a type _LIST_RESOURCE_CONFIG
-    # implements, _populate_list_group resolved and reported them and this
-    # branch is never reached. When they name anything else there is no
-    # resolver, _list_group_resource_type returns None, the group falls
-    # through to ordinary recursion, and the leaves arrive HERE. They used to
+    # row. Leaves arrive here by both routes: from _populate_list_children,
+    # once this row's record has produced no value for them, and from
+    # ordinary recursion when the group names a type _LIST_RESOURCE_CONFIG
+    # has no resolver for. Reporting lives HERE for both, which is what
+    # keeps one rule in one place. They used to
     # return silently: unanswered leaves and ZERO issues — no `issues`
     # parameter on the response at all — which is exactly the state the
     # ruling set out to remove, a caller reading silence as "this patient has

--- a/r6/sdc/populate.py
+++ b/r6/sdc/populate.py
@@ -225,6 +225,13 @@ def populate_questionnaire(questionnaire, subject, content_resources):
         copied onto each entry.
     """
     issues = []
+    # Per-request, and threaded exactly like `issues` beside it: the set of
+    # linkIds whose expression has already logged a failure. A leaf inside a
+    # list group is evaluated once per row, so without this a malformed
+    # expression logs a line per record — and the records come from the
+    # caller's own inline `content` Bundle. See r6/sdc/expressions.py's
+    # `warned`. It is NOT returned: nothing outside this call reads it.
+    warned = set()
     # The context carries a BOUNDED projection of `subject`, never the stored
     # Patient (r6/sdc/expressions.py). `subject` itself stays whole here
     # because the list-group and reference paths below match on it; only the
@@ -238,7 +245,7 @@ def populate_questionnaire(questionnaire, subject, content_resources):
     for item in questionnaire.get("item", []):
         answer_items.extend(_populate_item(
             item, subject, context, observations, issues, content_resources,
-            in_repeating_group=False))
+            warned, in_repeating_group=False))
 
     qr = {
         "resourceType": "QuestionnaireResponse",
@@ -253,7 +260,7 @@ def populate_questionnaire(questionnaire, subject, content_resources):
 
 
 def _populate_item(item, subject, context, observations, issues,
-                   content_resources, in_repeating_group):
+                   content_resources, warned, in_repeating_group):
     """Populate one questionnaire item. Always returns a list of zero or more
     QuestionnaireResponse items (zero or one for ordinary items; zero or many
     for a repeating list-resource group — one per matching resource).
@@ -271,7 +278,7 @@ def _populate_item(item, subject, context, observations, issues,
         if item.get("repeats") and list_resource_type:
             return _populate_list_group(item, list_resource_type, subject,
                                         context, observations,
-                                        content_resources, issues)
+                                        content_resources, issues, warned)
         # Ordinary group: recurse, keep the group only if it produced
         # child answers. A `repeats: true` group whose leaves name a type
         # with no resolver lands here too — that is what the flag carries
@@ -281,13 +288,13 @@ def _populate_item(item, subject, context, observations, issues,
         for child in item.get("item", []):
             children.extend(_populate_item(
                 child, subject, context, observations, issues,
-                content_resources, nested))
+                content_resources, warned, nested))
         if not children:
             return []
         return [{"linkId": link_id, "item": children}]
 
     answer_value, value_key = _resolve_answer(
-        item, item_type, context, observations, issues, link_id,
+        item, item_type, context, observations, issues, link_id, warned,
         in_repeating_group)
     # Leaf items are always emitted so the response mirrors the questionnaire's
     # structure; the answer array is attached only when a value resolved.
@@ -323,7 +330,7 @@ def _parse_definition(definition):
 
 
 def _populate_list_group(item, resource_type, subject, context, observations,
-                         content_resources, issues):
+                         content_resources, issues, warned):
     """Emit one repeat of `item` per matching, currently-relevant resource of
     `resource_type` for `subject`. Returns [] when there are none — an empty
     repeating group, never a default answer for a sibling item (see module
@@ -359,12 +366,13 @@ def _populate_list_group(item, resource_type, subject, context, observations,
     return [{"linkId": item.get("linkId"),
              "item": _populate_list_children(item.get("item", []),
                                              resource_type, config, resource,
-                                             context, observations, issues)}
+                                             context, observations, issues,
+                                             warned)}
             for resource in resources]
 
 
 def _populate_list_children(items, resource_type, config, resource, context,
-                            observations, issues):
+                            observations, issues, warned):
     """Resolve one row's leaves, AT EVERY DEPTH AND BY EVERY MECHANISM, and
     report the ones that resolve nothing.
 
@@ -410,7 +418,8 @@ def _populate_list_children(items, resource_type, config, resource, context,
         if child.get("type") == "group":
             nested = _populate_list_children(child.get("item", []),
                                              resource_type, config, resource,
-                                             context, observations, issues)
+                                             context, observations, issues,
+                                             warned)
             group_item = {"linkId": child.get("linkId")}
             if nested:
                 group_item["item"] = nested
@@ -434,7 +443,7 @@ def _populate_list_children(items, resource_type, config, resource, context,
             # nothing in the intake form or the fixtures has one.
             value, value_key = _resolve_answer(
                 child, child.get("type"), context, observations, issues,
-                link_id, in_repeating_group=True)
+                link_id, warned, in_repeating_group=True)
         child_item = {"linkId": link_id}
         if value is not None:
             child_item["answer"] = [{value_key: value}]
@@ -455,7 +464,7 @@ def _references_subject(resource, subject_field, subject_ref):
 
 
 def _resolve_answer(item, item_type, context, observations, issues, link_id,
-                    in_repeating_group):
+                    warned, in_repeating_group):
     value_key = _ANSWER_KEY_BY_TYPE.get(item_type, "valueString")
 
     expr = _initial_expression(item)
@@ -464,7 +473,7 @@ def _resolve_answer(item, item_type, context, observations, issues, link_id,
         # not the stored Patient — so the allowlist applies to the
         # resource-root form (`Patient.name.family`) as well as to `%patient`.
         value = evaluate(expr, context.get("patient"), context,
-                         link_id=link_id)
+                         link_id=link_id, warned=warned)
         if value is not None:
             return _coerce(value, item_type), value_key
         _report_unpopulated(issues, link_id)

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -30,7 +30,7 @@ from r6.access import Profile, TenantSource, fhir_response, tenant_from_request
 from r6.models import R6Resource
 from r6.audit import record_audit_event
 from r6.redaction import apply_redaction
-from r6.sdc.populate import populate_questionnaire
+from r6.sdc.populate import NOT_POPULATED, populate_questionnaire
 from r6.sdc.extract import extract_resources
 
 logger = logging.getLogger(__name__)
@@ -332,15 +332,33 @@ def _commit_bundle(bundle, tenant_id):
 
 
 def _issues_outcome(issues):
-    # severity=information, NOT warning. Under unconditional emission
-    # (r6/sdc/populate.py:_report_unpopulated) an ordinary form with one
-    # empty optional field carries an issue, and a conformant client reading
-    # `warning` treats that as a failed operation. Nothing here is a
-    # failure — every issue says "this leaf resolved no value", which is a
-    # restatement of the response's own missing `answer`.
+    # THE EXPLANATION IS SAID ONCE. It used to ride on every issue, and it
+    # is a 250-character constant that is identical for every leaf, so the
+    # response grew with the number of unanswered leaves times a fixed
+    # paragraph: 29.3KB of request came back 3519.6KB over HTTP, and a
+    # 293.0KB request produced 352.5MB in process. The CTO ruling on the QA
+    # review of #576 is to stop repeating it rather than to cap the list —
+    # a cap is a second control to reason about and would silently truncate
+    # a legitimate long form, while the amplification was the repetition and
+    # nothing else.
+    #
+    # So: one leading `informational` issue carrying the sentence, then one
+    # `incomplete` issue per unanswered leaf carrying ONLY its linkId. A
+    # caller still learns exactly which leaves were unanswered and exactly
+    # why, each per-leaf entry is still greppable by linkId — which is what
+    # a caller branches on — and the two kinds are told apart by `code`
+    # rather than by position.
+    #
+    # severity=information on both, NOT warning. Under unconditional
+    # emission (r6/sdc/populate.py:_report_unpopulated) an ordinary form
+    # with one empty optional field carries an issue, and a conformant
+    # client reading `warning` treats that as a failed operation. Nothing
+    # here is a failure — every issue says "this leaf resolved no value",
+    # which is a restatement of the response's own missing `answer`.
     return {
         "resourceType": "OperationOutcome",
-        "issue": [{"severity": "information", "code": "incomplete",
-                   "diagnostics": f"{i['linkId']}: {i['detail']}"}
-                  for i in issues],
+        "issue": [{"severity": "information", "code": "informational",
+                   "diagnostics": NOT_POPULATED}]
+        + [{"severity": "information", "code": "incomplete",
+            "diagnostics": i["linkId"]} for i in issues],
     }

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -333,7 +333,7 @@ def _commit_bundle(bundle, tenant_id):
 
 def _issues_outcome(issues):
     # THE EXPLANATION IS SAID ONCE. It used to ride on every issue, and it
-    # is a 250-character constant that is identical for every leaf, so the
+    # was a 230-character constant identical for every leaf, so the
     # response grew with the number of unanswered leaves times a fixed
     # paragraph: 29.3KB of request came back 3519.6KB over HTTP, and a
     # 293.0KB request produced 352.5MB in process. The CTO ruling on the QA

--- a/tests/test_populate_issue_property.py
+++ b/tests/test_populate_issue_property.py
@@ -42,10 +42,12 @@ questionnaire's own structure keeps this test independent of how populate.py
 decides.
 """
 
+import json
 from collections import Counter
 
 from r6.sdc.intake import intake_questionnaire
 from r6.sdc.populate import NOT_POPULATED, populate_questionnaire
+from r6.sdc.routes import _issues_outcome
 
 INITIAL_EXPR_URL = (
     "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
@@ -172,46 +174,7 @@ def _expression_questionnaire(expressions):
 # The property, and the two halves it is built from
 # ---------------------------------------------------------------------------
 
-#: The resource types list-group population actually implements. This is a
-#: LITERAL, deliberately, not an import of r6/sdc/populate.py's
-#: `_LIST_RESOURCE_CONFIG` — the repo's two-file convention (cf.
-#: `_UNREDACTED_EXITS` and tests/test_unredacted_exits.py). Adding a fourth
-#: type to the engine goes red here until someone updates this set, which is
-#: the point of writing it twice.
-#:
-#: It is here because "a list-group leaf with a `definition`" turned out to
-#: mean two different things. The engine reads it as "a leaf of a group whose
-#: leaves name a type in that table" — `_list_group_resource_type` returns
-#: None for anything else, the group falls through to ordinary-group
-#: recursion, and its leaves are then not attempted at all. The first version
-#: of this helper read it as "any `definition` leaf under any repeating
-#: group", which is the CTO addendum's literal wording. The two disagree on
-#: exactly one shape, pinned below by
-#: test_a_repeating_group_of_an_unsupported_type_is_silent, and no fixture
-#: here exercised it, so the disagreement was invisible. QA review of #576.
-LIST_POPULATED_TYPES = {"MedicationRequest", "AllergyIntolerance", "Condition"}
-
-
-def _list_group_type(item):
-    """The resource type this repeating group's leaves populate from, or None.
-
-    Mirrors r6/sdc/populate.py:_list_group_resource_type — the FIRST child
-    definition naming a supported type wins, and a group naming none is not a
-    list group at all.
-    """
-    if not item.get("repeats"):
-        return None
-    for child in item.get("item", []):
-        definition = child.get("definition") or ""
-        if "#" not in definition:
-            continue
-        rtype = definition.split("#", 1)[1].split(".", 1)[0]
-        if rtype in LIST_POPULATED_TYPES:
-            return rtype
-    return None
-
-
-def _attempted_link_ids(questionnaire):
+def _attempted_link_ids(questionnaire, in_repeating_group=False):
     """linkIds where the questionnaire asks populate to resolve something.
 
     Read from the Questionnaire, not from populate.py, so this test still
@@ -220,27 +183,34 @@ def _attempted_link_ids(questionnaire):
 
       - an initialExpression (FHIRPath against the %patient projection),
       - an `item.code` (Observation matching),
-      - a `definition` on a leaf of a repeating group that names one of
-        LIST_POPULATED_TYPES (list-resource population).
+      - a `definition` on a leaf ANYWHERE under a `repeats: true` group.
 
     `definition` alone is deliberately not enough: every demographics leaf on
     the intake form carries one for `$extract`'s benefit and populates by
-    expression. A definition-bearing leaf outside a repeating group is not an
-    attempted population — and neither, today, is one inside a repeating
-    group naming a type the engine does not implement. See
-    LIST_POPULATED_TYPES for why that second clause is stated out loud.
+    expression, and a definition-bearing leaf outside a repeating group is
+    not an attempted population.
+
+    THE THIRD CLAUSE NAMES NO RESOURCE TYPE, and that is finding 1 of the QA
+    review of #576 fixed at its root. This helper used to carry
+    `LIST_POPULATED_TYPES`, a hand-copied literal of
+    r6/sdc/populate.py's `_LIST_RESOURCE_CONFIG` keys, because the engine
+    attempted a repeating group only when its leaves named MedicationRequest
+    / AllergyIntolerance / Condition and went silent on every other type.
+    Two files restating one type table is a divergence waiting to happen —
+    and it had already happened, in the other direction, which is how a
+    shape with unanswered leaves and zero issues passed this file. The
+    engine's predicate is now about questionnaire structure only, so there
+    is no type table left to mirror: a fourth resource type changes which
+    leaves ANSWER, never which leaves report.
     """
     found = set()
     for item in questionnaire.get("item", []):
         if item.get("type") == "group":
-            if _list_group_type(item):
-                for child in item.get("item", []):
-                    if child.get("definition"):
-                        found.add(child["linkId"])
-            else:
-                found |= _attempted_link_ids(item)
+            found |= _attempted_link_ids(
+                item, in_repeating_group or bool(item.get("repeats")))
             continue
-        if _has_initial_expression(item) or item.get("code"):
+        if (_has_initial_expression(item) or item.get("code")
+                or (in_repeating_group and item.get("definition"))):
             found.add(item["linkId"])
     return found
 
@@ -263,13 +233,76 @@ def _leaf_occurrences(items):
             yield item
 
 
+def _response_items(items):
+    """Every item in the response, groups included, one per occurrence."""
+    for item in items:
+        yield item
+        if "item" in item:
+            yield from _response_items(item["item"])
+
+
+def _questionnaire_leaf_link_ids(item):
+    """Every leaf linkId under a questionnaire item, at any depth.
+
+    A group with no children counts as a leaf, which is how
+    `_leaf_occurrences` reads the response side — the two walks have to
+    agree on the word or the comparison below means nothing.
+    """
+    children = item.get("item") or []
+    if not children:
+        return [item.get("linkId")]
+    out = []
+    for child in children:
+        out.extend(_questionnaire_leaf_link_ids(child))
+    return out
+
+
+def _repeating_group_leaves(questionnaire):
+    """linkId -> the leaves every emitted repeat of that group must carry."""
+    out = {}
+
+    def walk(item):
+        for child in item.get("item", []):
+            if child.get("type") != "group":
+                continue
+            if child.get("repeats") and child.get("item"):
+                out[child["linkId"]] = sorted(
+                    _questionnaire_leaf_link_ids(child))
+            walk(child)
+
+    walk(questionnaire)
+    return out
+
+
 def _assert_zero_bits(questionnaire, qr, issues, label):
     """THE PROPERTY. Per linkId: unanswered attempted occurrences == issues.
 
     MUTATION: silence any attempted leaf (re-add a classifier, of any shape)
     -> the expected count exceeds the actual and this goes red naming the
     linkId. Emit for an unattempted leaf -> the second assertion goes red.
+
+    THE STRUCTURAL MIRROR FIRST, because without it the biconditional can be
+    satisfied by DROPPING a leaf. A leaf that is absent from the response is
+    neither answered nor unanswered: it contributes nothing to either side
+    of the count, so the property holds vacuously and green means nothing.
+    That is not hypothetical — `_populate_list_group` used to lose every
+    leaf inside a nested group and this file passed (QA addendum to the
+    review of #576). So every emitted repeat of a repeating group must carry
+    exactly the leaves the questionnaire puts in it, at every depth.
     """
+    for wanted_group, wanted_leaves in _repeating_group_leaves(
+            questionnaire).items():
+        for row in _response_items(qr.get("item", [])):
+            if row.get("linkId") != wanted_group:
+                continue
+            emitted = sorted(leaf.get("linkId")
+                             for leaf in _leaf_occurrences([row]))
+            assert emitted == wanted_leaves, (
+                f"[{label}] a repeat of {wanted_group} does not mirror the "
+                f"questionnaire: missing="
+                f"{sorted(set(wanted_leaves) - set(emitted))}, "
+                f"unexpected={sorted(set(emitted) - set(wanted_leaves))}")
+
     attempted = _attempted_link_ids(questionnaire)
     expected = Counter()
     unattempted_answered = []
@@ -297,9 +330,14 @@ def _assert_zero_bits(questionnaire, qr, issues, label):
         f"[{label}] leaves with no population mechanism were answered: "
         f"{sorted(unattempted_answered)}")
 
-    # Every issue says the same thing, and it is the neutral sentence.
+    # Every issue carries ONLY the linkId. The reason is the same constant
+    # for all of them, said once per response by
+    # r6/sdc/routes.py:_issues_outcome — see
+    # test_the_explanation_is_said_once_however_many_leaves_are_unanswered.
+    # A copy of it per issue is what made a 29.3KB request come back
+    # 3519.6KB.
     for issue in issues:
-        assert issue["detail"] == NOT_POPULATED, issue
+        assert set(issue) == {"linkId"}, issue
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +449,12 @@ def test_the_issue_text_is_true_whether_the_value_was_withheld_or_absent():
     held back when they simply have no email address — so the text states
     what did not happen (no value resolved) and hands over the allowlist for
     the caller to compare against their own expression.
+
+    Since the explanation became one constant said once per response, the
+    two causes are indistinguishable BY CONSTRUCTION rather than by matching
+    strings: the only thing an issue carries is the linkId the caller wrote.
+    So the assertion is that the two issue payloads differ in nothing but
+    that linkId, and the words are checked once, on the constant.
     """
     withheld_q = _expression_questionnaire({"mrn": WITHHELD_EXPRESSIONS["mrn"]})
     absent_q = _expression_questionnaire(ABSENT_BUT_ALLOWLISTED)
@@ -420,31 +464,36 @@ def test_the_issue_text_is_true_whether_the_value_was_withheld_or_absent():
     _qr, absent_issues = populate_questionnaire(
         absent_q, SPARSE_PATIENT, [SPARSE_PATIENT])
 
-    assert len(withheld_issues) == len(absent_issues) == 1
-    assert withheld_issues[0]["detail"] == absent_issues[0]["detail"]
+    assert withheld_issues == [{"linkId": "mrn"}]
+    assert absent_issues == [{"linkId": "email"}]
 
-    detail = withheld_issues[0]["detail"]
     # The allowlist is public and is the actionable half.
     for element in ("name", "birthDate", "gender", "telecom", "address"):
-        assert element in detail, element
+        assert element in NOT_POPULATED, element
     # Nothing that reads as a claim about this patient or this request.
     for forbidden in ("withheld", "refused", "denied", "not permitted",
                       "does not have", "no such"):
-        assert forbidden not in detail.lower(), forbidden
+        assert forbidden not in NOT_POPULATED.lower(), forbidden
 
 
 def test_the_expression_text_is_never_echoed_back():
     """A `where()` clause is a place a questionnaire author parks a literal;
     the OperationOutcome leaves the boundary. Pre-existing property of the
-    fixed sentence, pinned here because the retext could have lost it."""
+    fixed sentence, pinned here because the retext could have lost it.
+
+    Asserted on the RENDERED OperationOutcome, not on the engine's issue
+    list, because that is what crosses the boundary — and because the
+    rendering is now the only place any text is chosen.
+    """
     expression = "%patient.identifier.value.where($this='a-planted-literal')"
     q = _expression_questionnaire({"planted": expression})
 
     _qr, issues = populate_questionnaire(q, FULL_PATIENT, [FULL_PATIENT])
 
-    assert len(issues) == 1
-    assert "planted" not in issues[0]["detail"]
-    assert expression not in issues[0]["detail"]
+    assert issues == [{"linkId": "planted"}]
+    rendered = json.dumps(_issues_outcome(issues))
+    assert "a-planted-literal" not in rendered
+    assert expression not in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -514,34 +563,29 @@ def _unsupported_list_questionnaire():
     }
 
 
-def test_a_repeating_group_of_an_unsupported_type_is_silent():
-    """THE ONE PLACE THE RULING AND THE ENGINE READ THE SAME WORDS DIFFERENTLY.
+def test_a_repeating_group_of_an_unsupported_type_reports_every_leaf():
+    """THE SHAPE THAT USED TO REPORT NOTHING AT ALL (QA review of #576).
 
-    The CTO addendum states the exclusion predicate as: the issue attaches
-    where population was attempted — "an `initialExpression`, an `item.code`
-    Observation match, or a list-group leaf with a `definition`". A
-    `definition` leaf inside a `repeats: true` group satisfies that wording
-    whatever type it names.
+    A `definition` leaf inside a `repeats: true` group is an attempted
+    population whatever type it names. The engine used to read it narrower:
+    `_list_group_resource_type` recognises only MedicationRequest /
+    AllergyIntolerance / Condition, so a group naming anything else was not a
+    list group, fell through to ordinary-group recursion, and its leaves
+    reached `_resolve_answer` with no expression and no code — the "NOTHING
+    WAS ATTEMPTED" branch. A Questionnaire asking for immunizations came back
+    with two unanswered leaves, zero issues, and no `issues` parameter on the
+    response at all. That is precisely the silence the ruling set out to
+    remove: a caller reads it and concludes the patient has no immunizations.
 
-    The engine reads it narrower. `_list_group_resource_type` only recognises
-    a group whose leaves name MedicationRequest / AllergyIntolerance /
-    Condition; anything else is not a list group, falls through to
-    ordinary-group recursion, and its leaves reach `_resolve_answer` with no
-    expression and no code — the "NOTHING WAS ATTEMPTED" branch. So a
-    Questionnaire asking for immunizations gets unanswered leaves and NO
-    issue naming them: silence, which is the state the ruling set out to
-    remove ("a caller reads silence and concludes the patient has no such
-    value").
+    The predicate is now questionnaire structure alone, so this holds for
+    ANY type the engine has no resolver for — which is why this file no
+    longer keeps a copy of the engine's type table. What a fourth supported
+    type would change is the answers on the next assertion, never these
+    issues.
 
-    This test pins WHAT THE ENGINE DOES TODAY, not what it should do. It is
-    deliberately a plain assertion rather than a strict xfail — CLAUDE.md
-    records a strict-xfail row going red on the day someone fixed what it
-    pinned. If the reading is widened so these leaves report, this test is
-    one of the two places to update; LIST_POPULATED_TYPES is the other.
-
-    Not a leak: the silence is a function of the QUESTIONNAIRE's structure
-    only — same shape, same result, on every patient — which is what the loop
-    over PATIENT_MATRIX states.
+    Not a leak, before and after: the outcome is a function of the
+    QUESTIONNAIRE's structure only — same shape, same result, on every
+    patient — which is what the loop over PATIENT_MATRIX states.
     """
     q = _unsupported_list_questionnaire()
 
@@ -553,28 +597,196 @@ def test_a_repeating_group_of_an_unsupported_type_is_silent():
             f"[{label}] {leaf_ids}")
         assert not [leaf for leaf in _leaf_occurrences(qr["item"])
                     if "answer" in leaf], label
-        # The divergence, stated as the number it is: two unanswered
-        # definition leaves, zero issues.
-        assert issues == [], (
-            f"[{label}] the engine now reports unsupported-type list leaves — "
-            f"good, but LIST_POPULATED_TYPES and this test have to be updated "
-            f"together: {issues}")
+        # Two unanswered definition leaves, two issues, each naming itself.
+        assert [i["linkId"] for i in issues] == [
+            "immunizations.vaccine", "immunizations.date"], (
+            f"[{label}] an unanswered leaf came back silent: {issues}")
 
 
 def test_the_property_holds_on_the_unsupported_list_shape_too():
     """The biconditional, evaluated on the shape above.
 
-    It passes because `_attempted_link_ids` now reads "attempted" the way the
-    engine does. Before the QA review of #576 the helper called those two
-    leaves attempted while the engine did not, so this assertion would have
-    failed — and no fixture in this file exercised the shape, so the helper's
-    "implementation-independent" claim went untested exactly where it was
-    wrong.
+    Before the fix, `_attempted_link_ids` and the engine disagreed on
+    exactly this shape — the helper carried the ruling's wording, the engine
+    carried a resource-type table — and no fixture here exercised it, so the
+    docstring's "implementation-independent" claim went untested exactly
+    where it was wrong. Both sides now read "attempted" the same way, and
+    neither reads it from a list of types.
     """
     q = _unsupported_list_questionnaire()
     for label, patient in PATIENT_MATRIX.items():
         qr, issues = populate_questionnaire(q, patient, [patient])
         _assert_zero_bits(q, qr, issues, f"unsupported-list / {label}")
+
+
+# --- a nested group inside a repeating list group ---------------------------
+
+NESTED_ALLERGEN_DEF = ("http://hl7.org/fhir/StructureDefinition/"
+                       "AllergyIntolerance#AllergyIntolerance.code.text")
+NESTED_REACTION_DEF = (
+    "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+    "#AllergyIntolerance.reaction.manifestation.text")
+
+
+def _nested_list_questionnaire():
+    """A supported list group whose second leaf sits one group deeper."""
+    return {
+        "resourceType": "Questionnaire", "id": "nested-list",
+        "status": "active",
+        "item": [{
+            "linkId": "allergies.item", "type": "group", "repeats": True,
+            "item": [
+                {"linkId": "a.allergen", "type": "string",
+                 "definition": NESTED_ALLERGEN_DEF},
+                {"linkId": "a.reactions", "type": "group", "item": [
+                    {"linkId": "a.reactions.text", "type": "string",
+                     "definition": NESTED_REACTION_DEF}]},
+            ],
+        }],
+    }
+
+
+def _allergy(resource_id, code=None, manifestation=None):
+    resource = {"resourceType": "AllergyIntolerance", "id": resource_id,
+                "patient": {"reference": "Patient/p1"}}
+    if code:
+        resource["code"] = {"text": code}
+    if manifestation:
+        resource["reaction"] = [{"manifestation": [{"text": manifestation}]}]
+    return resource
+
+
+def test_a_nested_group_inside_a_repeating_list_group_keeps_its_leaves():
+    """THE SECOND SHAPE THAT REPORTED NOTHING (QA addendum to the review).
+
+    `_populate_list_group` used to iterate a row's DIRECT children and test
+    `child.get("definition")`. A child that is itself a group has none, so it
+    was emitted as a bare item and its own leaves were never visited: a
+    stored `reaction.manifestation.text` and the leaf asking for it were
+    both absent from the response — no answer, no issue, no item.
+
+    Worse than silence, it was invisible to the property: a leaf that is not
+    in the response is neither answered nor unanswered, so the biconditional
+    held over a hole. `_assert_zero_bits`'s structural mirror is what makes
+    that case red now; this test states the same thing as the values a
+    caller actually gets.
+    """
+    q = _nested_list_questionnaire()
+    content = [_allergy("a1", code="Penicillin", manifestation="Hives")]
+
+    qr, issues = populate_questionnaire(
+        q, {"resourceType": "Patient", "id": "p1"}, content)
+
+    row = qr["item"][0]
+    assert row["linkId"] == "allergies.item"
+    nested = next(c for c in row["item"] if c["linkId"] == "a.reactions")
+    assert [leaf["linkId"] for leaf in _leaf_occurrences([row])] == [
+        "a.allergen", "a.reactions.text"]
+    assert nested["item"][0]["answer"] == [{"valueString": "Hives"}]
+    assert issues == []
+
+
+def test_a_nested_list_leaf_that_resolves_nothing_names_itself():
+    """The other half: the nested leaf reports like any other attempted one.
+
+    One labelled allergy with no reaction, one with neither. Row count still
+    equals record count, and every unanswered definition leaf — at whatever
+    depth — is in the issue list once per occurrence.
+    """
+    q = _nested_list_questionnaire()
+    content = [_allergy("a1", code="Penicillin"), _allergy("a2")]
+
+    qr, issues = populate_questionnaire(
+        q, {"resourceType": "Patient", "id": "p1"}, content)
+
+    assert len(qr["item"]) == 2, "row count must equal record count"
+    assert Counter(i["linkId"] for i in issues) == Counter({
+        "a.reactions.text": 2, "a.allergen": 1})
+
+
+def test_the_property_holds_on_the_nested_list_shape_too():
+    """The biconditional and the structural mirror, over record shapes.
+
+    MUTATION: revert `_populate_list_children` to iterating direct children
+    -> `a.reactions.text` disappears from every row and the mirror goes red
+    on all four shapes, including the empty one.
+    """
+    q = _nested_list_questionnaire()
+    shapes = {
+        "nothing stored": [],
+        "labelled, with a reaction": [
+            _allergy("a1", code="Penicillin", manifestation="Hives")],
+        "labelled, no reaction": [_allergy("a1", code="Penicillin")],
+        "two unlabelled": [_allergy("a1"), _allergy("a2")],
+    }
+    patient = {"resourceType": "Patient", "id": "p1"}
+    for label, content in shapes.items():
+        qr, issues = populate_questionnaire(q, patient, content)
+        _assert_zero_bits(q, qr, issues, f"nested-list / {label}")
+
+
+# --- the explanation, said once ---------------------------------------------
+
+def test_the_explanation_is_said_once_however_many_leaves_are_unanswered():
+    """FINDING 2. The sentence is a constant; the linkId is what varies.
+
+    Emitting the 250-character explanation per leaf made the response grow
+    with the number of unanswered leaves TIMES a fixed paragraph — measured
+    at 3519.6KB back from a 29.3KB request over HTTP, and 352.5MB from a
+    293.0KB request in process. The ruling was to stop repeating it rather
+    than to cap the list, so the shape is: one `informational` issue
+    carrying the reason, then one `incomplete` issue per unanswered leaf
+    carrying ONLY its linkId.
+
+    MUTATION: put the sentence back into each per-leaf `diagnostics` (or
+    prefix it, or append it) -> the count assertion goes red at 51 rather
+    than 1, and the per-leaf equality goes red naming the leaf. Drop the
+    summary issue -> the count goes red at 0 and the caller loses the only
+    statement of why.
+    """
+    issues = [{"linkId": f"section.item.leaf-{n}"} for n in range(50)]
+
+    outcome = _issues_outcome(issues)
+    rendered = json.dumps(outcome)
+
+    summary = [i for i in outcome["issue"] if i["code"] == "informational"]
+    per_leaf = [i for i in outcome["issue"] if i["code"] == "incomplete"]
+
+    assert len(summary) == 1
+    assert summary[0]["diagnostics"] == NOT_POPULATED
+    assert rendered.count("%patient projection") == 1, (
+        "the explanation is repeated: it is the same constant for every "
+        "leaf, and repeating it is what amplified the response")
+
+    # Each per-leaf issue carries the linkId and nothing else, so it is
+    # greppable on its own — which is what a caller branches on.
+    assert len(per_leaf) == 50
+    assert [i["diagnostics"] for i in per_leaf] == [
+        i["linkId"] for i in issues]
+    assert {i["severity"] for i in outcome["issue"]} == {"information"}
+
+
+def test_the_response_grows_with_the_leaf_count_not_with_a_paragraph():
+    """The amplification, stated as the shape of the growth rather than a cap.
+
+    Ten times the leaves must cost about ten times the bytes plus a
+    constant. With the sentence on every issue the per-leaf cost carried a
+    250-character paragraph, so this ratio was pinned to the paragraph
+    instead of to the data.
+
+    MUTATION: restore the per-leaf sentence -> the marginal cost per leaf
+    rises past the bound and this goes red.
+    """
+    def rendered_bytes(n):
+        return len(json.dumps(_issues_outcome(
+            [{"linkId": f"section.item.leaf-{i}"} for i in range(n)])))
+
+    small, large = rendered_bytes(10), rendered_bytes(1000)
+    per_leaf = (large - small) / 990
+
+    # A linkId of ~21 characters plus the issue's own JSON envelope. The
+    # bound is generous; what it excludes is a fixed paragraph per leaf.
+    assert per_leaf < 100, f"{per_leaf:.1f} bytes per unanswered leaf"
 
 
 # --- the item.code Observation path -----------------------------------------

--- a/tests/test_populate_issue_property.py
+++ b/tests/test_populate_issue_property.py
@@ -730,10 +730,10 @@ def test_the_property_holds_on_the_nested_list_shape_too():
 def test_the_explanation_is_said_once_however_many_leaves_are_unanswered():
     """FINDING 2. The sentence is a constant; the linkId is what varies.
 
-    Emitting the 250-character explanation per leaf made the response grow
-    with the number of unanswered leaves TIMES a fixed paragraph — measured
-    at 3519.6KB back from a 29.3KB request over HTTP, and 352.5MB from a
-    293.0KB request in process. The ruling was to stop repeating it rather
+    Emitting the explanation on every leaf — 230 characters then, 285 now —
+    made the response grow with the number of unanswered leaves TIMES a
+    fixed paragraph, measured at 3519.6KB back from a 29.3KB request over
+    HTTP. The ruling was to stop repeating it rather
     than to cap the list, so the shape is: one `informational` issue
     carrying the reason, then one `incomplete` issue per unanswered leaf
     carrying ONLY its linkId.
@@ -771,8 +771,8 @@ def test_the_response_grows_with_the_leaf_count_not_with_a_paragraph():
 
     Ten times the leaves must cost about ten times the bytes plus a
     constant. With the sentence on every issue the per-leaf cost carried a
-    250-character paragraph, so this ratio was pinned to the paragraph
-    instead of to the data.
+    fixed paragraph, so this ratio was pinned to the paragraph instead of
+    to the data.
 
     MUTATION: restore the per-leaf sentence -> the marginal cost per leaf
     rises past the bound and this goes red.
@@ -784,9 +784,15 @@ def test_the_response_grows_with_the_leaf_count_not_with_a_paragraph():
     small, large = rendered_bytes(10), rendered_bytes(1000)
     per_leaf = (large - small) / 990
 
-    # A linkId of ~21 characters plus the issue's own JSON envelope. The
-    # bound is generous; what it excludes is a fixed paragraph per leaf.
-    assert per_leaf < 100, f"{per_leaf:.1f} bytes per unanswered leaf"
+    # The bound is the explanation itself, which is the honest way to state
+    # it: one more unanswered leaf must cost less than one more copy of the
+    # reason. Today that is ~91 bytes (a 21-character linkId plus the issue's
+    # JSON envelope) against a ~253-character constant. An absolute number
+    # here would be a second thing to keep true.
+    assert per_leaf < len(NOT_POPULATED), (
+        f"{per_leaf:.1f} bytes per unanswered leaf, against a "
+        f"{len(NOT_POPULATED)}-character explanation: the reason is being "
+        f"repeated per leaf again")
 
 
 # --- the item.code Observation path -----------------------------------------

--- a/tests/test_populate_issue_property.py
+++ b/tests/test_populate_issue_property.py
@@ -725,6 +725,113 @@ def test_the_property_holds_on_the_nested_list_shape_too():
         _assert_zero_bits(q, qr, issues, f"nested-list / {label}")
 
 
+# --- the OTHER two mechanisms, inside a supported list group -----------------
+
+def _list_group_with(extra_leaf):
+    """A supported (AllergyIntolerance) repeating group carrying one ordinary
+    definition leaf plus whatever `extra_leaf` is."""
+    return {
+        "resourceType": "Questionnaire", "id": "mechanism-in-list",
+        "status": "active",
+        "item": [{
+            "linkId": "allergies.item", "type": "group", "repeats": True,
+            "item": [
+                {"linkId": "a.allergen", "type": "string",
+                 "definition": NESTED_ALLERGEN_DEF},
+                extra_leaf,
+            ],
+        }],
+    }
+
+
+#: The two population mechanisms that are NOT `definition`, placed where the
+#: engine takes a different code path: inside a group `_list_group_resource_type`
+#: recognises. Everything else in this file puts them outside one.
+_MECHANISM_LEAVES = {
+    "initialExpression, allowlisted": {
+        "linkId": "a.mech", "type": "string",
+        "extension": [{"url": INITIAL_EXPR_URL, "valueExpression": {
+            "language": "text/fhirpath", "expression": "%patient.gender"}}]},
+    "initialExpression, withheld": {
+        "linkId": "a.mech", "type": "string",
+        "extension": [{"url": INITIAL_EXPR_URL, "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "%patient.identifier.value"}}]},
+    "item.code": {
+        "linkId": "a.mech", "type": "string",
+        "code": [{"system": LOINC, "code": "29463-7"}]},
+}
+
+
+def test_an_expression_or_code_leaf_inside_a_supported_list_group_reports():
+    """THE THIRD SHAPE OF FINDING 1, in the branch the fix did not reach.
+
+    `_populate_list_children` resolves a row's leaves by `definition` and by
+    nothing else, so a leaf carrying an `initialExpression` or an `item.code`
+    inside a MedicationRequest / AllergyIntolerance / Condition group is
+    never evaluated AND never reported: an unanswered leaf, zero issues, and
+    over HTTP no `issues` parameter on the response at all. That is the exact
+    state the ruling set out to remove and that finding 1 closed for the two
+    shapes it looked at.
+
+    It is not a leak — the silence is a function of the QUESTIONNAIRE's
+    structure, identical on every patient and every record — and the intake
+    form has no such leaf, so there is no live impact. What it is, is the
+    divergence this change claims to have removed. The module docstring of
+    r6/sdc/populate.py and `_attempted_link_ids` above both say attempted
+    means "an initialExpression, an `item.code`, or a `definition` on a leaf
+    anywhere under a repeating group"; `_populate_list_children` implements
+    only the third clause. Two files restating one rule, agreeing on the
+    prose and disagreeing on the code, with no fixture crossing the
+    difference — which is how the first two shapes shipped.
+
+    EITHER RESOLUTION CLOSES THIS, and both places must move together:
+    resolve expression and code leaves inside a list row (the rule as
+    written), or narrow the rule and this file's `_attempted_link_ids` to
+    say `definition` alone applies inside a list group — and rewrite the
+    module docstring, since the two clauses would then be conditional on
+    where the leaf sits.
+    """
+    for label, leaf in _MECHANISM_LEAVES.items():
+        q = _list_group_with(leaf)
+        qr, issues = populate_questionnaire(
+            q, FULL_PATIENT, [_allergy("a1", code="Penicillin")])
+
+        unanswered = Counter(x["linkId"] for x in _leaf_occurrences(qr["item"])
+                             if "answer" not in x)
+        named = Counter(i["linkId"] for i in issues)
+        # Stated as "no leaf is silently empty" rather than as one expected
+        # list, because an allowlisted expression legitimately ANSWERS once
+        # it is evaluated: that row must then report nothing, and this reads
+        # correctly either way.
+        assert unanswered == named, (
+            f"[{label}] a leaf inside a supported list group is unanswered "
+            f"and unreported: unanswered={dict(unanswered)}, "
+            f"issues={dict(named)}. A caller reads that silence as 'this "
+            f"patient has no such value'.")
+
+
+def test_the_property_holds_with_a_mechanism_leaf_inside_a_list_group():
+    """The biconditional over the same shape, across records and patients.
+
+    Held apart from the assertion above so the failure reads as the property
+    rather than as one expected list: `_assert_zero_bits` names the leaf and
+    the direction, and it is the pin the whole file is built on.
+    """
+    for label, leaf in _MECHANISM_LEAVES.items():
+        q = _list_group_with(leaf)
+        shapes = {
+            "nothing stored": [],
+            "one labelled": [_allergy("a1", code="Penicillin")],
+            "two unlabelled": [_allergy("a1"), _allergy("a2")],
+        }
+        for plabel, patient in PATIENT_MATRIX.items():
+            for slabel, content in shapes.items():
+                qr, issues = populate_questionnaire(q, patient, content)
+                _assert_zero_bits(
+                    q, qr, issues, f"{label} / {plabel} / {slabel}")
+
+
 # --- the explanation, said once ---------------------------------------------
 
 def test_the_explanation_is_said_once_however_many_leaves_are_unanswered():

--- a/tests/test_populate_lists.py
+++ b/tests/test_populate_lists.py
@@ -426,3 +426,70 @@ def test_the_attestation_items_never_appear_in_the_issue_list():
             assert attestation not in named, f"{label}: {attestation} reported"
             item = _by_link_id(qr, attestation)
             assert item is not None and "answer" not in item, label
+
+
+ALLERGEN_DEF = ("http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+                "#AllergyIntolerance.code.text")
+
+
+def _row_with_attestation():
+    """A supported list group carrying an attestation-shaped leaf INSIDE it.
+
+    `allergies.no-known-allergies` is a sibling of the repeating group on the
+    real intake form, so nothing there exercises a mechanism-less boolean
+    reaching the list-row path. This puts one exactly there.
+    """
+    return {
+        "resourceType": "Questionnaire", "id": "attestation-in-row",
+        "status": "active",
+        "item": [{
+            "linkId": "allergies.item", "type": "group", "repeats": True,
+            "item": [
+                {"linkId": "allergies.item.allergen", "type": "string",
+                 "definition": ALLERGEN_DEF},
+                {"linkId": "allergies.item.no-known-allergies",
+                 "type": "boolean"},
+            ],
+        }],
+    }
+
+
+def test_a_mechanism_less_boolean_inside_a_list_row_is_neither_answered_nor_reported():
+    """THE EXCLUSION, ON THE ROW PATH.
+
+    A row's leaves now resolve through `_resolve_answer` rather than by
+    `definition` alone, so a leaf with no mechanism at all reaches the
+    "NOTHING WAS ATTEMPTED" branch by a route it never took before. That
+    branch is what keeps `allergies.no-known-allergies` out of the issue
+    list, and an issue reading "not populated: no value resolved" against an
+    NKA-shaped boolean tells a model-facing reader the server TRIED to
+    determine no-known-allergies and failed — one step from inferring it,
+    which is the non-negotiable (CLAUDE.md).
+
+    Asserted with allergies on file and with none, because zero rows and
+    unlabelled rows are the two shapes where a helpful-sounding answer or
+    issue would be tempting. Zero rows emits no repeat at all, so the leaf
+    cannot be answered there either.
+
+    MUTATION: report any unresolved leaf in a row regardless of mechanism ->
+    the boolean is named and this goes red.
+    """
+    q = _row_with_attestation()
+    shapes = {
+        "nothing on file": [],
+        "one labelled": [_allergy("a1", "Penicillin")],
+        "two unlabelled": [_snomed_allergy("a1", "91936005"),
+                           _snomed_allergy("a2", "300916003")],
+    }
+
+    for label, allergies in shapes.items():
+        qr, issues = populate_questionnaire(q, PATIENT, [PATIENT] + allergies)
+
+        rows = _all_by_link_id(qr, "allergies.item")
+        assert len(rows) == len(allergies), (
+            f"{label}: row count must equal record count")
+        assert "allergies.item.no-known-allergies" not in _issue_ids(issues), (
+            f"{label}: a mechanism-less boolean inside a row was reported")
+        for item in _all_by_link_id(qr, "allergies.item.no-known-allergies"):
+            assert "answer" not in item, (
+                f"{label}: absent allergy data is not an attestation")

--- a/tests/test_sdc_expressions.py
+++ b/tests/test_sdc_expressions.py
@@ -198,3 +198,66 @@ def test_the_resource_root_form_still_evaluates_against_the_projection():
     ctx = build_context(subject=_FULL_PATIENT)
     assert evaluate("Patient.name.family", ctx["patient"], ctx) == "Lovelace"
     assert evaluate("Patient.identifier.value", ctx["patient"], ctx) is None
+
+
+def test_a_failing_expression_in_a_list_row_logs_once_not_once_per_record(
+        caplog):
+    """LOG VOLUME DOES NOT SCALE WITH THE CALLER'S RECORD COUNT.
+
+    A leaf inside a `repeats: true` list group is evaluated once per row —
+    that is what makes an expression leaf answer there at all, and it is
+    deliberate. The failure LOG is a different matter: the line is identical
+    for every row (a linkId and an exception class name), so 100 records
+    meant 100 identical warnings, and the records arrive in the caller's own
+    inline `content` Bundle. Cost that scales with attacker-supplied input
+    is worth removing while it is one small change.
+
+    Deduped at the log site (r6/sdc/expressions.py's `warned`), NOT by
+    evaluating once per group: evaluating once per group would rebuild a
+    second resolution path beside the one _populate_list_children was just
+    collapsed into, which is the divergence this branch exists to remove.
+    Resolution is untouched — every row still evaluates, and every row still
+    gets its own issue.
+
+    MUTATION: drop the `warned` guard -> the 10-record case logs 10 lines.
+    """
+    questionnaire = {
+        "resourceType": "Questionnaire", "status": "active",
+        "item": [{
+            "linkId": "allergies.item", "type": "group", "repeats": True,
+            "item": [
+                {"linkId": "a.allergen", "type": "string",
+                 "definition": ("http://hl7.org/fhir/StructureDefinition/"
+                                "AllergyIntolerance#AllergyIntolerance."
+                                "code.text")},
+                {"linkId": "a.bad", "type": "string", "extension": [{
+                    "url": INITIAL_EXPRESSION_URL,
+                    "valueExpression": {"language": "text/fhirpath",
+                                        "expression": "notAFunction()"}}]},
+            ],
+        }],
+    }
+    patient = {"resourceType": "Patient", "id": "p1"}
+
+    for record_count in (1, 10, 100):
+        allergies = [
+            {"resourceType": "AllergyIntolerance", "id": f"a{i}",
+             "patient": {"reference": "Patient/p1"},
+             "code": {"text": f"Allergen {i}"}}
+            for i in range(record_count)
+        ]
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="r6.sdc.expressions"):
+            qr, issues = populate_questionnaire(questionnaire, patient,
+                                                allergies)
+
+        records = [r for r in caplog.records if r.name == "r6.sdc.expressions"]
+        assert len(records) == 1, (
+            f"{record_count} records produced {len(records)} log lines; the "
+            f"caller supplies the records, so this must not scale with them")
+
+        # Resolution is unchanged: still one row per record, and still one
+        # issue per unresolved leaf occurrence — the dedupe is the log only.
+        rows = [x for x in qr["item"] if x["linkId"] == "allergies.item"]
+        assert len(rows) == record_count
+        assert sum(1 for i in issues if i["linkId"] == "a.bad") == record_count

--- a/tests/test_sdc_populate.py
+++ b/tests/test_sdc_populate.py
@@ -78,8 +78,11 @@ def test_populate_records_issue_for_unresolved_item():
 
     # No answer produced, and no spurious answer array on the item.
     assert "answer" not in qr["item"][0]
-    assert [i["linkId"] for i in issues] == ["missing"]
-    assert issues[0]["detail"] == NOT_POPULATED
+    # The issue carries the linkId and nothing else: the reason is the same
+    # constant for every leaf and is said once per response by
+    # r6/sdc/routes.py:_issues_outcome.
+    assert issues == [{"linkId": "missing"}]
+    assert "no value resolved" in NOT_POPULATED
 
 
 def test_populate_nested_group_items():

--- a/tests/test_sdc_populate_bounded.py
+++ b/tests/test_sdc_populate_bounded.py
@@ -238,9 +238,26 @@ def _answers(qr):
 
 
 def _issue_link_ids(params):
+    """The linkIds the OperationOutcome names, one per unanswered leaf.
+
+    `incomplete` issues are the per-leaf ones and their `diagnostics` is the
+    linkId alone. The reason they share is said once, in the single
+    `informational` issue this deliberately skips — see
+    r6/sdc/routes.py:_issues_outcome, and
+    test_the_explanation_is_said_once_in_the_response below for the pin on
+    that split.
+    """
     outcome = _param(params, "issues") or {}
-    return [issue["diagnostics"].split(":")[0]
-            for issue in outcome.get("issue", [])]
+    return [issue["diagnostics"] for issue in outcome.get("issue", [])
+            if issue["code"] == "incomplete"]
+
+
+def _issue_explanation(params):
+    outcome = _param(params, "issues") or {}
+    summary = [issue for issue in outcome.get("issue", [])
+               if issue["code"] == "informational"]
+    assert len(summary) == 1, summary
+    return summary[0]["diagnostics"]
 
 
 # ---------------------------------------------------------------------------
@@ -276,9 +293,10 @@ def test_a_withheld_expression_is_reported_as_an_issue_naming_its_link_id(
     operation refused to look. A caller told nothing would read the first
     from the second, so every withheld item names itself in an
     OperationOutcome issue. The diagnostics carry the linkId (questionnaire
-    structure, authored by the caller) and a fixed sentence; the expression
-    text is deliberately NOT echoed, because a `where()` clause is a place an
-    author can park a literal.
+    structure, authored by the caller); the expression text is deliberately
+    NOT echoed, because a `where()` clause is a place an author can park a
+    literal. The fixed sentence explaining them all is said once beside
+    them, not copied onto each.
     """
     _seed(app, tenant_id)
 
@@ -286,10 +304,10 @@ def test_a_withheld_expression_is_reported_as_an_issue_naming_its_link_id(
 
     assert sorted(_issue_link_ids(body)) == sorted(WITHHELD)
     outcome = _param(body, "issues")
-    diagnostics = outcome["issue"][0]["diagnostics"]
-    assert "%patient projection" in diagnostics
+    explanation = _issue_explanation(body)
+    assert "%patient projection" in explanation
     for expression in WITHHELD.values():
-        assert expression not in diagnostics
+        assert expression not in json.dumps(outcome)
     # One sentence for every leaf, at `information` severity — see
     # test_an_allowlisted_element_the_patient_lacks_reports_in_the_same_words
     # for why the wording may not distinguish withheld from absent.
@@ -349,15 +367,15 @@ def test_an_allowlisted_element_the_patient_lacks_reports_in_the_same_words(
     # Exactly one issue: the one leaf that got no answer. Not two.
     assert _issue_link_ids(body) == ["email"]
 
-    issue = _param(body, "issues")["issue"][0]
+    outcome = _param(body, "issues")
     # information, not warning: a form with one empty optional field is an
     # ordinary result, and a conformant client reading `warning` would treat
     # it as a failed operation.
-    assert issue["severity"] == "information"
-    diagnostics = issue["diagnostics"]
-    assert "%patient projection" in diagnostics
+    assert {i["severity"] for i in outcome["issue"]} == {"information"}
+    explanation = _issue_explanation(body)
+    assert "%patient projection" in explanation
     for claim in ("withheld", "refused", "denied"):
-        assert claim not in diagnostics.lower(), claim
+        assert claim not in explanation.lower(), claim
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the two MEDIUMs from the QA review of #576. Neither was a leak, and the
review's zero-bits argument still holds after both fixes.

## What

**Finding 1: leaves that reported nothing at all.** Two shapes came back with
unanswered leaves and zero issues. Over HTTP the response carried no `issues`
parameter.

1. A `repeats: true` group whose leaves name a resource type with no resolver
   was not a list group. It fell through to ordinary recursion, and its leaves
   reached the "nothing was attempted" branch of `_resolve_answer`.
2. `_populate_list_group` walked a row's direct children only and tested
   `child.get("definition")`. A child that is itself a group carries none, so
   it was emitted bare and its own leaves were never visited: no answer, no
   issue, no item in the response.

"Attempted" is now one rule about questionnaire structure and nothing else: an
`initialExpression`, an `item.code`, or a `definition` on a leaf anywhere under
a repeating group. List rows resolve at every depth. Adding a fourth resource
type changes which leaves answer, never which leaves report.

**Finding 2: the explanation was repeated per leaf.** The 230-character
sentence rode on every unanswered leaf, so the response grew with the leaf
count times a fixed paragraph. Per the ruling, no cap. The reason is stated
once as an `informational` issue and each `incomplete` issue carries only the
linkId. Per-leaf entries stay greppable by linkId, which is what a caller
branches on.

The sentence is now 285 characters, because it gained a clause pointing at the
per-leaf issues. Said once, that costs 55 bytes; said per leaf it would have
cost more than the old one did.

## Why

The cause of finding 1 is the reason it matters. `_attempted_link_ids` in the
property test encoded the *ruling's prose* while the engine encoded a
*resource-type table*, so the pin agreed with the description and disagreed
with the code. It passed only because no fixture exercised the difference.
That is `docs/2026-08-02-retro.md` pattern 1 sitting inside the change whose
whole argument is that it removed one.

The test now derives "attempted" the way the engine does, and neither side
keeps a copy of the type table, so there is nothing left to diverge. The
literal `LIST_POPULATED_TYPES` that QA added in `49f3149` is deleted for that
reason, not ignored: the engine no longer has a type-dependent predicate to
mirror.

`_assert_zero_bits` also gains a structural mirror, because the biconditional
alone cannot see finding 1's second shape. A leaf absent from the response is
neither answered nor unanswered, so dropping one satisfies the property while
defeating its purpose. Every emitted repeat of a repeating group must now
carry exactly the leaves the questionnaire puts in it, at every depth.

The NKA exclusion is untouched. Both of its independent reasons are now
written beside it: the attestation booleans carry no `definition`, and they
are siblings of the repeating group rather than children of it.

## Base note

Stacks on #578, which stacks on #576, which stacks on #562. **Merge in that
order: #562, #576, #578, then this.** The base branch here is
`fix/populate-drop-subject-append` (#578).

On `dependency-audit`, which the review of #576 reported red on every open PR
from npm advisories fixed in unmerged #544: it does not appear in `gh pr
checks` for #576, #578, or this PR. None of the three touches an npm file, so
the job looks path-filtered and simply did not run. The advisories are real
and #544 is still unmerged; the "red here" part does not reproduce on this
stack. Every check that did run on this PR passes.

## The size measurements

Same K x R shape the review measured: a caller supplies K definition leaves in
one repeating group and R records, so K x R leaf occurrences report. Measured
with one script, run on the base commit and on this branch.

In process (issue bytes, and total response over request):

| K x R | request | issues before | before | issues after | after |
| --- | --- | --- | --- | --- | --- |
| 10 x 10 | 3.0KB | 31.9KB | 12.1x | 9.6KB | 4.7x |
| 50 x 200 | 29.3KB | 3191.5KB | 122.8x | 926.2KB | 45.5x |
| 200 x 500 | 85.7KB | 31977.6KB | 420.4x | 9321.7KB | 156.2x |
| 500 x 2000 | 293.0KB | 320097.7KB | 1232.1x | 93535.6KB | 458.8x |

Live over HTTP, 50 x 200 against a running app on port 5423:

```
before: 29.3KB request -> 3519.6KB response, 120.1x, sentence repeated 10000x
after:  29.3KB request -> 1254.3KB response,  42.8x, sentence appears once
```

The residual is the pre-existing K x R shape of the QuestionnaireResponse
itself, which this PR does not touch. At 500 x 2000 the QR alone is 40.9MB
against a 293.0KB request, or 139.5x. The issue list is now 2.3x the QR rather
than 7.8x, against the review's pre-#576 figure of 75x for this shape.

The issue channel is therefore no longer the dominant term, but the operation
is still worth a look. It is listed as an observation below rather than fixed
here, because bounding the QR is a different change with different callers.

## Live run

Real intake form, seeded synthetic tenant, port 5423. Full demographics, two
allergies with unlabelled SNOMED codes, one ICD-10 condition, one RxNorm
medication with no `dosageInstruction`.

```
answered leaves (11): 10 demographics + medications.item.name
                      + conditions.item.name
  (QA's live run reported 10 answered / 6 issues. The difference is the seed,
   not the behaviour: my condition carries ICD-10 E11.9, which
   r6/terminology.py labels, so conditions.item.name resolves.)
unanswered leaves (7): allergies.item.allergen x2, allergies.item.reaction x2,
                       medications.item.dose, and the 2 attestations
per-leaf issues (5): the 5 unanswered leaves that were attempted
                     (the 2 attestations are named in 0 issues)
issue codes: informational x1 (the reason), incomplete x5 (one linkId each)
severities: information only
'%patient projection' in the whole response: 1 occurrence (was 5)
rows: allergies 2, conditions 1, medications 1, against 2/1/1 stored
PHI markers in the issues parameter: none of 3
```

Both fixed shapes, same running app:

```
shape 1, repeats:true group of Immunization leaves
  before: {"item":[{"linkId":"imm.vaccine"},{"linkId":"imm.date"}], ...}
          issues parameter present: False
  after:  same response items, per-leaf issues: ['imm.vaccine', 'imm.date']

shape 2, nested group inside a repeating AllergyIntolerance group
  before: a.reactions emitted bare, 'a.reactions.text' absent from the response
  after:  a.reactions carries a.reactions.text; 2 rows x 2 leaves = 4 issues
```

## Mutation checks

Applied to the committed tree, run, reverted. Restored green at 56.

| mutation | red |
| --- | --- |
| M1 finding 1 shape 1 reverted | 2, both unsupported-type tests |
| M2 finding 1 shape 2 reverted | 3, all nested-group tests |
| M3 the sentence copied back onto every per-leaf issue | 6 |
| M4 the reason never stated at all | 3 |
| M5 a list-row leaf dropped instead of emitted | 4 |
| M6 the exclusion removed, so an item with no mechanism reports | 13, including both NKA guards |

The finding-2 bound is stated against the explanation itself rather than an
absolute byte count: one more unanswered leaf must cost less than one more
copy of the reason. Today that is 90.9 bytes against 285. Under M3 it is
377.9, which is what makes the test red.

The two finding-2 tests are complementary on purpose, and the seam is worth
naming. A short constant prefix per leaf, say `"not populated: " + linkId`,
would pass the byte bound. It is caught by the other test, which asserts each
per-leaf `diagnostics` equals the linkId exactly. One pins "only the linkId",
the other pins "no paragraph". Neither alone is enough.

M2 is the one that matters, and only the structural mirror catches it. Under
M2 the counted biconditional passes, because the dropped leaf is not in the
response to be counted. The mirror fails with the right diagnosis:

```
AssertionError: [nested-list / labelled, with a reaction] a repeat of
allergies.item does not mirror the questionnaire:
missing=['a.reactions.text'], unexpected=['a.reactions']
```

## Tests changed rather than added

Both are shape changes the ruling required, not reviewer tests broken.

- `test_a_repeating_group_of_an_unsupported_type_is_silent` is inverted and
  renamed to `..._reports_every_leaf`. QA's own docstring names this file as
  one of the two places to update if the reading is widened; the other was
  `LIST_POPULATED_TYPES`, now deleted.
- `_issue_link_ids` in `tests/test_sdc_populate_bounded.py` reads the
  `incomplete` issues and no longer splits `diagnostics` on a colon. A second
  helper, `_issue_explanation`, asserts there is exactly one `informational`
  issue and returns it, so the two HTTP tests that check the wording check it
  where it now lives.

## Ran

```
uv run ruff check .
  All checks passed!
uv run python -m pytest tests/ -q -p no:cacheprovider
  3198 passed, 13 skipped, 1 xfailed          (3193 before, 5 tests added)
uv run python -m pytest tests/test_ratchets.py tests/test_guardrail_conformance.py -q
  50 passed                                   (Grade A green, no pin moved)
```

Live against a running app on port 5423, seeded synthetic tenant: the intake
run, both fixed shapes, and the amplification case, all quoted above. Before
and after numbers come from the same two scripts, run on the base commit and
on this branch.

## What was NOT run

- Postgres CI lane. SQLite only.
- `$extract` against a form populated by this code. Nothing new enters the
  answer set, but the round trip is not exercised.
- Any renderer. QA established that nothing reads the issues; the PDF path and
  the intake UI were not looked at.
- The MCP `questionnaire_populate` caller against the new issue shape. It
  returns the whole `Parameters` body verbatim and is severity-blind, so the
  extra `informational` issue reaches a model's context as one more line. That
  is a decrease from one 250-character sentence per unanswered leaf, but it is
  reasoned rather than measured.
- Concurrency. Every size number here is a single request.
- The QuestionnaireResponse's own K x R growth, which is now the dominant term
  in the amplification and is pre-existing on this route. Worth filing.

Also left alone, from the review's own noted list: `r6/actions/review.py:208`
still does `content = [patient]` with an unredacted Patient and calls no
`apply_redaction`, so D10's bound is a property of the `$populate` route
rather than of the engine. `$extract`'s duplicate-Patient write is still
unfiled. Both are outside this PR and #578's body already names the first.

## Ruling item 4

#576's body says no deferral is written for the ruling's fourth item. One is:
#570 records the decision about whether `questionnaire_populate` stays in the
model-facing tier, and why the reason for removing it no longer holds. #576's
body is updated to cite it.
