### PR TITLE
feat(audit): bring agent_runs under the audit rule, and strengthen the pin (B2)

### DIFF
--- a/docs/2026-08-05-healthclaw-2.0-playbook.md
+++ b/docs/2026-08-05-healthclaw-2.0-playbook.md
@@ -71,7 +71,7 @@ names its ratchet and its test-first artifact.
 | # | Chunk | Ratchet | Test-first |
 |---|---|---|---|
 | B1 | Audit for `command_center` (3 gated writes, currently 0 events) | coverage gap −1 | audit-assertion (#338 after-flush) turned on for these routes |
-| B2 | Audit for `agent_runs` (2 gated writes) | coverage gap −2 | same |
+| B2 | Audit for `agent_runs` — **shipped 2026-09-04**. "2 gated writes" was an undercount: the package has 14 routes and 10 of them are gated on a shared secret rather than step-up, which is also why the ratchet's step-up-only predicate barely covered its own subject. 8 routes audit, 6 are classified as timer chatter with reasons | coverage gap −2; unaudited-mutator set → empty (tripwire) | `tests/test_agent_run_writes_are_audited.py` — per-route classification, wire proof, PHI-free detail |
 | B3–B8 | `record_audit_event` → `add_audit_event`, one blueprint per PR (routes, curatr, labs, caregaps, shc/quality, actions/review) | 88→0 stepwise | audit-atomicity matrix: for each write path, assert audit row in `session.new` before commit |
 | B9 | Delete `record_audit_event` + its ambient commit | primitive count 2→1 | the ratchet at 0 is the precondition |
 | B10 | Enable `HC_ASSERT_AUDIT_COMMITTED` in production once B9 lands | tripwire live | prod_watch check |

--- a/r6/agent_runs/service.py
+++ b/r6/agent_runs/service.py
@@ -9,6 +9,7 @@ from datetime import timedelta, timezone
 from sqlalchemy.exc import IntegrityError
 
 from models import db
+from r6.access import audit
 from r6.agent_runs.models import (
     AgentRun,
     AgentRunEvent,
@@ -23,6 +24,76 @@ from r6.agent_runs.state import (
     require_tool_transition,
 )
 from r6.command_center.models import Conversation, ConversationMessage
+
+
+# ---------------------------------------------------------------------------
+# Audit (playbook B2)
+# ---------------------------------------------------------------------------
+#
+# Which mutations record evidence is a decision, and it is made here rather
+# than at the routes: every one of these functions owns its own transaction,
+# so an audit written anywhere else would commit separately from the change it
+# describes — fail-open on the data, fail-closed on the response. The kernel's
+# audit() flushes inside THIS transaction and never commits, so the row and
+# the state change resolve together.
+#
+# The line: a mutation a principal asked for is audited; a mutation the system
+# makes to itself on a timer is not. Deadline sweeps, lease recovery, claim
+# redelivery, heartbeats and the run's own event log stay out — they are
+# already fully recorded in AgentRunEvent, and putting them here would bury
+# the records an auditor needs under queue chatter.
+# tests/test_agent_run_writes_are_audited.py classifies all fourteen routes
+# and proves each audited one at the wire.
+
+def _detail(**fields) -> str:
+    """A PHI-FREE `key=value` detail line, in the command centre's shape.
+
+    Only ids, states, counts and regex-constrained identifiers may be passed.
+    Never a message body, a tool argument, or a tool result: this package
+    handles the assistant's answer and the arguments a model chose, and both
+    are the most sensitive field in their request. Fields that are None are
+    dropped rather than rendered, so a detail says nothing it does not know.
+    """
+    return " ".join(f"{key}={value}" for key, value in fields.items()
+                    if value is not None)
+
+
+def _audit_run_change(run: AgentRun, previous_status: str, **extra) -> None:
+    """Record one principal-requested change to a run's state."""
+    audit(
+        tenant=run.tenant_id,
+        event_type="update",
+        resource_type="AgentRun",
+        resource_id=run.id,
+        agent_id=run.agent_id,
+        detail=_detail(**{"from": previous_status, "status": run.status,
+                          "attempt": run.attempt,
+                          "error_class": run.error_class, **extra}),
+    )
+
+
+def _audit_tool_change(
+    run: AgentRun,
+    call: AgentToolCall,
+    event_type: str,
+    **extra,
+) -> None:
+    """Record one change to a tool call — the agent's real-world side effect.
+
+    `tool_name` is `_ID`-constrained at the route and `input_hash` is a digest,
+    so both are safe to name. `outcome_ref` is a free-form 256-character worker
+    string and is deliberately absent.
+    """
+    audit(
+        tenant=run.tenant_id,
+        event_type=event_type,
+        resource_type="AgentToolCall",
+        resource_id=call.id,
+        agent_id=run.agent_id,
+        detail=_detail(**{"run": run.id, "tool": call.tool_name,
+                          "status": call.status, "attempt": call.attempt,
+                          "error_class": call.error_class, **extra}),
+    )
 
 
 def create_run(
@@ -57,6 +128,19 @@ def create_run(
     try:
         db.session.flush()
         append_event(run, "run.queued", {"status": "queued"})
+        # Inside the try: a concurrent creation rolls this transaction back,
+        # and the audit row goes with it. The replay above returns before
+        # here, so a run that already existed is never recorded as created.
+        audit(
+            tenant=run.tenant_id,
+            event_type="create",
+            resource_type="AgentRun",
+            resource_id=run.id,
+            agent_id=run.agent_id,
+            detail=_detail(conversation=run.conversation_id,
+                           message=run.message_id, surface=run.surface,
+                           deadline_s=deadline_seconds),
+        )
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
@@ -583,21 +667,36 @@ def transition_owned_run(
         raise InvalidTransition(
             "completed is only allowed through atomic finalization")
     require_run_transition(run.status, target)
+    # Captured before the transition, and after every raise above: an audit
+    # flushed ahead of a refusal would be evidence of a write that did not
+    # happen, and the flush-only primitive would leave it pending at teardown.
+    previous = run.status
+    # commit=False throughout, so the audit is the last flush before the one
+    # commit that resolves the whole change.
     if _preserve_ambiguous_tools(
-            run, reason=f"worker_{target}_with_running_tool"):
+            run, reason=f"worker_{target}_with_running_tool", commit=False):
+        _audit_run_change(run, previous, requested=target)
+        db.session.commit()
         return run
     if run.cancel_requested and target != "cancelled":
-        return transition_run(
+        run = transition_run(
             run, "cancelled", event_type="run.cancelled",
-            payload={"status": "cancelled"})
-    return transition_run(
-        run,
-        target,
-        event_type=event_type,
-        payload=payload,
-        error_class=error_class,
-        available_in_seconds=available_in_seconds,
-    )
+            payload={"status": "cancelled"}, commit=False)
+    else:
+        run = transition_run(
+            run,
+            target,
+            event_type=event_type,
+            payload=payload,
+            error_class=error_class,
+            available_in_seconds=available_in_seconds,
+            commit=False,
+        )
+    # A worker declaring an outcome is a once-per-attempt fact, not a poll:
+    # this is where a run enters the human gate, fails, or is retried.
+    _audit_run_change(run, previous, requested=target)
+    db.session.commit()
+    return run
 
 
 def request_cancel(run: AgentRun) -> AgentRun:
@@ -610,19 +709,31 @@ def request_cancel(run: AgentRun) -> AgentRun:
     if locked is None:
         raise LookupError("unknown run")
     run = locked
+    # A finished run changes nothing, so it is not audited — an audit event
+    # for it would report a write that did not happen. The same holds for a
+    # repeat cancellation of a run already waiting on reconciliation, below.
+    # The `running` path is NOT idempotent: it re-sets the flag and appends
+    # another run.cancel_requested event on every call, which predates this
+    # change, so a repeat cancel there audits again.
     if run.status in TERMINAL_RUN_STATES:
         return run
+    previous = run.status
     if run.status == "waiting_for_human" and AgentToolCall.query.filter_by(
             run_id=run.id, status="needs_reconciliation").first() is not None:
         if not run.cancel_requested:
             run.cancel_requested = True
             append_event(run, "run.cancel_requested", {"status": run.status})
+            _audit_run_change(run, previous, cancel_requested=True)
             db.session.commit()
         return run
     if run.status in ("queued", "waiting_for_human"):
-        return transition_run(run, "cancelled")
+        run = transition_run(run, "cancelled", commit=False)
+        _audit_run_change(run, previous)
+        db.session.commit()
+        return run
     run.cancel_requested = True
     append_event(run, "run.cancel_requested", {"status": run.status})
+    _audit_run_change(run, previous, cancel_requested=True)
     db.session.commit()
     return run
 
@@ -640,9 +751,17 @@ def resume_run(run_id: str) -> AgentRun:
     if AgentToolCall.query.filter_by(
             run_id=run.id, status="needs_reconciliation").first() is not None:
         raise InvalidTransition("run has a tool awaiting reconciliation")
-    return transition_run(
+    previous = run.status
+    # The other half of the human gate. Entering `waiting_for_human` is
+    # audited by transition_owned_run; leaving it is audited here, so the
+    # trail can show a run that stopped for a person and the release that
+    # let it continue.
+    run = transition_run(
         run, "queued", event_type="run.resumed",
-        payload={"status": "queued"})
+        payload={"status": "queued"}, commit=False)
+    _audit_run_change(run, previous, resumed=True)
+    db.session.commit()
+    return run
 
 
 def register_tool_call(
@@ -677,6 +796,11 @@ def register_tool_call(
             "tool_name": tool_name,
             "input_hash": input_hash,
         })
+        # The moment an agent commits to a real-world side effect. The
+        # arguments themselves never leave input_json — the digest is what
+        # makes a replay provable without copying what was asked for.
+        _audit_tool_change(run, call, "create",
+                           input_sha256=input_hash[:12])
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
@@ -740,6 +864,9 @@ def transition_tool_call(
         "outcome_ref": outcome_ref,
         "error_class": error_class,
     })
+    # `result` is the provider's response about a patient and never appears
+    # here; the event log above already holds it for the worker's own replay.
+    _audit_tool_change(run, call, "update")
     db.session.commit()
     return call
 
@@ -797,7 +924,9 @@ def finalize_run(
             raise InvalidTransition(
                 "assistant request ID conflicts with persisted outcome")
         message = prior
+        created_message = False
     else:
+        created_message = True
         conversation = (
             Conversation.query
             .filter_by(tenant_id=run.tenant_id, id=run.conversation_id)
@@ -831,6 +960,7 @@ def finalize_run(
             "checkpoint_id": checkpoint_id,
             "text": text,
         })
+    previous = run.status
     transition_run(
         run,
         "completed",
@@ -838,6 +968,27 @@ def finalize_run(
         payload={"status": "completed"},
         commit=False,
     )
+    # The flush assigns message.id, so the audit can name the row it is
+    # evidence for.
+    db.session.flush()
+    if created_message:
+        # The mirror image of the command centre's audit on the user's turn
+        # (r6/command_center/routes.py). Auditing one and not the other would
+        # leave a trail that can show a question and never its answer.
+        # DETAIL IS PHI-FREE: `text` is the assistant's answer about a
+        # patient, so this carries its length and nothing of its content.
+        audit(
+            tenant=run.tenant_id,
+            event_type="create",
+            resource_type="ConversationMessage",
+            resource_id=message.id,
+            agent_id=run.agent_id,
+            detail=_detail(run=run.id, conversation=run.conversation_id,
+                           role="assistant", channel=run.surface,
+                           chars=len(text)),
+        )
+    _audit_run_change(run, previous, checkpoint=checkpoint_id,
+                      message=message.id)
     db.session.commit()
     return run, message, True
 
@@ -939,6 +1090,11 @@ def reconcile_tool_call(
         "run_status": run.status,
         "run_error_class": run.error_class,
     })
+    # A human asserting what happened in the world — the single most
+    # evidence-worthy mutation in this package. `evidence_ref` is _ID-
+    # constrained at the route, so it is an opaque handle rather than prose.
+    _audit_tool_change(run, call, "update", evidence=evidence_ref,
+                       run_status=run.status)
     db.session.commit()
     return call, run, True
 

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -1372,7 +1372,17 @@ _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
                      # is a ruling rather than a gate. Migrating these two is
                      # slice 17, and it stays blocked on their JSON wire
                      # shape.
-                     'r6/command_center/routes.py'}
+                     'r6/command_center/routes.py',
+                     # playbook B2: the durable agent-run control plane's
+                     # audit. It imports `audit` and nothing else — its
+                     # step-up check still calls the validator directly and
+                     # is still counted by _STEP_UP_CALLSITES, because one
+                     # guard per PR is the protocol. The service layer rather
+                     # than the routes is the adopter on purpose: each of
+                     # these functions owns its own transaction, and the
+                     # kernel's audit() only keeps its promise when it flushes
+                     # inside the transaction it is evidence for.
+                     'r6/agent_runs/service.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():

--- a/tests/test_agent_run_writes_are_audited.py
+++ b/tests/test_agent_run_writes_are_audited.py
@@ -1,0 +1,582 @@
+"""The durable agent-run control plane leaves evidence, PHI-free (playbook B2).
+
+`r6/agent_runs` was the last package in the codebase that mutated state and
+audited none of it: fourteen endpoints, ten of them authenticated by a shared
+secret rather than step-up, every one of them writing to the store and none of
+them recording that it had. An agent could register a tool call,
+execute a side effect, and persist an assistant answer with nothing in the
+audit trail to say it happened.
+
+`tests/test_ratchets.py` pinned that as the sole entry in the unaudited-mutator
+set. That pin measured a *package*: one call to any audit primitive anywhere
+inside `r6/agent_runs` would have emptied the set while thirteen endpoints
+stayed silent. This file is the pin that measures what the ratchet's name
+claims — every route in the blueprint is classified, and every route
+classified as audited proves it at the wire.
+
+The classification is the judgment call B2 exists to make, and it is
+deliberately not "audit everything". `claim` and `heartbeat` are polled on a
+timer by every live worker; auditing them would bury the records that matter
+under queue chatter, which is the failure mode of an audit trail nobody can
+read. The line drawn here: **a mutation a principal asked for is audited; a
+mutation the system makes to itself on a timer is not.** The run's own
+append-only `AgentRunEvent` log already holds the operational story.
+
+The PHI half matters more than the coverage half, exactly as it did for the
+command centre (`tests/test_command_center_writes_are_audited.py`, playbook
+B1). `finalize` writes the assistant's answer and `tool-calls` writes the
+arguments an agent chose — both are the most sensitive field in their request.
+An audit trail that helpfully recorded either would copy PHI into the one
+store whose whole contract is that it holds none.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+from models import db
+from r6.agent_runs.models import AgentRun, utcnow
+from r6.models import AuditEventRecord
+
+TENANT = "test-tenant"
+
+#: A distinctive string that must never reach the audit trail.
+_SECRET_TEXT = "Quintavious Zzyzxbarton says his A1c is 8.1 and he is scared"
+_SECRET_TOKENS = ("Quintavious", "Zzyzxbarton", "A1c", "8.1", "scared")
+
+
+# ---------------------------------------------------------------------------
+# The classification — every route in the blueprint, and why
+# ---------------------------------------------------------------------------
+
+#: endpoint -> (event_type, resource_type) that the mutation must record.
+_AUDITED = {
+    "agent_runs.create_agent_run": ("create", "AgentRun"),
+    "agent_runs.cancel_agent_run": ("update", "AgentRun"),
+    "agent_runs.resume_agent_run": ("update", "AgentRun"),
+    "agent_runs.transition_agent_run": ("update", "AgentRun"),
+    "agent_runs.create_agent_tool_call": ("create", "AgentToolCall"),
+    "agent_runs.transition_agent_tool_call": ("update", "AgentToolCall"),
+    "agent_runs.finalize_agent_run": ("create", "ConversationMessage"),
+    "agent_runs.reconcile_agent_tool_call": ("update", "AgentToolCall"),
+}
+
+#: endpoint -> why a state change here is NOT evidence worth keeping. Each of
+#: these does write to the store; the claim is about what an audit reader
+#: needs, not about whether a row moved.
+_UNAUDITED = {
+    "agent_runs.get_agent_run":
+        "read; the only write is the shared deadline sweep, which no "
+        "principal requested",
+    "agent_runs.get_agent_run_events":
+        "read; same deadline sweep",
+    "agent_runs.get_agent_worker_health":
+        "readiness poll; sweeps stranded runs on a timer",
+    "agent_runs.claim_agent_run":
+        "every live worker polls this continuously — the definition of "
+        "queue chatter",
+    "agent_runs.heartbeat_agent_run":
+        "lease renewal, several times per run per minute",
+    "agent_runs.append_agent_run_event":
+        "the run's own append-only log; auditing it would copy one log into "
+        "another once per streamed chunk",
+}
+
+
+def test_every_agent_run_route_is_classified(app):
+    """A new endpoint cannot land without a decision about its trail.
+
+    The ratchet this file replaces went green for the whole package the
+    moment one audit call existed anywhere in it. This is the property that
+    pin was named for: the classification is exhaustive, so endpoint fifteen
+    is red until somebody says which half it belongs to.
+
+    MUTATION: add a route to agent_runs_blueprint -> red.
+    """
+    routes = {
+        rule.endpoint for rule in app.url_map.iter_rules()
+        if rule.endpoint.startswith("agent_runs.")
+    }
+    assert routes, "the agent-runs blueprint is not registered"
+    classified = set(_AUDITED) | set(_UNAUDITED)
+    assert routes == classified, (
+        "unclassified: " + ", ".join(sorted(routes - classified))
+        + " | stale: " + ", ".join(sorted(classified - routes)))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def internal_headers(monkeypatch):
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "run-worker-secret")
+    return {"X-Internal-Secret": "run-worker-secret"}
+
+
+@pytest.fixture
+def reconcile_headers(monkeypatch):
+    monkeypatch.setenv("AGENT_RUN_RECONCILE_SECRET", "operator-secret")
+    return {"X-Reconciliation-Secret": "operator-secret"}
+
+
+def _events(app, resource_type=None):
+    with app.app_context():
+        query = AuditEventRecord.query.filter_by(tenant_id=TENANT)
+        if resource_type:
+            query = query.filter_by(resource_type=resource_type)
+        return [
+            {"action": event.event_type, "resource_type": event.resource_type,
+             "resource_id": event.resource_id, "detail": event.detail}
+            for event in query.all()
+        ]
+
+
+def _clear(app):
+    with app.app_context():
+        AuditEventRecord.query.delete()
+        db.session.commit()
+
+
+def _message(client, auth_headers, *, text="hello", request_id="request-1"):
+    response = client.post(
+        "/command-center/api/conversations",
+        headers=auth_headers,
+        json={
+            "tenant_id": TENANT,
+            "conversation_id": "careagents:juniper",
+            "agent_id": "juniper",
+            "surface": "web",
+            "request_id": request_id,
+            "role": "user",
+            "text": text,
+        },
+    )
+    assert response.status_code == 201, response.get_data(as_text=True)
+    return response.get_json()
+
+
+def _run(client, auth_headers, message_id):
+    return client.post(
+        "/command-center/api/runs",
+        headers=auth_headers,
+        json={"tenant_id": TENANT, "message_id": message_id},
+    )
+
+
+def _claimed_run(client, auth_headers, internal_headers, *, worker="worker-1",
+                 request_id="request-1"):
+    """A run in `running`, held by `worker`."""
+    message = _message(client, auth_headers, request_id=request_id)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    claimed = client.post(
+        "/command-center/api/runs/claim",
+        headers=internal_headers,
+        json={"worker_id": worker, "lease_seconds": 60},
+    )
+    assert claimed.status_code == 200, claimed.get_data(as_text=True)
+    return run_id
+
+
+def _register_tool(client, internal_headers, run_id, *, worker="worker-1",
+                   arguments=None, provider_call_id="provider-call-1"):
+    response = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={
+            "worker_id": worker,
+            "provider_call_id": provider_call_id,
+            "tool_name": "book_appointment",
+            "arguments": arguments if arguments is not None else {"slot": "s1"},
+        },
+    )
+    assert response.status_code == 201, response.get_data(as_text=True)
+    return response.get_json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# The audited mutations, one test each
+# ---------------------------------------------------------------------------
+
+def test_creating_a_run_is_audited(app, client, auth_headers):
+    """MUTATION: delete the audit() in create_run -> red."""
+    message = _message(client, auth_headers)
+    _clear(app)
+
+    created = _run(client, auth_headers, message["id"])
+    assert created.status_code == 201, created.get_data(as_text=True)
+
+    events = _events(app, "AgentRun")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "create"
+    assert events[0]["resource_id"] == created.get_json()["id"]
+
+
+def test_an_idempotent_run_replay_is_not_audited_twice(app, client,
+                                                       auth_headers):
+    """A replay creates nothing, so evidence of a creation would be false.
+
+    MUTATION: move the audit() above create_run's replay return -> red.
+    """
+    message = _message(client, auth_headers)
+    _clear(app)
+
+    first = _run(client, auth_headers, message["id"])
+    replay = _run(client, auth_headers, message["id"])
+
+    assert first.status_code == 201
+    assert replay.status_code == 200
+    assert replay.get_json()["idempotent_replay"] is True
+    assert len(_events(app, "AgentRun")) == 1, _events(app, "AgentRun")
+
+
+def test_cancelling_a_run_is_audited(app, client, auth_headers):
+    """MUTATION: delete the audit() in request_cancel -> red."""
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _clear(app)
+
+    cancelled = client.post(f"/command-center/api/runs/{run_id}/cancel",
+                            headers=auth_headers)
+    assert cancelled.status_code == 200, cancelled.get_data(as_text=True)
+
+    events = _events(app, "AgentRun")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "update"
+    assert events[0]["resource_id"] == run_id
+    assert "status=cancelled" in events[0]["detail"]
+
+
+def test_cancelling_an_already_finished_run_is_not_audited(
+        app, client, auth_headers, internal_headers):
+    """Nothing changed, so nothing is recorded.
+
+    MUTATION: audit unconditionally in request_cancel -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "failed"},
+    ).status_code == 200
+    _clear(app)
+
+    cancelled = client.post(f"/command-center/api/runs/{run_id}/cancel",
+                            headers=auth_headers)
+    assert cancelled.status_code == 200
+    assert _events(app) == []
+
+
+def test_a_worker_transition_is_audited(app, client, auth_headers,
+                                        internal_headers):
+    """Entering the human gate is a once-per-run fact, not queue chatter.
+
+    MUTATION: delete the audit() in transition_owned_run -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+
+    moved = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "waiting_for_human"},
+    )
+    assert moved.status_code == 200, moved.get_data(as_text=True)
+
+    events = _events(app, "AgentRun")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "update"
+    assert events[0]["resource_id"] == run_id
+    assert "status=waiting_for_human" in events[0]["detail"]
+
+
+def test_resuming_a_human_waiting_run_is_audited(app, client, auth_headers,
+                                                 internal_headers):
+    """The other half of the human gate: who let the agent continue.
+
+    MUTATION: delete the audit() in resume_run -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "waiting_for_human"},
+    ).status_code == 200
+    _clear(app)
+
+    resumed = client.post(f"/command-center/api/runs/{run_id}/resume",
+                          headers=internal_headers)
+    assert resumed.status_code == 200, resumed.get_data(as_text=True)
+
+    events = _events(app, "AgentRun")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "update"
+    assert events[0]["resource_id"] == run_id
+    assert "status=queued" in events[0]["detail"]
+
+
+def test_registering_a_tool_call_is_audited(app, client, auth_headers,
+                                            internal_headers):
+    """The moment an agent commits to a real-world side effect.
+
+    MUTATION: delete the audit() in register_tool_call -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+    call_id = _register_tool(client, internal_headers, run_id)
+
+    events = _events(app, "AgentToolCall")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "create"
+    assert events[0]["resource_id"] == call_id
+    assert "tool=book_appointment" in events[0]["detail"]
+
+
+def test_an_idempotent_tool_replay_is_not_audited_twice(
+        app, client, auth_headers, internal_headers):
+    """MUTATION: move the audit() above register_tool_call's replay return -> red."""
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+    _register_tool(client, internal_headers, run_id)
+
+    replay = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "provider_call_id": "provider-call-1",
+              "tool_name": "book_appointment", "arguments": {"slot": "s1"}},
+    )
+    assert replay.status_code == 200
+    assert replay.get_json()["idempotent_replay"] is True
+    assert len(_events(app, "AgentToolCall")) == 1
+
+
+def test_a_tool_call_outcome_is_audited(app, client, auth_headers,
+                                        internal_headers):
+    """MUTATION: delete the audit() in transition_tool_call -> red."""
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    call_id = _register_tool(client, internal_headers, run_id)
+    _clear(app)
+
+    endpoint = (
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition")
+    assert client.post(endpoint, headers=internal_headers,
+                       json={"worker_id": "worker-1",
+                             "status": "running"}).status_code == 200
+    assert client.post(endpoint, headers=internal_headers,
+                       json={"worker_id": "worker-1",
+                             "status": "completed",
+                             "result": {"confirmation": "ok"}}
+                       ).status_code == 200
+
+    events = _events(app, "AgentToolCall")
+    assert [event["action"] for event in events] == ["update", "update"]
+    assert {event["resource_id"] for event in events} == {call_id}
+    details = " ".join(event["detail"] for event in events)
+    assert "status=running" in details and "status=completed" in details
+
+
+def test_finalizing_a_run_audits_the_assistant_message_and_the_completion(
+        app, client, auth_headers, internal_headers):
+    """The assistant turn is a write of the same shape the command centre
+    audits for the user turn. Auditing one and not the other would leave the
+    trail able to show a question and never its answer.
+
+    MUTATION: delete either audit() in finalize_run -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+
+    finalized = client.post(
+        f"/command-center/api/runs/{run_id}/finalize",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "checkpoint_id": "round-1",
+              "text": "Your appointment brief is ready."},
+    )
+    assert finalized.status_code == 200, finalized.get_data(as_text=True)
+    message_id = finalized.get_json()["message_id"]
+
+    messages = _events(app, "ConversationMessage")
+    assert len(messages) == 1, messages
+    assert messages[0]["action"] == "create"
+    assert messages[0]["resource_id"] == message_id
+    assert "role=assistant" in messages[0]["detail"]
+
+    runs = _events(app, "AgentRun")
+    assert len(runs) == 1, runs
+    assert runs[0]["action"] == "update"
+    assert "status=completed" in runs[0]["detail"]
+
+
+def test_a_finalize_replay_is_not_audited_twice(app, client, auth_headers,
+                                                internal_headers):
+    """MUTATION: audit before finalize_run's completed-replay return -> red."""
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    payload = {"worker_id": "worker-1", "checkpoint_id": "round-1",
+               "text": "Your appointment brief is ready."}
+    endpoint = f"/command-center/api/runs/{run_id}/finalize"
+    _clear(app)
+
+    assert client.post(endpoint, headers=internal_headers,
+                       json=payload).status_code == 200
+    replay = client.post(endpoint, headers=internal_headers, json=payload)
+
+    assert replay.status_code == 200
+    assert replay.get_json()["idempotent_replay"] is True
+    assert len(_events(app, "ConversationMessage")) == 1
+    assert len(_events(app, "AgentRun")) == 1
+
+
+def test_reconciling_an_ambiguous_side_effect_is_audited(
+        app, client, auth_headers, internal_headers, reconcile_headers):
+    """Operator-attested provider truth is the single most evidence-worthy
+    mutation in this package: a human asserting what happened in the world.
+
+    MUTATION: delete the audit() in reconcile_tool_call -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers,
+                          worker="lost-worker")
+    call_id = _register_tool(client, internal_headers, run_id,
+                             worker="lost-worker")
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": "running"},
+    ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+    assert client.get(f"/command-center/api/runs/{run_id}/events",
+                      headers=auth_headers).get_json()[
+                          "status"] == "waiting_for_human"
+    _clear(app)
+
+    reconciled = client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/reconcile",
+        headers=reconcile_headers,
+        json={"status": "completed", "evidence_ref": "provider:truth:1"},
+    )
+    assert reconciled.status_code == 200, reconciled.get_data(as_text=True)
+
+    events = _events(app, "AgentToolCall")
+    assert len(events) == 1, events
+    assert events[0]["action"] == "update"
+    assert events[0]["resource_id"] == call_id
+    assert "evidence=provider:truth:1" in events[0]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# The half that would be a leak rather than a gap
+# ---------------------------------------------------------------------------
+
+def test_the_finalize_audit_never_carries_the_assistant_answer(
+        app, client, auth_headers, internal_headers):
+    """`text` is the agent's answer about a patient. CLAUDE.md: audit detail
+    stays PHI-free, and chat transcripts are PHI-adjacent.
+
+    MUTATION: put `text` (or any slice of it) into either detail -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+
+    client.post(
+        f"/command-center/api/runs/{run_id}/finalize",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "checkpoint_id": "round-1",
+              "text": _SECRET_TEXT},
+    )
+
+    blob = json.dumps(_events(app))
+    for token in _SECRET_TOKENS:
+        assert token not in blob, (
+            f"the audit trail carries {token!r} out of the assistant answer")
+
+
+def test_the_tool_call_audit_never_carries_the_arguments(
+        app, client, auth_headers, internal_headers):
+    """Tool arguments are model-authored and routinely carry the clinical
+    reason for the action.
+
+    MUTATION: put `arguments` into the register detail -> red.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers)
+    _clear(app)
+    call_id = _register_tool(
+        client, internal_headers, run_id,
+        arguments={"slot": "s1", "reason": _SECRET_TEXT})
+
+    client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "running"},
+    )
+    client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "failed",
+              "result": {"note": _SECRET_TEXT}},
+    )
+
+    blob = json.dumps(_events(app))
+    for token in _SECRET_TOKENS:
+        assert token not in blob, (
+            f"the audit trail carries {token!r} out of a tool call")
+
+
+# ---------------------------------------------------------------------------
+# The negative half — a classification that only ever says "yes" proves nothing
+# ---------------------------------------------------------------------------
+
+def test_a_refused_mutation_leaves_no_audit_event(app, client, auth_headers,
+                                                  internal_headers):
+    """Evidence of a write that was refused is worse than none.
+
+    Also the fail-closed check for the flush-only audit primitive: a handler
+    that audits and then raises must leave the row rolled back, not pending.
+
+    MUTATION: audit before the fence check in transition_owned_run -> red.
+    """
+    message = _message(client, auth_headers)
+    run_id = _claimed_run(client, auth_headers, internal_headers,
+                          request_id="request-2")
+    _clear(app)
+
+    unauthenticated = _run(client, {"X-Tenant-Id": TENANT}, message["id"])
+    wrong_worker = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "not-the-owner", "status": "failed"},
+    )
+
+    assert unauthenticated.status_code == 401
+    assert wrong_worker.status_code == 409
+    assert _events(app) == []
+
+
+def test_queue_chatter_is_deliberately_not_audited(app, client, auth_headers,
+                                                   internal_headers):
+    """The classification has to be false somewhere or it is not a decision.
+
+    These three fire on a timer for every live worker. If auditing them ever
+    becomes right, this test is the place that argues about it — not a silent
+    drift in either direction.
+    """
+    message = _message(client, auth_headers)
+    run_id = _run(client, auth_headers, message["id"]).get_json()["id"]
+    _clear(app)
+
+    assert client.post("/command-center/api/runs/claim",
+                       headers=internal_headers,
+                       json={"worker_id": "worker-1"}).status_code == 200
+    assert client.post(f"/command-center/api/runs/{run_id}/heartbeat",
+                       headers=internal_headers,
+                       json={"worker_id": "worker-1"}).status_code == 200
+    assert client.post(f"/command-center/api/runs/{run_id}/events",
+                       headers=internal_headers,
+                       json={"worker_id": "worker-1", "type": "agent.thought"}
+                       ).status_code == 201
+
+    assert _events(app) == []

--- a/tests/test_agent_run_writes_are_audited.py
+++ b/tests/test_agent_run_writes_are_audited.py
@@ -537,7 +537,17 @@ def test_a_refused_mutation_leaves_no_audit_event(app, client, auth_headers,
     Also the fail-closed check for the flush-only audit primitive: a handler
     that audits and then raises must leave the row rolled back, not pending.
 
-    MUTATION: audit before the fence check in transition_owned_run -> red.
+    Both refusals here are raised BEFORE the audit could be reached — 401 at
+    the route, and the wrong-worker 409 inside `lock_owned_run`, which has no
+    `run` to audit yet. So neither one exercises the stated mutation; moving
+    `_audit_run_change` above the fence is caught by the double-count in
+    test_a_worker_transition_is_audited, not here (verified 2026-09-04).
+    The third case below is the one that does: it passes the fence with the
+    right worker and is then refused, so an audit placed on that path WOULD
+    run. It also exercises the fail-closed half — a flushed row behind a 409
+    trips the kernel's install_audit_assertions at teardown.
+
+    MUTATION: audit before the `completed` raise in transition_owned_run -> red.
     """
     message = _message(client, auth_headers)
     run_id = _claimed_run(client, auth_headers, internal_headers,
@@ -550,9 +560,17 @@ def test_a_refused_mutation_leaves_no_audit_event(app, client, auth_headers,
         headers=internal_headers,
         json={"worker_id": "not-the-owner", "status": "failed"},
     )
+    # Right worker, past the fence, refused on the next line: `completed` is
+    # reachable only through finalize.
+    refused_past_the_fence = client.post(
+        f"/command-center/api/runs/{run_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "worker-1", "status": "completed"},
+    )
 
     assert unauthenticated.status_code == 401
     assert wrong_worker.status_code == 409
+    assert refused_past_the_fence.status_code == 409
     assert _events(app) == []
 
 
@@ -578,5 +596,68 @@ def test_queue_chatter_is_deliberately_not_audited(app, client, auth_headers,
                        headers=internal_headers,
                        json={"worker_id": "worker-1", "type": "agent.thought"}
                        ).status_code == 201
+
+    assert _events(app) == []
+
+
+def test_the_deadline_sweep_writes_the_human_gate_and_audits_nothing(
+        app, client, auth_headers, internal_headers):
+    """The other three exemptions, and the one asymmetry they cost.
+
+    `test_queue_chatter_is_deliberately_not_audited` covers claim, heartbeat
+    and the event log — three of the six exempt endpoints. The other three are
+    the GETs, and calling them "reads" undersells what they do: the shared
+    deadline sweep runs inside them, and on a run holding a RUNNING tool call
+    it commits the run into `waiting_for_human` and the tool call into
+    `needs_reconciliation`. That is entry into the human gate, and it is the
+    same state `POST /transition` reaches — where it IS audited.
+
+    So the classification is per-code-path, not per-route: the gate is audited
+    when a worker declares it and silent when the deadline reaches it. The
+    consequence is that a `reconcile` audit — the package's most
+    evidence-worthy row — can stand in the trail with no record of how its
+    call became ambiguous. The same sweep also runs inside
+    `_enforce_worker_fence`, so `/transition`, `/heartbeat`, `/tool-calls`,
+    `/finalize` and `POST /events` each have a path that commits this and then
+    answers 409.
+
+    This test does not argue that is wrong — `AgentRunEvent` holds the story
+    and a timer is not a principal. It pins it, so a change of mind is an edit
+    here rather than drift, and so the three GET exemptions are exercised at
+    the wire like the other three.
+    """
+    run_id = _claimed_run(client, auth_headers, internal_headers,
+                          worker="lost-worker")
+    call_id = _register_tool(client, internal_headers, run_id,
+                             worker="lost-worker")
+    assert client.post(
+        f"/command-center/api/runs/{run_id}/tool-calls/{call_id}/transition",
+        headers=internal_headers,
+        json={"worker_id": "lost-worker", "status": "running"},
+    ).status_code == 200
+    with app.app_context():
+        run = db.session.get(AgentRun, run_id)
+        run.deadline_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+    _clear(app)
+
+    # GET #1: the read that terminalizes.
+    detail = client.get(f"/command-center/api/runs/{run_id}",
+                        headers=auth_headers)
+    assert detail.status_code == 200, detail.get_data(as_text=True)
+    body = detail.get_json()
+    # The write really happened, so "nothing was audited" is a decision about
+    # evidence and not an observation that nothing moved.
+    assert body["status"] == "waiting_for_human", body
+    assert [call["status"] for call in body["tool_calls"]] == [
+        "needs_reconciliation"], body
+
+    # GET #2 and #3: the event replay and the readiness poll, both of which
+    # run the same sweep.
+    assert client.get(f"/command-center/api/runs/{run_id}/events",
+                      headers=auth_headers).status_code == 200
+    assert client.get(
+        "/command-center/api/runs/workers/health",
+        headers=internal_headers).status_code in (200, 503)
 
     assert _events(app) == []

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -212,26 +212,48 @@ def test_post_commit_audit_callsites_only_decrease():
         'New audit calls must use add_audit_event (same transaction).')
 
 
