### PR TITLE
docs(guide): publish the approval-is-a-merge and stacked-CI traps (#585)

### DIFF
--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -190,6 +190,37 @@ auditor.
   updates its own matrix row in the *same* PR. Three security PRs skipped that
   and left `main` red for a day, each of them individually green. The matrix
   must report **0 failed and 0 xpassed** — an XPASS is a failure, not a pass.
+- **A maintainer's approval is the merge, not a verdict on it.** The
+  `auto-merge-when-satisfied` job in `.github/workflows/claude-pr-review.yml`
+  runs `gh pr merge --squash --auto` as soon as it sees an approving review
+  from an OWNER, MEMBER or COLLABORATOR. Once armed, GitHub merges when the
+  *required* checks pass — `main` requires eight, and every other base branch
+  requires none, so on a stacked PR arming is merging. The job fires on
+  `opened`/`synchronize`/`reopened`/`ready_for_review` and not on the review
+  event, which makes this worse rather than milder: a standing approval arms
+  on somebody else's later push, hours on, with the approver no longer
+  watching. There is no "approve now, merge when I say so" state — approve
+  only what you are willing to have land unattended. For the same reason,
+  check `gh pr view <n> --json autoMergeRequest` before you approve *and*
+  before you fix whatever is holding a PR red: an armed merge fires the moment
+  the last check goes green, including the check you just fixed, and
+  `--disable-auto` cannot help once it has fired. On 2026-08-16 that merged a
+  PR mid-review, carrying content a review board had been convened to decide
+  on (#527).
+- **Never read a stacked pull request's green as tested.** `ci.yml` filtered
+  `pull_request` on `branches: [main, master]`, and that filter matches the
+  pull request's *base* — so a change stacked on another feature branch matched
+  nothing, and the whole workflow, every test lane in it, was skipped.
+  Measured 2026-09-03: **19 checks** on a pull request into `main`, **6** on a
+  stacked one, and none of the six was a test. One of the six was
+  `auto-merge-when-satisfied`, which is how the trap above becomes a merge with
+  zero tests behind it. #585 has the per-job detail; #588 drops the filter.
+  Two things survive that fix. Feature-branch bases carry no protection at all
+  (`GET /branches/<branch>/protection` returns 404), so with the filter gone a
+  red test on a stacked pull request is *visible* but still blocks nothing. And
+  CodeQL here is GitHub default setup, which runs only against the default
+  branch, so a stacked pull request gets 15 checks where one into `main` gets
+  19. Count the checks on a stacked pull request; don't read the tick.
 
 ---
 
@@ -198,9 +229,12 @@ auditor.
 - Ask before large refactors of `r6/routes.py` — a carve-up is already planned
   (#56) and uncoordinated splits will conflict.
 - Prefer small, reviewable PRs. Every PR gets an automated standards review
-  ([.github/REVIEW_STANDARDS.md](../.github/REVIEW_STANDARDS.md)) plus CI.
+  ([.github/REVIEW_STANDARDS.md](../.github/REVIEW_STANDARDS.md)); how much CI
+  it gets depends on its base branch, which §6 covers.
 - **A maintainer approves before merge.** Agent-authored PRs do not
-  self-merge — the human stays the final authority on this project.
+  self-merge — the human stays the final authority on this project. That
+  approval is also the merge instruction (§6), so it is the last point at
+  which anything is decided, not a checkpoint before one.
 - If an issue's requirements turn out to be wrong once you're in the code, say
   so in the issue rather than silently building something different.
 

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -204,9 +204,10 @@ auditor.
   check `gh pr view <n> --json autoMergeRequest` before you approve *and*
   before you fix whatever is holding a PR red: an armed merge fires the moment
   the last check goes green, including the check you just fixed, and
-  `--disable-auto` cannot help once it has fired. On 2026-08-16 that merged a
-  PR mid-review, carrying content a review board had been convened to decide
-  on (#527).
+  `--disable-auto` cannot help once it has fired. On 2026-08-16 it fired on
+  exactly that: a lint fix turned the last check green, #519 merged while the
+  problem in it was still being worked on, and what it put on public `main`
+  had to be corrected afterwards (#527).
 - **Never read a stacked pull request's green as tested.** `ci.yml` filtered
   `pull_request` on `branches: [main, master]`, and that filter matches the
   pull request's *base* — so a change stacked on another feature branch matched
@@ -219,8 +220,8 @@ auditor.
   (`GET /branches/<branch>/protection` returns 404), so with the filter gone a
   red test on a stacked pull request is *visible* but still blocks nothing. And
   CodeQL here is GitHub default setup, which runs only against the default
-  branch, so a stacked pull request gets 15 checks where one into `main` gets
-  19. Count the checks on a stacked pull request; don't read the tick.
+  branch, so even once #588 has landed a stacked pull request gets 15 checks
+  where one into `main` gets 19. Count the checks on a stacked pull request; don't read the tick.
 
 ---
 


### PR DESCRIPTION
Two traps cost real time today and lived only in a local, gitignored file. Per
`docs/agent-task-guide.md`'s own rule — *if something is only in CLAUDE.md,
that's a bug in this guide* — they are published here.

Both go in **§6, "Traps that have actually bitten this project"**, rather than a
new section: they are traps, they are process rather than code, and the second
one only makes sense next to the first.

## Trap 1 — a maintainer's approval is the merge

`auto-merge-when-satisfied` in `.github/workflows/claude-pr-review.yml` runs
`gh pr merge --squash --auto` once an approving review from an OWNER, MEMBER or
COLLABORATOR exists. Once armed, GitHub merges when the *required* checks pass:
`main` requires eight, and no other base branch requires any.

**One correction to the reported shape, and it is load-bearing.** The task
described this as "no gap between the click and the merge". The workflow has no
`pull_request_review` trigger — `on: pull_request_target: [opened, synchronize,
reopened, ready_for_review]` — which settles it on its own, since an event not
in `on:` cannot fire the workflow. Corroborated:
`gh run list --workflow claude-pr-review.yml --limit 100 --json event` groups as
`[{"event": "pull_request_target", "n": 100}]` — 100 of 100, none on a review. So
the approval does not itself run the job; it arms on the next open, push, reopen
or ready-for-review after the approval exists. Written that way, because a trap
that overstates its mechanism is the shape #529 just had to correct. The entry
says plainly that the delay makes it *worse*: a standing approval fires on
someone else's later push, with the approver no longer watching.

The entry also absorbs the `gh pr view <n> --json autoMergeRequest` check and
the 2026-08-16 mid-review merge. The task described trap 1 as compounding an
auto-merge trap "already documented there" — it is not in the guide, only in the
local file, so rather than leave a dangling reference the mitigation now carries
that lesson.

## Trap 2 — never read a stacked pull request's green as tested

`ci.yml` filtered `pull_request` on `branches: [main, master]`; that filter
matches the pull request's *base*, so a stacked change matched nothing and every
test lane was skipped. Measured today: 19 checks into `main`, 6 stacked, none of
the six a test — and one of the six is the auto-merge job, which is how trap 1
becomes a merge with zero tests behind it. #585 has the detail, #588 drops the
filter.

Written to read correctly either side of #588 landing. What survives the fix is
stated as present tense and verified here independently:

- feature-branch bases carry no protection — `GET
  /branches/fix/populate-drop-subject-append/protection` returns **404 Branch
  not protected** — so with the filter gone a red test on a stacked pull request
  is *visible* but blocks nothing;
- `main` protection is 8 required contexts, `strict: true`,
  `enforce_admins: true`, `required_pull_request_reviews: null` (confirmed via
  the API), which is why arming equals merging on any other base;
- CodeQL is GitHub default setup, which runs only against the default branch, so
  even once #588 has landed a stacked pull request gets 15 checks where one into
  `main` gets 19.

The 2026-08-16 mid-review merge is cited as **#519** (the second commit fixes an
earlier draft that credited it to #527, which is the fix, not the incident).
Per #527's own body, auto-merge was armed on #519 and a lint fix turned the last
check green — the trap's mitigation in one sentence.

## What was already there and is now wrong

§7 had two lines the traps falsify. Both corrected in place, not duplicated:

- "Every PR gets an automated standards review **plus CI**" — false for stacked
  pull requests. Now says the standards review is unconditional and the CI half
  depends on the base branch, pointing at §6.
- "**A maintainer approves before merge.** … the human stays the final
  authority" — temporally true, but it implies a separate merge decision that
  does not exist. Now says the approval *is* the merge instruction, so it is the
  last point at which anything is decided.

Nothing else in §6 is wrong because of these two.

## Ran

- `uv run ruff check .` → `All checks passed!`
- `uv run python -m pytest tests/ -q` → `3157 passed, 13 skipped, 1 xfailed,
  2 warnings in 130.26s`

Docs only, no behavior change, so no test accompanies it. Nothing in `tests/`
pins the content of this guide (`test_ratchets.py` references it in a docstring
only).

## Noticed, deliberately not touched

- The workflow's own staged comment — "this PR will merge automatically the
  moment a maintainer approves and CI is green" — overstates for the same reason
  trap 1 does: no event fires on the approval. Fixing the workflow is a separate
  decision.
- §6 still says Playwright e2e is red on `main` and gives no signal. #588's
  measurement on #587 shows `playwright-tests` passing, so that entry may be
  stale — out of scope here, worth a look.

## Checklist

- [x] `uv run python -m pytest tests/ -q` passes, counts quoted above
- [x] `uv run ruff check .` passes
- [x] No PHI in code, tests, fixtures, or logs
- [ ] Touches auth/audit/redaction/tenancy? No — documentation only.
- [ ] Node changes: none
- [x] Anything deliberately left undone is named above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
