### PR TITLE
fix(careagents): the other two message channels announce too (#590)

### DIFF
--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -458,6 +458,16 @@ button.linkish { background: none; border: 0; color: var(--clay-deep);
   grid-column: 1 / -1; margin-top: 2px;
   background: #FBE9E2; border-radius: 12px; padding: 10px 14px;
 }
+/* Both message elements are revealed EMPTY and written into ANNOUNCE_DELAY_MS
+   later, so the live region is in the accessibility tree before its text
+   changes (#590). While empty they must draw nothing, or that window is a
+   flash of blank colour and a layout jump. Padding and background only:
+   `display: none` or `visibility: hidden` would take the region back out of
+   the accessibility tree, which is the whole thing the wait is buying. Ties
+   with the rule above on specificity, so it has to come after it. */
+.inline-msg:empty, .conn-refresh-msg:empty {
+  margin: 0; padding: 0; background: none;
+}
 
 /* --- picker / code / delete dialogs --------------------------------------- */
 .modal.sheet { align-items: flex-end; }

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -91,6 +91,53 @@
     return { close, result };
   }
 
+  // How long the empty live region sits in the page before its text lands.
+  //
+  // A wall-clock number, not a frame count. What has to elapse is time for
+  // assistive technology to register the region; requestAnimationFrame
+  // measures paints, so the two nested frames this replaces were ~33ms on a
+  // 60Hz phone, ~16ms at 120Hz and never at all in a backgrounded tab —
+  // under the ~100ms that accessibility libraries conventionally allow. 150ms
+  // clears that and stays below the ~200ms where a person feels a wait, and
+  // `:empty` in the stylesheet keeps the window from drawing anything.
+  //
+  // Chosen from documented practice, not measured against a screen reader —
+  // no screen reader has been run against any of this (#590).
+  const ANNOUNCE_DELAY_MS = 150;
+  const announceTimers = new WeakMap();
+
+  // Put `text` into a message element so a live region actually announces it.
+  //
+  // A live region announces only a change made while it is IN the
+  // accessibility tree, and `hidden` is display:none. Text written in the same
+  // task as the unhide is a change nothing was listening for, which is exactly
+  // the FIRST message on any of these elements — the one a tester meets. So a
+  // hidden region is revealed empty, and the text follows a beat later.
+  //
+  // An already-settled visible region is written straight into: that is the
+  // textbook live-region update, and deferring it would blank the message
+  // between "Checking…" and its result for no gain. It also keeps the two 5s
+  // pollers quiet — while the record store is down they repeat one sentence
+  // every tick, and clearing the region for each would blink the card and
+  // re-announce it.
+  //
+  // A pending write that is overtaken is cancelled and re-armed with the newer
+  // text. Delete arms "Deleting…" and then awaits the request; a failure that
+  // lands inside the wait would otherwise be papered over by the stale
+  // "Deleting…" arriving on top of "Your records were not deleted."
+  function announce(el, text, after) {
+    const pending = announceTimers.get(el);
+    if (pending) clearTimeout(pending);
+    const write = () => { el.textContent = text; if (after) after(); };
+    if (!el.hidden && !pending) return write();
+    el.textContent = "";
+    el.hidden = false;
+    announceTimers.set(el, setTimeout(() => {
+      announceTimers.delete(el);
+      write();
+    }, ANNOUNCE_DELAY_MS));
+  }
+
   // Inline message: shown in the page beside what the user touched.
   //
   // The element is MOVED next to `anchor` before it is shown. A message that
