### PR TITLE
fix(auth): a non-ASCII byte in a credential is a refusal, not a 500 (#557)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ignore = ["E402"]
 [tool.mypy]
 python_version = "3.11"
 files = [
+    "r6/constant_time.py",
     "r6/runtime_config.py",
     "r6/read_auth.py",
     "r6/actions/state.py",

--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -16,7 +16,6 @@ Approve-is-the-commit (Task 10):
 Audit detail and Telegram pushes use ProposedAction.summary() ONLY (no PHI).
 """
 
-import hmac
 import json
 import logging
 import os
@@ -25,6 +24,7 @@ import uuid
 from flask import Blueprint, jsonify, request
 
 from models import db
+from r6 import constant_time
 from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
                        tenant_from_request)
 from r6.actions import errors
@@ -643,7 +643,7 @@ def issue_action_approval_token(action_id):
 
     expected = os.environ.get('INTERNAL_TOKEN_MINT_SECRET', '')
     provided = request.headers.get('X-Internal-Secret', '')
-    if not expected or not hmac.compare_digest(provided, expected):
+    if not expected or not constant_time.equal(provided, expected):
         return _error(403, 'Forbidden')
 
     action = ProposedAction.query.filter_by(
@@ -725,7 +725,7 @@ def action_callback(provider):
     # unconfigured secret rejects ALL callbacks — fail closed.
     expected = os.environ.get('ACTIONS_WEBHOOK_SECRET', '')
     supplied = request.args.get('secret', '')
-    if not expected or not hmac.compare_digest(supplied.encode(), expected.encode()):
+    if not expected or not constant_time.equal(supplied, expected):
         return _error(403, 'Webhook verification failed')
 
     action_id = request.args.get('action_id', '')

--- a/r6/agent_runs/routes.py
+++ b/r6/agent_runs/routes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hmac
 import logging
 import os
 import re
@@ -11,6 +10,7 @@ from flask import Blueprint, jsonify, request, session
 from sqlalchemy.exc import SQLAlchemyError
 
 from models import db
+from r6 import constant_time
 from r6.agent_runs.models import AgentRun, AgentRunEvent, AgentToolCall
 from r6.agent_runs.service import (
     append_event,
@@ -70,13 +70,13 @@ def _tenant_authorized(tenant_id: str) -> bool:
 def _internal_authorized() -> bool:
     expected = os.environ.get("INTERNAL_TOKEN_MINT_SECRET", "")
     provided = request.headers.get("X-Internal-Secret", "")
-    return bool(expected and hmac.compare_digest(provided, expected))
+    return bool(expected and constant_time.equal(provided, expected))
 
 
 def _reconciler_authorized() -> bool:
     expected = os.environ.get("AGENT_RUN_RECONCILE_SECRET", "")
     provided = request.headers.get("X-Reconciliation-Secret", "")
-    return bool(expected and hmac.compare_digest(provided, expected))
+    return bool(expected and constant_time.equal(provided, expected))
 
 
 def _run_or_404(run_id: str) -> AgentRun | None:

--- a/r6/constant_time.py
+++ b/r6/constant_time.py
@@ -1,0 +1,59 @@
+"""Constant-time comparison of a caller-supplied string against a secret.
+
+`hmac.compare_digest` takes two bytes-likes, or two `str`s that are BOTH
+ASCII-only. Handed a `str` carrying anything else it raises TypeError. That
+is a CPython type constraint, not an authorization fact — and every gate in
+this repository compares a value the caller controls (a header, a query
+argument, half of a signed token) against one the server computed. r6/ held
+13 calls to it, 11 of which passed that caller-supplied value as a raw `str`:
+one non-ASCII byte in any of them raises out of the gate (#557).
+
+The refusal is made TOTAL rather than the input pre-screened, and the
+difference matters. A pre-check would add a second refusal path whose only
+cause is an encoding: the caller would learn their credential was rejected
+for how it was spelled rather than for being wrong, which is a distinction
+with no authorization meaning behind it. Comparing bytes sends every wrong
+credential — ASCII garbage, a UTF-8 name, a lone surrogate — out through the
+one door the gate already had.
+
+Callers pass strings and this module owns the encode, so `hmac.compare_digest`
+is called in exactly one production module. That is pinned by
+tests/test_constant_time.py, not left to review.
+"""
+
+import hmac
+
+__all__ = ['as_bytes', 'equal']
+
+
+def as_bytes(value: str | bytes | bytearray) -> bytes:
+    """Encode `value` to bytes for a byte operation, without ever raising.
+
+    'surrogatepass' is load-bearing rather than defensive: `json.loads` of
+    `'"\\ud800"'` yields a lone surrogate, so a credential read out of a JSON
+    body arrives as a `str` that strict UTF-8 refuses to encode. Bytes pass
+    through unchanged, so a caller already holding raw bytes need not decode
+    them first only to have them re-encoded here.
+
+    Exported alongside `equal` because a comparison is not the only byte
+    operation an untrusted string reaches: r6/stepup.py feeds one to
+    `hmac.new` on the line above its comparison, and that encode was just as
+    partial as the compare.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return value.encode('utf-8', 'surrogatepass')
+
+
+def equal(provided: str | bytes | bytearray,
+          expected: str | bytes | bytearray) -> bool:
+    """True iff `provided` equals `expected`, compared in constant time.
+
+    `provided` is named first because it is the untrusted half; the order
+    does not change the answer, but at a call site it says which side the
+    caller controls.
+
+    Length is not hidden — `hmac.compare_digest` never hid it either, and the
+    expected values here are fixed-width digests and configured secrets.
+    """
+    return hmac.compare_digest(as_bytes(provided), as_bytes(expected))

--- a/r6/email_inbound.py
+++ b/r6/email_inbound.py
@@ -20,6 +20,8 @@ import os
 import requests
 from flask import Blueprint, request
 
+from r6 import constant_time
+
 logger = logging.getLogger(__name__)
 
 email_blueprint = Blueprint("email_inbound", __name__)
@@ -46,7 +48,7 @@ def _verify_svix(secret: str, headers, payload: bytes) -> bool:
     signed = f"{msg_id}.{timestamp}.{payload.decode()}".encode()
     expected = base64.b64encode(hmac.new(key, signed, hashlib.sha256).digest()).decode()
     for part in signatures.split(" "):
-        if "," in part and hmac.compare_digest(part.split(",", 1)[1], expected):
+        if "," in part and constant_time.equal(part.split(",", 1)[1], expected):
             return True
     return False
 

--- a/r6/fasten/verify.py
+++ b/r6/fasten/verify.py
@@ -16,6 +16,8 @@ import logging
 import os
 import time
 
+from r6 import constant_time
+
 logger = logging.getLogger(__name__)
 
 _REPLAY_TOLERANCE_SECONDS = 300  # reject webhooks older than 5 minutes
@@ -82,7 +84,7 @@ def verify_webhook(headers: dict, raw_body: bytes) -> bool:
     for sig_entry in msg_signature.split(' '):
         parts = sig_entry.split(',', 1)
         if len(parts) == 2 and parts[0] == 'v1':
-            if hmac.compare_digest(parts[1], computed):
+            if constant_time.equal(parts[1], computed):
                 return True
 
     logger.warning('Fasten webhook: signature mismatch')

--- a/r6/internal_auth.py
+++ b/r6/internal_auth.py
@@ -10,11 +10,11 @@ drive an operator action across all tenants.
 Extracted so `/internal/*` ingestion (#267) and `/r6/ops/*` (#304) share one
 gate rather than each carrying its own copy. Tenant-independent by design.
 """
-import hmac
 import os
 
 from flask import request
 
+from r6 import constant_time
 from r6.runtime_config import resolve_app_env
 
 
@@ -29,5 +29,5 @@ def internal_secret_authorized():
     mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
     if mint_secret:
         provided = request.headers.get('X-Internal-Secret', '')
-        return hmac.compare_digest(provided, mint_secret)
+        return constant_time.equal(provided, mint_secret)
     return resolve_app_env() != 'production'

--- a/r6/rate_limit.py
+++ b/r6/rate_limit.py
@@ -6,13 +6,13 @@ Production deployments should use Redis-backed rate limiting.
 """
 
 import hashlib
-import hmac
 import logging
 import os
 import threading
 import time
 from typing import Any
 from flask import g, request, jsonify, session
+from r6 import constant_time
 from r6.read_auth import TENANT_SESSION_KEY
 from r6.runtime_config import resolve_app_env
 from r6.stepup import validate_step_up_token
@@ -145,7 +145,7 @@ def _tenant_claim_is_authenticated(tenant_id):
     is only armed in production is a limiter nobody can prove works.
     """
     mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
-    if mint_secret and hmac.compare_digest(
+    if mint_secret and constant_time.equal(
             request.headers.get('X-Internal-Secret', ''), mint_secret):
         return True
     if session.get(TENANT_SESSION_KEY) == tenant_id:

--- a/r6/routes.py
+++ b/r6/routes.py
@@ -12,7 +12,6 @@ Validation: structural checks for required fields. Falls back when external
 validator unavailable. No StructureDefinition or terminology binding validation.
 """
 
-import hmac
 import json
 import logging
 import os
@@ -31,6 +30,7 @@ from werkzeug.http import (
     unquote_header_value,
 )
 from models import db
+from r6 import constant_time
 from r6.models import R6Resource, ContextEnvelope, ContextItem, AuditEventRecord
 from r6.context_builder import ContextBuilder
 from r6.validator import R6Validator
@@ -2022,7 +2022,7 @@ def _internal_mint_authorized(tenant_id):
     mint_secret = os.environ.get('INTERNAL_TOKEN_MINT_SECRET')
     if mint_secret:
         provided = request.headers.get('X-Internal-Secret', '')
-        return hmac.compare_digest(provided, mint_secret)
+        return constant_time.equal(provided, mint_secret)
     # Secret unset → open only outside production.
     return resolve_app_env() != 'production'
 

--- a/r6/sdc/delivery.py
+++ b/r6/sdc/delivery.py
@@ -23,6 +23,7 @@ from urllib.parse import quote
 
 from flask import Blueprint, Response, request
 
+from r6 import constant_time
 from r6.sdc.documents import get_document_pdf_bytes
 from r6.audit import record_audit_event
 
@@ -79,7 +80,7 @@ def verify_document_link(tenant_id, docref_id, exp, sig, *, now=None):
     except (TypeError, ValueError):
         return False, 'malformed'
     expected = _sign(tenant_id, docref_id, exp_int)
-    if not hmac.compare_digest(expected, sig):
+    if not constant_time.equal(sig, expected):
         return False, 'bad-signature'
     if int(now or time.time()) > exp_int:
         return False, 'expired'

--- a/r6/shc/routes.py
+++ b/r6/shc/routes.py
@@ -35,7 +35,6 @@ Environment variables:
 """
 
 import collections
-import hmac
 import logging
 import os
 import threading
@@ -46,6 +45,7 @@ from flask import Blueprint, request, jsonify, current_app
 from markupsafe import escape
 
 from models import db
+from r6 import constant_time
 from r6.access import TenantRejected, TenantSource, tenant_from_request
 from r6.audit import record_audit_event
 
@@ -74,7 +74,7 @@ def _verify_secret() -> bool:
     if not auth.startswith('Bearer '):
         return False
     token = auth[len('Bearer '):]
-    return hmac.compare_digest(token.encode(), expected.encode())
+    return constant_time.equal(token, expected)
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────

--- a/r6/stepup.py
+++ b/r6/stepup.py
@@ -19,6 +19,7 @@ import secrets
 import threading
 import time
 
+from r6 import constant_time
 from r6.runtime_config import resolve_app_env
 
 logger = logging.getLogger(__name__)
@@ -217,11 +218,21 @@ def validate_step_up_token(token, tenant_id, consume_nonce=False,
 
     payload_b64, sig = parts
 
-    # Verify HMAC signature (constant-time comparison)
+    # Verify HMAC signature (constant-time comparison).
+    #
+    # Both halves of the token are caller-supplied, so both reach a byte
+    # operation through r6/constant_time (#557). Neither `str.encode` nor
+    # `hmac.compare_digest` is total over `str`: strict UTF-8 refuses a lone
+    # surrogate, and compare_digest refuses any non-ASCII `str` outright.
+    # Either one raised TypeError/UnicodeEncodeError out of this validator,
+    # past a `_evaluate` that deliberately does not catch, and answered an
+    # anonymous caller with a 500 that said their token was NOT merely wrong.
+    # A token that cannot be spelled is a token that does not verify, and it
+    # is refused right here with every other one that does not verify.
     expected_sig = hmac.new(
-        secret.encode(), payload_b64.encode(), hashlib.sha256
+        secret.encode(), constant_time.as_bytes(payload_b64), hashlib.sha256
     ).hexdigest()
-    if not hmac.compare_digest(sig, expected_sig):
+    if not constant_time.equal(sig, expected_sig):
         return False, 'Invalid token signature'
 
     # Decode and validate payload

--- a/r6/wearables/routes.py
+++ b/r6/wearables/routes.py
@@ -20,6 +20,7 @@ from flask import Blueprint, Response, current_app, jsonify, redirect, request
 from markupsafe import escape
 
 from models import db
+from r6 import constant_time
 from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
                        tenant_from_request)
 from r6.audit import record_audit_event
@@ -60,7 +61,7 @@ def _verify_state(state: str) -> dict | None:
     expected = hmac.new(
         _state_secret(), body.encode(), hashlib.sha256,
     ).hexdigest()
-    if not hmac.compare_digest(expected, sig):
+    if not constant_time.equal(sig, expected):
         return None
     try:
         padding = '=' * (-len(body) % 4)

--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -1,0 +1,153 @@
+"""A credential comparison is total: no input spelling can crash a gate.
+
+`hmac.compare_digest` raises TypeError on a `str` that is not ASCII, and
+`str.encode` raises UnicodeEncodeError on a lone surrogate. Every gate in
+this repository feeds it a value the caller controls, so one non-ASCII byte
+in a header, a query argument or a token turned an authorization refusal into
+an unauthenticated 500 (#557).
+
+`r6/constant_time.py` makes the comparison total instead of screening the
+input, so a credential that cannot be spelled is refused as what it is — a
+credential that does not match — through the same door as any other wrong
+one. See the module docstring for why that is the choice rather than a
+pre-check.
+
+MUTATION: revert `equal` to `hmac.compare_digest(provided, expected)` on the
+raw strings -> every case in TestEqualIsTotal reddens.
+MUTATION: change `as_bytes` to `value.encode('utf-8')` ->
+test_a_lone_surrogate_compares_without_raising reddens.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from r6 import constant_time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: The same production tree tests/test_ratchets.py walks, for the same
+#: reason: a scan that walks nothing passes forever.
+_PRODUCTION_DIRS = ('r6', 'careagents', 'adapters', 'api', 'services',
+                    'scripts', 'openclaw', 'hermes', 'migrations')
+_PRODUCTION_ROOT_FILES = ('main.py', 'app.py', 'models.py')
+_SCAN_FLOOR = 100
+
+
+def _production_python_files():
+    for name in _PRODUCTION_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            yield path
+    for folder in _PRODUCTION_DIRS:
+        base = REPO_ROOT / folder
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob('*.py')):
+            if '__pycache__' not in path.parts:
+                yield path
+
+
+# ---------------------------------------------------------------------------
+# The comparison is total
+# ---------------------------------------------------------------------------
+
+class TestEqualIsTotal:
+
+    @pytest.mark.parametrize('provided', [
+        'plain-ascii-but-wrong',
+        'café',            # a latin-1 name, what a header actually carries
+        '€' * 8,           # outside latin-1 entirely
+        '\U0001f600',           # astral plane
+        '\ud800',               # a lone surrogate: json.loads can produce one
+        '',
+        b'raw-bytes',
+    ], ids=['ascii', 'latin1', 'euro', 'astral', 'surrogate', 'empty',
+            'bytes'])
+    def test_a_wrong_credential_answers_false_however_it_is_spelled(
+            self, provided):
+        """No spelling of a wrong value raises; every one of them is False."""
+        assert constant_time.equal(provided, 'the-expected-secret') is False
+
+    def test_a_lone_surrogate_compares_without_raising(self):
+        """`'\\ud800'.encode('utf-8')` raises. 'surrogatepass' is what makes
+        `as_bytes` total, so this case is what keeps it in the source."""
+        assert constant_time.equal('\ud800', '\ud800') is True
+
+    def test_equal_values_are_equal(self):
+        assert constant_time.equal('s3cret', 's3cret') is True
+        assert constant_time.equal(b's3cret', 's3cret') is True
+        assert constant_time.equal('café', 'café') is True
+
+    def test_the_expected_half_may_also_be_unspellable(self):
+        """A misconfigured secret is a server problem, not a crash lever: the
+        environment decodes with surrogateescape, so `expected` can carry the
+        same shapes `provided` can."""
+        assert constant_time.equal('x', '\udcff') is False
+
+    def test_bytes_pass_through_unchanged(self):
+        assert constant_time.as_bytes(b'\xff\xfe') == b'\xff\xfe'
+        assert constant_time.as_bytes(bytearray(b'ab')) == b'ab'
+
+
+# ---------------------------------------------------------------------------
+# One home
+# ---------------------------------------------------------------------------
+
+#: `hmac.compare_digest` is allowed in exactly these production modules.
+#: Each entry is a decision with a reason, not an exemption granted by
+#: whoever wrote the line.
+_COMPARE_DIGEST_HOMES = {
+    'r6/constant_time.py':
+        'the one home: it owns the encode so no caller has to remember it',
+    'careagents/accounts.py':
+        'both operands are hexdigests this process just computed, so no '
+        'caller-supplied string reaches the comparison. CareAgents cannot '
+        'import r6 either (tests/test_import_acyclicity.py), so routing it '
+        'through the helper would mean duplicating the helper',
+}
+
+
+def test_compare_digest_has_one_home():
+    """MUTATION: call `hmac.compare_digest` directly in a new gate -> red.
+
+    Not a ratchet (those are counts that only fall); an invariant. r6/ held 13
+    copies of this comparison and 11 of them passed a caller-supplied `str`
+    straight in, because a convention repeated at N call sites is the
+    generator behind `docs/2026-08-02-retro.md`. A new gate reaching for
+    `hmac.compare_digest` gets the non-total version by default, so the
+    default has to be unavailable rather than discouraged.
+    """
+    offenders = []
+    scanned = 0
+    for path in _production_python_files():
+        scanned += 1
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in _COMPARE_DIGEST_HOMES:
+            continue
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Attribute)
+                    and node.attr == 'compare_digest'):
+                offenders.append(f'{rel}:{node.lineno}')
+    assert scanned >= _SCAN_FLOOR, (
+        f'walked only {scanned} production modules; the path list is broken '
+        'and this test is reporting a green it did not measure')
+    assert not offenders, (
+        f'{offenders} call hmac.compare_digest directly. It raises TypeError '
+        'on a non-ASCII str (#557), so a caller-supplied value must reach it '
+        'through r6.constant_time.equal, which owns the encode. If the '
+        'operands genuinely cannot come from a caller, add the module to '
+        '_COMPARE_DIGEST_HOMES with the reason.')
+
+
+def test_every_allowed_home_still_exists_and_records_why():
+    """A home listed for a file that no longer uses the call is dead
+    configuration, and dead configuration reads as coverage."""
+    for rel, why in _COMPARE_DIGEST_HOMES.items():
+        path = REPO_ROOT / rel
+        assert path.exists(), f'{rel} is allowlisted but does not exist'
+        assert 'compare_digest' in path.read_text(encoding='utf-8'), (
+            f'{rel} is allowlisted but no longer calls compare_digest')
+        assert len(why) > 30, f'{rel} is allowlisted without a recorded reason'

--- a/tests/test_step_up_refuses_a_non_ascii_token.py
+++ b/tests/test_step_up_refuses_a_non_ascii_token.py
@@ -1,0 +1,302 @@
+"""A non-ASCII byte in a step-up token is a wrong token, not a crash (#557).
+
+`hmac.compare_digest` raises TypeError on a `str` that is not ASCII.
+`validate_step_up_token` passed it the caller's signature half raw, nothing
+caught it — `r6/access._evaluate` does not catch validator exceptions, by
+design — so every endpoint that reached the gate answered an anonymous caller
+with a 500 where ASCII garbage got a 401. It failed closed, so this was noise
+and information disclosure rather than a bypass: a 500 told a prober their
+token was something other than merely wrong.
+
+THE PROPERTY: a token carrying a non-ASCII byte is answered EXACTLY as ASCII
+garbage is — same status, same body. Not "answered 401": /wearables/sync-now
+answers 403, and pinning one status here would encode a normalization nobody
+has decided (`r6/access.require_grant`'s absent_status/rejected_status exist
+for exactly that reason). Sameness is the property; the status each row
+already answers is carried alongside it so a row cannot pass by refusing
+earlier, for some other reason, in both requests.
+
+Every surface reaching require_grant gets a row, and
+test_every_require_grant_site_has_a_row fails when a new one is added without
+one — enumerating routes by hand covers the ten that exist today and none of
+the ones written next month.
+
+MUTATION: revert r6/stepup.py to `hmac.compare_digest(sig, expected_sig)` ->
+every row raises TypeError out of the test client (TESTING propagates; in
+production it is the 500 this issue reports).
+"""
+
+import ast
+import json
+import pathlib
+
+import pytest
+
+from r6.stepup import generate_step_up_token, validate_step_up_token
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: The same production tree tests/test_constant_time.py and
+#: tests/test_ratchets.py walk. Kernel adoption is confined to r6/ and main.py
+#: today; the pin should not depend on that staying true.
+_PRODUCTION_DIRS = ('r6', 'careagents', 'adapters', 'api', 'services',
+                    'scripts', 'openclaw', 'hermes', 'migrations')
+_PRODUCTION_ROOT_FILES = ('main.py', 'app.py', 'models.py')
+_SCAN_FLOOR = 100
+
+
+def _production_python_files():
+    for name in _PRODUCTION_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            yield path
+    for folder in _PRODUCTION_DIRS:
+        base = REPO_ROOT / folder
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob('*.py')):
+            if '__pycache__' not in path.parts:
+                yield path
+
+#: Appended to a valid token to make it wrong. The pair differs ONLY in
+#: whether the added byte is ASCII, so anything but sameness in the two
+#: answers is caused by the encoding and nothing else.
+_ASCII_SUFFIX = 'x'
+_NON_ASCII_SUFFIX = 'é'
+
+#: `r6/routes.py:check_human_confirmation` is a blueprint before_request,
+#: so a clinical write on /r6/fhir answers 428 before the handler runs and
+#: never reaches its step-up gate. Carrying the header is what puts these
+#: rows in front of the gate they are here to measure — the same thing
+#: tests/test_rx_transfer.py does to seed. Nothing here builds a write path
+#: on the header (#214): every request in this file is refused at step-up.
+_HUMAN_CONFIRMED = {'X-Human-Confirmed': 'true'}
+
+
+# ---------------------------------------------------------------------------
+# The surfaces
+# ---------------------------------------------------------------------------
+
+class Row:
+    """One request that reaches a require_grant gate.
+
+    `site` names the gate, so the AST pin below can check the rows against
+    the source rather than against a number somebody remembered to bump.
+    """
+
+    def __init__(self, id, site, method, path, status, body=None,
+                 headers=None, seed=None):
+        self.id = id
+        self.site = site
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body
+        self.headers = headers or {}
+        self.seed = seed
+
+
+def _seed_medication_request(client, tenant_id, token):
+    """rx-transfer/propose only becomes a write once a draft exists — with no
+    transferable medication it answers 422 before it ever reaches its gate,
+    and the row would then pass while measuring nothing."""
+    med = {'resourceType': 'MedicationRequest', 'status': 'active',
+           'intent': 'order',
+           'medicationCodeableConcept': {'text': 'Atorvastatin 20 mg tablet'},
+           'subject': {'reference': 'Patient/non-ascii-probe'}}
+    resp = client.post('/r6/fhir/MedicationRequest',
+                       headers={'X-Tenant-Id': tenant_id,
+                                'X-Step-Up-Token': token,
+                                **_HUMAN_CONFIRMED,
+                                'Content-Type': 'application/fhir+json'},
+                       data=json.dumps(med))
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+
+
+ROWS = [
+    Row('fhir-create', 'r6/routes.py:create_resource',
+        'POST', '/r6/fhir/Observation', 401,
+        body={'resourceType': 'Observation'}, headers=_HUMAN_CONFIRMED),
+    Row('fhir-update', 'r6/routes.py:update_resource',
+        'PUT', '/r6/fhir/Observation/no-such-observation', 401,
+        body={'resourceType': 'Observation'}, headers=_HUMAN_CONFIRMED),
+    Row('fhir-share-bundle', 'r6/routes.py:share_bundle',
+        'POST', '/r6/fhir/$share-bundle', 401, body={}),
+    Row('actions-rx-transfer-propose',
+        'r6/actions/routes.py:propose_rx_transfer',
+        'POST', '/r6/actions/rx-transfer/propose', 401,
+        body={'to_pharmacy': {'name': 'Walgreens Main St',
+                              'phone': '+15551230000'}},
+        seed=_seed_medication_request),
+    Row('actions-commit', 'r6/actions/routes.py:commit_action',
+        'POST', '/r6/actions/no-such-action/commit', 401, body={}),
+    Row('actions-confirm', 'r6/actions/routes.py:confirm_action',
+        'POST', '/r6/actions/no-such-action/confirm', 401, body={}),
+    Row('actions-review-get', 'r6/actions/review.py:_require_step_up',
+        'GET', '/r6/actions/no-such-action/review', 401),
+    Row('actions-review-post', 'r6/actions/review.py:_require_step_up',
+        'POST', '/r6/actions/no-such-action/review', 401, body={}),
+    Row('smbp-reading', 'r6/smbp/routes.py:reading',
+        'POST', '/r6/smbp/reading', 401, body={'systolic': 120,
+                                               'diastolic': 80}),
+    # The minority dialect: this gate answers 403, which is why the rows
+    # assert sameness rather than 401.
+    Row('wearables-sync-now', 'r6/wearables/routes.py:sync_now',
+        'POST', '/wearables/sync-now', 403, body={}),
+]
+
+
+def _call(client, row, tenant_id, token):
+    kwargs = {'headers': {'X-Tenant-Id': tenant_id,
+                          'X-Step-Up-Token': token,
+                          'Content-Type': 'application/json',
+                          **row.headers}}
+    if row.body is not None:
+        kwargs['data'] = json.dumps(row.body)
+    return client.open(row.path, method=row.method, **kwargs)
+
+
+@pytest.mark.parametrize('row', ROWS, ids=lambda r: r.id)
+def test_a_non_ascii_token_is_refused_exactly_as_ascii_garbage_is(
+        client, tenant_id, step_up_token, row):
+    """MUTATION: revert the compare in r6/stepup.py -> TypeError, not 401.
+
+    Both requests carry a VALID token with one extra character, so the only
+    difference between them is whether that character is ASCII.
+    """
+    if row.seed is not None:
+        row.seed(client, tenant_id, step_up_token)
+
+    ascii_resp = _call(client, row, tenant_id,
+                       step_up_token + _ASCII_SUFFIX)
+    assert ascii_resp.status_code == row.status, (
+        f'{row.id}: ASCII garbage answered {ascii_resp.status_code}, not the '
+        f'pinned {row.status} — this row is not reaching its step-up gate, '
+        f'so it would measure nothing: {ascii_resp.get_data(as_text=True)}')
+
+    non_ascii_resp = _call(client, row, tenant_id,
+                           step_up_token + _NON_ASCII_SUFFIX)
+    assert non_ascii_resp.status_code == ascii_resp.status_code, (
+        f'{row.id}: a non-ASCII byte in the token answered '
+        f'{non_ascii_resp.status_code} where ASCII garbage answered '
+        f'{ascii_resp.status_code}')
+    assert non_ascii_resp.get_data() == ascii_resp.get_data(), (
+        f'{row.id}: the refusal body distinguishes a non-ASCII token from an '
+        f'ordinary wrong one — {non_ascii_resp.get_data(as_text=True)!r} vs '
+        f'{ascii_resp.get_data(as_text=True)!r}')
+
+
+def test_the_refusal_does_not_name_the_encoding(client, tenant_id,
+                                                step_up_token):
+    """One refusal path, not two.
+
+    The alternative fix — screen the token before the comparison — would have
+    answered 'Malformed step-up token' here and 'Invalid token signature' for
+    ASCII garbage, telling a caller their credential was rejected for how it
+    was spelled. That is a distinction with no authorization meaning behind
+    it, and the second refusal path this issue asked not to create.
+
+    MUTATION: add an is-ascii pre-check returning 'Malformed step-up token'
+    -> red.
+    """
+    resp = client.post('/r6/fhir/Observation',
+                       headers={'X-Tenant-Id': tenant_id,
+                                'X-Step-Up-Token': step_up_token + 'é',
+                                **_HUMAN_CONFIRMED,
+                                'Content-Type': 'application/json'},
+                       data=json.dumps({'resourceType': 'Observation'}))
+    assert resp.status_code == 401
+    assert 'Invalid token signature' in resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# The validator itself — the shapes no route can currently deliver
+# ---------------------------------------------------------------------------
+
+class TestTheValidatorIsTotal:
+    """`validate_step_up_token` is a public function, and `require_grant`
+    reads tokens from a JSON body as well as from headers. A header cannot
+    carry a lone surrogate (Werkzeug decodes latin-1), but `json.loads` of
+    `'"\\ud800"'` produces one — so the body source can, and `also_body_field`
+    exists for endpoints to opt into. No live route uses it today; these
+    cases keep the validator total for the one that will.
+    """
+
+    @pytest.mark.parametrize('token', [
+        'é.abc',                       # non-ASCII payload half
+        'abc.é',                       # non-ASCII signature half
+        '€.€',                         # outside latin-1 in both halves
+        '\ud800.abc',                  # lone surrogate: strict UTF-8 refuses
+        'abc.\ud800',
+        '\U0001f600.\U0001f600',
+    ], ids=['payload-latin1', 'sig-latin1', 'euro', 'payload-surrogate',
+            'sig-surrogate', 'astral'])
+    def test_it_refuses_rather_than_raises(self, app, tenant_id, token):
+        with app.app_context():
+            valid, error = validate_step_up_token(token, tenant_id)
+        assert valid is False
+        assert error == 'Invalid token signature', (
+            'a token that cannot be spelled leaves through the same door as '
+            f'any other one that does not verify, not a new one: {error!r}')
+
+    def test_a_valid_token_still_validates(self, app, tenant_id):
+        """The comparison changed; what it decides did not.
+
+        MUTATION: make `equal` return False unconditionally -> red.
+        """
+        with app.app_context():
+            valid, error = validate_step_up_token(
+                generate_step_up_token(tenant_id), tenant_id)
+        assert (valid, error) == (True, None)
+
+
+# ---------------------------------------------------------------------------
+# The rows are the surfaces
+# ---------------------------------------------------------------------------
+
+def _require_grant_sites():
+    """Every function in the production tree that calls require_grant."""
+    sites = set()
+    scanned = 0
+    for path in _production_python_files():
+        scanned += 1
+        rel = str(path.relative_to(REPO_ROOT))
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Call):
+                    continue
+                # Both spellings: the bare name every site uses today, and
+                # `access.require_grant(...)`, which a new module reaching
+                # for the kernel could just as easily write.
+                func = inner.func
+                named = ((isinstance(func, ast.Name)
+                          and func.id == 'require_grant')
+                         or (isinstance(func, ast.Attribute)
+                             and func.attr == 'require_grant'))
+                if named:
+                    sites.add(f'{rel}:{node.name}')
+    return sites, scanned
+
+
+def test_every_require_grant_site_has_a_row():
+    """MUTATION: add a require_grant call in a new handler -> red.
+
+    #557 was reported through one route. It was never one route's bug: the
+    crash is in the validator every gate shares, so the fix is only pinned if
+    the pin follows the gates rather than the route that happened to be
+    measured.
+    """
+    sites, scanned = _require_grant_sites()
+    assert scanned >= _SCAN_FLOOR, (
+        f'walked only {scanned} production modules; the scan is broken and '
+        'this test is reporting a green it did not measure')
+    covered = {row.site for row in ROWS}
+    assert sites == covered, (
+        f'require_grant sites without a row: {sorted(sites - covered)}\n'
+        f'rows naming a site that no longer exists: {sorted(covered - sites)}\n'
+        'Every surface behind the step-up gate gets a row, so a new one '
+        'cannot be added without saying how it answers a token it cannot '
+        'read.')