-#: The two step-up-gated mutators that emit no audit events at all. They
-#: perform authenticated writes with no trail — the worst shape in the
-#: codebase for a system whose constitution says every FHIR resource access
-#: emits an AuditEvent. Playbook B1, B2. This ratchet counts blueprints
-#: that mutate without auditing; it goes to 0 and then becomes a tripwire.
-#: r6/command_center left this set on 2026-08-10 (playbook B1): its three
-#: step-up-gated writes now call add_audit_event inside their own
-#: transaction. r6/agent_runs stays, and stays deliberately — claim,
-#: heartbeat and transition fire on a timer, so auditing them would bury
-#: real access records under queue chatter. B2 is a decision about WHICH of
-#: its twelve endpoints deserve a trail, not a sweep.
-_UNAUDITED_MUTATOR_PACKAGES = {'r6/agent_runs'}
+#: Packages that mutate the store and emit no audit events at all — an
+#: authenticated write with no trail, the worst shape in the codebase for a
+#: system whose constitution says every resource access emits an AuditEvent.
+#: Playbook B1, B2. The set is now EMPTY, which makes this a tripwire rather
+#: than a ratchet (playbook A7's shape): a new silent mutator goes red on
+#: arrival instead of being counted.
+#:
+#: r6/command_center left the set on 2026-08-10 (B1) and r6/agent_runs on
+#: 2026-09-04 (B2).
+#:
+#: TWO THINGS THIS TEST DOES NOT PROVE, and both were true of the version
+#: that pinned agent_runs, so read them before trusting a green here:
+#:
+#: 1. It is a PRESENCE check per package, not per mutation. One audit call
+#:    anywhere in a package satisfies it while every other write stays
+#:    silent. The per-endpoint pin is
+#:    tests/test_agent_run_writes_are_audited.py, which classifies all
+#:    fourteen agent-run routes and proves each audited one at the wire;
+#:    tests/test_command_center_writes_are_audited.py is B1's equivalent. A
+#:    package arriving here needs one of those, not just an import.
+#: 2. Until 2026-09-04 it qualified a package as a mutator only if the
+#:    package validated STEP-UP. agent_runs gates ten of its fourteen
+#:    endpoints on a shared secret instead, so the guard's own subject was
+#:    mostly outside its scope — it caught this package by ONE call site,
+#:    the step-up check inside `_tenant_authorized`, and would have missed a
+#:    package that used no step-up at all (verified by mutation: with that
+#:    one call renamed, the old predicate does not flag this package).
+#:    The predicate below now also counts a package that
+#:    calls db.session.commit(): if it commits, it mutates. Measured before
+#:    the widening (2026-09-04): the commit predicate adds r6/fasten to the
+#:    mutator set and NOTHING to the silent set — every other committing
+#:    package already audits. So the widening is inert today and is a trap
+#:    laid for tomorrow, which is what a tripwire is for.
+_UNAUDITED_MUTATOR_PACKAGES = set()
 
 
 def test_no_new_package_mutates_without_auditing():
     """MUTATION: delete the audit import from a gated blueprint -> red.
 
     A package qualifies as a mutator if it validates step-up (it guards a
-    write). If it does that and never calls either audit primitive, the
-    write is authenticated and invisible.
+    write) or commits a transaction (it performs one). If it does either and
+    never calls any audit primitive, its writes are invisible.
     """
     gates, audits = {}, {}
     scanned = 0
