### PR TITLE
DO NOT MERGE — evidence for #585: does CI fire on a stacked PR?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI - FHIR MCP Guardrails
 on:
   push:
     branches: [main, master, 'claude/**']
+  # No `branches:` filter here on purpose. That filter matches the PR's BASE
+  # branch, so a change stacked on another feature branch matched nothing and
+  # this entire workflow was skipped — every test lane with it (#585). Every
+  # job below is read-only reporting, so it is safe on any base; if one ever
+  # becomes too expensive for a stack, gate that job, not the workflow.
   pull_request:
-    branches: [main, master]
 
 # Least privilege: every job here only reads the repo (tests, lint, gitleaks,
 # audits). No job writes contents, comments, or uploads results.

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -67,3 +67,22 @@ def test_local_compose_security_defaults_are_documented_and_loopback_bound():
     )
     assert "MCP_AUTH_TOKEN=" in example_env
     assert "READ_AUTH_ENABLED=" in example_env
+
+
+def test_ci_runs_on_every_pull_request_including_stacked_ones():
+    """No base-branch filter on `pull_request`, or stacked PRs get no tests.
+
+    A `branches:` list under `pull_request` filters on the *base* branch, so a
+    PR stacked on another feature branch matched nothing and the whole test
+    pipeline was skipped — 19 checks on a PR into main, 6 on a stacked one,
+    none of the 6 a test, while the job that arms auto-merge ran on both (#585).
+    """
+    workflow = _workflow("ci.yml")
+    # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
+    triggers = workflow.get(True) or workflow["on"]
+    pull_request = triggers["pull_request"] or {}
+
+    assert "branches" not in pull_request, (
+        "ci.yml filters pull_request on the base branch; stacked PRs would "
+        f"run no tests at all: {pull_request}"
+    )


### PR DESCRIPTION
Throwaway draft. Sole purpose: measure whether the ci.yml fix in #585 fires on a **stacked** pull request (base is a feature branch, not `main`) before that fix is on any base branch.

Draft on purpose — `claude-standards-review` is guarded by `if: !draft` and `auto-merge-when-satisfied` needs it, so neither runs here. Nothing can be armed from this PR.

Will be closed and the branch deleted once the check list is recorded.