### PR DESCRIPTION
Closes #557.

**What to expect from the diff:** wide but mechanical. The reported crash is two lines in `r6/stepup.py`; the same shape sat at 13 call sites across 9 modules, and all 13 move to one helper. Every migration is `hmac.compare_digest(a, b)` → `constant_time.equal(a, b)`. The thinking is in `r6/constant_time.py` and the two test files.

## The bug

`hmac.compare_digest` raises `TypeError` on a `str` that is not ASCII. `r6/stepup.py:224` handed it the caller's signature half raw, and `r6/access._evaluate` deliberately does not catch validator exceptions — so a valid step-up token plus one non-ASCII byte answered an unauthenticated caller with a 500 where ASCII garbage answered 401.

It fails closed, so this is noise and information disclosure rather than a bypass. What leaked is the distinction: a 500 told a prober their token was something other than merely wrong.

**One line above the reported crash, the same partiality sat in the digest input.** The issue named the comparison. `expected_sig = hmac.new(secret.encode(), payload_b64.encode(), ...)` runs first, and `str.encode` is strict UTF-8 — it raises `UnicodeEncodeError` on a lone surrogate. `require_grant(also_body_field=...)` reads a token out of a JSON body, and `json.loads('"\ud800"')` yields exactly that. No live route uses `also_body_field` today, so that half was latent rather than reachable; fixing only the comparison would have left it to surface the day a route opts in. Both are fixed, and `'surrogatepass'` is why.