@@ -100,22 +147,19 @@
   // one element keeps the id stable for anything addressing it.
   function say(anchor, el, text) {
     if (anchor && el.previousElementSibling !== anchor) {
+      // The move is a remove-then-insert, so the region leaves the
+      // accessibility tree even when it was already on screen. Hide it first
+      // and announce() brings it back the way it brings back any newly shown
+      // region — present and empty before the text arrives.
+      el.hidden = true;
       anchor.insertAdjacentElement("afterend", el);
+    } else if (!el.hidden && el.textContent === text) {
+      // Re-tapping the same closed tile repeats the same sentence, and
+      // rewriting a string with itself is not a change anything has to
+      // announce. Send it back through the reveal, the way a moved one goes.
+      el.hidden = true;
     }
-    // #connect-msg is a live region, and a live region announces only a change
-    // made while it is IN the accessibility tree. Both things this function
-    // does take it out: `hidden` is display:none, and the move above is a
-    // remove-then-insert. Setting the text in the same task as either one is a
-    // change nothing is listening for — the refusal a closed tile gives would
-    // be read out by no screen reader at all. So show the empty region, let a
-    // frame paint, then write into it. Nested rAF because a single one runs
-    // BEFORE that paint, which is the same task as far as the a11y tree is
-    // concerned; two frames is ~32ms, under the threshold where an empty box
-    // is perceptible.
-    el.textContent = "";
-    el.hidden = false;
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-      el.textContent = text;
+    announce(el, text, () => {
       // Only scrolls if it isn't already fully visible, and only as far as it
       // has to — no jump when the message is already under the user's thumb.
       // Never while a dialog is up: the message is behind the overlay, so the
@@ -125,7 +169,7 @@
       if (!document.querySelector(".modal:not([hidden])")) {
         el.scrollIntoView({ block: "nearest" });
       }
-    }));
+    });
   }
 
   // Scroll a section into view and pulse it — the in-page way to point at the
@@ -135,9 +179,11 @@
   function flashSection(el, msgEl, text) {
     if (!el) { if (msgEl) say(null, msgEl, text); return; }
     if (msgEl) {
+      // Moved, so out of the accessibility tree and back in — hidden across
+      // the move for the same reason say() hides.
+      msgEl.hidden = true;
       el.insertAdjacentElement("afterend", msgEl);
-      msgEl.textContent = text;
-      msgEl.hidden = false;
+      announce(msgEl, text);
     }
     el.scrollIntoView({ behavior: "smooth", block: "center" });
     el.classList.add("flash");
@@ -227,8 +273,7 @@
       // "pending" forever, and keep polling so it clears itself when the
       // record store comes back.
       if (r.status === 503 && d.error === "records_unavailable") {
-        msg.textContent = d.message;
-        msg.hidden = false;
+        announce(msg, d.message);
         saidUnavailable = true;
         return;
       }
@@ -249,7 +294,7 @@
       const msg = card.querySelector(".conn-refresh-msg");
       // Named apart from the module-scope say(anchor, el, text): this one is
       // card-local and takes only the text.
-      const report = (t) => { msg.textContent = t; msg.hidden = false; };
+      const report = (t) => announce(msg, t);
       btn.disabled = true;
       report("Checking…");
       let res = await post(`/api/connections/${btn.dataset.conn}/refresh`);
@@ -320,9 +365,10 @@
   let currentUploadCard = null;
 
   function sayUpload(msg, text, cls) {
-    msg.textContent = text;
+    // Class first, text through announce(): the result box is styled while it
+    // is still empty, and `:empty` keeps it from drawing until it has words.
     msg.className = "conn-refresh-msg" + (cls ? " " + cls : "");
-    msg.hidden = false;
+    announce(msg, text);
   }
 
   document.querySelectorAll(".conn-upload").forEach((btn) => {
@@ -415,8 +461,7 @@
       const res = await post(`/api/connections/${btn.dataset.conn}/disconnect`);
       if (!res.ok) {
         btn.disabled = false;
-        msg.textContent = res.d.error || "Couldn't disconnect.";
-        msg.hidden = false;
+        announce(msg, res.d.error || "Couldn't disconnect.");
         return;
       }
       location.reload();
@@ -434,8 +479,7 @@
       if (!agreed) return;
 
       btn.disabled = true;
-      msg.textContent = "Deleting…";
-      msg.hidden = false;
+      announce(msg, "Deleting…");
       const r = await fetch(`/api/connections/${btn.dataset.conn}`,
                             { method: "DELETE" });
       const d = await r.json().catch(() => ({}));
@@ -444,9 +488,10 @@
         // Never imply a partial wipe — and never assert a whole one either
         // way. This fallback said "Your records were not deleted", which the
         // server itself can no longer say: a purge that ran and lost its
-        // answer reaches here too.
-        msg.textContent = d.message ||
-          "We couldn't confirm your records were deleted.";
+        // answer reaches here too. Announced, not just set, so the live
+        // region reads it (#590).
+        announce(msg, d.message ||
+          "We couldn't confirm your records were deleted.");
         return;
       }
       location.reload();
@@ -485,14 +530,14 @@
       // Same distinction as the pending poller: an unreachable record store
       // is reported, never rendered as "nothing new yet".
       if (r.status === 503 && d.error === "records_unavailable") {
-        msg.textContent = d.message;
+        announce(msg, d.message);
         return;
       }
       if (!r.ok) return;
       if (typeof d.new_records === "number" && d.new_records > 0) {
         clearInterval(iv);
-        msg.textContent = `${d.new_records} new record` +
-          (d.new_records === 1 ? "" : "s") + " added.";
+        announce(msg, `${d.new_records} new record` +
+          (d.new_records === 1 ? "" : "s") + " added.");
       }
     }, 5000);
   }

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -123,7 +123,11 @@
       {% endif %}
       <div class="surface soon"><b>Phone app</b><span>install from browser</span></div>
     </div>
