### PR TITLE
fix(copy): three pages promised a messaging channel that is not served (#564)

### DIFF
--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -123,7 +123,7 @@ def dashboard():
             )
         return render_template(
             "command_center_login.html",
-            error="This link has expired or is invalid. Ask your Telegram agent for a fresh one.",
+            error="This link has expired or is invalid. Request a fresh one — see below.",
         ), 401
 
     tenant = _tenant()

--- a/templates/command_center_login.html
+++ b/templates/command_center_login.html
@@ -47,7 +47,7 @@
 <div class="cc-login">
     <i class="fas fa-shield-heart" style="font-size:2.75rem;color:var(--cc-accent,#38bdf8);margin-bottom:0.5rem"></i>
     <h1>Your personal health command center</h1>
-    <p>The dashboard for private tenants is protected. Ask your OpenClaw Telegram agent for a signed access link.</p>
+    <p>The dashboard for private tenants is protected. Access is by signed link, and there is no self-serve route to a private tenant during the beta.</p>
 
     {% if error %}
     <div class="cc-login-err"><i class="fas fa-triangle-exclamation"></i> {{ error }}</div>
@@ -55,11 +55,11 @@
 
     <div class="cc-login-steps">
         <strong>How to get in:</strong>
-        <ol style="margin:0.5rem 0 0 1rem;padding:0;line-height:1.8">
-            <li>Open your HealthClaw Telegram bot</li>
-            <li>Send <code>/dashboard</code> — the bot replies with a signed link</li>
-            <li>Click the link — valid for 24 hours</li>
-        </ol>
+        <p style="margin:0.5rem 0 0;line-height:1.7">
+            Email <a href="mailto:support@healthclaw.io" style="color:var(--cc-accent,#38bdf8)">support@healthclaw.io</a>
+            with your tenant id and we will issue you a signed link. Links are
+            valid for 24 hours from the moment they are issued.
+        </p>
     </div>
 
     <p style="margin-top:1.5rem;font-size:0.85rem">

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -241,6 +241,7 @@
       <li><strong>Claude Desktop / Claude Code</strong> — Anthropic's clients connect over native MCP. Use the published <code>.mcp.json</code> config or the hosted Railway URL.</li>
     </ul>
     <p>All four use the same MCP server, the same skills library, and the same guardrails. Pick by where you want to type, not by what you can do.</p>
+    <p><strong>One exception right now:</strong> the Telegram surface is not currently served — the bot has been out of service since June — so OpenClaw, and the Telegram channel of Hermes, describe what those components are rather than somewhere you can reach us today.</p>
   </div>
 </div>
 

--- a/templates/fasten_connect.html
+++ b/templates/fasten_connect.html
@@ -262,15 +262,18 @@
       back to HealthClaw, which registers it against tenant
       <strong>{{ tenant_id }}</strong>. From then on, every record export from
       Fasten arrives at <code style="color:var(--cyan);font-family:var(--font-mono);font-size:12px">/fasten/webhook</code>,
-      gets ingested, scanned by Curatr for data-quality issues, and emits a
-      Telegram notification (if the chat is bound via <code>/start</code>).
+      gets ingested, and is scanned by Curatr for data-quality issues.
     </p>
     <div class="next-steps">
-      When you see the Telegram ping, try:<br>
-      &nbsp;&nbsp;<code>/summary</code> — high-level review<br>
-      &nbsp;&nbsp;<code>/conditions</code> — list with redacted IDs<br>
-      &nbsp;&nbsp;<code>/curatr</code> — data-quality findings<br>
-      &nbsp;&nbsp;<code>/dashboard</code> — visual review surface
+      Nothing notifies you when records land, so there is no message to wait
+      for. What to expect on this page instead:<br>
+      &nbsp;&nbsp;<strong>Within a minute or two</strong> — the connection is
+      verified and your assistant setup appears below.<br>
+      &nbsp;&nbsp;<strong>5–45 minutes</strong> — records keep arriving in the
+      background.<br>
+      &nbsp;&nbsp;<strong>Nothing appears</strong> — email
+      <a href="mailto:support@healthclaw.io" style="color:var(--cyan)">support@healthclaw.io</a>
+      with your tenant id and we will check the connection.
     </div>
   </div>
 </div>
@@ -319,7 +322,7 @@
       });
       showStatus(
         resp.ok
-          ? 'Connection registered. Records will stream in over the next 5–45 minutes. Check Telegram for a ping when they land.'
+          ? 'Connection registered. Records will stream in over the next 5–45 minutes. Nothing will notify you when they land.'
           : 'Connection registration failed (HTTP ' + resp.status + ').',
         resp.ok ? 'success' : 'error'
       );