## The choice, and why

The issue offered two fixes: reject a non-conforming token before the comparison, or make the comparison total. **Total.**

A pre-check would add a second refusal path whose only cause is an encoding. The caller would learn their credential was rejected for how it was *spelled* rather than for being *wrong* — a distinction with no authorization meaning behind it, and exactly the "leaks whether it was well-formed" this issue asked to avoid. `compare_digest`'s ASCII-only restriction on `str` is a CPython type constraint, not an authorization fact.

Comparing bytes sends every wrong credential — ASCII garbage, a UTF-8 name, a lone surrogate — out through the door the gate already had: `'Invalid token signature'`. No new refusal reason, `r6/access._PUBLIC_REASONS` untouched, `tests/test_step_up_states_why.py` unchanged.

The fix is in the validator, not in `_evaluate`. Wrapping the call in `try/except` would convert an unexpected raise into a clean 401, which is the defect shape `r6/access.py:245-263` exists to prevent.

### Why the refusal reasons are not collapsed here

This fix adds no new distinguishable answer, and it does not remove any existing one. The owner ruling of 2026-08-10 at `r6/access.py:273-320` — a refusal names its cause, with `'Token tenant mismatch'` withheld — stands, and the line it draws is the right one: a caller learns nothing from `'Step-up token expired'` that they could not get by decoding the token they are already holding, whereas tenant mismatch confirms the token is real and merely issued elsewhere, which is what a prober is trying to establish. `tests/test_step_up_states_why.py` pins it and stays green.