-    <p class="inline-msg" id="surfaces-msg" hidden></p>
+    {# The refusal for these surfaces, and the words explaining every section
+       flash, arrive here. Same live-region treatment as #connect-msg and
+       .conn-refresh-msg; announce() shows it before writing into it. #}
+    <p class="inline-msg" id="surfaces-msg" role="status" aria-live="polite"
+       hidden></p>
   </section>
 </main>
 

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -5259,20 +5259,131 @@ def test_the_connect_refusal_is_announced_to_a_screen_reader():
     assert 'aria-live="polite"' in tag, tag
 
     # ...and the attributes alone are not the fix. A live region announces a
-    # change made while it is IN the accessibility tree; `hidden` is
-    # display:none, and say() also MOVES the element (a remove-then-insert).
-    # Writing the text in the same task as either one is a change nothing is
-    # listening for. So the region is shown first and written into after.
+    # change made while it is IN the accessibility tree, and say() MOVES the
+    # element next to the tapped tile — a remove-then-insert, which takes it
+    # out. So say() hides the region across the move and hands the write to
+    # announce(), which reveals it before the text lands. The ordering itself
+    # is pinned on announce(), below.
     body = re.sub(r"//[^\n]*", "",
                   _HOME_JS.split("function say(")[1].split("\n  }")[0])
-    assert body.index("el.hidden = false") < body.index("el.textContent = text")
-    # MUTATION (QA review): `"requestAnimationFrame" in body` passed with a
-    # SINGLE rAF — the case say()'s own comment says does not announce, because
-    # one frame's callback runs BEFORE the paint that puts the region in the
-    # accessibility tree. The count is the property, so the count is pinned.
-    assert body.count("requestAnimationFrame") == 2, body
-    assert re.search(
-        r"requestAnimationFrame\(\(\)\s*=>\s*requestAnimationFrame\(", body), body
+    assert body.index("el.hidden = true") < body.index("insertAdjacentElement"), body
+    assert re.search(r"announce\(el, text", body), body
+    # A re-tap of the same tile repeats the same sentence, and rewriting a
+    # string with itself is not a change anything has to announce — so that
+    # one is hidden and revealed again too. It lives here rather than in
+    # announce(), which is shared with two 5s pollers that repeat one sentence
+    # per tick and must not blink.
+    assert "el.textContent === text" in body, body
+    # MUTATION: writing the text here, on either side of the move, is the
+    # defect — the region is absent when the text lands.
+    assert "el.textContent = text" not in body, body
+
+
+def test_a_live_region_is_revealed_empty_and_written_into_after_a_wall_clock_wait():
+    """Every message element on this page is written through announce(), and
+    announce() reveals the region empty, waits, then writes. Without the wait
+    the text lands in the same task as the unhide, which is a change nothing
+    was listening for — the case that made the FIRST message on a connection
+    card silent (#590).
+
+    The wait is a wall-clock constant rather than a frame count. Two nested
+    `requestAnimationFrame`s — what #571 shipped — measure paints, not time:
+    ~33ms on a 60Hz phone, ~16ms at 120Hz, and none at all in a backgrounded
+    tab. The number that has to be big enough is a number of milliseconds, so
+    that is the unit.
+
+    Source-level, like the guards above: this executes no JavaScript, and
+    nothing here establishes that the region is SPOKEN. No screen reader has
+    been run against it (#590).
+    """
+    body = re.sub(r"//[^\n]*", "",
+                  _HOME_JS.split("function announce(")[1].split("\n  }")[0])
+    # Revealed empty first...
+    assert body.index('el.textContent = ""') < body.index("el.hidden = false"), body
+    assert body.index("el.hidden = false") < body.index("setTimeout("), body
+    # ...and the text is written in exactly one place, which the timer reaches
+    # and the unhide does not. MUTATION: hoisting that write up beside the
+    # unhide is the whole defect, and it leaves every other assertion green.
+    assert body.count("el.textContent = text") == 1, body
+    revealed = body[body.index("el.hidden = false"):]
+    armed = revealed.index("setTimeout(")
+    assert "= text" not in revealed[:armed], revealed[:armed]
+    deferred = revealed[armed:]
+    assert "write()" in deferred or "el.textContent = text" in deferred, deferred
+    assert "requestAnimationFrame" not in body, body
+    # MUTATION: `setTimeout(fn, 0)` restores the defect exactly, and 16 or 33
+    # restores the frame counts this replaced. The value is the property, so
+    # the value is pinned.
+    m = re.search(r"const ANNOUNCE_DELAY_MS = (\d+);", _HOME_JS)
+    assert m, "the wait has no named constant"
+    assert int(m.group(1)) >= 100, m.group(0)
+    # A deferred write that is overtaken has to be cancelled. Delete arms
+    # "Deleting…" and then awaits the DELETE; a failure that lands inside the
+    # wait would otherwise be papered over by the stale "Deleting…" arriving
+    # on top of "Your records were not deleted."
+    assert "clearTimeout" in body, body
+
+
+def test_no_connection_card_message_sets_its_text_before_it_is_shown():
+    """`.conn-refresh-msg` has carried `role="status"` + `aria-live="polite"`
+    since the refresh flow landed, and every one of its writers defeated them:
+    the text was set BEFORE `hidden = false`, so the region was absent when
+    the text landed and unchanged when it appeared. "Checking…", "Deleting…",
+    the poller's 503, an upload result and a failed disconnect all announced
+    nothing at all (#590).
+
+    Pinned as an absence — no card writer touches `.textContent` or `.hidden`
+    on a message element; both are announce()'s job now.
+    """
+    js = re.sub(r"//[^\n]*", "", _HOME_JS)
+    assert not re.findall(r"\b(?:msg|msgEl)\.textContent\s*=", js)
+    assert not re.findall(r"\b(?:msg|msgEl)\.hidden\s*=\s*false", js)
+    # ...and the sites that used to do it announce instead: the pending
+    # poller, report(), sayUpload(), disconnect, delete's two messages, and
+    # watchForNewRecords' two.
+    assert js.count("announce(msg") >= 8, js.count("announce(msg")
+
+
+def test_the_surfaces_message_is_a_live_region_too():
+    """`#surfaces-msg` carries the refusal for the messaging surfaces and the
+    words explaining every section flash ("Create an agent first, then connect
+    iMessage."), and had no live-region attributes at all — #571 gave the
+    treatment to one of the page's two message channels and the PR's framing
+    implied there was only one (#590).
+    """
+    tag = _HOME_HTML[_HOME_HTML.index('<p class="inline-msg" id="surfaces-msg"'):]
+    tag = tag[:tag.index(">") + 1]
+    assert 'role="status"' in tag, tag
+    assert 'aria-live="polite"' in tag, tag
+
+    # flashSection moves it next to the section being scrolled to, so it hides
+    # across the move for the same reason say() does.
+    body = re.sub(r"//[^\n]*", "",
+                  _HOME_JS.split("function flashSection(")[1].split("\n  }")[0])
+    assert body.index("msgEl.hidden = true") < body.index("insertAdjacentElement"), body
+    assert "announce(msgEl, text)" in body, body
+
+
+def test_an_empty_live_region_draws_nothing_while_it_waits():
+    """The region is revealed empty and written into a beat later. Inside the
+    marketplace grid `.inline-msg` has a background and 10px of padding, and
+    an upload result carries `.form-ok`/`.form-warn` — so that window would be
+    a flash of empty colour and a layout jump on the phone the tester is
+    holding.
+
+    It has to collapse while empty WITHOUT leaving the accessibility tree:
+    `display: none` or `visibility: hidden` here would take the region back
+    out and defeat the deferral it is waiting on.
+    """
+    rule = _CSS.split(".inline-msg:empty")[1].split("}")[0]
+    assert "padding: 0" in rule, rule
+    assert "background: none" in rule, rule
+    assert "display: none" not in rule, rule
+    assert "visibility" not in rule, rule
+    assert ".conn-refresh-msg:empty" in _CSS
+    # Same specificity as `.marketplace > .inline-msg`, so it only wins by
+    # coming after it.
+    assert _CSS.index(".inline-msg:empty") > _CSS.index(".marketplace > .inline-msg")
 
 
 def test_the_password_reassurance_is_absent_while_those_logins_are_closed(


### PR DESCRIPTION
## What

#571 gave `#connect-msg` the live-region attributes and an ordering that puts
the region in the accessibility tree before the text lands. The review of it
(#590) found that covers one of the hub's **three** message channels, and both
of the others are on the path a beta tester walks.

**1. `#surfaces-msg` had no live-region attributes at all.** It carries the
refusal for the messaging surfaces and the words explaining every section flash
("Create an agent first, then connect iMessage."). It has `role="status"` +
`aria-live="polite"` now.

**2. `.conn-refresh-msg` had the attributes and its writers defeated them.**
The element #571 was modelled on has carried both since the refresh flow
landed, and all five of its writers set the text *before* revealing the
element, so the region was absent when the text landed and unchanged when it
appeared. **The first message on any connection card announced nothing** —
"Checking…", "Deleting…", the poller's 503, an upload result, a failed
disconnect.

One helper now owns every write. `announce()` reveals a hidden region empty,
waits, then writes; `say()` and `flashSection()` hide across their move,
because a move is a remove-then-insert that takes the region out of the tree
even when it was already on screen.

## The wait: an explicit delay, not a frame count

#571 used two nested `requestAnimationFrame`s. The review measured that at
~180ms in the test browser and asked whether the margin is safe.

**It wants an explicit delay, and it is now `ANNOUNCE_DELAY_MS = 150`.** The
reason is the unit, not the size. What has to elapse is time for assistive
technology to register the region; frames measure *paints* — ~33ms on a 60Hz
phone, ~16ms at 120Hz, and none at all in a backgrounded tab. The 180ms the
review saw was headless throttling, not a margin the code asks for. 150ms
clears the ~100ms that accessibility libraries conventionally allow, sits below
the ~200ms where a person feels a wait, and does not move with refresh rate.

**The number is chosen from documented practice, not measured against a screen
reader.** That is stated in the code comment as well.

## The overtake fix (the safety-relevant half)

Deferring the write introduces a race, so `announce()` cancels a pending write
and re-arms with the newer text. Without it: Delete arms "Deleting…", the
request fails inside the wait, and the stale "Deleting…" lands **on top of**
"Your records were not deleted" — telling a patient a deletion is under way
that the server refused.

Driven from hidden, in the browser, with the observer installed before the tap:

```
t=128.7  attr:hidden -> false   text ""      (the reveal; "Deleting…" armed)
t=292.9  childList              text "Your records were not deleted. …"
```

One text arrives, and it is the failure.

**Behaviour change worth knowing:** when a request fails inside 150ms,
"Checking…"/"Deleting…" never appear at all. The final state is right and
nothing stale lands; against a real provider the request outlives the wait and
the progress line shows as before.

## The `:empty` rule is part of the fix

Inside the marketplace grid `.inline-msg` has a background and 10px of padding,
and an upload result carries `.form-ok`/`.form-warn`. Two frames hid that
window; 150ms would flash an empty pink box and jump the layout. `:empty`
collapses margin, padding and background — **padding and background only**;
`display: none` or `visibility: hidden` would take the region back out of the
accessibility tree, which is the whole thing the wait buys. Measured in the
browser while empty: `padding 0px`, transparent, height 0, still
`display: block` / `visibility: visible`.

The rule sits after `.marketplace > .inline-msg`, which it ties with on
specificity. `.inline-msg` is used on exactly these two elements.

## Verified in the browser, at phone size

Chromium at 390×844 against a local CareAgents (beta posture: `CARE_REAL_RECORDS`
unset), mutation observers and `performance.now()` stamps installed before each
tap. All three channels:

| channel | driven by | reveal (empty, in tree) | text lands |
|---|---|---|---|
| `#connect-msg` | tap the closed Fasten tile | t=10.0, moved at 10.2 still empty | t=165.2 |
| `.conn-refresh-msg` | Refresh (503) | t=2.7 | t=172.6 |
| `#surfaces-msg` | iMessage tile, no agent | t=2.7, moved, still empty | t=151.4 |

Accessibility tree afterwards, one per channel:

```yaml
- status: Connecting your own records isn't open in this beta yet. Start with the sample records.
- status: records service unavailable
- status: Create an agent first, then connect iMessage.
```

Also driven: a re-tap of the same tile (repeating an identical string is not a
change anything has to announce, so `say()` sends it back through the reveal —
`t=714.8` empty, `t=868.6` text); a move to a *different* tile while visible;
and the pending card's 5s poller across three ticks, which writes straight in
with **no** hidden toggle and no clear, so a card whose record store is down
does not blink or re-announce every five seconds.

## What was NOT run

- **No screen reader.** Nothing here establishes that these regions are
  *spoken* — only that they are `status` regions whose text changes while they
  are in the accessibility tree, which is the shape a screen reader needs.
  Whether VoiceOver, NVDA or JAWS actually reads them is unverified, and no
  automated suite in this repo can settle it. Someone has to listen.
- The browser evidence used a `ca_connections` row inserted straight into
  SQLite, and every 503 came from `HEALTHCLAW_BASE` pinned to a dead port. So
  the Refresh/Delete **failure** paths were driven; the success paths were not.
- Nothing against a running HealthClaw; no ids crossed the boundary. Nothing
  deployed.

## Ran

- `uv run ruff check .` → `All checks passed!`
- `uv run python -m pytest tests/ -q -p no:cacheprovider` →
  `3187 passed, 13 skipped, 1 xfailed, 2 warnings in 114.74s`
- `cd e2e && npx playwright test` → `39 passed (21.9s)`
- **#569's spec overlaid from its branch and then removed** → `9 passed`.
  Its `toBeVisible` / `toHaveText` / `toBeInViewport` assertions on the refusal
  auto-retry, so the 150ms wait and the zero-height empty window do not disturb
  them. (It needs its own `playwright.config.ts` third webServer entry; with
  only the spec overlaid, its two allowlist tests fail on a server that never
  boots — unrelated to this change. #569 has since updated its `REFUSED`
  constant, so the two string failures #571 reported are gone.)

Ports: `E2E_PORT=5399 CARE_E2E_PORT=5403` for the suite, `5407` for #569's
allowlist server, and `5411` for the manual pass. 5000 is AirPlay; the 51xx/52xx
range has been held by other agents on this machine.

## Base

**This stacks on #571** (`fix/beta-hub-copy-and-announcement`), which stacks on
#553. One commit here; review it, not the diff against `main`.

## Noticed, deliberately not touched

- `#modal-err` (home.js:517/529) has no live-region attributes either. It is
  inside a modal, which is a different announcement problem, and outside #590.
- The `hidden = true` resets (home.js:27, 238, 259, 536, 554) can leave a
  pending timer writing into an element that is already hidden again. Harmless
  — the callback sets text only, never `hidden` — and all five are user-paced.