@@ -246,16 +268,23 @@ def test_no_new_package_mutates_without_auditing():
             if not isinstance(node, ast.Call):
                 continue
             name = _called_name(node)
-            if name == 'validate_step_up_token' or name == 'require_grant':
+            if name in ('validate_step_up_token', 'require_grant', 'commit'):
                 gates.setdefault(package, []).append(f'{rel}:{node.lineno}')
             elif name in ('record_audit_event', 'add_audit_event', 'audit'):
                 audits.setdefault(package, []).append(f'{rel}:{node.lineno}')
     assert scanned > 40, f'the mutator scan only walked {scanned} r6 files'
+    #: A predicate that matched nothing would pass this forever, and the
+    #: widening above is exactly the edit that could break it silently.
+    assert len(gates) > 5, (
+        f'the mutator predicate matched only {len(gates)} packages — it is '
+        f'broken, and an empty silent set below means nothing')
     silent = {pkg for pkg in gates if pkg not in audits}
     assert silent <= _UNAUDITED_MUTATOR_PACKAGES, _report(
         sorted(silent - _UNAUDITED_MUTATOR_PACKAGES),
         len(_UNAUDITED_MUTATOR_PACKAGES),
-        'A package that gates writes with step-up must audit them.')
+        'A package that mutates the store must audit its writes. Presence '
+        'here is not enough: add a per-endpoint pin like '
+        'tests/test_agent_run_writes_are_audited.py in the same PR.')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -249,13 +249,17 @@ _UNAUDITED_MUTATOR_PACKAGES = set()
 
 
 def test_no_new_package_mutates_without_auditing():