Recorded here so the question is not re-opened from this PR: collapsing those reasons would be a reversal of a made decision, and a crash fix is not where that would belong.

## The audit: the same shape at 13 sites, not one

`r6/` held 13 `hmac.compare_digest` calls. **11 passed a caller-supplied `str` straight in** — a header, a query argument, half of a signed token — and would raise on the same input:

| site | untrusted input |
|---|---|
| `r6/stepup.py:224` | step-up token signature (the reported one) |
| `r6/internal_auth.py:32`, `r6/routes.py:2025`, `r6/rate_limit.py:148`, `r6/actions/routes.py:646`, `r6/agent_runs/routes.py:73,79` | `X-Internal-Secret` / `X-Reconciliation-Secret` header |
| `r6/email_inbound.py:49`, `r6/fasten/verify.py:85` | webhook signature header |
| `r6/wearables/routes.py:63`, `r6/sdc/delivery.py:82` | signature in a query argument |

`r6/shc/routes.py:77` and `r6/actions/routes.py:728` already encoded first and were **not** crashing. All 13 now route through `r6/constant_time.py`, which owns the encode.

`tests/test_constant_time.py::test_compare_digest_has_one_home` pins `compare_digest` to one production module, so a new gate cannot reach for the partial version by default. That is an invariant, not a ratchet, so it lives with the helper rather than in `tests/test_ratchets.py`.