--- a/templates/fasten_connect.html
+++ b/templates/fasten_connect.html
@@ -268,7 +268,8 @@
       Nothing notifies you when records land, so there is no message to wait
       for. What to expect on this page instead:<br>
       &nbsp;&nbsp;<strong>Within a minute or two</strong> — the connection is
-      verified and your assistant setup appears below.<br>
+      verified and your assistant setup appears in Step 1, under the Share
+      Records button.<br>
       &nbsp;&nbsp;<strong>5–45 minutes</strong> — records keep arriving in the
       background.<br>
       &nbsp;&nbsp;<strong>Nothing appears</strong> — email

--- a/tests/test_command_center.py
+++ b/tests/test_command_center.py
@@ -655,7 +655,35 @@ class TestSignedLinkFlow:
     def test_login_page_renders(self, client):
         resp = client.get("/command-center/login")
         assert resp.status_code == 200
-        assert b"/dashboard" in resp.data
+        # The page must name a way to actually get a link. This asserted
+        # b"/dashboard" — the bot slash command that was the only documented
+        # route in, and could not be followed (#564).
+        assert b"support@healthclaw.io" in resp.data
+
+    def test_login_page_sends_nobody_to_an_unserved_surface(self, client):
+        """Both places this page states how to get in, in one test.
+
+        It told a private-tenant user to open their Telegram bot and send
+        /dashboard for a signed link, and the invalid-link 401 told them to
+        ask that agent for a fresh one. The surface is not served (council
+        ruling D6), so the only documented way in could not be followed and
+        the dashboard was unreachable while it is down (#564).
+
+        The 401 render is the second location of the one claim, and the
+        second location is where copy like this survives a fix.
+
+        MUTATION: restore "Ask your Telegram agent for a fresh one." in
+        r6/command_center/routes.py, or the "Open your HealthClaw Telegram
+        bot" step in templates/command_center_login.html -> reddens.
+        Verified 2026-09-04.
+        """
+        page = client.get("/command-center/login")
+        expired = client.get("/command-center", query_string={"t": "garbage"})
+        assert expired.status_code == 401
+        for resp in (page, expired):
+            assert b"Telegram" not in resp.data, (
+                "the command center login page routes a user through a "
+                "surface that is not served")
 
     def test_logout_clears_session(self, client):
         from r6.command_center import access

--- a/tests/test_fasten_import_not_fabricated.py
+++ b/tests/test_fasten_import_not_fabricated.py
@@ -56,9 +56,15 @@ def _front_end_sources():
 
 # The wording the honest patient-facing page already uses. The dashboard must
 # reuse it verbatim rather than grow a second, drifting version.
+#
+# It used to end "Check Telegram for a ping when they land". The messaging
+# surface has not been served since June (council ruling D6), so a patient who
+# had just connected their records was told to wait for a notification that
+# could not arrive, and would conclude the connection had failed (#564). What
+# replaced it says the one thing that stops the wait.
 PENDING_COPY = (
     "Connection registered. Records will stream in over the next 5–45 "
-    "minutes. Check Telegram for a ping when they land."
+    "minutes. Nothing will notify you when they land."
 )
 
 
@@ -126,3 +132,35 @@ def test_the_connect_page_uses_the_pending_wording():
     assert PENDING_COPY in CONNECT_HTML.read_text(), (
         "templates/fasten_connect.html no longer carries the honest "
         "'records will stream in' wording")
+
+
+# --- #564: the page sends nobody to a surface that is not served ------------
+
+def test_the_connect_page_names_no_messaging_channel():
+    """A patient who has just connected is sent to nothing that is off.
+
+    This page told them to watch for a Telegram ping and listed the slash
+    commands to send when it arrived. The ping cannot arrive: the surface is
+    not served (council ruling D6, 2026-09-02). Someone who follows the
+    instruction waits, then concludes the connection failed — the same defect
+    as the fabricated import above, inverted: the page asserts an outcome the
+    system cannot produce, on the surface a first-time tester meets first.
+
+    SCOPE OF PROOF. The file, not the rendered page — as with every source
+    check in this module. Scoped to this one template on purpose:
+    privacy.html, index.html, wiki.html, security.html and faq.html describe
+    the component rather than promising a delivery, and a repo-wide ban would
+    redden on prose that is not the defect.
+
+    When the surface is served again, delete this test. That is a deliberate
+    act, which is the point of pinning it.
+
+    MUTATION: put "Check Telegram for a ping when they land." back into the
+    registration status string -> this and
+    test_the_connect_page_uses_the_pending_wording both redden.
+    Verified 2026-09-04.
+    """
+    assert "Telegram" not in CONNECT_HTML.read_text(encoding="utf-8"), (
+        "templates/fasten_connect.html points a patient at a messaging "
+        "channel; that surface is not served, so the instruction cannot be "
+        "followed")


