### PR TITLE
test(connectors): the "2 of 4 proven live" claim, re-run by someone else (#530)

### DIFF
--- a/docs/2026-08-16-hard-truths.md
+++ b/docs/2026-08-16-hard-truths.md
@@ -17,7 +17,7 @@ found wanting" — never run.
 | Set | Measured state |
 |---|---|
 | Guardrail core | Grade A local; **proxy mode unmeasured** |
-| Connectors | **2 of 4** kinds proven live |
+| Connectors | **2 of 4** kinds proven live — reproduced by a second person 2026-09-04 |
 | Consumer journey | **unmeasured** |
 | Action rail | **unmeasured** |
 | Clinical rails | **unmeasured** |
@@ -65,6 +65,13 @@ This is the uncomfortable pattern, and it is consistent:
 
 The polish is the risk. A rough edge invites inspection; a confident sentence
 next to a passing test does not.
+
+Row 1 and row 3 have since been fixed (#514, #512). The 2026-09-04 re-run of
+the same walkthrough grades that same HAPI **B 6/7** — the pack's diagnosis
+that the F came from the probe and not from the guardrails, confirmed by
+changing only the probe. The rows stay as written because they are what was
+true on 2026-08-16, and the pattern they illustrate is not repealed by fixing
+two instances of it.
 
 ## 5. Guards are written narrower than the property they are named after
 

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -44,14 +44,21 @@ problem it was written to solve.
 ## The four upstream connectors, and which are proven
 
 Measured 2026-08-16 by the set-2 evidence run
-(`docs/evidence/2026-08-16-set2-connectors.md`):
+(`docs/evidence/2026-08-16-set2-connectors.md`), and **re-run on 2026-09-04 by
+someone other than its author** (`docs/evidence/2026-09-04-set2-connectors-rerun.md`,
+#530). The two `yes` rows reproduced step for step.
 
 | Kind | Auth | Proven live against |
 |---|---|---|
-| `hapi` | Basic / anonymous | **HAPI FHIR 8.11.16** ✓ |
-| `generic` | Basic / anonymous | **Firely Server 6.9.1** ✓ |
-| `aidbox` | HTTP Basic | **not run** — local server down |
-| `medplum` | OAuth2 client-credentials | **not run** — local server down |
+| `hapi` | Basic / anonymous | **HAPI FHIR 8.11.16** ✓ twice |
+| `generic` | Basic / anonymous | **Firely Server 6.9.1** ✓ twice |
+| `aidbox` | HTTP Basic | **not run** — local server down, both days |
+| `medplum` | OAuth2 client-credentials | **not run** — local server down, both days |
+
+Anyone can now re-run the two: `scripts/walkthrough-upstream.sh hapi|generic`,
+transcripts in `docs/evidence/2026-09-04-set2-rerun/`. Until 2026-09-04 the
+claim rested on an uncommitted script and could not be checked by anyone but
+its author, which is what #530 was.
 
 ## Architecture ratchets
 

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -50,8 +50,8 @@ someone other than its author** (`docs/evidence/2026-09-04-set2-connectors-rerun
 
 | Kind | Auth | Proven live against |
 |---|---|---|
-| `hapi` | Basic / anonymous | **HAPI FHIR 8.11.16** ✓ twice |
-| `generic` | Basic / anonymous | **Firely Server 6.9.1** ✓ twice |
+| `hapi` | Basic / anonymous | **HAPI FHIR 8.11.16-SNAPSHOT** ✓ twice — same build both days (`7e7129efb5`) |
+| `generic` | Basic / anonymous | **Firely Server 6.9.1** ✓ twice — same build both days |
 | `aidbox` | HTTP Basic | **not run** — local server down, both days |
 | `medplum` | OAuth2 client-credentials | **not run** — local server down, both days |
 

--- a/docs/2026-08-16-tester-program.md
+++ b/docs/2026-08-16-tester-program.md
@@ -137,8 +137,9 @@ not depend on them, is a prerequisite to hiring anyone and is tracked
 separately.
 
 Run one set end to end first (**set 2, connectors** — smallest, two of four
-kinds already proven, a real deadline attached) to find out what the gate
-actually costs before committing five more.
+kinds already proven and re-proven by a second person on 2026-09-04, a real
+deadline attached) to find out what the gate actually costs before committing
+five more.
 
 **Phase 3 — real-record beta, gated.**
 A **waitlist can open now**; a *connect* cannot. Collecting an email and an

--- a/docs/evidence/2026-08-16-set2-connectors.md
+++ b/docs/evidence/2026-08-16-set2-connectors.md
@@ -2,6 +2,17 @@
 
 **Owner:** owner-connectors · **Date:** 2026-08-16 · **Verdict: EVIDENCE PARTIAL**
 
+> **2026-09-04 (#530):** §3 and §4 — the two live runs, and the "2 of 4" claim
+> the process documents carry — were **re-run by someone other than this pack's
+> author and reproduced**, against the same two public servers, from a script
+> now committed as `scripts/walkthrough-upstream.sh`. One line differs and is
+> better: `$conformance` against HAPI graded **B 6/7**, not the F 1/7 in §3,
+> because #514 fixed the probe collision §3 diagnosed. See
+> `docs/evidence/2026-09-04-set2-connectors-rerun.md`. Sections 5, 6 and 7 have
+> **not** been independently re-run — their scripts are still uncommitted and
+> the scratch directory is gone. Nothing below is rewritten; 2026-08-16's
+> findings stand as 2026-08-16's findings.
+
 **One redaction:** the operator's home-directory name in pasted shell output
 reads `<user>`. Nothing else in any transcript below is altered — the redaction
 is incidental to every claim the output supports.
@@ -559,7 +570,11 @@ the fallback is `sqlite:///mcp_server.db`, so the container writes to
 `instance/mcp_server.db`, not to the path the compose file names. Harmless today
 and misleading to anyone reasoning about where the example's data lives.
 
-**R8 — There is no `hapi` or `generic` walkthrough in the repo. No issue yet.**
+**R8 — There is no `hapi` or `generic` walkthrough in the repo. CLOSED
+2026-09-04 by `scripts/walkthrough-upstream.sh` (#530).** Both kinds were
+re-run from it by someone other than this pack's author and reproduced; see
+`docs/evidence/2026-09-04-set2-connectors-rerun.md`. The finding as written on
+2026-08-16 was:
 The evidence in §3 and §4 was produced by a re-pointed copy of
 `examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh` living in a
 scratch directory, which means it is not runnable by anyone else and will not
@@ -636,7 +651,20 @@ corrected.
 
 ## Reproducing this
 
-Scratch directory for this pass (scripts and raw run logs):
-`…/scratchpad/set2/` — `walkthrough-hapi.sh`, `registry-contract.sh`,
-`auth_probe.py`, `halfconfig.sh`, `medplum-qa.sh`, and the `*-run.txt` capture
-of each. Not committed; R8 covers what should be.
+**Updated 2026-09-04 (#530).** The scratch directory this section named is
+gone, and nothing was recovered from it. The two live walkthroughs are now
+reproducible from the repository:
+
+- `scripts/walkthrough-upstream.sh hapi` and `… generic`
+- transcripts of a second person's run: `docs/evidence/2026-09-04-set2-rerun/`
+- what that run found: `docs/evidence/2026-09-04-set2-connectors-rerun.md`
+
+The four other scripts of this pass — `registry-contract.sh`, `auth_probe.py`,
+`halfconfig.sh`, `medplum-qa.sh` — are still uncommitted and still gone. §5, §6
+and R1 rest on them and have **not** been independently re-run. What this
+section said on 2026-08-16:
+
+> Scratch directory for this pass (scripts and raw run logs):
+> `…/scratchpad/set2/` — `walkthrough-hapi.sh`, `registry-contract.sh`,
+> `auth_probe.py`, `halfconfig.sh`, `medplum-qa.sh`, and the `*-run.txt` capture
+> of each. Not committed; R8 covers what should be.

--- a/docs/evidence/2026-09-04-set2-connectors-rerun.md
+++ b/docs/evidence/2026-09-04-set2-connectors-rerun.md
@@ -56,16 +56,30 @@ Docker was down again, exactly as on 2026-08-16, so the MCP server did not run
 in either walkthrough. Step 5 is red for absence in both. That is not a
 connector finding either way.
 
-## Both upstreams answered
+## Both upstreams answered, and are the same builds as on 2026-08-16
 
-| Server | `/metadata` | Version |
+| Server | `/metadata` | `software.version`, measured today |
 |---|---|---|
-| `hapi.fhir.org/baseR4` | HTTP 200 in 0.98s | HAPI FHIR Server, FHIR 4.0.1 |
-| `server.fire.ly/R4` | HTTP 200 in 7.46s | Firely Server, FHIR 4.0.1 |
+| `hapi.fhir.org/baseR4` | HTTP 200 in 0.98s | `HAPI FHIR Server 8.11.16-SNAPSHOT/7e7129efb5/2026-07-08` |
+| `server.fire.ly/R4` | HTTP 200 in 7.46s | `Firely Server 6.9.1+e4f2e63c5e20f326898f61339c3b3fcd48017201` |
 
-Neither was down, so neither run has an outage to discount. Firely's 7.5s is
-why every request in the script carries `--max-time 60`: a 10s timeout would
-report a working server as unreachable.
+Both report FHIR 4.0.1. Neither was down, so neither run has an outage to
+discount. Firely's 7.5s is why every request in the script carries
+`--max-time 60`: a 10s timeout would report a working server as unreachable.
+
+**The versions were measured separately, by two `curl` calls, not by the
+script.** The walkthrough prints `software` and `fhir_version` from the proxy's
+health payload — `HAPI FHIR Server` and `4.0.1` — and never reads
+`software.version`, so the transcripts do not record which build answered. The
+8.11.16 and 6.9.1 in the topology and in PRD 02 were the 2026-08-16 pack's
+numbers; they are re-confirmed here rather than carried forward on trust. HAPI
+runs SNAPSHOT builds that move, and this one has not: same build hash, same
+2026-07-08 date as the pack's day.
+
+Follow-up worth doing, deliberately not done here: have the script print
+`software.version` so a transcript records the build on its own. Changing it
+now would break the property that the committed script is byte-identical to
+the one that produced these transcripts.
 
 ## Step-by-step, pack against today
 

--- a/docs/evidence/2026-09-04-set2-connectors-rerun.md
+++ b/docs/evidence/2026-09-04-set2-connectors-rerun.md
@@ -1,0 +1,174 @@
+# Feature set 2 — connectors: the "2 of 4" claim, re-run by someone else
+
+**Run by:** QA (not the author of the 2026-08-16 pack) · **Date:** 2026-09-04 ·
+**Verdict: THE CLAIM REPRODUCES, with one step now passing that failed before.**
+
+Issue #530. Three merged documents assert that two of four connector kinds are
+proven live. Until today that rested on a re-pointed copy of the Aidbox
+walkthrough living in an uncommitted scratch directory — the 2026-08-16 pack
+says so itself, in register entry R8 — so the most load-bearing measured claim
+in the process documents sat in the document whose thesis is that
+unreproducible assertions are the defect.
+
+The scratch directory is gone. Nothing was recovered from it; the script below
+was written fresh from the pack's transcripts, which is itself the check on
+whether those transcripts describe something reproducible. They do.
+
+## What is now committed
+
+| Artifact | Path |
+|---|---|
+| The walkthrough | `scripts/walkthrough-upstream.sh` |
+| HAPI transcript | `docs/evidence/2026-09-04-set2-rerun/hapi-run.txt` |
+| Firely transcript | `docs/evidence/2026-09-04-set2-rerun/generic-run.txt` |
+| Negative control | `docs/evidence/2026-09-04-set2-rerun/negative-control-local-mode.txt` |
+
+Run it:
+
+```
+export FHIR_UPSTREAM_KIND=hapi FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR4
+export READ_AUTH_ENABLED=true STEP_UP_SECRET=dev-secret APP_ENV=development
+export SQLALCHEMY_DATABASE_URI=sqlite:////tmp/hc-hapi.db PORT=5099
+uv run flask --app main init-db && uv run python main.py &
+scripts/walkthrough-upstream.sh hapi
+```
+
+and the same with `FHIR_UPSTREAM_KIND=generic`,
+`FHIR_UPSTREAM_URL=https://server.fire.ly/R4`, `walkthrough-upstream.sh generic`.
+
+One parametrized script rather than the `walkthrough-hapi.sh` plus near-copy
+that #530 asks for. Two copies of one assertion list is how the Aidbox script's
+status codes drifted from its own README (#499), and a second copy would need
+its own "tells the truth" pin to stop it drifting again.
+
+## The environment differs from the pack's in one way that matters
+
+Both runs used the source tree at `89b42fb` via `uv run python main.py`, with a
+throwaway SQLite database outside the repository. The pack ran at `2b7872d`.
+
+Between the two, four defects the pack found were fixed and merged: #512
+(`hapi` dropping its credentials), #513 (health reporting `upstream` while
+writes landed in SQLite), #514 (`$conformance` colliding on a shared server),
+#518 (an unknown kind booting then 500-ing). **#514 is why one line of the HAPI
+result is different, and better.**
+
+Docker was down again, exactly as on 2026-08-16, so the MCP server did not run
+in either walkthrough. Step 5 is red for absence in both. That is not a
+connector finding either way.
+
+## Both upstreams answered
+
+| Server | `/metadata` | Version |
+|---|---|---|
+| `hapi.fhir.org/baseR4` | HTTP 200 in 0.98s | HAPI FHIR Server, FHIR 4.0.1 |
+| `server.fire.ly/R4` | HTTP 200 in 7.46s | Firely Server, FHIR 4.0.1 |
+
+Neither was down, so neither run has an outage to discount. Firely's 7.5s is
+why every request in the script carries `--max-time 60`: a 10s timeout would
+report a working server as unreachable.
+
+## Step-by-step, pack against today
+
+`≡` means the line matched the 2026-08-16 pack.
+
+| Step | `hapi` (2026-08-16) | `hapi` (today) | `generic` (2026-08-16) | `generic` (today) |
+|---|---|---|---|---|
+| 0 preflight — mode, kind, connected | PASS | ≡ PASS | PASS | ≡ PASS |
+| 0 anonymous upstream | NOTE | ≡ NOTE | NOTE | ≡ NOTE |
+| 1a create reached upstream | PASS | ≡ PASS | PASS | ≡ PASS |
+| 1b gate matrix 428/401/428/201 | PASS ×4 | ≡ PASS ×4 | PASS ×4 | ≡ PASS ×4 |
+| 1b Observation landed upstream | PASS | ≡ PASS | PASS | ≡ PASS |
+| 2 redaction + `_source: upstream` | PASS | ≡ PASS | PASS | ≡ PASS |
+| 3 audit written, PHI-free | PASS (5 entries) | PASS (3 entries) | PASS (3) | ≡ PASS (3) |
+| 4 `$conformance` | **FAIL — grade F 1/7** | **PASS — grade B 6/7** | PASS — B 6/7 | ≡ PASS — B 6/7 |
+| 5 MCP `tools/list` | FAIL — HTTP 000 | ≡ FAIL — HTTP 000 | FAIL — HTTP 000 | ≡ FAIL — HTTP 000 |
+
+Every guardrail assertion the claim rests on held again, on a different day,
+from a script written by someone who did not write the first one, against the
+same two public servers.
+
+Two rows are not `≡`, and neither is a guardrail difference:
+
+**Step 4 on HAPI: F 1/7 → B 6/7.** This is #514 landing.
+`_synthetic_patient()` now carries a `uuid4` identifier, so HAPI's
+duplicate-detection interceptor no longer answers the second and later probe
+creates with 412 `HAPI-2840`. The pack's diagnosis was that the F was caused by
+the harness and not by the guardrails, and that the same harness grading B
+against Firely was the control confirming it. Both halves are now confirmed
+directly: with the harness fixed and nothing else changed, HAPI grades what
+Firely graded. The two servers now agree, and `error_fidelity` (#498) is the
+only failure on either.
+
+**Step 3 audit count on HAPI: 5 → 3.** The pack's HAPI run happened after
+earlier attempts against the same scratch database (the pack records a first
+§3 run "before the script was corrected"). Today's runs each used a fresh
+database, so both show 3. The assertion is that entries exist and carry no PHI,
+not how many; the count is reported because it moved.
+
+## The script can fail
+
+A walkthrough that has never gone red is a demo of itself. The `_source`
+assertion in step 2 is the one line separating this run from the false pass the
+pack found in `smoke_medplum.py` — 7 of 8 checks green against a Medplum that
+did not exist (R2) — so the same trap was set for this script deliberately.
+
+With no upstream configured, the app running in local mode, and the script
+still told `hapi`:
+
+```
+0. Preflight
+    proxy version 1.10.0, mode local
+
+The proxy is running in LOCAL mode — it is not talking to hapi at all.
+Everything below would pass against the proxy's own SQLite store and prove
+nothing about the connector. Check FHIR_UPSTREAM_URL is exported.
+```
+
+Exit 2 at step 0. No request reached either public server, and no step reported
+a pass. Full transcript in `negative-control-local-mode.txt`.
+
+## What this run does NOT prove
+
+Unchanged from the 2026-08-16 pack except where noted:
+
+- **`aidbox` and `medplum`, in any respect.** Not attempted. Docker is still
+  down on this machine and no Medplum client credentials exist here. The
+  four-row table is still two rows of yes.
+- **`generic` with HTTP Basic against a server that requires it.** Firely's
+  public server takes no credential, so this exercised the anonymous branch
+  again. The Basic branch was proven on the wire in the pack's §6 and was not
+  re-tested here.
+- **`hapi` with a credential.** Same reason. #512 changed `hapi` to
+  `AUTH_BASIC` after the pack found the drop; this run does not exercise that
+  fix, because a public sandbox cannot. The unit tests cover it.
+- **The "proxy holds its own credential" property**, for either kind. Both
+  upstreams serve anonymous callers, which the script reports as a NOTE rather
+  than asserting a guaranteed red.
+- **The MCP server**, in either run. Docker is down. Step 5 is red for that
+  reason and no other.
+- **The pinned container images.** Both runs used the source tree, not the
+  1.10.0 images.
+- **The `qa/demo.spec.ts` recording**, still missing, still needs the compose
+  stack. The 2026-08-16 pack is EVIDENCE PARTIAL for that reason and this run
+  does not change it.
+- **Cleanup of synthetic resources on the public servers.** One Patient and one
+  Observation on each, plus whatever `$conformance` created on each during its
+  probe run. All synthetic, no PHI, left in place — same footprint as the
+  pack's day. Today's carry nonces `86425f1cde39` (HAPI) and `471213ce4181`
+  (Firely).
+- **Production was not touched.** The two Flask processes were ephemeral, bound
+  to localhost:5099, used scratch SQLite databases outside the repository, and
+  were stopped at the end.
+
+## What this changes in the 2026-08-16 pack
+
+Two of its statements are now false, and are annotated there rather than
+rewritten — the findings of that day stand as that day's findings:
+
+- **R8** — "There is no `hapi` or `generic` walkthrough in the repo" — closed by
+  `scripts/walkthrough-upstream.sh`.
+- **"Reproducing this"** — the scratch directory it names is gone. The committed
+  paths above replace it.
+
+Its §3 Grade F for HAPI and hard-truths §4's "graded F, 1/7" row are dated
+observations that were true on 2026-08-16, and stay as written.

--- a/docs/evidence/2026-09-04-set2-rerun/generic-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/generic-run.txt
@@ -1,0 +1,51 @@
+walkthrough-upstream.sh  kind=generic  upstream=https://server.fire.ly/R4
+run nonce 471213ce4181  (all created resources carry it)
+date 2026-09-04T09:01:36Z
+
+0. Preflight
+    proxy version 1.10.0, mode upstream
+    upstream: kind=generic software='Firely Server' fhirVersion=4.0.1 status=connected
+  PASS proxy is in upstream mode, connected, and reports the kind it was built as
+  NOTE the upstream serves ANONYMOUS callers (HTTP 200). Expected for a public
+       sandbox (this kind degrades to anonymous when no credential is set).
+       The "proxy holds its own credential" property is NOT demonstrated by
+       this run.
+
+1a. A subject to write about (synthetic)
+  PASS guardrailed create -> upstream (Patient/a50568a6-505f-4883-a1dc-2507f93ef156)
+  PASS the write reached the upstream (asked https://server.fire.ly/R4 directly)
+
+1b. A CLINICAL write, and two gates that do not substitute for each other
+    neither gate               -> HTTP 428
+  PASS neither gate
+    confirmed, no credential   -> HTTP 401
+  PASS confirmed, no credential
+    credential, no human       -> HTTP 428
+  PASS credential, no human
+    both gates satisfied       -> HTTP 201
+  PASS both gates satisfied
+  PASS the Observation reached the upstream (1 found)
+
+2. The same resource, both ways
+  through the guardrail proxy:
+    {"resourceType": "Patient", "id": "a50568a6-505f-4883-a1dc-2507f93ef156", "name": [{"family": "Z.", "given": ["E."]}], "identifier": [{"system": "urn:walkthrough:471213ce4181", "value": "***5409"}], "birthDate": "1980", "telecom": [{"system": "phone", "value": "[Redacted]"}], "_source": "upstream"}
+  PASS the upstream holds the full record; the agent's path does not (_source=upstream)
+
+3. The read left a record
+    AuditEvent entries: 3
+  PASS audit written, and PHI-free
+
+4. Grade the deployment
+    grade B (6/7)
+    failing properties: error_fidelity
+  PASS 6/7 — only error fidelity fails (known, #498)
+
+5. What the agent actually connects to
+    tools/list, no token      -> HTTP 000
+  FAIL expected 401 from an unauthenticated tools/list, got 000 (NOT RUNNING = not checked)
+
+Created on https://server.fire.ly/R4 and left in place (synthetic): Patient/a50568a6-505f-4883-a1dc-2507f93ef156, one Observation,
+plus whatever $conformance created. All carry nonce 471213ce4181.
+
+Walkthrough FAILED. A guardrail this connector claims did not hold,
+or a step could not be run. Read which above — they are not the same thing.

--- a/docs/evidence/2026-09-04-set2-rerun/hapi-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/hapi-run.txt
@@ -1,0 +1,51 @@
+walkthrough-upstream.sh  kind=hapi  upstream=https://hapi.fhir.org/baseR4
+run nonce 86425f1cde39  (all created resources carry it)
+date 2026-09-04T09:00:49Z
+
+0. Preflight
+    proxy version 1.10.0, mode upstream
+    upstream: kind=hapi software='HAPI FHIR Server' fhirVersion=4.0.1 status=connected
+  PASS proxy is in upstream mode, connected, and reports the kind it was built as
+  NOTE the upstream serves ANONYMOUS callers (HTTP 200). Expected for a public
+       sandbox (this kind degrades to anonymous when no credential is set).
+       The "proxy holds its own credential" property is NOT demonstrated by
+       this run.
+
+1a. A subject to write about (synthetic)
+  PASS guardrailed create -> upstream (Patient/138005212)
+  PASS the write reached the upstream (asked https://hapi.fhir.org/baseR4 directly)
+
+1b. A CLINICAL write, and two gates that do not substitute for each other
+    neither gate               -> HTTP 428
+  PASS neither gate
+    confirmed, no credential   -> HTTP 401
+  PASS confirmed, no credential
+    credential, no human       -> HTTP 428
+  PASS credential, no human
+    both gates satisfied       -> HTTP 201
+  PASS both gates satisfied
+  PASS the Observation reached the upstream (1 found)
+
+2. The same resource, both ways
+  through the guardrail proxy:
+    {"resourceType": "Patient", "id": "138005212", "name": [{"family": "Z.", "given": ["E."]}], "identifier": [{"system": "urn:walkthrough:86425f1cde39", "value": "***5409"}], "birthDate": "1980", "telecom": [{"system": "phone", "value": "[Redacted]"}], "_source": "upstream"}
+  PASS the upstream holds the full record; the agent's path does not (_source=upstream)
+
+3. The read left a record
+    AuditEvent entries: 3
+  PASS audit written, and PHI-free
+
+4. Grade the deployment
+    grade B (6/7)
+    failing properties: error_fidelity
+  PASS 6/7 — only error fidelity fails (known, #498)
+
+5. What the agent actually connects to
+    tools/list, no token      -> HTTP 000
+  FAIL expected 401 from an unauthenticated tools/list, got 000 (NOT RUNNING = not checked)
+
+Created on https://hapi.fhir.org/baseR4 and left in place (synthetic): Patient/138005212, one Observation,
+plus whatever $conformance created. All carry nonce 86425f1cde39.
+
+Walkthrough FAILED. A guardrail this connector claims did not hold,
+or a step could not be run. Read which above — they are not the same thing.

--- a/docs/evidence/2026-09-04-set2-rerun/negative-control-local-mode.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/negative-control-local-mode.txt
@@ -1,0 +1,10 @@
+walkthrough-upstream.sh  kind=hapi  upstream=https://hapi.fhir.org/baseR4
+run nonce d114478e72aa  (all created resources carry it)
+date 2026-09-04T09:02:26Z
+
+0. Preflight
+    proxy version 1.10.0, mode local
+
+The proxy is running in LOCAL mode — it is not talking to hapi at all.
+Everything below would pass against the proxy's own SQLite store and prove
+nothing about the connector. Check FHIR_UPSTREAM_URL is exported.

--- a/docs/prd/02-connectors.md
+++ b/docs/prd/02-connectors.md
@@ -28,8 +28,8 @@ Not a mock, and not one kind standing in for another. A connector proven only ag
 
 | Kind | Proven live | Against | Re-run by a second person |
 |---|---|---|---|
-| `hapi` | **yes** | HAPI FHIR 8.11.16 | **yes** — 2026-09-04, reproduced |
-| `generic` | **yes** | Firely Server 6.9.1 | **yes** — 2026-09-04, reproduced |
+| `hapi` | **yes** | HAPI FHIR 8.11.16-SNAPSHOT (`7e7129efb5`) | **yes** — 2026-09-04, reproduced, same build |
+| `generic` | **yes** | Firely Server 6.9.1 | **yes** — 2026-09-04, reproduced, same build |
 | `aidbox` | **no** | server down 2026-08-16 | still down 2026-09-04 |
 | `medplum` | **no** | server down; no credentials present | unchanged |
 

--- a/docs/prd/02-connectors.md
+++ b/docs/prd/02-connectors.md
@@ -26,14 +26,23 @@ Not a mock, and not one kind standing in for another. A connector proven only ag
 
 ## 4. Current state, measured
 
-| Kind | Proven live | Against |
-|---|---|---|
-| `hapi` | **yes** | HAPI FHIR 8.11.16 |
-| `generic` | **yes** | Firely Server 6.9.1 |
-| `aidbox` | **no** | server down 2026-08-16 |
-| `medplum` | **no** | server down; no credentials present |
+| Kind | Proven live | Against | Re-run by a second person |
+|---|---|---|---|
+| `hapi` | **yes** | HAPI FHIR 8.11.16 | **yes** — 2026-09-04, reproduced |
+| `generic` | **yes** | Firely Server 6.9.1 | **yes** — 2026-09-04, reproduced |
+| `aidbox` | **no** | server down 2026-08-16 | still down 2026-09-04 |
+| `medplum` | **no** | server down; no credentials present | unchanged |
 
 - Pack: `docs/evidence/2026-08-16-set2-connectors.md` — **EVIDENCE PARTIAL**, 2 of 4.
+- Re-run: `docs/evidence/2026-09-04-set2-connectors-rerun.md` (#530). The
+  2026-08-16 runs came from an uncommitted script, so nobody but the author
+  could check them. The walkthrough is now `scripts/walkthrough-upstream.sh`,
+  the transcripts are in `docs/evidence/2026-09-04-set2-rerun/`, and QA re-ran
+  both kinds against the same two public servers. Every guardrail assertion
+  held again. One line changed: `$conformance` against HAPI graded **B 6/7**,
+  not the 2026-08-16 **F 1/7**, because #514 fixed the probe collision the pack
+  diagnosed. Still not proven: either kind with a credential (both sandboxes
+  are anonymous), and the MCP step, which needs Docker.
 - Four defects fixed today off this run:
   - `hapi` dropping its credentials (#512)
   - health lying about upstream mode (#513)

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -6,7 +6,7 @@ shape.
 | # | Set | What "works" means | Measured state |
 |---|---|---|---|
 | [1](01-guardrail-core.md) | Guardrail core | conformance A local / B proxy, gap named | **A 7/7 local; proxy unmeasured** |
-| [2](02-connectors.md) | Upstream connectors | each kind runs its own live walkthrough | **2 of 4 proven live** |
+| [2](02-connectors.md) | Upstream connectors | each kind runs its own live walkthrough | **2 of 4 proven live**, and both re-run by a second person 2026-09-04 (#530) |
 | [3](03-consumer-journey.md) | CareAgents journey | a person finishes it without help | **unmeasured** |
 | [4](04-action-rail.md) | Action rail | nothing executes without an out-of-band human | **unmeasured; #215 says nothing could execute** |
 | [5](05-clinical-rails.md) | Clinical rails | a clinician does not have to correct it | **unmeasured** |

--- a/scripts/walkthrough-upstream.sh
+++ b/scripts/walkthrough-upstream.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# The connector walkthrough, against a PUBLIC FHIR server.
+#
+# Why this exists: `examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh`
+# proves the `aidbox` kind and needs a local Aidbox, a seeded `Patient/pt-demo`
+# and a Basic credential. The `hapi` and `generic` kinds were proven live on
+# 2026-08-16 by a re-pointed COPY of that script living in an uncommitted
+# scratch directory (evidence pack R8), so the most load-bearing measured claim
+# in the process documents — "2 of 4 connector kinds proven live" — rested on a
+# run nobody but its author could re-execute. This is that script, committed.
+#
+# One parametrized script rather than `walkthrough-hapi.sh` plus a near-copy
+# for `generic`: two near-copies of an assertion list is exactly how the Aidbox
+# script's status codes drifted from its own README (#499 and the "tells the
+# truth" test that now pins them).
+#
+# It creates SYNTHETIC resources on a shared public server and does not delete
+# them. Never point it at anything holding real records.
+#
+# Usage:
+#   scripts/walkthrough-upstream.sh hapi
+#   scripts/walkthrough-upstream.sh generic
+#   UPSTREAM_URL=https://example.org/R4 scripts/walkthrough-upstream.sh generic
+#
+# It does NOT start the app. Start it first, in upstream mode, e.g.:
+#   export FHIR_UPSTREAM_KIND=hapi FHIR_UPSTREAM_URL=https://hapi.fhir.org/baseR4
+#   export READ_AUTH_ENABLED=true STEP_UP_SECRET=dev-secret APP_ENV=development
+#   export SQLALCHEMY_DATABASE_URI=sqlite:////tmp/hc-hapi.db PORT=5099
+#   uv run flask --app main init-db && uv run python main.py
+#
+# Each step prints what it asked for and what came back. Steps that assert a
+# guardrail FAIL LOUDLY when the guardrail does not hold — a walkthrough that
+# prints "OK" whatever happens is a demo of itself, not of the system.
+set -uo pipefail
+
+KIND="${1:-${FHIR_UPSTREAM_KIND:-}}"
+case "$KIND" in
+  hapi)    DEFAULT_URL="https://hapi.fhir.org/baseR4" ;;
+  generic) DEFAULT_URL="https://server.fire.ly/R4" ;;
+  "")      echo "usage: $0 <hapi|generic>   (or set FHIR_UPSTREAM_KIND)" >&2; exit 2 ;;
+  *)       DEFAULT_URL="" ;;
+esac
+UPSTREAM="${UPSTREAM_URL:-${FHIR_UPSTREAM_URL:-$DEFAULT_URL}}"
+[ -z "$UPSTREAM" ] && { echo "set UPSTREAM_URL for kind '${KIND}'" >&2; exit 2; }
+
+HC="http://localhost:${HEALTHCLAW_PORT:-${PORT:-5099}}"
+TENANT="${TENANT:-desktop-demo}"
+# Public sandboxes are slow and shared. Firely answered /metadata in 7.4s on
+# 2026-09-04, so a 10s timeout would report a working server as unreachable.
+CURL=(curl -sS --max-time 60)
+
+# Every resource this run creates carries the same nonce, so a re-run against
+# the same shared server is a DIFFERENT body. Without it hapi.fhir.org's
+# duplicate-detection interceptor answers the second run with 412 HAPI-2840,
+# which is what graded the deployment F on 2026-08-16 (#514).
+NONCE=$(python3 -c "import uuid; print(uuid.uuid4().hex[:12])")
+SYSTEM="urn:walkthrough:${NONCE}"
+
+# Distinctive synthetic values. The redaction assertions test for THESE
+# strings, not for the shape of a mask: asserting on '***' would pass if
+# redaction were replaced by a function that returns '***' and nothing else.
+FAMILY="Zzyzxbrook"
+GIVEN="Everdeen"
+MRN="900775409"
+PHONE="555-0166"
+BIRTHDATE="1980-03-11"
+
+fail=0
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; fail=1; }
+note() { printf '  \033[33mNOTE\033[0m %s\n' "$*"; }
+die()  { printf '\n\033[31m%s\033[0m\n' "$*"; exit 2; }
+
+printf 'walkthrough-upstream.sh  kind=%s  upstream=%s\n' "$KIND" "$UPSTREAM"
+printf 'run nonce %s  (all created resources carry it)\n' "$NONCE"
+printf 'date %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+# ---------------------------------------------------------------------------
+step "0. Preflight"
+
+health=$("${CURL[@]}" "${HC}/r6/fhir/health" 2>/dev/null)
+[ -z "$health" ] && die "The guardrail proxy is not answering on ${HC}.
+Is it up?  PORT=5099 uv run python main.py
+On macOS, port 5000 belongs to AirPlay Receiver — use PORT=5099."
+
+python3 - "$health" "$KIND" <<'PY' || exit 2
+import json, sys
+h = json.loads(sys.argv[1]); want_kind = sys.argv[2]
+mode = h.get("mode"); up = h.get("checks", {}).get("upstream")
+print(f"    proxy version {h.get('version')}, mode {mode}")
+
+if mode != "upstream":
+    print(f"""
+\033[31mThe proxy is running in LOCAL mode — it is not talking to {want_kind} at all.\033[0m
+Everything below would pass against the proxy's own SQLite store and prove
+nothing about the connector. Check FHIR_UPSTREAM_URL is exported.""")
+    sys.exit(1)
+
+if not isinstance(up, dict):
+    # 'misconfigured' or 'not_configured' — #513. A named upstream that could
+    # not be built used to report healthy while writes went to SQLite.
+    print(f"\n\033[31mupstream check is '{up}', not a proxy health payload.\033[0m")
+    sys.exit(1)
+
+print(f"    upstream: kind={up.get('kind')} software={up.get('software')!r} "
+      f"fhirVersion={up.get('fhir_version')} status={up.get('status')}")
+if up.get("status") != "connected":
+    print(f"\n\033[31mThe proxy cannot reach the upstream (status: {up.get('status')}).\033[0m")
+    sys.exit(1)
+if up.get("kind") != want_kind:
+    print(f"\n\033[31mThe proxy reports kind={up.get('kind')!r}, not {want_kind!r}.\033[0m")
+    print("One kind standing in for another proves nothing about this one.")
+    sys.exit(1)
+print("  \033[32mPASS\033[0m proxy is in upstream mode, connected, and reports "
+      "the kind it was built as")
+PY
+[ $? -ne 0 ] && exit 2
+
+# The Aidbox walkthrough ASSERTS that the upstream refuses anonymous callers,
+# because there the proxy holding its own credential is the point. A public
+# sandbox is auth=none by design, so the same assertion here would be a
+# guaranteed red that says nothing. Reported, not asserted — and the property
+# it would have proven is recorded as NOT demonstrated rather than assumed.
+anon=$("${CURL[@]}" -o /dev/null -w '%{http_code}' "${UPSTREAM}/metadata?_summary=true")
+if [ "$anon" = "200" ]; then
+  note "the upstream serves ANONYMOUS callers (HTTP 200). Expected for a public
+       sandbox (this kind degrades to anonymous when no credential is set).
+       The \"proxy holds its own credential\" property is NOT demonstrated by
+       this run."
+else
+  ok "the upstream refuses anonymous callers (HTTP ${anon}) — the credential matters"
+fi
+
+# READ_AUTH_ENABLED is on, so a tenant header alone gets a 401, not a redacted
+# record. Minted BEFORE the reads: without it every read returns an
+# OperationOutcome, which contains no PHI, and every redaction assertion below
+# would pass VACUOUSLY on a refusal. That was #499.
+token=$("${CURL[@]}" -X POST -H 'Content-Type: application/json' \
+  -H "X-Tenant-Id: ${TENANT}" -d "{\"tenant_id\":\"${TENANT}\"}" \
+  "${HC}/r6/fhir/internal/step-up-token" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null)
+[ -z "$token" ] && die "Could not mint a step-up token on ${HC}.
+Every read and write below needs one. Is STEP_UP_SECRET set?"
+AUTH=(-H "X-Tenant-Id: ${TENANT}" -H "X-Step-Up-Token: ${token}")
+
+# ---------------------------------------------------------------------------
+step "1a. A subject to write about (synthetic)"
+
+patient=$(cat <<JSON
+{"resourceType":"Patient",
+ "name":[{"family":"${FAMILY}","given":["${GIVEN}"]}],
+ "identifier":[{"system":"${SYSTEM}","value":"${MRN}"}],
+ "birthDate":"${BIRTHDATE}",
+ "telecom":[{"system":"phone","value":"${PHONE}"}]}
+JSON
+)
+
+created=$("${CURL[@]}" -X POST "${AUTH[@]}" \
+  -H 'Content-Type: application/fhir+json' -d "$patient" "${HC}/r6/fhir/Patient")
+PID=$(echo "$created" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+if [ -z "$PID" ]; then
+  bad "guardrailed create did not return a Patient id:"
+  echo "$created" | head -c 400 | sed 's/^/        /'
+  die "Nothing below would be testing this connector."
+fi
+ok "guardrailed create -> upstream (Patient/${PID})"
+
+# The proxy reporting its own 201 says nothing about storage. Ask the upstream,
+# going around the proxy.
+landed=$("${CURL[@]}" "${UPSTREAM}/Patient?identifier=${SYSTEM}|${MRN}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
+[ "${landed:-0}" -ge 1 ] \
+  && ok "the write reached the upstream (asked ${UPSTREAM} directly)" \
+  || bad "the create returned an id but ${UPSTREAM} has no such Patient"
+
+# ---------------------------------------------------------------------------
+step "1b. A CLINICAL write, and two gates that do not substitute for each other"
+
+# Four requests, not two. A sequence of two refusals only shows that SOME
+# refusal happened; it cannot tell you whether the second gate would have
+# accepted the first gate's credential. The matrix can.
+#
+#   neither          -> 428   human confirmation is missing
+#   confirmed only   -> 401   a confirmation is not a credential
+#   token only       -> 428   a credential is not a confirmation
+#   both             -> 201   and only then
+#
+# The bare request reports 428 rather than 401 because the human-in-the-loop
+# check runs in a before_request hook, ahead of every handler's auth gate.
+#
+# This matrix is a property of CLINICAL writes. The Patient create above takes
+# the step-up token alone, because require_human_confirmation fires on
+# CLINICAL_RESOURCE_TYPES and Consent only (evidence pack R12).
+obs=$(cat <<JSON
+{"resourceType":"Observation","status":"final",
+ "subject":{"reference":"Patient/${PID}"},
+ "effectiveDateTime":"2026-09-04",
+ "identifier":[{"system":"${SYSTEM}","value":"obs-${NONCE}"}],
+ "code":{"coding":[{"system":"http://loinc.org","code":"85354-9"}]},
+ "valueQuantity":{"value":128,"unit":"mmHg"}}
+JSON
+)
+
+write() {  # write <expected> <label> [extra curl args...]
+  local expected="$1" label="$2"; shift 2
+  local code
+  code=$("${CURL[@]}" -o /dev/null -w '%{http_code}' -X POST \
+    -H "X-Tenant-Id: ${TENANT}" -H 'Content-Type: application/fhir+json' \
+    "$@" -d "$obs" "${HC}/r6/fhir/Observation")
+  printf '    %-26s -> HTTP %s\n' "$label" "$code"
+  [ "$code" = "$expected" ] && ok "$label" \
+                            || bad "$label: expected ${expected}, got ${code}"
+}
+
+write 428 "neither gate"
+write 401 "confirmed, no credential" -H 'X-Human-Confirmed: true'
+write 428 "credential, no human" -H "X-Step-Up-Token: ${token}"
+write 201 "both gates satisfied" -H "X-Step-Up-Token: ${token}" \
+                                 -H 'X-Human-Confirmed: true'
+
+obs_landed=$("${CURL[@]}" "${UPSTREAM}/Observation?identifier=${SYSTEM}|obs-${NONCE}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
+[ "${obs_landed:-0}" -ge 1 ] \
+  && ok "the Observation reached the upstream (${obs_landed} found)" \
+  || bad "the write returned 201 but the upstream has no such Observation"
+
+# ---------------------------------------------------------------------------
+step "2. The same resource, both ways"
+
+proxied=$("${CURL[@]}" "${AUTH[@]}" "${HC}/r6/fhir/Patient/${PID}")
+echo "  through the guardrail proxy:"
+echo "$proxied" | python3 -c "
+import json,sys
+r=json.load(sys.stdin)
+keys=('resourceType','id','name','identifier','birthDate','telecom','_source')
+print('   ', json.dumps({k:r.get(k) for k in keys if k in r})[:400])" 2>/dev/null
+
+python3 - "$proxied" "$PID" "$FAMILY" "$GIVEN" "$MRN" "$PHONE" "$BIRTHDATE" <<'PY'
+import json, sys
+proxied = json.loads(sys.argv[1]); pid = sys.argv[2]; leaks = sys.argv[3:]
+
+# 1. We are looking at the record, not at an error about the record. Checks 2
+#    and 3 are satisfied by ANY response lacking the identifiers — including a
+#    refusal — so this one comes first and gates them.
+if proxied.get("resourceType") != "Patient" or proxied.get("id") != pid:
+    print(f"  \033[31mFAIL\033[0m the proxy did not return Patient/{pid}. "
+          "Nothing below would be testing redaction:")
+    print("        " + json.dumps(proxied)[:300]); sys.exit(1)
+
+# 2. It came from the upstream, not from the proxy's own SQLite. This single
+#    field is the whole distance between this run and a false pass — it is the
+#    one check that failed in the Medplum QA run against no Medplum at all
+#    (evidence pack R2).
+if proxied.get("_source") != "upstream":
+    print(f"  \033[31mFAIL\033[0m _source is {proxied.get('_source')!r}, not "
+          "'upstream'. The record came from the proxy's own store, so this "
+          "proves nothing about the connector."); sys.exit(1)
+
+# 3. The distinctive values are gone.
+raw = json.dumps(proxied)
+leaked = [t for t in leaks if t in raw]
+if leaked:
+    print(f"  \033[31mFAIL\033[0m identifiers survived redaction: {leaked}")
+    sys.exit(1)
+print("  \033[32mPASS\033[0m the upstream holds the full record; the agent's "
+      "path does not (_source=upstream)")
+PY
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "3. The read left a record"
+
+"${CURL[@]}" "${AUTH[@]}" "${HC}/r6/fhir/AuditEvent?_count=5" | python3 -c "
+import json,sys
+b=json.load(sys.stdin)
+# Same trap as step 2: a refusal is a JSON object with no entries, and 'no PHI
+# in it' is trivially true of a refusal. Check the shape first.
+if b.get('resourceType') != 'Bundle':
+    print('  \033[31mFAIL\033[0m expected a Bundle of AuditEvents, got:')
+    print('        ' + json.dumps(b)[:300]); sys.exit(1)
+n=b.get('total', len(b.get('entry',[])))
+print(f'    AuditEvent entries: {n}')
+if not b.get('entry'):
+    print('  \033[31mFAIL\033[0m the read emitted no AuditEvent'); sys.exit(1)
+raw=json.dumps(b)
+for tok in ('${FAMILY}','${GIVEN}','${MRN}','${PHONE}','${BIRTHDATE}'):
+    if tok in raw:
+        print(f'  \033[31mFAIL\033[0m PHI in the audit trail: {tok}'); sys.exit(1)
+print('  \033[32mPASS\033[0m audit written, and PHI-free')
+"
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "4. Grade the deployment"
+
+# NOT an assertion that the grade is A. In upstream mode error fidelity fails
+# for a reason worth stating rather than hiding behind a softer threshold: a
+# search carrying an unknown parameter is forwarded upstream, which answers
+# 404/502, instead of being refused by the guardrail with an OperationOutcome
+# naming the parameter. Tracked as #498.
+#
+# So the assertion is: every OTHER property holds, and error fidelity is the
+# only failure. Anything else regressing goes red, and the day #498 closes this
+# still passes at 7/7 without an edit.
+"${CURL[@]}" "${HC}/r6/fhir/\$conformance" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+score = d['score']
+failed = [p['key'] for p in d.get('properties', []) if not p.get('passed')]
+print(f\"    grade {d.get('grade')} ({score['passed']}/{score['total']})\"
+      + (' [cached]' if d.get('cached') else ''))
+if failed:
+    print('    failing properties: ' + ', '.join(sorted(failed)))
+KNOWN = {'error_fidelity'}
+unexpected = set(failed) - KNOWN
+if unexpected:
+    print('  \033[31mFAIL\033[0m properties that should hold did not: '
+          + ', '.join(sorted(unexpected)))
+    sys.exit(1)
+if failed:
+    print('  \033[32mPASS\033[0m ' + str(score['passed']) + '/'
+          + str(score['total']) + ' — only error fidelity fails (known, #498)')
+else:
+    print('  \033[32mPASS\033[0m Grade A, 7/7')
+"
+[ $? -ne 0 ] && fail=1
+
+# ---------------------------------------------------------------------------
+step "5. What the agent actually connects to"
+
+# The MCP server runs in Docker. When Docker is down this reports HTTP 000,
+# which is an ABSENCE, not a refusal — red because nothing ran, which is the
+# correct report. Do not read a 000 as "the MCP server rejected the call".
+MCP="http://localhost:${MCP_PORT:-3001}"
+mcp_code=$("${CURL[@]}" -o /dev/null -w '%{http_code}' -X POST "${MCP}/mcp/rpc" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' 2>/dev/null)
+echo "    tools/list, no token      -> HTTP ${mcp_code}"
+if [ "$mcp_code" = "401" ]; then
+  ok "the MCP server refuses unauthenticated callers"
+elif [ "$mcp_code" = "000" ]; then
+  bad "expected 401 from an unauthenticated tools/list, got 000 (NOT RUNNING = not checked)"
+else
+  bad "expected 401 from an unauthenticated tools/list, got ${mcp_code}"
+fi
+
+# ---------------------------------------------------------------------------
+printf '\nCreated on %s and left in place (synthetic): Patient/%s, one Observation,\n' \
+  "$UPSTREAM" "$PID"
+printf 'plus whatever $conformance created. All carry nonce %s.\n' "$NONCE"
+
+if [ "$fail" -ne 0 ]; then
+  printf '\n\033[31mWalkthrough FAILED.\033[0m A guardrail this connector claims did not hold,\n'
+  printf 'or a step could not be run. Read which above — they are not the same thing.\n'
+  exit 1
+fi
+printf '\n\033[32mWalkthrough passed.\033[0m The agent did useful work and could not finish alone.\n'

--- a/tests/test_public_walkthrough_tells_the_truth.py
+++ b/tests/test_public_walkthrough_tells_the_truth.py
@@ -1,0 +1,234 @@
+"""`scripts/walkthrough-upstream.sh` is now load-bearing. Pin it.
+
+Issue #530: three merged documents asserted that two of four connector kinds
+were proven live, and the run behind that claim came from a script in an
+uncommitted scratch directory. Nobody but its author could re-execute it, so
+the most load-bearing measured claim in the process documents sat in the
+document whose thesis is that unreproducible assertions are the defect.
+
+Committing the script fixes that once. This file is what stops it coming back,
+and it guards two different things:
+
+  1. The script asserts the status codes THIS SERVER returns. Its Aidbox
+     sibling shipped asserting 401 for a bare clinical write where the server
+     returns 428 — the human-in-the-loop check runs in a before_request hook,
+     ahead of the handler's auth gate — and a reader's first run would have
+     gone red on the first assertion.
+     `tests/test_aidbox_example_tells_the_truth.py` is that guard for
+     `walkthrough.sh`; this is the same guard for the public-server script,
+     written now rather than after the same defect ships twice.
+
+  2. The documents name paths that exist. A doc citing a deleted script is
+     #530 again with an extra step. Deleting the script or the transcripts
+     while the topology, the PRDs and hard-truths still point at them turns
+     this red.
+
+Needs no Docker, no network, and no public FHIR server: the status codes come
+from this repo's app, and the script is checked against them.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WALKTHROUGH = ROOT / "scripts" / "walkthrough-upstream.sh"
+TRANSCRIPTS = ROOT / "docs" / "evidence" / "2026-09-04-set2-rerun"
+RERUN_PACK = ROOT / "docs" / "evidence" / "2026-09-04-set2-connectors-rerun.md"
+
+#: A `write <expected> "<label>" [-H 'Header: value' ...]` call in step 1b.
+_WRITE_CALL = re.compile(r"^\s*write\s+(\d{3})\s+\"([^\"]+)\"(.*)$", re.M)
+_HEADER_ARG = re.compile(r"-H\s+(['\"])([^'\"]+)\1")
+
+
+def _write_matrix():
+    """(expected_status, label, {header: value}) for each write in step 1b."""
+    rows = []
+    # Join shell line-continuations first. The last row spans two lines, and
+    # a line-anchored match reads it as having one header instead of two —
+    # which makes this test agree with a matrix that has no fourth row.
+    script = re.sub(r"\\\n\s*", " ", WALKTHROUGH.read_text())
+    for status, label, rest in _WRITE_CALL.findall(script):
+        headers = {}
+        for _, raw in _HEADER_ARG.findall(rest):
+            name, _, value = raw.partition(":")
+            headers[name.strip()] = value.strip()
+        rows.append((int(status), label, headers))
+    return rows
+
+
+@pytest.fixture(scope="module")
+def matrix():
+    rows = _write_matrix()
+    # A pin that stops finding its subject reports success forever. Four is
+    # the point of the matrix — one row per combination of the two gates.
+    assert len(rows) == 4, (
+        f"expected 4 write() calls in walkthrough-upstream.sh, found "
+        f"{len(rows)}. If step 1b was restructured, restructure this test "
+        "with it rather than relaxing the count.")
+    return rows
+
+
+@pytest.fixture
+def no_stray_validator(monkeypatch):
+    """Pin the profile validator to unavailable (#488).
+
+    `FHIR_VALIDATOR_URL` defaults to http://localhost:8080 and availability is
+    "GET /health answered under 400", so anything bound on the developer's
+    8080 is mistaken for a validator and turns the 201 row into a 422. The
+    script runs against a remote upstream with nothing on local 8080, so
+    unavailable is what it actually runs with.
+    """
+    from r6.validator import R6Validator
+    monkeypatch.setattr(R6Validator, "_is_validator_available",
+                        lambda self: False)
+
+
+class TestTheWalkthroughAssertsWhatTheServerReturns:
+    """MUTATION: change any expected status in the script -> red."""
+
+    def test_every_row_matches(self, client, tenant_id, step_up_token, matrix,
+                               no_stray_validator):
+        body = {
+            "resourceType": "Observation",
+            "status": "final",
+            "subject": {"reference": "Patient/pt-demo"},
+            "effectiveDateTime": "2026-09-04",
+            "code": {"coding": [{"system": "http://loinc.org",
+                                 "code": "85354-9"}]},
+            "valueQuantity": {"value": 128, "unit": "mmHg"},
+        }
+        wrong = []
+        for expected, label, headers in matrix:
+            sent = {"X-Tenant-Id": tenant_id,
+                    "Content-Type": "application/fhir+json"}
+            for name, value in headers.items():
+                # The script interpolates the token it minted at run time.
+                sent[name] = (step_up_token
+                              if "${token}" in value or "$token" in value
+                              else value)
+            response = client.post("/r6/fhir/Observation",
+                                   data=json.dumps(body), headers=sent)
+            if response.status_code != expected:
+                wrong.append(f"{label!r}: script says {expected}, "
+                             f"server returns {response.status_code}")
+        assert not wrong, (
+            "walkthrough-upstream.sh asserts status codes this server does "
+            "not return. Someone re-running the #530 evidence against a "
+            "fresh checkout sees FAIL:\n  " + "\n  ".join(wrong))
+
+    def test_the_two_gates_are_independent(self, matrix):
+        """Neither credential nor confirmation alone may reach 2xx.
+
+        The property the matrix exists to demonstrate. An edit that leaves
+        four rows but lets one gate carry the write on its own has removed
+        the demonstration while keeping its shape.
+        """
+        alone = [(status, label) for status, label, headers in matrix
+                 if len(headers) == 1 and status < 300]
+        assert not alone, (
+            "a single gate reached a 2xx in the matrix, so the script no "
+            f"longer shows the two gates are independent: {alone}")
+
+        both = [status for status, _, headers in matrix if len(headers) == 2]
+        assert both == [201], (
+            "expected exactly one row presenting both gates, expecting 201; "
+            f"found {both}")
+
+
+class TestTheWalkthroughCannotPassVacuously:
+    """The checks that separate this run from a false pass.
+
+    `smoke_medplum.py` reported 7 of 8 checks green against a Medplum that did
+    not exist (2026-08-16 pack, R2), and two of its passes were on the body of
+    a 401 (R3). Both are the same defect: an assertion satisfied by a refusal.
+    Three lines in this script are the whole distance from that, so a future
+    edit may not quietly drop them.
+    """
+
+    def test_it_refuses_to_run_in_local_mode(self):
+        script = WALKTHROUGH.read_text()
+        assert 'mode != "upstream"' in script, (
+            "the preflight no longer refuses local mode. Every step below it "
+            "would pass against the proxy's own SQLite and prove nothing "
+            "about the connector.")
+
+    def test_it_asserts_the_record_came_from_the_upstream(self):
+        """The COMPARISON, not the word.
+
+        This assertion first read `'_source' in script`, which stayed green
+        when the conditional around it was replaced with `if False:` — the
+        string survives in the print statement and in the field list that
+        formats the output. A guard written from the name of the property
+        rather than from the property is hard-truths §5, committed by the
+        person who wrote that document's re-run.
+        """
+        script = WALKTHROUGH.read_text()
+        assert 'proxied.get("_source") != "upstream"' in script, (
+            "the _source comparison is gone or was rewritten. It is the one "
+            "line that failed in the Medplum QA run against no Medplum at "
+            "all (R2), and without it this script passes against the proxy's "
+            "own SQLite store.")
+        assert "sys.exit(1)" in script.split(
+            'proxied.get("_source") != "upstream"')[1][:400], (
+            "the _source check no longer exits on failure, so it reports a "
+            "false pass instead of refusing.")
+
+    def test_it_checks_the_resource_before_checking_its_contents(self):
+        """Redaction assertions must be gated on having received a record."""
+        script = WALKTHROUGH.read_text()
+        resource_check = script.find('resourceType") != "Patient"')
+        leak_check = script.find("survived redaction")
+        assert resource_check != -1, "the shape check before redaction is gone"
+        assert leak_check != -1, "the redaction assertion is gone"
+        assert resource_check < leak_check, (
+            "the redaction assertion now runs before the check that a Patient "
+            "was returned, so it passes vacuously on an OperationOutcome — "
+            "the defect #499 fixed in the Aidbox script.")
+
+    def test_the_conformance_step_names_its_one_known_failure(self):
+        """Not 'grade >= B'. A threshold hides a second regression."""
+        script = WALKTHROUGH.read_text()
+        assert "KNOWN = {'error_fidelity'}" in script, (
+            "the conformance step no longer asserts that error_fidelity is "
+            "the ONLY failure. A softer threshold passes while a second "
+            "property regresses, and stops passing at 7/7 when #498 closes.")
+
+
+class TestTheDocumentsPointAtSomethingThatExists:
+    """#530's own property: the claim must stay checkable by a stranger."""
+
+    def test_the_script_and_transcripts_are_committed(self):
+        assert WALKTHROUGH.exists(), f"{WALKTHROUGH} is gone"
+        assert RERUN_PACK.exists(), f"{RERUN_PACK} is gone"
+        for name in ("hapi-run.txt", "generic-run.txt",
+                     "negative-control-local-mode.txt"):
+            assert (TRANSCRIPTS / name).exists(), (
+                f"{name} is gone. The documents cite it as the evidence for "
+                "'2 of 4 proven live'.")
+
+    @pytest.mark.parametrize("doc", [
+        "docs/2026-08-16-system-topology.md",
+        "docs/prd/02-connectors.md",
+        "docs/prd/README.md",
+        "docs/2026-08-16-hard-truths.md",
+        "docs/2026-08-16-tester-program.md",
+        "docs/evidence/2026-08-16-set2-connectors.md",
+    ])
+    def test_every_claim_site_says_when_it_was_re_run(self, doc):
+        """A bare '2 of 4' with no date and no runner is the #530 defect."""
+        text = (ROOT / doc).read_text()
+        assert "2026-09-04" in text, (
+            f"{doc} carries the connector claim but no longer says when it "
+            "was last re-run, or by whom. That is what #530 was.")
+
+    def test_no_operator_username_in_the_transcripts(self):
+        """Redaction the 2026-08-16 pack needed and this one must not."""
+        for path in sorted(TRANSCRIPTS.glob("*.txt")):
+            text = path.read_text()
+            assert "/Users/" not in text and "/home/" not in text, (
+                f"{path.name} contains a home-directory path. An operator's "
+                "OS username in an evidence pack merged to a public repo is "
+                "the 2026-08-16 incident.")


### PR DESCRIPTION
Closes #530.

## The finding

**The claim reproduces.** Two of four connector kinds are proven live, and as
of this PR someone other than the original author has shown it, from a script
anyone can run.

Three merged documents assert "2 of 4 proven live". The 2026-08-16 run behind
that claim came from a re-pointed copy of the Aidbox walkthrough living in an
uncommitted scratch directory — the evidence pack says so itself, in R8 — so
the most load-bearing measured claim in the process documents sat in the
document whose thesis is that unreproducible assertions are the defect.

The scratch directory is gone. Nothing was recovered from it. The script here
was written fresh from the pack's transcripts, which is itself the check on
whether those transcripts describe something reproducible. They do.

## What was run

`scripts/walkthrough-upstream.sh hapi` and `… generic`, against
`hapi.fhir.org/baseR4` and `server.fire.ly/R4`, on 2026-09-04, at `89b42fb`.
Both servers answered (0.98s and 7.46s on `/metadata`), so neither run has an
outage to discount. One run per server; no retries, no load.

| Step | `hapi` 08-16 | `hapi` today | `generic` 08-16 | `generic` today |
|---|---|---|---|---|
| 0 preflight — mode, kind, connected | PASS | PASS | PASS | PASS |
| 1a create reached upstream | PASS | PASS | PASS | PASS |
| 1b gate matrix 428/401/428/201 | PASS x4 | PASS x4 | PASS x4 | PASS x4 |
| 1b Observation landed upstream | PASS | PASS | PASS | PASS |
| 2 redaction + `_source: upstream` | PASS | PASS | PASS | PASS |
| 3 audit written, PHI-free | PASS | PASS | PASS | PASS |
| 4 `$conformance` | **FAIL F 1/7** | **PASS B 6/7** | PASS B 6/7 | PASS B 6/7 |
| 5 MCP `tools/list` | FAIL — 000 | FAIL — 000 | FAIL — 000 | FAIL — 000 |

**One line differs, and it is better.** `$conformance` against HAPI now grades
B 6/7 because #514 fixed the probe collision the pack diagnosed. The pack
argued the F came from the harness rather than the guardrails, with Firely's B
as the control; changing only the probe makes HAPI grade what Firely graded, so
both halves of that diagnosis are now confirmed directly.

Step 5 is red on both days for one reason: the MCP server runs in Docker, and
Docker was down on this machine both times. That is an absence, not a refusal.

## The script can fail

`docs/evidence/2026-09-04-set2-rerun/negative-control-local-mode.txt`: told
`hapi` with the app in local mode, it exits 2 at step 0 and reports no pass.
That is the trap `smoke_medplum.py` fell into — 7 of 8 green against a Medplum
that did not exist (R2) — set for this script deliberately.

## What is now committed

- `scripts/walkthrough-upstream.sh` — one parametrized script, not
  `walkthrough-hapi.sh` plus a near-copy. Two copies of one assertion list is
  how the Aidbox script's status codes drifted from its own README (#499), and
  a second copy would need its own pin to stop it drifting again. Flagging the
  deviation from #530's literal step 1 for the reviewer.
- `docs/evidence/2026-09-04-set2-rerun/*.txt` — raw transcripts, ANSI stripped,
  scanned for home-directory paths (the 2026-08-16 incident).
- `docs/evidence/2026-09-04-set2-connectors-rerun.md` — what was run, what
  matched, what did not, and what this still does not prove.
- `tests/test_public_walkthrough_tells_the_truth.py` — 14 tests. Pins the four
  status codes against this app, the three lines that stop the script passing
  vacuously, and that every document citing this evidence still names a path
  that exists.

## Documents corrected

Five claim sites, not the three #530 names — `docs/prd/README.md` and
`docs/2026-08-16-tester-program.md` repeat the number too. Each now carries the
re-run date, that a second person ran it, the script path and the transcript
path.

The 2026-08-16 pack is **annotated, not rewritten**. R8 is closed;
"Reproducing this" named a directory that no longer exists and now points at
the committed paths. Its sections 5, 6 and 7 rest on four other uncommitted
scripts (`registry-contract.sh`, `auth_probe.py`, `halfconfig.sh`,
`medplum-qa.sh`) that are also gone, and are marked as still not independently
re-run. hard-truths §4's "graded F" row stays as written — it was true that
day — with a note that #514 and #512 have since fixed two of its five rows.

## What this does NOT cover

- `aidbox` and `medplum` — not attempted. Docker still down, no Medplum
  credentials here. The table is still two rows of yes.
- Either kind **with a credential**. Both public sandboxes are anonymous, so
  the "proxy holds its own credential" property is not demonstrated by either
  run; the script reports that as a NOTE rather than a guaranteed red.
- The MCP step, the pinned 1.10.0 images, and the `qa/demo.spec.ts` recording.
  The 2026-08-16 pack stays EVIDENCE PARTIAL.
- Cleanup on the public servers: one Patient and one Observation each, plus
  whatever `$conformance` created, all synthetic, left in place — same
  footprint as the pack's day. Nonces `86425f1cde39` and `471213ce4181`.

## Gates

```
uv run ruff check .   -> All checks passed!
uv run python -m pytest tests/ -q
  -> 3171 passed, 13 skipped, 1 xfailed, 2 warnings in 100.97s
uv run python -m pytest tests/test_guardrail_conformance.py -q
  -> 37 passed
```

No production code changed. Three mutations were run against the new tests to
confirm they fail without what they pin; the first version of the `_source`
guard survived one of them and was rewritten (noted in the test's docstring).

**Do not approve or enable auto-merge.** An approval here arms a merge that
fires on the next green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