### Checked and found clean

- **`careagents/accounts.py:171`** — both operands are hexdigests the process just computed; no caller-supplied string reaches the comparison. Allowlisted with that reason (CareAgents also cannot import `r6` — `tests/test_import_acyclicity.py`).
- **`secrets.compare_digest`** — no uses anywhere in the production tree. The structural pin matches the attribute name, so it would catch one.
- **`hmac.new` digest inputs from caller data** (`r6/wearables/routes.py:60`, `r6/sdc/delivery.py:48`, `r6/fasten/verify.py:78`) — a caller-supplied `str` reaches a strict `.encode()`, but Werkzeug decodes headers latin-1 and query/path with `errors='replace'`, so no lone surrogate can arrive. Left as they are. `r6/stepup.py` is the one exception, above.

## Tests

17 tests fail on the unfixed code (verified by reverting only the two lines in `r6/stepup.py`):

- **10 route rows** — every surface reaching `require_grant`, not just the reported `POST /r6/fhir/Observation`. `test_every_require_grant_site_has_a_row` checks the rows against the source by AST, so a gate added next month fails until it has one.
- Each row asserts the non-ASCII answer is **byte-identical** to the ASCII-garbage answer, rather than asserting 401. `/wearables/sync-now` answers 403, and normalizing 401-vs-403 is not this fix's call (`require_grant`'s `absent_status`/`rejected_status` exist for that reason). Each row also pins the status it already answers, so a row cannot pass by refusing earlier for some other reason in both requests.
- **The validator directly** — non-latin-1 and lone-surrogate tokens in both halves.
- **The one-home pin** and the helper's own totality cases.

```
3189 passed, 13 skipped, 1 xfailed in 103.24s
uv run ruff check .   All checks passed!
uv run mypy           Success: no issues found in 6 source files
```

Conformance stays Grade A (`tests/test_guardrail_conformance.py`, in the suite above). No ratchet moved: `r6/routes.py` is net zero lines, and no `validate_step_up_token` call site was added.

## Deliberately not touched

- `r6/access.py:474`'s docstring points `also_body_field` at `r6/routes.py:2097-2098`, which is now `record_connect_diagnostic` and does not use it. Stale reference, left alone.
- The 401/403 split across step-up gates.
- `CHANGELOG.md` — this repo updates it at release time, not per fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)