### PR DESCRIPTION
## What

Council ruling D6 hides the messaging channel for the beta and does not service the bot. Three pages still promised it. Copy only — no behaviour change beyond one 401 message string.

- **`templates/fasten_connect.html`** — the one that costs a tester real time. After connecting records, Step 2 promised a Telegram ping and listed the slash commands to send when it arrived. The ping cannot arrive: someone who has just connected waits for it, then concludes the connection failed. Step 2 now states that nothing notifies them and gives what the page can actually offer — the connection verifies within a minute or two and the existing assistant-setup card appears below it, records keep arriving for 5–45 minutes, and `support@healthclaw.io` if nothing shows up. The registration status string drops the ping the same way. No channel is named.
- **`templates/command_center_login.html`** + **`r6/command_center/routes.py`** — the bot was the only documented route to a signed link, so the dashboard was unreachable while the surface is down. The page now says plainly there is no self-serve route to a private tenant during the beta, and gives one that does not depend on the bot: email support with your tenant id, links valid 24 hours. The invalid-link 401 (`routes.py:126`) is the second location of that same instruction and stops naming the agent too — the page renders it, so fixing one without the other leaves the instruction standing.
- **`templates/faq.html`** — one clause after the gateway list. The descriptions stay: what a component *is* stays true whether or not it is served.
- **`templates/privacy.html` §6 — deliberately unchanged.** It says what may happen over messaging platforms, which is a policy statement, not a promise that a surface works.

## Pins, and where I stopped

- **Connect page: pinned.** `PENDING_COPY` in `tests/test_fasten_import_not_fabricated.py` had to change regardless — it pinned the ping sentence verbatim, so the honest wording could not land without it. `test_the_connect_page_names_no_messaging_channel` goes with it: no channel named in that one file. Scoped to the file on purpose — a repo-wide ban would redden on `privacy.html`, `index.html`, `wiki.html`, `security.html` and `faq.html`, which describe rather than promise.
- **Login page: pinned cheaply.** One test asserts across both places the claim renders (the page and the 401), matching the "same claim, second location" precedent in `test_metadata_security.py`.
- **FAQ: not pinned.** Descriptive copy; the cost of the clause drifting is a reader's mild confusion, not an hour of waiting, and a pin there would redden on any honest rewrite of the gateway list.

Both pins are written to be **deleted** when the surface is served again — that deletion is the deliberate act the pin exists to force.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3159 passed, 13 skipped, 1 xfailed, 2 warnings in 102.89s (0:01:42)
```

Both gates were run again on the second commit, which is what those numbers are from.

The four new/changed assertions were confirmed red before the copy changed (`4 failed, 59 passed`), including `test_login_page_renders`, which asserted `b"/dashboard"` — the bot slash command — and so pinned the instruction that could not be followed.

## What was NOT run

- No browser. These are source and rendered-response assertions; nothing here proves the connect page looks right on a phone.
- Not exercised against a live Fasten connection, so the "within a minute or two" wording is read off the poll loop (30 attempts × 3s) rather than measured.
- No deploy.

## Noticed, deliberately not touched

- The pre-existing **"Connect your AI assistant"** card on the connect page hands out tenant + read token for "Claude, Perplexity, or any MCP agent". Per #290 (measured live 2026-08-16) the production MCP endpoint still requires `MCP_AUTH_TOKEN` at boot, so that handoff may be a second instruction a stranger cannot follow. Out of scope here, and this PR deliberately does not lean on it: the new copy points at the card as the thing that appears, without restating what the assistant can then do. Worth its own issue.
- Other Telegram claims outside #564's list: `templates/index.html:243,254,257,407`, `templates/wiki.html:478-490`, `templates/security.html:132`. All descriptive, none instruct a wait.
- `careagents/templates/home.html:104` still ships the live Telegram tile with `connect →`; PR #553 (which hides it) is not on `main` at `89b42fb`. No overlap with this PR.
- `.cc-login-steps code` in `command_center_login.html` is now unused CSS. Left in place rather than widening the diff.
- Second commit fixes a positional error in my own first draft: the assistant card is inserted at `statusEl.nextSibling`, and `#stitch-status` lives in the **Step 1** card, so "appears below" (written in Step 2) pointed the reader the wrong way. It now names Step 1 and the Share Records button.

Closes #564
Refs #536, #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