-    """MUTATION: delete the audit import from a gated blueprint -> red.
+    """MUTATION: rename the audit CALLS in a mutating package -> red.
+
+    Not the import: this walks the AST for call names, so deleting
+    `from r6.access import audit` while leaving `audit(...)` in place stays
+    green (verified 2026-09-04). The import is not what is measured.
 
     A package qualifies as a mutator if it validates step-up (it guards a
     write) or commits a transaction (it performs one). If it does either and
     never calls any audit primitive, its writes are invisible.
     """
-    gates, audits = {}, {}
+    gates, stepup_gates, audits = {}, {}, {}
     scanned = 0
     for path in _production_python_files():
         rel = _rel(path)
@@ -270,6 +274,9 @@ def test_no_new_package_mutates_without_auditing():
             name = _called_name(node)
             if name in ('validate_step_up_token', 'require_grant', 'commit'):
                 gates.setdefault(package, []).append(f'{rel}:{node.lineno}')
+                if name != 'commit':
+                    stepup_gates.setdefault(package, []).append(
+                        f'{rel}:{node.lineno}')
             elif name in ('record_audit_event', 'add_audit_event', 'audit'):
                 audits.setdefault(package, []).append(f'{rel}:{node.lineno}')
     assert scanned > 40, f'the mutator scan only walked {scanned} r6 files'
@@ -278,6 +285,20 @@ def test_no_new_package_mutates_without_auditing():
     assert len(gates) > 5, (
         f'the mutator predicate matched only {len(gates)} packages — it is '
         f'broken, and an empty silent set below means nothing')
+    #: The floor above does NOT pin the widening: deleting 'commit' from the
+    #: tuple drops the mutator set from 8 packages to 7, which still clears
+    #: `> 5`, so the 2026-09-04 strengthening could be reverted green
+    #: (verified by mutation). This is the pin for it — the commit half has to
+    #: still be reaching a package the step-up half does not, which is the
+    #: whole reason it was added. If this ever goes empty the widening has
+    #: become redundant and may be deleted, but that is then a deliberate
+    #: edit here rather than a silent one above.
+    commit_only = sorted(set(gates) - set(stepup_gates))
+    assert commit_only, (
+        "the 'commit' half of the mutator predicate now catches nothing the "
+        "step-up half does not — it has been neutered, or every committing "
+        "package has since adopted step-up. Do not delete this assertion to "
+        "go green; decide which it is.")
     silent = {pkg for pkg in gates if pkg not in audits}
     assert silent <= _UNAUDITED_MUTATOR_PACKAGES, _report(
         sorted(silent - _UNAUDITED_MUTATOR_PACKAGES),

--- a/tests/test_write_guard_matrix.py
+++ b/tests/test_write_guard_matrix.py
@@ -572,22 +572,28 @@ BY_ID = {row.id: row for row in MATRIX}
 
 NON_CLINICAL_MUTATORS = {
     # Durable agent-run queue: execution bookkeeping, not patient data.
-    # NOTE: none of these emits an AuditEvent, and that is a decision rather
-    # than an oversight: claim/heartbeat/transition fire on a timer, so
-    # auditing them would bury real access records under queue chatter. The
-    # three command-centre writes below were the half of this note worth
-    # acting on, and they now audit.
-    "agent_runs.create_agent_run": "queue: tenant session or step-up",
-    "agent_runs.cancel_agent_run": "queue: tenant session or step-up",
-    "agent_runs.claim_agent_run": "queue: internal secret",
-    "agent_runs.heartbeat_agent_run": "queue: internal secret",
-    "agent_runs.transition_agent_run": "queue: internal secret",
-    "agent_runs.append_agent_run_event": "queue: internal secret",
-    "agent_runs.create_agent_tool_call": "queue: internal secret",
-    "agent_runs.transition_agent_tool_call": "queue: internal secret",
-    "agent_runs.finalize_agent_run": "queue: internal secret",
-    "agent_runs.resume_agent_run": "queue: internal secret",
-    "agent_runs.reconcile_agent_tool_call": "queue: reconciliation secret",
+    # The old NOTE here said none of these emitted an AuditEvent and called
+    # that a decision. Half of it was: claim and heartbeat are polled by every
+    # live worker, and auditing them would bury real records under queue
+    # chatter. The other half was an oversight, and playbook B2 corrected it —
+    # a run's creation, its outcomes, every tool call an agent registers or
+    # resolves, an operator's reconciliation, and the assistant answer a
+    # finalize persists all audit now. They stay in this dict because they are
+    # non-clinical, not because they are unaudited;
+    # tests/test_agent_run_writes_are_audited.py classifies all fourteen
+    # routes and holds each line, PHI-free detail included.
+    "agent_runs.create_agent_run": "queue: tenant session or step-up; audited",
+    "agent_runs.cancel_agent_run": "queue: tenant session or step-up; audited",
+    "agent_runs.claim_agent_run": "queue: internal secret; timer poll",
+    "agent_runs.heartbeat_agent_run": "queue: internal secret; timer poll",
+    "agent_runs.transition_agent_run": "queue: internal secret; audited",
+    "agent_runs.append_agent_run_event": "queue: internal secret; run event log",
+    "agent_runs.create_agent_tool_call": "queue: internal secret; audited",
+    "agent_runs.transition_agent_tool_call": "queue: internal secret; audited",
+    "agent_runs.finalize_agent_run": "queue: internal secret; audited",
+    "agent_runs.resume_agent_run": "queue: internal secret; audited",
+    "agent_runs.reconcile_agent_tool_call":
+        "queue: reconciliation secret; audited",
     # Command-center activity log: _authz_write = session or step-up.
     # These three DO emit AuditEvents now (the note above no longer covers
     # them). They stay in this dict because they are non-clinical, not


### PR DESCRIPTION
Ratchet slice B2 (council ruling D11, parallel lane). Touches nothing else in flight.

## The gap

`r6/agent_runs` was the last package in the codebase that mutated state and audited none of it. Fourteen routes, ten of them authenticated by a shared secret rather than step-up, every one writing to the store, none recording that it had. An agent could register a tool call, execute a side effect, and persist an assistant answer with nothing in the audit trail to say it happened.

## What is audited, and what is not

Eight routes audit; six are classified as timer chatter with a stated reason. The line: **a mutation a principal asked for is audited; a mutation the system makes to itself on a timer is not.** The run's own append-only `AgentRunEvent` log already holds the operational story — deadline sweeps, lease recovery, claim redelivery, heartbeats and the event log itself stay out, because putting them in the audit trail would bury the records an auditor needs under queue chatter, which is how an audit trail becomes unreadable.

| Route | Audited | Why |
|---|---|---|
| `POST /runs` | `create AgentRun` | a principal enqueues agent work |
| `POST /runs/<id>/cancel` | `update AgentRun` | a person stops an agent |
| `POST /runs/<id>/transition` | `update AgentRun` | once-per-attempt outcome — including entering the human gate |
| `POST /runs/<id>/resume` | `update AgentRun` | the other half of the human gate |
| `POST /runs/<id>/tool-calls` | `create AgentToolCall` | the moment an agent commits to a real-world side effect |
| `POST .../tool-calls/<id>/transition` | `update AgentToolCall` | the outcome of that side effect |
| `POST /runs/<id>/finalize` | `create ConversationMessage` + `update AgentRun` | the assistant's answer, mirroring the command centre's audit of the user's turn |
| `POST .../tool-calls/<id>/reconcile` | `update AgentToolCall` | a human asserting what happened in the world |
| `POST /runs/claim`, `POST /runs/<id>/heartbeat` | no | polled continuously by every live worker |
| `POST /runs/<id>/events` | no | the run's own log; auditing would copy one log into another per streamed chunk |
| the three GETs | no | reads; their only write is the shared deadline sweep, which no principal requested |

The finalize case is the one that matters most: `command_center` audits the user's turn, so auditing the run's assistant turn is what stops the trail being able to show a question and never its answer.

## Two judgment calls, stated

**Audit lives in the service layer, not the routes.** Each of these functions owns its own transaction. An audit written at the route would commit separately from the change it describes — fail-open on the data, fail-closed on the response, the exact shape `record_audit_event` has. Every call site sits after the last raise and before the one commit, so a refusal leaves nothing pending.

**It adopts the kernel's `audit()` rather than `add_audit_event` directly.** This package has no prior audit call sites, so it can land on the spec's one audit call directly rather than adopting a primitive slice 13 exists to retire. It also sets the `g` marker `install_read_audit_assertion` needs. Only `audit` is imported — the step-up gate here still calls the validator directly and is still counted by `_STEP_UP_CALLSITES`, because one guard per PR is the protocol.

## The pin needed strengthening, not just lowering

`_UNAUDITED_MUTATOR_PACKAGES` measured two things its name did not claim:

1. **Presence per package, not per mutation.** One `audit()` call anywhere in `r6/agent_runs` would have emptied the set while thirteen endpoints stayed silent.
2. **Its own subject was mostly out of scope.** It qualified a package as a mutator only if the package validated step-up. Ten of these fourteen routes gate on a shared secret, and the other four reach step-up through a single call site inside `_tenant_authorized`. Verified by mutation: with step-up removed from this package, the old predicate does not flag it at all — it caught this one by accident, and would have missed a package that used no step-up.

So the predicate now also counts a package that commits (if it commits, it mutates), with a floor so a predicate that matches nothing cannot pass. Measured before widening: the commit predicate adds `r6/fasten` to the mutator set and **nothing** to the silent set — inert today, a trap laid for tomorrow. The set goes to empty and becomes a tripwire (playbook A7's shape).

`tests/test_agent_run_writes_are_audited.py` is the per-mutation pin the ratchet structurally cannot be. It classifies all fourteen routes as a set equality, so route fifteen is red until somebody decides which half it belongs to; proves each audited route at the wire; proves the exempt ones emit nothing, so the classification is false somewhere and is therefore a decision; and proves a refused write, an idempotent replay, and a cancel of an already-finished run leave no evidence of a write that did not happen.

## PHI

`detail` carries ids, states, counts, a regex-constrained tool name and a 12-character digest. Never a message body, a tool argument, or a result. `outcome_ref` is a free-form 256-character worker string and is deliberately absent; `evidence_ref` and `checkpoint_id` are `_ID`-constrained at the route, so they are opaque handles rather than prose. Two tests drive a distinctive sentence through `finalize` and through tool arguments and results, then assert no token of it reaches the trail.

## Gates

- `uv run python -m pytest tests/ -q` — **3174 passed, 13 skipped, 1 xfailed**
- `uv run ruff check .` — **All checks passed**
- Ratchets pass; the mutator tripwire verified to fire (neutralise the audit calls → red)
- Conformance Grade A: `tests/test_guardrail_conformance.py` — 37 passed

Do not merge or approve — maintainer gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
