### PR TITLE
candidate: run the test pipeline on stacked pull requests (#585)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI - FHIR MCP Guardrails
 on:
   push:
     branches: [main, master, 'claude/**']
+  # No `branches:` filter here on purpose. That filter matches the PR's BASE
+  # branch, so a change stacked on another feature branch matched nothing and
+  # this entire workflow was skipped — every test lane with it (#585). Every
+  # job below is read-only reporting, so it is safe on any base; if one ever
+  # becomes too expensive for a stack, gate that job, not the workflow.
   pull_request:
-    branches: [main, master]
 
 # Least privilege: every job here only reads the repo (tests, lint, gitleaks,
 # audits). No job writes contents, comments, or uploads results.

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -76,13 +76,104 @@ def test_ci_runs_on_every_pull_request_including_stacked_ones():
     PR stacked on another feature branch matched nothing and the whole test
     pipeline was skipped — 19 checks on a PR into main, 6 on a stacked one,
     none of the 6 a test, while the job that arms auto-merge ran on both (#585).
+
+    PINNED BY SHAPE, NOT BY THE ONE WORD THAT WAS DELETED. `branches` was how
+    it was spelled; `branches-ignore: ['fix/**']` recreates #585 exactly and
+    is a different word, and `paths` / `paths-ignore` reach the same end state
+    on a different axis — the workflow skipped, no test run, the pull request
+    page clean. A test that only forbids `branches` would pass through all
+    three, which is the failure mode #585 is about.
     """
     workflow = _workflow("ci.yml")
     # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
     triggers = workflow.get(True) or workflow["on"]
+
+    assert "pull_request" in triggers, (
+        "ci.yml no longer runs on pull requests at all: "
+        f"{sorted(map(str, triggers))}"
+    )
     pull_request = triggers["pull_request"] or {}
 
-    assert "branches" not in pull_request, (
-        "ci.yml filters pull_request on the base branch; stacked PRs would "
-        f"run no tests at all: {pull_request}"
+    reinstated = sorted({"branches", "branches-ignore",
+                         "paths", "paths-ignore"} & set(pull_request))
+    assert not reinstated, (
+        f"ci.yml scopes its pull_request trigger with {reinstated}; a pull "
+        f"request the filter does not match runs no test at all: "
+        f"{pull_request}"
     )
+
+    # And nothing may put the filter back one level down. A job gated on
+    # `github.base_ref` is the same filter wearing an `if:`, and it skips
+    # green — which reads as a pass rather than as an absence.
+    #
+    # Only `if:` is inspected. The `lint` job legitimately READS
+    # `${GITHUB_BASE_REF}` in a `run:` step to pick the diff base for
+    # scripts/check_table_stakes.py; that is the job doing its work on a
+    # stacked base, not refusing to.
+    for job_name, job in workflow["jobs"].items():
+        gates = [("job", job.get("if"))]
+        gates += [(f"step {n}", step.get("if"))
+                  for n, step in enumerate(job.get("steps") or [])]
+        for where, gate in gates:
+            if not gate:
+                continue
+            assert "base_ref" not in str(gate), (
+                f"{job_name} ({where}) gates itself on the base branch, which "
+                f"is the #585 filter one level down: {gate}")
+            assert "pull_request.base" not in str(gate), (
+                f"{job_name} ({where}) gates itself on the base branch, which "
+                f"is the #585 filter one level down: {gate}")
+
+
+def test_nothing_that_runs_on_a_pull_request_can_write_anything():
+    """The safety argument for dropping the base filter, stated as a test.
+
+    Removing the filter is only safe because every job it re-enables reads.
+    Now that `ci.yml` fires on a pull request into ANY base, a workflow that
+    publishes an image, deploys, files an issue or comments would start doing
+    it from an unreviewed feature branch — worse than the bug #585 describes.
+    So: every workflow triggered by `pull_request` gets read-only
+    permissions, at the workflow level and at every job.
+
+    `pull_request_target` is deliberately NOT in scope. `claude-pr-review.yml`
+    needs `pull-requests: write` to post its review and label its verdict, and
+    is safe on a fork because it checks out the DEFAULT branch and never
+    executes pull-request code. It also already ran on stacked pull requests
+    before this change — it was two of the six.
+
+    MUTATION: add `packages: write` to ci.yml's `permissions:`, or give any
+    single job its own write scope -> red naming the workflow and the scope.
+    """
+    workflow_dir = ROOT / ".github" / "workflows"
+    checked = []
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        workflow = yaml.safe_load(path.read_text())
+        triggers = workflow.get(True) or workflow.get("on")
+        if isinstance(triggers, str):
+            triggers = [triggers]
+        if isinstance(triggers, list):
+            triggers = dict.fromkeys(triggers)
+        if "pull_request" not in (triggers or {}):
+            continue
+        checked.append(path.name)
+
+        scopes = [("workflow", workflow.get("permissions"))]
+        scopes += [(name, job.get("permissions"))
+                   for name, job in workflow["jobs"].items()]
+        for where, permissions in scopes:
+            if permissions is None:
+                # No declaration at a job means it inherits the workflow's,
+                # which this same loop has already checked.
+                continue
+            assert isinstance(permissions, dict), (
+                f"{path.name} ({where}) grants permissions wholesale: "
+                f"{permissions!r}")
+            writes = sorted(scope for scope, level in permissions.items()
+                            if level != "read" and level != "none")
+            assert not writes, (
+                f"{path.name} ({where}) can write {writes} and runs on every "
+                f"pull request, into any base branch")
+
+    # The loop above is vacuous if it matched nothing, and a workflow file
+    # renamed out of the glob would make it so silently.
+    assert sorted(checked) == ["ci.yml", "security-baseline.yml"], checked

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -165,6 +165,12 @@ def test_nothing_that_runs_on_a_pull_request_can_write_anything():
                 # No declaration at a job means it inherits the workflow's,
                 # which this same loop has already checked.
                 continue
+            if permissions == "read-all":
+                # The string form GitHub also accepts at this position.
+                # `read-all` is read-only and passes; `write-all` is caught
+                # by the assertion below, which is why this only whitelists
+                # the one value rather than every string.
+                continue
             assert isinstance(permissions, dict), (
                 f"{path.name} ({where}) grants permissions wholesale: "
                 f"{permissions!r}")

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -67,3 +67,22 @@ def test_local_compose_security_defaults_are_documented_and_loopback_bound():
     )
     assert "MCP_AUTH_TOKEN=" in example_env
     assert "READ_AUTH_ENABLED=" in example_env
+
+
+def test_ci_runs_on_every_pull_request_including_stacked_ones():
+    """No base-branch filter on `pull_request`, or stacked PRs get no tests.
+
+    A `branches:` list under `pull_request` filters on the *base* branch, so a
+    PR stacked on another feature branch matched nothing and the whole test
+    pipeline was skipped — 19 checks on a PR into main, 6 on a stacked one,
+    none of the 6 a test, while the job that arms auto-merge ran on both (#585).
+    """
+    workflow = _workflow("ci.yml")
+    # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
+    triggers = workflow.get(True) or workflow["on"]
+    pull_request = triggers["pull_request"] or {}
+
+    assert "branches" not in pull_request, (
+        "ci.yml filters pull_request on the base branch; stacked PRs would "
+        f"run no tests at all: {pull_request}"
+    )


### PR DESCRIPTION
Closes #585.

## What

`.github/workflows/ci.yml` triggered on `pull_request: branches: [main, master]`.
That filter matches the pull request's **base** branch, so a change stacked on
another feature branch matched nothing and the entire workflow — every test lane
in it — was skipped. The filter is removed. The `push` trigger's branch list is
unchanged.

Also adds `test_ci_runs_on_every_pull_request_including_stacked_ones` to
`tests/test_ci_hardening.py`, next to the other static workflow guards, so the
filter cannot come back unnoticed.

## Why

Measured across the open pull requests before this change:

| Base | Checks |
|---|---|
| `main` (#580) | **19** |
| stacked on a feature branch (#584, #578, #571 — identical) | **6** |

The six were `claude-standards-review`, `auto-merge-when-satisfied`,
`scan / scan changed files` ×2, and Vercel ×2. **None of the six is a test.**

`auto-merge-when-satisfied` is one of them. On this repository a maintainer
approval arms a squash merge, and with no test job present there is no failing
required check to hold it — so approving a stacked change merged it having run
zero tests, over a pull request page that looked clean. Seven stacked changes
are open in that state right now (#566, #569, #571, #576, #578, #579, #584).

## Before and after

Per-job, from the actual check lists:

| Job | `main` PR, before | stacked PR, before | stacked PR, after |
|---|---|---|---|
| `lint` | yes | **no** | **yes** |
| `python-tests` | yes | **no** | **yes** |
| `postgres-tests` | yes | **no** | **yes** |
| `node-tests` | yes | **no** | **yes** |
| `playwright-tests` | yes | **no** | **yes** |
| `compose-smoke` | yes | **no** | **yes** |
| `secret-scan` | yes | **no** | **yes** |
| `dependency-audit` | yes | **no** | **yes** |
| `compliance-gates` | yes | **no** | **yes** |
| `claude-standards-review` | yes | yes | yes |
| `auto-merge-when-satisfied` | yes | yes | yes |
| `scan / scan changed files` ×2 | yes | yes | yes |
| Vercel, Vercel Preview Comments | yes | yes | yes |
| `CodeQL`, `Analyze` ×3 | yes | **no** | **still no** — see below |

**6 → 15.** A pull request into `main` gets 19. The remaining difference of 4 is
code scanning, and this pull request cannot close it: CodeQL here is GitHub
*default setup* (`GET /code-scanning/default-setup` returns
`"state": "configured"`), which lives in repository settings, not in
`.github/workflows/`, and only runs on pull requests targeting the default
branch. Closing that gap means converting to an advanced `codeql.yml`, which is
a separate decision, not a side effect of this one.

## Verified on a real stacked pull request, before merge

Reading the file is not evidence — a workflow change that looks right and does
not fire is the defect this issue is about. So: #587, a throwaway **draft**
stacked on `fix/populate-drop-subject-append` (the base of #578) carrying only
this commit.

Run: https://github.com/aks129/HealthClawGuardrails/actions/runs/33828597815

Final check list on #587: **15 checks, all nine `ci.yml` jobs present** —
`lint`, `python-tests`, `postgres-tests`, `node-tests`, `playwright-tests`,
`compose-smoke`, `secret-scan`, `dependency-audit`, `compliance-gates`. Before
this change a stacked pull request produced **none** of the nine. Eight passed,
including `compliance-gates` and `playwright-tests`, on a branch CI had never
looked at.

`dependency-audit` failed, and it is **not** this change and not stacked-specific:
`npm audit` got `503 Service Unavailable` from the npm registry. The same job is
failing right now on #583, which targets `main`. Worth one line in a follow-up
that `npm audit` has no retry, so a registry outage reads as a vulnerability
finding — noticed here, deliberately not touched.

**So the fix is observable before merge, not only after.** That is worth stating
plainly because the opposite is widely assumed: for `pull_request`, GitHub
evaluates the workflow file from the pull request's merge ref, so a change to
the `on:` block takes effect for the pull request carrying it. The
"only once it is on the base branch" rule is real, but it applies to
`pull_request_target` — which is why `claude-pr-review.yml` is unaffected either
way. #587 is draft on purpose: `claude-standards-review` is guarded by
`if: !draft` and `auto-merge` `needs:` it, so both showed `skipping` and nothing
could be armed from it. Closed and its branch deleted once the measurement was recorded (see the
closing comment on #587).

## Workflows deliberately left filtered

- **`publish.yml`** — `release: [published]` + `workflow_dispatch`. Builds and
  **pushes Docker images to ghcr.io**. Side effects beyond reporting; it must
  never fire from a feature branch. Untouched.
- **`prod-watch.yml`** — `schedule` + `workflow_dispatch`. Probes **live
  production** and opens/closes a GitHub issue on the result. Side effects
  beyond reporting, and running it per-pull-request would file alarms about
  production from a branch that has nothing to do with it. Untouched.

Checked and found to need no change:

- **`claude-pr-review.yml`** — `pull_request_target`, no branch filter. Already
  runs on stacked pull requests; it is 2 of the 6 checks they get today. This is
  the asymmetry the issue is about, and it is now resolved from the other side.
- **`security-baseline.yml`** — `on: [pull_request, push]`, no branch filter.
  Already runs everywhere; the duplicate `scan / scan changed files` is the
  push-plus-pull-request pair, not a bug.

Vercel and CodeQL are GitHub Apps / repository settings, not workflow files.

## No job is gated

The task allowed gating an individual job if one were genuinely too expensive to
run on every stack. I cannot name a cost that outweighs "these pull requests
currently get zero tests," so everything runs. Every job in `ci.yml` is
read-only — the workflow declares `permissions: contents: read` and no job
writes contents, comments, or artifacts beyond a failure report. The comment
added above the trigger says to gate a job rather than the workflow if that ever
changes.

## One thing this does NOT fix

Running is not the same as blocking. `GET /branches/main/protection` requires 8
contexts on `main`; the only repository ruleset (`Protection`, id 16908482)
carries just `deletion` and `non_fast_forward` and no required status checks, and
the feature branches used as stacked bases return **`404 Branch not protected`**.

So after this change a failing test on a stacked pull request shows a red X and
is visible to a reviewer — but nothing at the repository level *forces* the
merge to wait for it. Making it a hard stop is a branch-protection/ruleset
change, which only the maintainer can make. Naming it here rather than implying
this pull request closes the whole gap.

## Mutations run

- With `branches: [main, master]` still present under `pull_request` (the
  pre-change state), the new guard went **RED** —
  `AssertionError: ci.yml filters pull_request on the base branch; stacked PRs
  would run no tests at all: {'branches': ['main', 'master']}`.
  (This is the pre-change state; the guard was written first and observed
  failing before `ci.yml` was edited.)
- The guard reads the parsed YAML, not the file text, so a commented-out or
  reformatted filter cannot fool it. It deliberately does not pin the `push`
  branch list — that was out of scope and pinning it would over-constrain.

## This pull request's own red check

`dependency-audit` is red on **this** pull request too, with the identical
`503 Service Unavailable - POST https://registry.npmjs.org/.../security/audits/quick`.
It is red on #583 and was red on #587 in the same window. The npm registry's
audit endpoint is down; nothing in this change touches dependencies. The other
18 checks pass. Re-run the job when the registry recovers.

## Ran

- `uv run ruff check .` → `All checks passed!`
- `uv run python -m pytest tests/ -q -p no:cacheprovider` →
  `3158 passed, 13 skipped, 1 xfailed, 2 warnings in 140.62s`
- `grep -rln workflow tests/` → no test pins the `on:` trigger of any workflow;
  nothing had to move with this change.
- Live check-list measurement on #580, #583 (base `main`) and #584, #578, #571
  (stacked), plus the #587 demonstration above.

## What was NOT run

- **CodeQL on a stacked pull request** — out of reach from a workflow file, as
  above.
- **Chasing #587's one red to green.** `dependency-audit` failed there on an
  npm registry 503, which reproduces on `main` — an infrastructure flake, not a
  finding about the stacked branch and not something this pull request should
  fix.
- **Nothing was merged or approved.** Auto-merge was `null` on #584, #578 and
  #571 when checked, and #587 is draft so the arming job never ran.

## Checklist

- [x] Tests added/updated and `uv run python -m pytest tests/ -q` passes
- [x] `uv run ruff check .` passes
- [x] No PHI in code, tests, fixtures, or logs
- [ ] Touches auth/audit/redaction/tenancy? No — CI trigger configuration only.
      It does make the audit/redaction/tenancy tests run on stacked changes,
      where they did not before.
- [ ] Node changes: none
- [x] Read against `docs/defect-catalogue.md` — this is §0 ("a confident report
      from a check that did not run") and §5 ("silence that cannot be told from
      success"): a stacked pull request with no test job looked exactly like one
      with every test green.
- [x] New guard mutation-tested, result above
- [x] Anything deliberately left undone is named above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
