### PR TITLE
test(connectors): §5, §6 and §7 of the set-2 pack, re-run by someone else (#602)

### DIFF
--- a/docs/evidence/2026-08-16-set2-connectors.md
+++ b/docs/evidence/2026-08-16-set2-connectors.md
@@ -345,6 +345,17 @@ section 6 — but not end to end against a server that requires it.
 
 ## 5. Registry contract, asserted against a booted app
 
+> **2026-09-04 (#602): re-run by someone other than this pack's author, and
+> reproduced.** `registry-contract.sh` and `halfconfig.sh` are still gone;
+> `scripts/connector-registry-contract.py` is one script written from the
+> three transcripts below and committed. Run against `2b7872d` — the tree this
+> pack measured — it prints all three cases as they are written here,
+> including case 3's four lines verbatim. Run against `89b42fb` two of them
+> differ, both because a defect this section found has since been fixed: case
+> 2 now refuses to boot (#518, register entry R6) and case 3 now reports
+> degraded rather than healthy (#513, register entry R1). Transcripts and the
+> comparison: `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md`.
+
 Not unit tests. Each case boots the real Flask app with a real environment and
 asks `/r6/fhir/health` what it resolved.
 
@@ -390,6 +401,16 @@ this is where the half-configured behaviour was found.
 
 ## 6. What the proxy actually sends, per kind
 
+> **2026-09-04 (#602): re-run by someone other than this pack's author, and
+> reproduced.** `auth_probe.py` is still gone;
+> `scripts/connector-auth-probe.py` is it, rewritten from the transcript below
+> and committed. Against `2b7872d` it prints exactly what this section prints —
+> `hapi` sends nothing, `generic` sends `Basic`, from identical credentials.
+> Against `89b42fb` both send `Basic`: R5 is closed on the wire by #512. The
+> transcript here does not say which request was sent, so the committed script
+> sends the health check and records that as a reconstruction decision. See
+> `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md`.
+
 The `hapi` connector's published summary — the string `supported_connectors()`
 returns to an operator asking what this build supports — reads:
 
@@ -414,6 +435,17 @@ Question: what Authorization header reaches the upstream?
 to set.** Register entry R5 — the highest-severity finding in this pass.
 
 ## 7. Image pins
+
+> **2026-09-04 (#602): the baseline below has now been used, and this section
+> named no script.** Unlike §5 and §6 there was no transcript to rewrite —
+> only "resolved today via the registry HTTP API" — so
+> `scripts/image-pin-digests.sh` was written from this table instead. Result:
+> both `1.10.0` tags resolve to the digests recorded here, so neither was
+> re-pushed; **both unpinned tags have moved** — `healthsamurai/aidboxone:edge`
+> and `postgres:18` (R9, no longer a prediction). The two supporting
+> observations below still hold. Nothing was pulled, so this says the tags
+> moved and nothing about what is inside them. See
+> `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md`.
 
 `examples/aidbox-healthclaw-guardrails/docker-compose.yaml` names four images.
 Resolved today via the registry HTTP API (Docker was down, so not via `docker`):
@@ -461,7 +493,15 @@ Ordered by severity. None of these were fixed — no production code was modifie
 in this pass.
 
 **R1 — A half-configured upstream reports `mode: "upstream"` and `status:
-"healthy"` while serving from the local store. No issue yet.**
+"healthy"` while serving from the local store. FIXED by #513; re-run and
+confirmed 2026-09-04 (#602).** Reproduced exactly as written against `2b7872d`,
+and at `89b42fb` the same script reports HTTP 503, `status degraded`,
+`mode local`, `checks.upstream misconfigured`. Only the *reporting* changed:
+the write still lands in the proxy's own SQLite with `_source: None`, which is
+the correct fallback — the defect was never where the data went, it was that
+the health page said everything was fine. The citation below is stale;
+`is_proxy_enabled` now lives in `r6/fhir_proxy.py`, split against
+`upstream_intended()`. The finding as written on 2026-08-16 was:
 With `MEDPLUM_BASE_URL` and `MEDPLUM_CLIENT_ID` set and `MEDPLUM_CLIENT_SECRET`
 missing, `get_proxy()` correctly returns `None` (refusing to make anonymous
 requests at a record system), but `is_proxy_enabled()` at `r6/routes.py:1980`
@@ -526,7 +566,10 @@ imported in that module. Related but not the same: #463 (closed) covered tenant
 pollution by the same harness.
 
 **R5 — The `hapi` connector silently drops the credentials its own summary tells
-operators to set. No issue yet. Highest severity.**
+operators to set. FIXED by #512; re-run and confirmed 2026-09-04 (#602).**
+`scripts/connector-auth-probe.py` reproduces this exactly against `2b7872d`,
+and at `89b42fb` `hapi` puts the configured credential on the wire. The finding
+as written on 2026-08-16 was:
 Measured on the wire in §6. `CONNECTORS["hapi"]` is `auth=AUTH_NONE`, and
 `UpstreamConfig.basic_auth` returns credentials only when `auth == AUTH_BASIC`,
 so `FHIR_UPSTREAM_CLIENT_ID`/`_SECRET` are accepted, logged as configured, and
@@ -544,7 +587,10 @@ the wire. This is a pin that encodes the defect; per standing order 4 it has not
 been edited.
 
 **R6 — An unknown `FHIR_UPSTREAM_KIND` boots and 500s per request rather than
-refusing to start. No issue yet. Low severity.**
+refusing to start. FIXED by #518; re-run and confirmed 2026-09-04 (#602).**
+`scripts/connector-registry-contract.py --case 2` reproduces this exactly
+against `2b7872d`, and at `89b42fb` the process exits 1 before binding a port,
+carrying the same message. The finding as written on 2026-08-16 was:
 Measured in §5 case 2. The security property holds (it raises; it does not
 default to anonymous). Under compose it still fails closed, because that
 healthcheck raises on non-2xx. Worth knowing that the symptom of a typo is a
@@ -572,6 +618,12 @@ be demonstrated by these two kinds at all.
 **R9 — `healthsamurai/aidboxone:edge` is not pinned.** `pull_policy: always` on a
 moving tag, in the same file whose comment explains why the guardrails image is
 pinned. Digest recorded in §7. `postgres:18` floats at the patch level.
+**2026-09-04 (#602): both tags have moved.** Measured, not predicted — see §7
+and `scripts/image-pin-digests.sh`. One consequence for whoever owns the call:
+the floating-tag exemption in `tests/test_aidbox_example_tells_the_truth.py`
+justifies itself with "verified end to end against `edge` as of 2026-08-16, and
+against nothing else", and `edge` no longer resolves to that image. Nothing was
+edited here.
 
 **R10 — `$conformance` responses are cached.** The payload carries
 `"cached": true` with a `measured_at`, so a re-run after a configuration change
@@ -636,7 +688,25 @@ corrected.
 
 ## Reproducing this
 
-Scratch directory for this pass (scripts and raw run logs):
-`…/scratchpad/set2/` — `walkthrough-hapi.sh`, `registry-contract.sh`,
-`auth_probe.py`, `halfconfig.sh`, `medplum-qa.sh`, and the `*-run.txt` capture
-of each. Not committed; R8 covers what should be.
+**Updated 2026-09-04 (#602).** The scratch directory this section named is
+gone, and nothing was recovered from it. §5, §6 and §7 are now reproducible
+from the repository, by a second person, with the transcripts of that run
+committed:
+
+- `scripts/connector-registry-contract.py` — §5, all three cases (case 3 is
+  register entry R1). Replaces `registry-contract.sh` and `halfconfig.sh`.
+- `scripts/connector-auth-probe.py` — §6. Replaces `auth_probe.py`.
+- `scripts/image-pin-digests.sh` — §7, which named no script at all.
+- transcripts, negative controls and mutation checks:
+  `docs/evidence/2026-09-04-set2-rerun/`
+- what that run found: `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md`
+
+`medplum-qa.sh` is **§2's** script, not one of these, and is still gone. §2
+needs a running Medplum and a client credential; neither exists on this
+machine, so it stays as 2026-08-16 left it. What this section said on
+2026-08-16:
+
+> Scratch directory for this pass (scripts and raw run logs):
+> `…/scratchpad/set2/` — `walkthrough-hapi.sh`, `registry-contract.sh`,
+> `auth_probe.py`, `halfconfig.sh`, `medplum-qa.sh`, and the `*-run.txt` capture
+> of each. Not committed; R8 covers what should be.

--- a/docs/evidence/2026-08-16-set2-connectors.md
+++ b/docs/evidence/2026-08-16-set2-connectors.md
@@ -349,8 +349,8 @@ section 6 — but not end to end against a server that requires it.
 > reproduced.** `registry-contract.sh` and `halfconfig.sh` are still gone;
 > `scripts/connector-registry-contract.py` is one script written from the
 > three transcripts below and committed. Run against `2b7872d` — the tree this
-> pack measured — it prints all three cases as they are written here,
-> including case 3's four lines verbatim. Run against `89b42fb` two of them
+> pack measured — it prints all three cases with the values written here,
+> including case 3's four lines value for value. Run against `89b42fb` two of them
 > differ, both because a defect this section found has since been fixed: case
 > 2 now refuses to boot (#518, register entry R6) and case 3 now reports
 > degraded rather than healthy (#513, register entry R1). Transcripts and the

--- a/docs/evidence/2026-09-04-set2-rerun/auth-probe-at-2b7872d-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/auth-probe-at-2b7872d-run.txt
@@ -1,0 +1,25 @@
+# §6 re-run against the tree the 2026-08-16 pack measured (2b7872d), exported with git archive and booted with THIS checkout's interpreter, so the only variable is source code.
+$ uv run python scripts/connector-auth-probe.py --repo /tmp/hc-qa-602/at-2b7872d
+connector-auth-probe.py
+date      2026-09-04T10:18:53Z
+repo      ../../../../../../../private/tmp/hc-qa-602/at-2b7872d
+recorder  http://127.0.0.1:55713
+request   GET /r6/fhir/health -> proxy GET http://127.0.0.1:55713/metadata
+
+Identical env for both cases:
+  FHIR_UPSTREAM_CLIENT_ID     = set2-probe-client
+  FHIR_UPSTREAM_CLIENT_SECRET = <set>
+Question: what Authorization header reaches the upstream?
+
+  kind=hapi     -> Authorization: None (NO credential sent)
+  kind=generic  -> Authorization: Basic <redacted>
+
+Against 2026-08-16 (§6 of docs/evidence/2026-08-16-set2-connectors.md):
+  kind=hapi     same as 2026-08-16 (no credential sent)
+  kind=generic  same as 2026-08-16 (Basic)
+
+  R5 STILL OPEN: hapi accepts the credentials its summary asks for
+  and does not send them.
+
+at least one assertion failed
+(exit 1)

--- a/docs/evidence/2026-09-04-set2-rerun/auth-probe-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/auth-probe-run.txt
@@ -1,0 +1,24 @@
+# §6 re-run at HEAD (89b42fb), 2026-09-04.
+$ uv run python scripts/connector-auth-probe.py 
+connector-auth-probe.py
+date      2026-09-04T10:18:52Z
+repo      .
+recorder  http://127.0.0.1:55702
+request   GET /r6/fhir/health -> proxy GET http://127.0.0.1:55702/metadata
+
+Identical env for both cases:
+  FHIR_UPSTREAM_CLIENT_ID     = set2-probe-client
+  FHIR_UPSTREAM_CLIENT_SECRET = <set>
+Question: what Authorization header reaches the upstream?
+
+  kind=hapi     -> Authorization: Basic <redacted>
+  kind=generic  -> Authorization: Basic <redacted>
+
+Against 2026-08-16 (§6 of docs/evidence/2026-08-16-set2-connectors.md):
+  kind=hapi     DIFFERS: 2026-08-16 sent no credential, today sends Basic
+  kind=generic  same as 2026-08-16 (Basic)
+
+  R5 CLOSED on the wire: both kinds send the configured credential.
+
+no assertion failed
+(exit 0)

--- a/docs/evidence/2026-09-04-set2-rerun/image-pins-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/image-pins-run.txt
@@ -1,0 +1,29 @@
+image-pin-digests.sh
+compose  examples/aidbox-healthclaw-guardrails/docker-compose.yaml
+date     2026-09-04T10:19:13Z
+accept   application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+baseline docs/evidence/2026-08-16-set2-connectors.md §7 (2026-08-16)
+
+1. Manifest digests for every image the compose file names
+  image                                                digest today
+  postgres:18                                          sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
+  NOTE postgres:18: MOVED since 2026-08-16 (sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941 -> sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280). This is R9: an unpinned tag, and `pull_policy: always` on one of them.
+  healthsamurai/aidboxone:edge                         sha256:90c4e72811765b6c420387d79f6033069fd0b045281e7f491be7b8cf6b3c3952
+  NOTE healthsamurai/aidboxone:edge: MOVED since 2026-08-16 (sha256:42e4e8e10d9d42b54bf3f4602b3f584e06acc70738cdcf280ce7634bdb5e58b3 -> sha256:90c4e72811765b6c420387d79f6033069fd0b045281e7f491be7b8cf6b3c3952). This is R9: an unpinned tag, and `pull_policy: always` on one of them.
+  ghcr.io/aks129/healthclaw-guardrails:1.10.0          sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b
+  PASS ghcr.io/aks129/healthclaw-guardrails:1.10.0: same digest as 2026-08-16. The version tag was not re-pushed.
+  ghcr.io/aks129/healthclaw-mcp-server:1.10.0          sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53
+  PASS ghcr.io/aks129/healthclaw-mcp-server:1.10.0: same digest as 2026-08-16. The version tag was not re-pushed.
+
+2. The two observations §7 recorded next to the table
+  ghcr.io/aks129/healthclaw-guardrails tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-guardrails: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: latest still resolves to the same digest as 1.10.0 (sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b).
+  ghcr.io/aks129/healthclaw-mcp-server tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: latest still resolves to the same digest as 1.10.0 (sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53).
+
+Result
+  no assertion failed

--- a/docs/evidence/2026-09-04-set2-rerun/mutation-auth-probe.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/mutation-auth-probe.txt
@@ -1,0 +1,70 @@
+# Mutation checks for scripts/connector-auth-probe.py
+# Run 2026-09-04 at HEAD (89b42fb). Each mutant must FAIL.
+
+# M1: the recorder is replaced with a dead port, so the proxy's request never arrives. 'Authorization: None' and 'no request happened' print the same way; only one of them is a measurement.
+#   guard under test: the recorder saw no /metadata request
+# The mutant is this script with one line changed. To reproduce:
+#   sed -e 's|upstream = f"http://127.0.0.1:{server.server_port}"|upstream = "http://127.0.0.1:1"  # MUTANT|' \
+#       scripts/connector-auth-probe.py > /tmp/mutant.py
+# The line it changes:
+#   -    upstream = f"http://127.0.0.1:{server.server_port}"
+#   +    upstream = "http://127.0.0.1:1"  # MUTANT
+$ uv run python /tmp/mutant.py --repo .
+connector-auth-probe.py
+date      2026-09-04T10:19:07Z
+repo      .
+recorder  http://127.0.0.1:1
+request   GET /r6/fhir/health -> proxy GET http://127.0.0.1:1/metadata
+
+Identical env for both cases:
+  FHIR_UPSTREAM_CLIENT_ID     = set2-probe-client
+  FHIR_UPSTREAM_CLIENT_SECRET = <set>
+Question: what Authorization header reaches the upstream?
+
+  kind=hapi     -> FAIL the recorder saw no /metadata request. Nothing was measured for this kind. (health mode='upstream', upstream={'error': '[Errno 61] Connection refused', 'status': 'unreachable', 'upstream_url': 'http://127.0.0.1:1'})
+  kind=generic  -> FAIL the recorder saw no /metadata request. Nothing was measured for this kind. (health mode='upstream', upstream={'error': '[Errno 61] Connection refused', 'status': 'unreachable', 'upstream_url': 'http://127.0.0.1:1'})
+
+Against 2026-08-16 (§6 of docs/evidence/2026-08-16-set2-connectors.md):
+  kind=hapi     NOT MEASURED this run — no comparison is possible
+  kind=generic  NOT MEASURED this run — no comparison is possible
+
+  NO VERDICT ON R5. Not every kind produced a header this run,
+  so nothing here says whether hapi sends its credential.
+
+at least one assertion failed
+(exit 1)
+
+# M2: the app is given a different client id from the one asserted on.
+#   guard under test: the Basic header must carry the configured client id
+# The mutant is this script with one line changed. To reproduce:
+#   sed -e 's|env\["FHIR_UPSTREAM_CLIENT_ID"\] = CLIENT_ID|env["FHIR_UPSTREAM_CLIENT_ID"] = "someone-else"  # MUTANT|' \
+#       scripts/connector-auth-probe.py > /tmp/mutant.py
+# The line it changes:
+#   -        env["FHIR_UPSTREAM_CLIENT_ID"] = CLIENT_ID
+#   +        env["FHIR_UPSTREAM_CLIENT_ID"] = "someone-else"  # MUTANT
+$ uv run python /tmp/mutant.py --repo .
+connector-auth-probe.py
+date      2026-09-04T10:19:08Z
+repo      .
+recorder  http://127.0.0.1:55765
+request   GET /r6/fhir/health -> proxy GET http://127.0.0.1:55765/metadata
+
+Identical env for both cases:
+  FHIR_UPSTREAM_CLIENT_ID     = set2-probe-client
+  FHIR_UPSTREAM_CLIENT_SECRET = <set>
+Question: what Authorization header reaches the upstream?
+
+  kind=hapi     -> Authorization: Basic <redacted>
+           FAIL the Basic header carries 'someone-else', not the configured 'set2-probe-client'
+  kind=generic  -> Authorization: Basic <redacted>
+           FAIL the Basic header carries 'someone-else', not the configured 'set2-probe-client'
+
+Against 2026-08-16 (§6 of docs/evidence/2026-08-16-set2-connectors.md):
+  kind=hapi     DIFFERS: 2026-08-16 sent no credential, today sends Basic
+  kind=generic  same as 2026-08-16 (Basic)
+
+  NO VERDICT ON R5. Not every kind produced a header this run,
+  so nothing here says whether hapi sends its credential.
+
+at least one assertion failed
+(exit 1)

--- a/docs/evidence/2026-09-04-set2-rerun/mutation-registry-contract.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/mutation-registry-contract.txt
@@ -1,0 +1,119 @@
+# Mutation and negative controls for scripts/connector-registry-contract.py
+# Run 2026-09-04 at HEAD (89b42fb). None of these may report a pass.
+
+# M1: FHIR_UPSTREAM_URL is dropped, so MEDPLUM_BASE_URL wins — precedence reversed.
+#   guard under test: the resolved upstream must be the FHIR_UPSTREAM_URL one, reachable and named by the upstream
+# The mutant is this script with the line(s) below changed. To reproduce:
+#   sed -e 's|            "FHIR_UPSTREAM_URL": CASE1_UPSTREAM,|            # MUTANT: removed|' \
+#       scripts/connector-registry-contract.py > /tmp/mutant.py
+#   -            "FHIR_UPSTREAM_URL": CASE1_UPSTREAM,
+#   +            # MUTANT: removed
+$ uv run python /tmp/mutant.py --repo . --case 1
+connector-registry-contract.py
+date  2026-09-04T10:19:03Z
+repo  .
+cases [1]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  FHIR_UPSTREAM_URL = https://server.fire.ly/R4
+  MEDPLUM_BASE_URL  = https://hapi.fhir.org/baseR4   (must be IGNORED)
+  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used
+
+  resolved -> mode='upstream' upstream={'error': "Client error '404 Not Found' for url 'https://hapi.fhir.org/oauth2/token'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404", 'status': 'unreachable', 'upstream_url': 'https://hapi.fhir.org/baseR4'}
+  FAIL the proxy could not reach the upstream (status 'unreachable'). The 'software' field below would not be the upstream naming itself.
+
+Result
+  at least one assertion failed
+(exit 1)
+
+# M2: case 2 is given a kind that IS in the registry, so nothing is refused.
+#   guard under test: an app that answers 2xx with the case's kind set has resolved it, and must not read as a refusal
+# The mutant is this script with the line(s) below changed. To reproduce:
+#   sed -e 's|^CASE2_KIND = "totally-made-up"|CASE2_KIND = "generic"  # MUTANT|' \
+#       scripts/connector-registry-contract.py > /tmp/mutant.py
+#   -CASE2_KIND = "totally-made-up"
+#   +CASE2_KIND = "generic"  # MUTANT
+$ uv run python /tmp/mutant.py --repo . --case 2
+connector-registry-contract.py
+date  2026-09-04T10:19:04Z
+repo  .
+cases [2]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 2 — an unknown kind is refused rather than guessed at
+  FHIR_UPSTREAM_KIND = generic
+  /r6/fhir/health -> HTTP 200
+  FAIL /r6/fhir/health answered HTTP 200 with an unknown kind set. body='{"checks": {"database": "ok", "upstream": {"fhir_version": "4.0.1", "kind": "generic", "software": "Firely Server", "status": "connected", "upstream_url": "https://server.fire.ly/R4"}}, "fhirVersion":'. An unknown kind must not resolve.
+
+Result
+  at least one assertion failed
+(exit 1)
+
+# M3: no case ever gets an answer out of the app.
+#   guard under test: the script must not exit 0 having measured nothing
+# The mutant is this script with the line(s) below changed. To reproduce:
+#   sed -e 's|^    deadline = time.time() + timeout|    return None, None  # MUTANT\n    deadline = time.time() + timeout|' \
+#       scripts/connector-registry-contract.py > /tmp/mutant.py
+#   +    return None, None  # MUTANT
+$ uv run python /tmp/mutant.py --repo .
+connector-registry-contract.py
+date  2026-09-04T10:19:06Z
+repo  .
+cases [1, 2, 3]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  FHIR_UPSTREAM_URL = https://server.fire.ly/R4
+  MEDPLUM_BASE_URL  = https://hapi.fhir.org/baseR4   (must be IGNORED)
+  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used
+  FAIL the app never answered /r6/fhir/health — case 1 measured nothing
+
+Case 2 — an unknown kind is refused rather than guessed at
+  FHIR_UPSTREAM_KIND = totally-made-up
+  FAIL the app exited -15 without the registry's message. Something else stopped it; this case proves nothing.
+
+Case 3 — MEDPLUM_BASE_URL with no credentials  (register entry R1)
+  MEDPLUM_BASE_URL  = https://medplum.example.invalid/fhir
+  MEDPLUM_CLIENT_ID = set
+  MEDPLUM_CLIENT_SECRET = MISSING
+  FAIL the app never answered /r6/fhir/health — case 3 measured nothing
+
+Result
+  case(s) [1, 3] never produced a measurement
+  at least one assertion failed
+(exit 1)
+
+# M4: no upstream configured at all, so the app is genuinely in local mode. M1 does not reach this guard, because dropping only FHIR_UPSTREAM_URL leaves MEDPLUM_BASE_URL to build a proxy that is merely unreachable.
+#   guard under test: checks.upstream must be a proxy health payload, not the string 'not_configured'
+# The mutant is this script with the line(s) below changed. To reproduce:
+#   sed -e 's|            "FHIR_UPSTREAM_URL": CASE1_UPSTREAM,|            # MUTANT: removed|' \
+#   sed -e 's|            "MEDPLUM_BASE_URL": CASE1_MEDPLUM_DECOY,|            # MUTANT: removed|' \
+#       scripts/connector-registry-contract.py > /tmp/mutant.py
+#   -            "FHIR_UPSTREAM_URL": CASE1_UPSTREAM,
+#   -            "MEDPLUM_BASE_URL": CASE1_MEDPLUM_DECOY,
+#   +            # MUTANT: removed
+#   +            # MUTANT: removed
+$ uv run python /tmp/mutant.py --repo . --case 1
+connector-registry-contract.py
+date  2026-09-04T10:19:06Z
+repo  .
+cases [1]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  FHIR_UPSTREAM_URL = https://server.fire.ly/R4
+  MEDPLUM_BASE_URL  = https://hapi.fhir.org/baseR4   (must be IGNORED)
+  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used
+
+  resolved -> mode='local' upstream='not_configured'
+  FAIL checks.upstream is 'not_configured', not a proxy health payload. No upstream was resolved, so precedence was not exercised.
+
+Result
+  at least one assertion failed
+(exit 1)
+
+# NC: a checkout with no app in it. Must refuse, not report a result.
+$ uv run python scripts/connector-registry-contract.py --repo /nonexistent
+no main.py under ../../../../../../../nonexistent — nothing to boot
+(exit 2)

--- a/docs/evidence/2026-09-04-set2-rerun/mutation-tests.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/mutation-tests.txt
@@ -50,3 +50,14 @@ $ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_the_transcripts_
 
 $ pytest tests/test_set2_sections_5_to_7_evidence.py -q     (after restoring every file)
   35 passed in 0.20s
+
+# one hex digit of a digest quoted in the write-up drifts from the transcript
+#   file: docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
+#   Added after an abbreviated digest in the write-up's §7 was off by one
+#   character. The abbreviation is gone; this is the guard that replaces it.
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_every_digest_the_write_up_prints_was_actually_measured
+  1 failed, 35 deselected in 0.04s
+  -> RED (correct)
+
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q     (after restoring the write-up)
+  36 passed in 0.22s

--- a/docs/evidence/2026-09-04-set2-rerun/mutation-tests.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/mutation-tests.txt
@@ -1,0 +1,52 @@
+# Mutation checks for tests/test_set2_sections_5_to_7_evidence.py
+# Run 2026-09-04 at HEAD (89b42fb).
+# Each mutation must turn its named test RED. A test that stays green
+# is not testing what it says it tests.
+
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q     (unmutated)
+  35 passed in 0.21s
+
+# a home-directory path appears in a committed transcript
+#   file: docs/evidence/2026-09-04-set2-rerun/auth-probe-run.txt
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_the_committed_transcripts_carry_no_home_path
+  1 failed, 9 passed, 25 deselected in 0.03s
+  -> RED (correct)
+
+# a script prints the absolute checkout path again
+#   file: scripts/connector-auth-probe.py
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_a_script_never_prints_an_absolute_checkout_path
+  1 failed, 1 passed, 33 deselected in 0.11s
+  -> RED (correct)
+
+# one hex digit of an image baseline drifts from the pack
+#   file: scripts/image-pin-digests.sh
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_every_image_digest_the_script_compares_against_is_in_the_pack
+  1 failed, 34 deselected in 0.03s
+  -> RED (correct)
+
+# the auth probe's baseline is flipped to say hapi sent Basic in August
+#   file: scripts/connector-auth-probe.py
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_the_auth_probe_compares_against_what_section_6_recorded
+  1 failed, 34 deselected in 0.03s
+  -> RED (correct)
+
+# the write-up's is_proxy_enabled citation drifts
+#   file: docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_the_correction_to_the_packs_stale_citation_is_itself_correct
+  1 failed, 34 deselected in 0.03s
+  -> RED (correct)
+
+# the image-pin script reports success on a compose naming no images
+#   file: scripts/image-pin-digests.sh
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_a_compose_file_with_no_images_is_refused
+  1 failed, 34 deselected in 0.04s
+  -> RED (correct)
+
+# a transcript the write-up rests on is deleted
+#   file: docs/evidence/2026-09-04-set2-rerun/registry-contract-at-2b7872d-run.txt
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q -k test_the_transcripts_are_committed
+  1 failed, 9 passed, 25 deselected in 0.03s
+  -> RED (correct)
+
+$ pytest tests/test_set2_sections_5_to_7_evidence.py -q     (after restoring every file)
+  35 passed in 0.20s

--- a/docs/evidence/2026-09-04-set2-rerun/negative-control-auth-probe.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/negative-control-auth-probe.txt
@@ -1,0 +1,32 @@
+# Negative controls for scripts/connector-auth-probe.py
+# Run 2026-09-04 at HEAD (89b42fb).
+
+# 1. No credential configured. Neither kind may send a header — a Basic
+#    here would mean the script reads a credential from somewhere other
+#    than the environment it sets.
+$ uv run python scripts/connector-auth-probe.py --no-credential
+connector-auth-probe.py
+date      2026-09-04T10:18:55Z
+repo      .
+recorder  http://127.0.0.1:55724
+request   GET /r6/fhir/health -> proxy GET http://127.0.0.1:55724/metadata
+
+Identical env for both cases:
+  FHIR_UPSTREAM_CLIENT_ID     = <unset>   (negative control)
+  FHIR_UPSTREAM_CLIENT_SECRET = <unset>   (negative control)
+Question: what Authorization header reaches the upstream?
+
+  kind=hapi     -> Authorization: None (NO credential sent)
+  kind=generic  -> Authorization: None (NO credential sent)
+
+Negative control. With no credentials set, both kinds must send
+nothing: AUTH_BASIC degrades to anonymous rather than inventing a
+header. A 'Basic' here would mean this script reads a credential
+from somewhere other than the environment it sets.
+  PASS neither kind sent an Authorization header
+(exit 0)
+
+# 2. A checkout that cannot be booted. Must refuse, not report a result.
+$ uv run python scripts/connector-auth-probe.py --repo /nonexistent
+no main.py under ../../../../../../../nonexistent — nothing to boot
+(exit 2)

--- a/docs/evidence/2026-09-04-set2-rerun/negative-control-image-pins.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/negative-control-image-pins.txt
@@ -1,0 +1,84 @@
+# Negative controls for scripts/image-pin-digests.sh
+# None of these may report a pass. Run 2026-09-04.
+
+$ scripts/image-pin-digests.sh /tmp/hc-qa-602/compose-missing-tag.yaml
+image-pin-digests.sh
+compose  /tmp/hc-qa-602/compose-missing-tag.yaml
+date     2026-09-04T10:19:10Z
+accept   application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+baseline docs/evidence/2026-08-16-set2-connectors.md §7 (2026-08-16)
+
+1. Manifest digests for every image the compose file names
+  image                                                digest today
+  ghcr.io/aks129/healthclaw-guardrails:9.9.9-not-a-real-tag (no digest)
+  FAIL ghcr.io/aks129/healthclaw-guardrails:9.9.9-not-a-real-tag: the registry returned no Docker-Content-Digest. This run measured nothing for this row.
+  FAIL ghcr.io/aks129/healthclaw-guardrails:1.10.0 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-missing-tag.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL ghcr.io/aks129/healthclaw-mcp-server:1.10.0 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-missing-tag.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL healthsamurai/aidboxone:edge is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-missing-tag.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL postgres:18 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-missing-tag.yaml no longer names it, so §7's question went unanswered for that row.
+
+2. The two observations §7 recorded next to the table
+  ghcr.io/aks129/healthclaw-guardrails tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-guardrails: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: latest still resolves to the same digest as 1.10.0 (sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b).
+  ghcr.io/aks129/healthclaw-mcp-server tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: latest still resolves to the same digest as 1.10.0 (sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53).
+
+Result
+  at least one assertion failed
+(exit 1)
+
+$ scripts/image-pin-digests.sh /tmp/hc-qa-602/compose-no-images.yaml
+image-pin-digests.sh
+compose  /tmp/hc-qa-602/compose-no-images.yaml
+date     2026-09-04T10:19:11Z
+accept   application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+baseline docs/evidence/2026-08-16-set2-connectors.md §7 (2026-08-16)
+
+1. Manifest digests for every image the compose file names
+
+no image: lines in /tmp/hc-qa-602/compose-no-images.yaml — nothing was measured
+(exit 2)
+
+$ scripts/image-pin-digests.sh /nonexistent/compose.yaml
+
+no compose file at /nonexistent/compose.yaml (run from the repo root)
+(exit 2)
+
+# Mutation: the baseline comparison itself. A version-tag row is fed a
+# digest that is NOT its baseline, by pointing the compose at 1.9.0 while
+# the script still matches the ref string for 1.10.0 -> row falls to the
+# 'not in the 2026-08-16 table' branch, which must NOT read as a pass.
+
+$ scripts/image-pin-digests.sh /tmp/hc-qa-602/compose-wrong-digest.yaml
+image-pin-digests.sh
+compose  /tmp/hc-qa-602/compose-wrong-digest.yaml
+date     2026-09-04T10:19:11Z
+accept   application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+baseline docs/evidence/2026-08-16-set2-connectors.md §7 (2026-08-16)
+
+1. Manifest digests for every image the compose file names
+  image                                                digest today
+  ghcr.io/aks129/healthclaw-guardrails:1.9.0           sha256:815d8568daf3dde7e25ffa0e0b4ea8c437f080836ea2ef3d241bb34b9d9c1a12
+  NOTE ghcr.io/aks129/healthclaw-guardrails:1.9.0: not in the 2026-08-16 table, so there is nothing to compare it to.
+  FAIL ghcr.io/aks129/healthclaw-guardrails:1.10.0 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-wrong-digest.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL ghcr.io/aks129/healthclaw-mcp-server:1.10.0 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-wrong-digest.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL healthsamurai/aidboxone:edge is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-wrong-digest.yaml no longer names it, so §7's question went unanswered for that row.
+  FAIL postgres:18 is in §7's table but was not compared this run — /tmp/hc-qa-602/compose-wrong-digest.yaml no longer names it, so §7's question went unanswered for that row.
+
+2. The two observations §7 recorded next to the table
+  ghcr.io/aks129/healthclaw-guardrails tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-guardrails: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-guardrails: latest still resolves to the same digest as 1.10.0 (sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b).
+  ghcr.io/aks129/healthclaw-mcp-server tags: latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: tag list identical to 2026-08-16.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: still no 1.10 alias, unlike every prior minor.
+  NOTE ghcr.io/aks129/healthclaw-mcp-server: latest still resolves to the same digest as 1.10.0 (sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53).
+
+Result
+  at least one assertion failed
+(exit 1)

--- a/docs/evidence/2026-09-04-set2-rerun/registry-contract-at-2b7872d-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/registry-contract-at-2b7872d-run.txt
@@ -1,0 +1,42 @@
+# §5 re-run against the tree the 2026-08-16 pack measured (2b7872d),
+# exported with git archive and booted with THIS checkout's interpreter,
+# so the only variable between the two runs is source code.
+$ uv run python scripts/connector-registry-contract.py --repo /tmp/hc-qa-602/at-2b7872d
+connector-registry-contract.py
+date  2026-09-04T10:18:48Z
+repo  ../../../../../../../private/tmp/hc-qa-602/at-2b7872d
+cases [1, 2, 3]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  FHIR_UPSTREAM_URL = https://server.fire.ly/R4
+  MEDPLUM_BASE_URL  = https://hapi.fhir.org/baseR4   (must be IGNORED)
+  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used
+
+  resolved -> mode='upstream' upstream={'fhir_version': '4.0.1', 'kind': 'generic', 'software': 'Firely Server', 'status': 'connected', 'upstream_url': 'https://server.fire.ly/R4'}
+  PASS FHIR_UPSTREAM_URL won; MEDPLUM_BASE_URL was not used
+  PASS kind is 'generic' — the MEDPLUM_* names did not imply the kind
+  PASS the upstream names itself 'Firely Server' in its CapabilityStatement
+
+Case 2 — an unknown kind is refused rather than guessed at
+  FHIR_UPSTREAM_KIND = totally-made-up
+  /r6/fhir/health -> HTTP 500
+  ValueError: FHIR_UPSTREAM_KIND='totally-made-up' is not one of ['aidbox', 'generic', 'hapi', 'medplum']. Refusing to guess: an unknown kind means an unknown aut
+  PASS the app boots and raises per request, as §5 recorded (R6); in the app's log
+
+Case 3 — MEDPLUM_BASE_URL with no credentials  (register entry R1)
+  MEDPLUM_BASE_URL  = https://medplum.example.invalid/fhir
+  MEDPLUM_CLIENT_ID = set
+  MEDPLUM_CLIENT_SECRET = MISSING
+
+  GET /r6/fhir/health -> HTTP 200
+  status = 'healthy' | mode = 'upstream' | checks.upstream = 'not_configured'
+  POST /r6/fhir/Patient -> HTTP 201, id 66f4fe4b-82e8-4e14-b000-9215f0226870
+  GET  /r6/fhir/Patient/66f4fe4b-82e8-4e14-b000-9215f0226870 -> HTTP 200, _source = None
+    r6_resources Patient rows = 1
+  NOTE the write landed in the proxy's own SQLite, not in a Medplum — unchanged from 2026-08-16, and the correct fallback.
+  FAIL R1 STILL OPEN: /r6/fhir/health reports mode 'upstream' and status 'healthy' while the write landed locally. A container healthcheck and any orchestrator probe both report this deployment fine.
+
+Result
+  at least one assertion failed
+(exit 1)

--- a/docs/evidence/2026-09-04-set2-rerun/registry-contract-run.txt
+++ b/docs/evidence/2026-09-04-set2-rerun/registry-contract-run.txt
@@ -1,0 +1,41 @@
+# §5 (cases 1-3, case 3 = register entry R1) re-run at HEAD (89b42fb), 2026-09-04.
+$ uv run python scripts/connector-registry-contract.py
+connector-registry-contract.py
+date  2026-09-04T10:18:44Z
+repo  .
+cases [1, 2, 3]
+baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1
+
+Case 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  FHIR_UPSTREAM_URL = https://server.fire.ly/R4
+  MEDPLUM_BASE_URL  = https://hapi.fhir.org/baseR4   (must be IGNORED)
+  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used
+
+  resolved -> mode='upstream' upstream={'fhir_version': '4.0.1', 'kind': 'generic', 'software': 'Firely Server', 'status': 'connected', 'upstream_url': 'https://server.fire.ly/R4'}
+  PASS FHIR_UPSTREAM_URL won; MEDPLUM_BASE_URL was not used
+  PASS kind is 'generic' — the MEDPLUM_* names did not imply the kind
+  PASS the upstream names itself 'Firely Server' in its CapabilityStatement
+
+Case 2 — an unknown kind is refused rather than guessed at
+  FHIR_UPSTREAM_KIND = totally-made-up
+  process exited 1 before binding a port
+  ValueError: FHIR_UPSTREAM_KIND='totally-made-up' is not one of ['aidbox', 'generic', 'hapi', 'medplum']. Refusing to guess: an unknown kind means an unknown aut
+  PASS the app REFUSES TO START on an unknown kind, naming the kind
+  NOTE §5 recorded the app BOOTING and answering 500 per request (register entry R6). This run differs.
+
+Case 3 — MEDPLUM_BASE_URL with no credentials  (register entry R1)
+  MEDPLUM_BASE_URL  = https://medplum.example.invalid/fhir
+  MEDPLUM_CLIENT_ID = set
+  MEDPLUM_CLIENT_SECRET = MISSING
+
+  GET /r6/fhir/health -> HTTP 503
+  status = 'degraded' | mode = 'local' | checks.upstream = 'misconfigured'
+  POST /r6/fhir/Patient -> HTTP 201, id c38f2ba7-c1da-4992-bb33-44f1eefaec9f
+  GET  /r6/fhir/Patient/c38f2ba7-c1da-4992-bb33-44f1eefaec9f -> HTTP 200, _source = None
+    r6_resources Patient rows = 1
+  NOTE the write landed in the proxy's own SQLite, not in a Medplum — unchanged from 2026-08-16, and the correct fallback.
+  PASS R1 CLOSED: health reports HTTP 503, status 'degraded', mode 'local', checks.upstream 'misconfigured' — a named upstream that could not be built is visible to a probe.
+
+Result
+  no assertion failed
+(exit 0)

--- a/docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
+++ b/docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
@@ -12,9 +12,11 @@ committed; one section turned out never to have had a script at all.
 
 **Every measurement §5 and §6 recorded reproduces exactly**, against the tree
 the pack measured. Run against `2b7872d`, the new scripts print §5's three
-cases and §6's two rows as the pack prints them — including R1's four lines
-verbatim, down to `checks.upstream = 'not_configured'` and
-`r6_resources Patient rows = 1`.
+cases and §6's two rows with the same values the pack records — including R1's
+four lines value for value, down to `checks.upstream` reading `not_configured`
+and `r6_resources Patient rows = 1`. Not character for character: this script
+also prints the HTTP status of the write and the read, which the pack's
+transcript does not show.
 
 At `89b42fb` three of those measurements differ. The same script against both
 trees is what says each difference is a fix rather than drift:
@@ -147,18 +149,35 @@ hard-coding them, so a change to the compose file changes what is measured; the
 baseline digests are hard-coded, because they are a record of one day and must
 not follow anything.
 
-| image | pinned? | §7 digest, 2026-08-16 | today | |
-|---|---|---|---|---|
-| `ghcr.io/aks129/healthclaw-guardrails:1.10.0` | version tag | `sha256:57b345e0…c4c0e225b` | identical | **not re-pushed** |
-| `ghcr.io/aks129/healthclaw-mcp-server:1.10.0` | version tag | `sha256:d37c997e…d8d012cd53` | identical | **not re-pushed** |
-| `healthsamurai/aidboxone:edge` | **no** — moving tag, `pull_policy: always` | `sha256:42e4e8e1…4bdb5e58b3` | `sha256:90c4e728…cf6b3c3952` | **moved** |
-| `postgres:18` | partial — floating patch | `sha256:06cad38a…576dedcd941` | `sha256:4ef4dbc9…3ea3c2280` | **moved** |
+Digests are written out in full. An abbreviated one is a place for a
+transcription error to hide, in a document whose subject is measurements being
+restated wrongly.
 
-The full digests are in the transcript. A manifest digest depends on the
-`Accept` header the request sends — a multi-arch index and a single-platform
-manifest have different digests — so the script prints the header it used, and
-the two identical rows confirm the header matches what 2026-08-16 must have
-sent.
+`ghcr.io/aks129/healthclaw-guardrails:1.10.0` — a version tag. **Not
+re-pushed:** identical to 2026-08-16.
+
+    sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b
+
+`ghcr.io/aks129/healthclaw-mcp-server:1.10.0` — a version tag. **Not
+re-pushed:** identical to 2026-08-16.
+
+    sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53
+
+`healthsamurai/aidboxone:edge` — not pinned; a moving tag with
+`pull_policy: always`. **Moved.**
+
+    2026-08-16  sha256:42e4e8e10d9d42b54bf3f4602b3f584e06acc70738cdcf280ce7634bdb5e58b3
+    today       sha256:90c4e72811765b6c420387d79f6033069fd0b045281e7f491be7b8cf6b3c3952
+
+`postgres:18` — floating at the patch level. **Moved.**
+
+    2026-08-16  sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+    today       sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
+
+A manifest digest depends on the `Accept` header the request sends — a
+multi-arch index and a single-platform manifest have different digests — so the
+script prints the header it used, and the two identical rows confirm the header
+matches what 2026-08-16 must have sent.
 
 **R9 is no longer a prediction.** The compose file's comment explains why the
 guardrails image is pinned, in the same file that runs Aidbox off a moving tag

--- a/docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
+++ b/docs/evidence/2026-09-04-set2-sections-5-7-rerun.md
@@ -1,0 +1,222 @@
+# Set-2 pack §5, §6 and §7 — re-run by someone other than their author
+
+**Date:** 2026-09-04 · **Repo at:** `89b42fb` · **Issue:** #602, item 1 ·
+**Continues:** #530 and the §3/§4 re-run in #601
+
+Sections 5, 6 and 7 of `docs/evidence/2026-08-16-set2-connectors.md` rested on
+scripts that lived only in an uncommitted scratch directory. The directory is
+gone. Three scripts have been rewritten from the pack's own transcripts and
+committed; one section turned out never to have had a script at all.
+
+## The finding
+
+**Every measurement §5 and §6 recorded reproduces exactly**, against the tree
+the pack measured. Run against `2b7872d`, the new scripts print §5's three
+cases and §6's two rows as the pack prints them — including R1's four lines
+verbatim, down to `checks.upstream = 'not_configured'` and
+`r6_resources Patient rows = 1`.
+
+At `89b42fb` three of those measurements differ. The same script against both
+trees is what says each difference is a fix rather than drift:
+
+| what changed | fixed by |
+|---|---|
+| `hapi` sends the credential it used to drop (R5) | #512 |
+| a half-configured upstream reports degraded, not healthy (R1) | #513 |
+| an unknown kind refuses to boot instead of 500-ing per request (R6) | #518 |
+
+**§7 is the different one.** It named no script — it says only "resolved today
+via the registry HTTP API" — so there was no transcript to turn back into one,
+and one was written from the section's own table instead. It answers the
+question §7 said could not be answered. §7 recorded its four digests as "the
+baseline for the next run"; this is that run, and both version-pinned images
+resolve to the same digest they did on 2026-08-16 while **both unpinned tags
+have moved**.
+
+## What each section needed, and whether it was reachable
+
+Determined before anything was run, because a section that cannot be reached
+here is worth more marked than approximated.
+
+| Section | Missing script | What a re-run needs | Reachable here |
+|---|---|---|---|
+| §5 cases 1–2 | `registry-contract.sh` | the app booted locally; one read from `server.fire.ly` | yes |
+| §5 case 3 (R1) | `halfconfig.sh` | the app booted locally, nothing else | yes |
+| §6 | `auth_probe.py` | the app booted locally, against a loopback recorder | yes |
+| §7 | **none named** | anonymous manifest reads from `ghcr.io` and Docker Hub | yes |
+| §2 `medplum` | `medplum-qa.sh` | a running Medplum and client credentials | **no — not attempted** |
+
+**The four-script framing in #602 and #601 is off by two.** Both say sections
+5, 6 and 7 rest on four uncommitted scripts. In fact: `registry-contract.sh`
+and `halfconfig.sh` are §5 (case 3 being the one the pack files as register
+entry R1), `auth_probe.py` is §6, §7 had no script, and `medplum-qa.sh` is
+**§2**, not §5–7. §2 is out of scope here and stays unverified: it needs a
+running Medplum and a client credential, and this machine has neither.
+
+## Method
+
+Each script was written from the pack's transcript, not recovered — which is
+itself the test of whether the transcript describes something reproducible.
+
+Then each was run twice:
+
+- against `89b42fb`, the current tree;
+- against `2b7872d`, the tree the pack says its live runs used, exported with
+  `git archive` and booted with **this** checkout's interpreter.
+
+`git diff --stat 2b7872d 89b42fb -- uv.lock pyproject.toml` is empty, so the
+dependency set is identical across the two and the only variable between the
+runs is source code. That is measured, not assumed.
+
+Every guard in the three scripts was checked by mutation: one line changed in
+a copy, and the guard that is supposed to catch it observed going red. The
+mutants are reproducible — each transcript carries the `sed` that made it and
+a diff of the line it changed.
+
+## §5 — the registry contract, asserted against a booted app
+
+`scripts/connector-registry-contract.py`. Transcripts:
+`docs/evidence/2026-09-04-set2-rerun/registry-contract-run.txt` and
+`…-at-2b7872d-run.txt`.
+
+One script where the pack had two. `registry-contract.sh` and `halfconfig.sh`
+boot the same app and ask the same endpoint; two near-copies of one boot
+sequence is how the Aidbox walkthrough's status codes drifted from its own
+README (#499).
+
+| Case | §5 as written, 2026-08-16 | at `2b7872d` today | at `89b42fb` today |
+|---|---|---|---|
+| 1 — `FHIR_UPSTREAM_URL` beats `MEDPLUM_BASE_URL` | resolved to `server.fire.ly/R4`, kind `generic`, software `Firely Server` | **same** | **same** |
+| 2 — unknown kind | app boots; `/r6/fhir/health` → 500; `ValueError: … is not one of …` | **same** (message in the app's log) | **differs** — the process exits 1 before binding a port, with the same message |
+| 3 — half-configured, health (R1) | HTTP 200, `status healthy`, `mode upstream`, `checks.upstream not_configured` | **same** | **differs** — HTTP 503, `status degraded`, `mode local`, `checks.upstream misconfigured` |
+| 3 — half-configured, write (R1) | create returns an id, `_source` is `None`, 1 local `Patient` row | **same** | **same** |
+
+Case 1 asserts on `software`, which is the Firely server naming itself in its
+own CapabilityStatement — the upstream confirming which server was reached
+rather than our configuration restating itself. It reported `Firely Server`
+and `fhir_version 4.0.1` on both trees today.
+
+Case 2's assertion is the registry's own message, not "the app did not start".
+A port collision also stops the app starting, and would otherwise read as this
+guard holding.
+
+**R1's second half is unchanged and correct.** #513 fixed the *reporting*: a
+named upstream that could not be built is now visible to a container
+healthcheck and to any orchestrator probe. Writes still land in the proxy's own
+SQLite, which is the right fallback — the defect was never where the data went,
+it was that the health page said everything was fine.
+
+The pack cites `is_proxy_enabled()` at `r6/routes.py:1980`. It now lives at
+`r6/fhir_proxy.py:775`, split against `upstream_intended()`.
+
+## §6 — what the proxy actually sends, per kind
+
+`scripts/connector-auth-probe.py`. Transcripts:
+`docs/evidence/2026-09-04-set2-rerun/auth-probe-run.txt` and
+`…-at-2b7872d-run.txt`.
+
+Identical credentials in both cases; only the kind changes. That is the
+comparison §6 makes, and this run keeps to it.
+
+| kind | §6 as written, 2026-08-16 | at `2b7872d` today | at `89b42fb` today |
+|---|---|---|---|
+| `hapi` | `Authorization: None` (no credential sent) | **same** | **differs** — `Basic` |
+| `generic` | `Authorization: Basic` | **same** | **same** |
+
+So R5 — the highest-severity finding of that pass — is real, was real on the
+tree the pack measured, and is closed on the wire at HEAD by #512.
+
+**One reconstruction decision.** §6's transcript does not say which request the
+proxy was made to send. This script sends the health check, because
+`/r6/fhir/health` reaches the upstream through `FHIRUpstreamProxy.healthy()` on
+the same client that carries `basic_auth`, needs no step-up token, and creates
+nothing. A different choice of request would exercise the same `basic_auth`
+property; recording the choice rather than leaving it implicit is the point.
+
+The recorder decodes the Basic header and asserts it carries the configured
+client id. Without that, any `Basic` at all would satisfy the `hapi` row.
+
+## §7 — image pins
+
+`scripts/image-pin-digests.sh`. Transcript:
+`docs/evidence/2026-09-04-set2-rerun/image-pins-run.txt`.
+
+The script reads the image refs out of
+`examples/aidbox-healthclaw-guardrails/docker-compose.yaml` rather than
+hard-coding them, so a change to the compose file changes what is measured; the
+baseline digests are hard-coded, because they are a record of one day and must
+not follow anything.
+
+| image | pinned? | §7 digest, 2026-08-16 | today | |
+|---|---|---|---|---|
+| `ghcr.io/aks129/healthclaw-guardrails:1.10.0` | version tag | `sha256:57b345e0…c4c0e225b` | identical | **not re-pushed** |
+| `ghcr.io/aks129/healthclaw-mcp-server:1.10.0` | version tag | `sha256:d37c997e…d8d012cd53` | identical | **not re-pushed** |
+| `healthsamurai/aidboxone:edge` | **no** — moving tag, `pull_policy: always` | `sha256:42e4e8e1…4bdb5e58b3` | `sha256:90c4e728…cf6b3c3952` | **moved** |
+| `postgres:18` | partial — floating patch | `sha256:06cad38a…576dedcd941` | `sha256:4ef4dbc9…3ea3c2280` | **moved** |
+
+The full digests are in the transcript. A manifest digest depends on the
+`Accept` header the request sends — a multi-arch index and a single-platform
+manifest have different digests — so the script prints the header it used, and
+the two identical rows confirm the header matches what 2026-08-16 must have
+sent.
+
+**R9 is no longer a prediction.** The compose file's comment explains why the
+guardrails image is pinned, in the same file that runs Aidbox off a moving tag
+with `pull_policy: always`. Nineteen days later that tag points somewhere else,
+and `postgres:18` does too. Nothing was pulled, so this says the tags moved and
+nothing about what is inside them.
+
+**One consequence worth a decision, not fixed here.** The floating-tag
+exemption in `tests/test_aidbox_example_tells_the_truth.py` justifies itself
+with "the example is verified end to end against `edge` as of 2026-08-16, and
+against nothing else". `edge` no longer resolves to the image that run used, so
+the exemption's own reason has expired. The test was not edited; this is for
+whoever owns that call.
+
+§7's two supporting observations were re-read rather than restated. Both ghcr
+repositories publish the same tag list as 2026-08-16, `latest` still resolves to
+the same digest as `1.10.0` for both, and `1.10.0` still has no `1.10` alias.
+
+## What this run does NOT cover
+
+- **`aidbox` and `medplum`, in any respect.** Not attempted. `medplum-qa.sh`
+  is §2's script, needs a running Medplum and a client credential, and neither
+  exists here. §2 stays as 2026-08-16 left it.
+- **A connector against a server that requires a credential.** #602's item 2.
+  Untouched. §6 shows the header leaving the proxy against a recorder on
+  loopback; a recorder that demanded the credential would still not be the
+  upstream-holds-a-credential property, so none was built. Every walkthrough
+  performed to date still runs against anonymous sandboxes.
+- **The MCP step, the pinned images running, and the `qa/demo.spec.ts`
+  recording.** No container was started. §7 read manifests; it pulled nothing,
+  so nothing here says the 1.10.0 images behave as the source does. The
+  2026-08-16 pack stays **EVIDENCE PARTIAL**.
+- **Whether §5 case 1 exercises anything about `medplum` beyond precedence.**
+  It sets `MEDPLUM_CLIENT_ID`/`_SECRET` to `must-not-be-used` and asserts they
+  were not used. It says nothing about the Medplum connector working.
+- **Any version string this run did not read.** The pack's HAPI and Firely
+  build numbers, the app's own version: not measured here, so not repeated
+  here.
+
+## Footprint
+
+Reads only, and only three hosts were contacted:
+
+- `server.fire.ly/R4/metadata` — one read per §5 case-1 boot, across both
+  runs, the mutation checks, and the iterations while the script was being
+  written. No writes, no search, nothing created.
+- `hapi.fhir.org/oauth2/token` — one 404 from mutation M1, which drops
+  `FHIR_UPSTREAM_URL` so `MEDPLUM_BASE_URL` builds an OAuth2 client and points
+  it there. `hapi.fhir.org/baseR4` itself was never asked for anything.
+- `ghcr.io` and `registry-1.docker.io` — manifest and tag-list reads, with an
+  anonymous pull token. **No image was pulled.**
+
+**Nothing was created, changed or deleted on any public server, and no
+container, service or deployment was started, stopped or rebuilt.** §5 case 3's
+synthetic Patient landed in a SQLite file in a temporary directory, deleted
+when the script exited. The Flask processes were ephemeral, bound to loopback
+on unused ports, and stopped at the end of each case. The `2b7872d` export and
+the mutants live in a temporary directory outside the checkout — several tests
+here walk every `*.py` under the repository root, and a second copy of
+`r6/access.py` inside it turns `test_the_checked_flag_is_set_in_exactly_one_place`
+red.

--- a/docs/prd/02-connectors.md
+++ b/docs/prd/02-connectors.md
@@ -39,7 +39,8 @@ Not a mock, and not one kind standing in for another. A connector proven only ag
   - health lying about upstream mode (#513)
   - `$conformance` colliding on a shared server (#514)
   - an unknown kind booting then 500-ing (#518)
-- The example's Aidbox image is **unpinned** (`:edge`, `pull_policy: always`) with a dated exemption recorded in `tests/test_aidbox_example_tells_the_truth.py`.
+- The example's Aidbox image is **unpinned** (`:edge`, `pull_policy: always`) with a dated exemption recorded in `tests/test_aidbox_example_tells_the_truth.py`. As of 2026-09-04 that tag resolves to a different digest than the run the exemption cites (#602, `scripts/image-pin-digests.sh`), so the exemption's own reason has expired.
+- Three of those four fixes now have a run behind them, not just a diff: `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md` (#602) re-runs §5, §6 and §7 of the pack against both the tree that found them and the tree that fixed them. #514 is the one it does not cover; #601 does.
 
 ## 5. Known gaps — the open issues in this set
 

--- a/docs/prd/02-connectors.md
+++ b/docs/prd/02-connectors.md
@@ -49,7 +49,7 @@ Not a mock, and not one kind standing in for another. A connector proven only ag
   - `$conformance` colliding on a shared server (#514)
   - an unknown kind booting then 500-ing (#518)
 - The example's Aidbox image is **unpinned** (`:edge`, `pull_policy: always`) with a dated exemption recorded in `tests/test_aidbox_example_tells_the_truth.py`. As of 2026-09-04 that tag resolves to a different digest than the run the exemption cites (#602, `scripts/image-pin-digests.sh`), so the exemption's own reason has expired.
-- Three of those four fixes now have a run behind them, not just a diff: `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md` (#602) re-runs §5, §6 and §7 of the pack against both the tree that found them and the tree that fixed them. #514 is the one it does not cover; #601 does.
+- Three of those four fixes now have a run behind them, not just a diff. The rerun in `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md` (#602) covers §5, §6 and §7 of the pack. It runs against both the tree that found them and the tree that fixed them. #514 is the one it does not cover; #601 does.
 
 ## 5. Known gaps — the open issues in this set
 

--- a/scripts/connector-auth-probe.py
+++ b/scripts/connector-auth-probe.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""What Authorization header the proxy actually puts on the wire, per kind.
+
+Why this exists: §6 of `docs/evidence/2026-08-16-set2-connectors.md` measured
+the single highest-severity finding of that pass — R5, "the `hapi` connector
+silently drops the credentials its own summary tells operators to set" — by
+pointing the proxy at a local HTTP server that records the Authorization header
+it receives, with identical credentials set, changing only the kind. That
+script (`auth_probe.py`) lived in an uncommitted scratch directory and is gone,
+so the finding could not be re-run by anyone. This is it, rewritten from the
+transcript and committed (#602).
+
+The transcript does not say WHICH request the proxy was made to send. This
+script sends the health check, because `/r6/fhir/health` reaches the upstream
+through `FHIRUpstreamProxy.healthy()` on the same client that carries
+`basic_auth`, needs no step-up token and creates nothing. That is a
+reconstruction decision, recorded here and in the rerun evidence rather than
+left implicit.
+
+It boots the real app twice, against a recording server on loopback. No public
+server is touched and nothing is created anywhere.
+
+Usage:
+  uv run python scripts/connector-auth-probe.py                 # the comparison
+  uv run python scripts/connector-auth-probe.py --no-credential # negative control
+  uv run python scripts/connector-auth-probe.py --repo /path/to/another/checkout
+
+`--repo` exists so this measurement can be taken against an older tree. A
+difference between two runs of the same script is evidence; a difference
+between this run and a transcript nobody can re-execute is an assumption.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# The credentials §6 used. The client id is asserted on, so a Basic header the
+# proxy invented from somewhere else would not pass.
+CLIENT_ID = "set2-probe-client"
+CLIENT_SECRET = "set2-probe-secret"
+
+# What 2026-08-16 recorded, for the comparison this script exists to make.
+BASELINE = {"hapi": None, "generic": "Basic"}
+
+KINDS = ("hapi", "generic")
+
+
+class Recorder(BaseHTTPRequestHandler):
+    """A FHIR server that answers /metadata and remembers who asked."""
+
+    seen: list[dict] = []
+
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's spelling
+        Recorder.seen.append(
+            {"path": self.path, "authorization": self.headers.get("Authorization")}
+        )
+        body = json.dumps(
+            {
+                "resourceType": "CapabilityStatement",
+                "fhirVersion": "4.0.1",
+                "software": {"name": "auth-probe recorder"},
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/fhir+json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def short(path: Path) -> str:
+    """A path fit for a transcript: relative, never the operator's home.
+
+    An absolute path here is the operator's OS username, and this repository
+    has committed one into a public evidence pack before. Printing a relative
+    path makes that impossible rather than something a reviewer has to catch.
+    """
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return path.name
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def boot_app(kind, upstream, port, db_path, with_credential, repo):
+    """Start the real app in upstream mode. Returns the process."""
+    env = dict(os.environ)
+    for key in list(env):
+        if key.startswith(("FHIR_UPSTREAM_", "MEDPLUM_")):
+            del env[key]
+    env.update(
+        {
+            "FHIR_UPSTREAM_KIND": kind,
+            "FHIR_UPSTREAM_URL": upstream,
+            "APP_ENV": "development",
+            "STEP_UP_SECRET": "auth-probe-secret",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+            "PORT": str(port),
+            "DISABLE_COMMAND_CENTER": "1",
+        }
+    )
+    if with_credential:
+        env["FHIR_UPSTREAM_CLIENT_ID"] = CLIENT_ID
+        env["FHIR_UPSTREAM_CLIENT_SECRET"] = CLIENT_SECRET
+    return subprocess.Popen(
+        [sys.executable, "main.py"],
+        cwd=str(repo),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def wait_for_health(port: int, proc, timeout: float = 45.0) -> dict | None:
+    """Poll /r6/fhir/health until it answers. Returns the parsed body."""
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/r6/fhir/health"
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return None
+        try:
+            with urllib.request.urlopen(url, timeout=10) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:  # 503 degraded is still an answer
+            return json.loads(exc.read())
+        except Exception:
+            time.sleep(0.4)
+    return None
+
+
+def describe(auth: str | None) -> str:
+    if auth is None:
+        return "None (NO credential sent)"
+    scheme = auth.split(" ", 1)[0]
+    return f"{scheme} <redacted>"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--repo",
+        default=str(REPO),
+        help="checkout to boot (default: this one)",
+    )
+    ap.add_argument(
+        "--no-credential",
+        action="store_true",
+        help="negative control: run with no credentials set at all",
+    )
+    args = ap.parse_args()
+    with_credential = not args.no_credential
+    repo = Path(args.repo).resolve()
+    if not (repo / "main.py").is_file():
+        print(f"no main.py under {short(repo)} — nothing to boot")
+        return 2
+
+    server = HTTPServer(("127.0.0.1", 0), Recorder)
+    upstream = f"http://127.0.0.1:{server.server_port}"
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    print("connector-auth-probe.py")
+    print(f"date      {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+    print(f"repo      {short(repo)}")
+    print(f"recorder  {upstream}")
+    print(f"request   GET /r6/fhir/health -> proxy GET {upstream}/metadata")
+    print("")
+    print("Identical env for both cases:")
+    if with_credential:
+        print(f"  FHIR_UPSTREAM_CLIENT_ID     = {CLIENT_ID}")
+        print("  FHIR_UPSTREAM_CLIENT_SECRET = <set>")
+    else:
+        print("  FHIR_UPSTREAM_CLIENT_ID     = <unset>   (negative control)")
+        print("  FHIR_UPSTREAM_CLIENT_SECRET = <unset>   (negative control)")
+    print("Question: what Authorization header reaches the upstream?")
+    print("")
+
+    failed = False
+    observed: dict[str, str | None] = {}
+    identity_bad: set[str] = set()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        for kind in KINDS:
+            Recorder.seen.clear()
+            port = free_port()
+            db_path = os.path.join(tmp, f"{kind}.db")
+            proc = boot_app(kind, upstream, port, db_path, with_credential, repo)
+            try:
+                health = wait_for_health(port, proc)
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+            if health is None:
+                print(f"  kind={kind:<8} -> FAIL the app never answered /r6/fhir/health")
+                failed = True
+                continue
+
+            metadata = [r for r in Recorder.seen if r["path"].startswith("/metadata")]
+            if not metadata:
+                # The trap this guard exists for: "Authorization: None" and
+                # "the proxy never called the upstream at all" print the same
+                # way, and only one of them is a measurement.
+                print(
+                    f"  kind={kind:<8} -> FAIL the recorder saw no /metadata request. "
+                    f"Nothing was measured for this kind. "
+                    f"(health mode={health.get('mode')!r}, "
+                    f"upstream={health.get('checks', {}).get('upstream')!r})"
+                )
+                failed = True
+                continue
+
+            auth = metadata[-1]["authorization"]
+            observed[kind] = auth
+            print(f"  kind={kind:<8} -> Authorization: {describe(auth)}")
+
+            if auth is not None and auth.startswith("Basic "):
+                try:
+                    decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+                except Exception:
+                    decoded = ""
+                sent_id = decoded.split(":", 1)[0]
+                if sent_id != CLIENT_ID:
+                    print(
+                        f"           FAIL the Basic header carries {sent_id!r}, "
+                        f"not the configured {CLIENT_ID!r}"
+                    )
+                    identity_bad.add(kind)
+                    failed = True
+
+    server.shutdown()
+
+    if not with_credential:
+        print("")
+        print("Negative control. With no credentials set, both kinds must send")
+        print("nothing: AUTH_BASIC degrades to anonymous rather than inventing a")
+        print("header. A 'Basic' here would mean this script reads a credential")
+        print("from somewhere other than the environment it sets.")
+        for kind in KINDS:
+            if observed.get(kind) is not None:
+                print(f"  FAIL kind={kind} sent {describe(observed[kind])} with no credential configured")
+                failed = True
+        if not failed:
+            print("  PASS neither kind sent an Authorization header")
+        return 1 if failed else 0
+
+    print("")
+    print("Against 2026-08-16 (§6 of docs/evidence/2026-08-16-set2-connectors.md):")
+    for kind in KINDS:
+        if kind not in observed:
+            print(f"  kind={kind:<8} NOT MEASURED this run — no comparison is possible")
+            failed = True
+            continue
+        auth = observed[kind]
+        now = None if auth is None else auth.split(" ", 1)[0]
+        was = BASELINE[kind]
+        if now == was:
+            print(f"  kind={kind:<8} same as 2026-08-16 ({was or 'no credential sent'})")
+        else:
+            print(
+                f"  kind={kind:<8} DIFFERS: 2026-08-16 sent "
+                f"{was or 'no credential'}, today sends {now or 'no credential'}"
+            )
+
+    # The verdict is only available when both kinds actually produced a header
+    # this run. Without this the "no header seen" and "the upstream was never
+    # reached" cases print the same R5 verdict, and a mutation that pointed the
+    # proxy at a dead port reported "R5 STILL OPEN" having measured nothing —
+    # the control that looks like one thing and quietly does two, again.
+    print("")
+    if set(observed) != set(KINDS) or identity_bad:
+        print("  NO VERDICT ON R5. Not every kind produced a header this run,")
+        print("  so nothing here says whether hapi sends its credential.")
+        failed = True
+    elif observed.get("hapi") is None:
+        print("  R5 STILL OPEN: hapi accepts the credentials its summary asks for")
+        print("  and does not send them.")
+        failed = True
+    elif observed.get("generic") is None:
+        print("  FAIL generic sent no credential either. The comparison §6 makes")
+        print("  needs generic as its control; without it the hapi row means nothing.")
+        failed = True
+    else:
+        print("  R5 CLOSED on the wire: both kinds send the configured credential.")
+
+    print("")
+    print("no assertion failed" if not failed else "at least one assertion failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/connector-registry-contract.py
+++ b/scripts/connector-registry-contract.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""The connector registry's contract, asserted against a booted app.
+
+Why this exists: §5 of `docs/evidence/2026-08-16-set2-connectors.md` asserted
+three properties of `r6/upstream_connectors.py` — not as unit tests, but by
+booting the real Flask app with a real environment and asking
+`/r6/fhir/health` what it resolved. The two scripts behind it
+(`registry-contract.sh` for cases 1 and 2, `halfconfig.sh` for case 3, which
+the pack files as register entry R1) lived in an uncommitted scratch directory
+and are gone. This is both of them, rewritten from the transcripts and
+committed as one script, because they boot the same app and ask the same
+endpoint (#602).
+
+The three cases:
+
+  1  FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL
+  2  an unknown FHIR_UPSTREAM_KIND is refused, not guessed at
+  3  a half-configured upstream must not report a healthy upstream while
+     writes land in the local store  (R1)
+
+Case 1 contacts a public FHIR server (read only, `/metadata` via the proxy's
+own health check) so that the `software` field is the UPSTREAM naming itself
+rather than our configuration restating itself. Cases 2 and 3 are entirely
+local: case 3's upstream host is deliberately unroutable, because the point of
+that case is that no client is ever built for it.
+
+Usage:
+  uv run python scripts/connector-registry-contract.py
+  uv run python scripts/connector-registry-contract.py --repo /path/to/checkout
+  uv run python scripts/connector-registry-contract.py --case 2
+
+`--repo` exists so this can be run against an older tree: a difference between
+two runs of the same script is evidence, where a difference between this run
+and a transcript nobody can re-execute is an assumption.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+CASE1_UPSTREAM = "https://server.fire.ly/R4"
+CASE1_MEDPLUM_DECOY = "https://hapi.fhir.org/baseR4"
+# Case 3's upstream is never contacted: get_proxy() refuses to build an OAuth2
+# client with no secret, so nothing resolves this name. An unroutable host
+# makes that visible — if a client were ever built, the health check would say
+# 'unreachable' rather than 'misconfigured'/'not_configured'.
+CASE3_MEDPLUM = "https://medplum.example.invalid/fhir"
+
+# The exact sentence resolve_upstream_config raises on. Asserting on the
+# message and not merely on "the app did not start" matters: a port collision
+# also stops the app starting, and would otherwise read as this guard holding.
+CASE2_MESSAGE = "is not one of"
+CASE2_KIND = "totally-made-up"
+
+TENANT = "desktop-demo"
+STEP_UP_SECRET = "registry-contract-secret"
+
+
+class Result:
+    def __init__(self):
+        self.failed = False
+        self.ran: set[int] = set()
+
+    def ok(self, msg):
+        print(f"  PASS {msg}")
+
+    def bad(self, msg):
+        print(f"  FAIL {msg}")
+        self.failed = True
+
+    def note(self, msg):
+        print(f"  NOTE {msg}")
+
+
+def short(path: Path) -> str:
+    """A path fit for a transcript: relative, never the operator's home.
+
+    An absolute path here is the operator's OS username, and this repository
+    has committed one into a public evidence pack before. Printing a relative
+    path makes that impossible rather than something a reviewer has to catch.
+    """
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return path.name
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def base_env(repo: Path, port: int, db_path: str) -> dict:
+    env = dict(os.environ)
+    for key in list(env):
+        if key.startswith(("FHIR_UPSTREAM_", "MEDPLUM_")):
+            del env[key]
+    env.update(
+        {
+            "APP_ENV": "development",
+            "STEP_UP_SECRET": STEP_UP_SECRET,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+            "PORT": str(port),
+            "DISABLE_COMMAND_CENTER": "1",
+        }
+    )
+    return env
+
+
+def init_db(repo: Path, env: dict) -> str:
+    """Create the schema. Without it the first write is an AuditWriteError."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "flask", "--app", "main", "init-db"],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return "" if proc.returncode == 0 else (proc.stderr or proc.stdout)
+
+
+def boot(repo: Path, env: dict, capture: bool = False):
+    return subprocess.Popen(
+        [sys.executable, "main.py"],
+        cwd=str(repo),
+        env=env,
+        stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+        stderr=subprocess.PIPE if capture else subprocess.DEVNULL,
+        text=True,
+    )
+
+
+def http(url: str, method: str = "GET", body: bytes | None = None, headers=None):
+    """Returns (status, parsed body or raw text). Never raises on 4xx/5xx."""
+    req = urllib.request.Request(url, data=body, method=method)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        status = exc.code
+    except Exception as exc:
+        return None, str(exc)
+    try:
+        return status, json.loads(raw)
+    except Exception:
+        return status, raw.decode(errors="replace")
+
+
+def wait_for_health(port: int, proc, timeout: float = 60.0):
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/r6/fhir/health"
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return None, None
+        status, body = http(url)
+        if status is not None:
+            return status, body
+        time.sleep(0.4)
+    return None, None
+
+
+def stop(proc):
+    proc.terminate()
+    try:
+        return proc.communicate(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        return proc.communicate()
+
+
+# ---------------------------------------------------------------------------
+
+
+def case1(repo: Path, r: Result, tmp: str):
+    print("\nCase 1 — FHIR_UPSTREAM_URL takes precedence over MEDPLUM_BASE_URL")
+    print(f"  FHIR_UPSTREAM_URL = {CASE1_UPSTREAM}")
+    print(f"  MEDPLUM_BASE_URL  = {CASE1_MEDPLUM_DECOY}   (must be IGNORED)")
+    print("  MEDPLUM_CLIENT_ID / _SECRET = must-not-be-used")
+
+    port = free_port()
+    env = base_env(repo, port, os.path.join(tmp, "case1.db"))
+    env.update(
+        {
+            "FHIR_UPSTREAM_URL": CASE1_UPSTREAM,
+            "MEDPLUM_BASE_URL": CASE1_MEDPLUM_DECOY,
+            "MEDPLUM_CLIENT_ID": "must-not-be-used",
+            "MEDPLUM_CLIENT_SECRET": "must-not-be-used",
+        }
+    )
+    proc = boot(repo, env)
+    try:
+        status, body = wait_for_health(port, proc)
+    finally:
+        stop(proc)
+
+    if status is None:
+        r.bad("the app never answered /r6/fhir/health — case 1 measured nothing")
+        return
+    r.ran.add(1)
+
+    up = (body or {}).get("checks", {}).get("upstream")
+    print(f"\n  resolved -> mode={(body or {}).get('mode')!r} upstream={up!r}")
+
+    if not isinstance(up, dict):
+        # 'not_configured' or 'misconfigured'. Without this the case could
+        # "pass" against an app in local mode, which resolves nothing at all.
+        r.bad(
+            f"checks.upstream is {up!r}, not a proxy health payload. No upstream "
+            "was resolved, so precedence was not exercised."
+        )
+        return
+    if up.get("status") != "connected":
+        r.bad(
+            f"the proxy could not reach the upstream (status {up.get('status')!r}). "
+            "The 'software' field below would not be the upstream naming itself."
+        )
+        return
+
+    if up.get("upstream_url") == CASE1_UPSTREAM:
+        r.ok("FHIR_UPSTREAM_URL won; MEDPLUM_BASE_URL was not used")
+    elif up.get("upstream_url") == CASE1_MEDPLUM_DECOY:
+        r.bad("MEDPLUM_BASE_URL won. Precedence is REVERSED from what §5 recorded.")
+    else:
+        r.bad(f"resolved to {up.get('upstream_url')!r}, neither configured URL")
+
+    if up.get("kind") == "generic":
+        r.ok("kind is 'generic' — the MEDPLUM_* names did not imply the kind")
+    else:
+        r.bad(f"kind is {up.get('kind')!r}, not 'generic'")
+
+    software = up.get("software")
+    if software and software != "unknown":
+        r.ok(f"the upstream names itself {software!r} in its CapabilityStatement")
+    else:
+        r.bad(
+            f"software is {software!r} — this run has no confirmation from the "
+            "upstream about which server was reached"
+        )
+
+
+def case2(repo: Path, r: Result, tmp: str):
+    print("\nCase 2 — an unknown kind is refused rather than guessed at")
+    print(f"  FHIR_UPSTREAM_KIND = {CASE2_KIND}")
+
+    port = free_port()
+    env = base_env(repo, port, os.path.join(tmp, "case2.db"))
+    env.update({"FHIR_UPSTREAM_KIND": CASE2_KIND, "FHIR_UPSTREAM_URL": CASE1_UPSTREAM})
+    proc = boot(repo, env, capture=True)
+    status, body = wait_for_health(port, proc)
+    out, err = stop(proc)
+    combined = f"{out or ''}{err or ''}"
+
+    if status is None and proc.returncode not in (0, None):
+        # Today's behaviour. The message is the assertion: the app failing to
+        # start for some OTHER reason must not read as this guard holding.
+        r.ran.add(2)
+        if CASE2_MESSAGE in combined and CASE2_KIND in combined:
+            line = next(
+                (ln for ln in combined.splitlines() if CASE2_MESSAGE in ln), ""
+            )
+            print(f"  process exited {proc.returncode} before binding a port")
+            print(f"  {line.strip()[:160]}")
+            r.ok("the app REFUSES TO START on an unknown kind, naming the kind")
+            r.note(
+                "§5 recorded the app BOOTING and answering 500 per request "
+                "(register entry R6). This run differs."
+            )
+        else:
+            r.bad(
+                f"the app exited {proc.returncode} without the registry's message. "
+                "Something else stopped it; this case proves nothing."
+            )
+        return
+
+    if status is None:
+        r.bad("the app neither started nor exited — case 2 measured nothing")
+        return
+
+    r.ran.add(2)
+    print(f"  /r6/fhir/health -> HTTP {status}")
+    text = body if isinstance(body, str) else json.dumps(body)
+    if status >= 500 and (CASE2_MESSAGE in text or CASE2_MESSAGE in combined):
+        # §5's transcript shows the ValueError under a "Traceback (most recent
+        # call last)", which is the app's own stderr — Flask's 500 body carries
+        # no traceback with debug off. Both are checked so the case reads the
+        # same evidence §5 read.
+        where = "the response body" if CASE2_MESSAGE in text else "the app's log"
+        line = next(
+            (ln for ln in f"{text}\n{combined}".splitlines() if CASE2_MESSAGE in ln), ""
+        )
+        print(f"  {line.strip()[:160]}")
+        r.ok(f"the app boots and raises per request, as §5 recorded (R6); in {where}")
+    elif status >= 500:
+        r.bad(
+            "the app 500s but neither the body nor the log carries the registry's "
+            "message. This case cannot say the 500 came from the unknown kind."
+        )
+    else:
+        # The security property. Anything that answers 2xx here has resolved
+        # the typo to SOMETHING, and 'generic' means anonymous requests at a
+        # record system.
+        r.bad(
+            f"/r6/fhir/health answered HTTP {status} with an unknown kind set. "
+            f"body={text[:200]!r}. An unknown kind must not resolve."
+        )
+
+
+def case3(repo: Path, r: Result, tmp: str):
+    print("\nCase 3 — MEDPLUM_BASE_URL with no credentials  (register entry R1)")
+    print(f"  MEDPLUM_BASE_URL  = {CASE3_MEDPLUM}")
+    print("  MEDPLUM_CLIENT_ID = set")
+    print("  MEDPLUM_CLIENT_SECRET = MISSING")
+
+    port = free_port()
+    db_path = os.path.join(tmp, "case3.db")
+    env = base_env(repo, port, db_path)
+    env.update(
+        {
+            "MEDPLUM_BASE_URL": CASE3_MEDPLUM,
+            "MEDPLUM_CLIENT_ID": "half-configured",
+        }
+    )
+    err = init_db(repo, env)
+    if err:
+        r.bad(f"init-db failed, so the write half of R1 cannot run: {err[-200:]}")
+        return
+    proc = boot(repo, env)
+    try:
+        status, body = wait_for_health(port, proc)
+        if status is None:
+            r.bad("the app never answered /r6/fhir/health — case 3 measured nothing")
+            return
+        r.ran.add(3)
+        body = body or {}
+        health_status = body.get("status")
+        mode = body.get("mode")
+        upstream_check = body.get("checks", {}).get("upstream")
+        print(f"\n  GET /r6/fhir/health -> HTTP {status}")
+        print(
+            f"  status = {health_status!r} | mode = {mode!r} | "
+            f"checks.upstream = {upstream_check!r}"
+        )
+
+        base = f"http://127.0.0.1:{port}"
+        tok_status, tok_body = http(
+            f"{base}/r6/fhir/internal/step-up-token",
+            method="POST",
+            body=json.dumps({"tenant_id": TENANT}).encode(),
+            headers={"Content-Type": "application/json", "X-Tenant-Id": TENANT},
+        )
+        token = (tok_body or {}).get("token") if isinstance(tok_body, dict) else None
+        if not token:
+            r.bad(
+                f"could not mint a step-up token (HTTP {tok_status}). The write "
+                "half of R1 was NOT measured this run."
+            )
+            return
+
+        patient = json.dumps(
+            {
+                "resourceType": "Patient",
+                "name": [{"family": "Halfconfig", "given": ["Register"]}],
+                "birthDate": "1980-03-11",
+            }
+        ).encode()
+        cr_status, created = http(
+            f"{base}/r6/fhir/Patient",
+            method="POST",
+            body=patient,
+            headers={
+                "Content-Type": "application/fhir+json",
+                "X-Tenant-Id": TENANT,
+                "X-Step-Up-Token": token,
+            },
+        )
+        pid = created.get("id") if isinstance(created, dict) else None
+        if not pid:
+            r.bad(
+                f"the create returned HTTP {cr_status} and no id "
+                f"({str(created)[:160]!r}). The write half of R1 was NOT measured."
+            )
+            return
+        print(f"  POST /r6/fhir/Patient -> HTTP {cr_status}, id {pid}")
+
+        rd_status, read = http(
+            f"{base}/r6/fhir/Patient/{pid}",
+            headers={"X-Tenant-Id": TENANT, "X-Step-Up-Token": token},
+        )
+        source = read.get("_source") if isinstance(read, dict) else "<unreadable>"
+        print(f"  GET  /r6/fhir/Patient/{pid} -> HTTP {rd_status}, _source = {source!r}")
+    finally:
+        stop(proc)
+
+    rows = None
+    try:
+        conn = sqlite3.connect(db_path)
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM r6_resources WHERE resource_type = 'Patient'"
+        ).fetchone()[0]
+        conn.close()
+    except Exception as exc:
+        r.bad(f"could not count local rows ({exc}); where the write landed is unknown")
+        return
+    print(f"    r6_resources Patient rows = {rows}")
+
+    if rows < 1:
+        r.bad(
+            "the create returned an id and the local store holds no Patient. "
+            "This case cannot say where the write went."
+        )
+        return
+
+    r.note(
+        "the write landed in the proxy's own SQLite, not in a Medplum — "
+        "unchanged from 2026-08-16, and the correct fallback."
+    )
+
+    # The property, stated as what must NOT be true: an operator reading the
+    # health page must not be told the upstream is fine while writes are
+    # landing somewhere else.
+    if mode == "upstream" and health_status == "healthy":
+        r.bad(
+            "R1 STILL OPEN: /r6/fhir/health reports mode 'upstream' and status "
+            "'healthy' while the write landed locally. A container healthcheck "
+            "and any orchestrator probe both report this deployment fine."
+        )
+    elif health_status == "healthy":
+        r.bad(
+            f"health reports 'healthy' (mode {mode!r}) while a named upstream "
+            "was never built and the write landed locally."
+        )
+    else:
+        r.ok(
+            f"R1 CLOSED: health reports HTTP {status}, status {health_status!r}, "
+            f"mode {mode!r}, checks.upstream {upstream_check!r} — a named upstream "
+            "that could not be built is visible to a probe."
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=str(REPO), help="checkout to boot")
+    ap.add_argument(
+        "--case", type=int, choices=(1, 2, 3), action="append", help="run one case"
+    )
+    args = ap.parse_args()
+    repo = Path(args.repo).resolve()
+    if not (repo / "main.py").is_file():
+        print(f"no main.py under {short(repo)} — nothing to boot")
+        return 2
+
+    wanted = sorted(set(args.case)) if args.case else [1, 2, 3]
+
+    print("connector-registry-contract.py")
+    print(f"date  {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+    print(f"repo  {short(repo)}")
+    print(f"cases {wanted}")
+    print("baseline docs/evidence/2026-08-16-set2-connectors.md §5 and R1")
+
+    r = Result()
+    with tempfile.TemporaryDirectory() as tmp:
+        for n in wanted:
+            {1: case1, 2: case2, 3: case3}[n](repo, r, tmp)
+
+    print("\nResult")
+    missing = [n for n in wanted if n not in r.ran]
+    if missing:
+        # Without this the script can print no FAIL line and exit 0 having
+        # never got an app up. A case that did not run is not a case that passed.
+        print(f"  case(s) {missing} never produced a measurement")
+        r.failed = True
+    print("  no assertion failed" if not r.failed else "  at least one assertion failed")
+    return 1 if r.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/image-pin-digests.sh
+++ b/scripts/image-pin-digests.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# What the example's compose pins resolve to TODAY, against the 2026-08-16 baseline.
+#
+# Why this exists: §7 of `docs/evidence/2026-08-16-set2-connectors.md` recorded
+# four manifest digests and said plainly that "do they still resolve to the
+# digest they were pinned at" could not be answered, because no baseline had
+# ever been recorded — so those four digests were "the baseline for the next
+# run". This is the next run, and unlike §5 and §6 that section named no script
+# at all: it says only "resolved today via the registry HTTP API". This script
+# is that sentence, written down (#602).
+#
+# It reads the image refs OUT of the compose file rather than hard-coding them,
+# so a change to the compose file changes what is measured. The baselines below
+# are hard-coded, because they are a historical record of one day and must not
+# follow anything.
+#
+# Reads only. No pull, no `docker` (the 2026-08-16 pass had no daemon either),
+# nothing created anywhere.
+#
+# Usage:
+#   scripts/image-pin-digests.sh
+#   scripts/image-pin-digests.sh path/to/other-compose.yaml     # negative control
+set -uo pipefail
+
+COMPOSE="${1:-examples/aidbox-healthclaw-guardrails/docker-compose.yaml}"
+
+# The Accept header decides WHICH manifest the registry returns, and a
+# multi-arch index and a single-platform manifest have different digests. Send
+# a different set from the 2026-08-16 run and every row reads "changed" as an
+# artifact of the request rather than a re-push. This set is printed in the
+# output so the next run can send the same one.
+ACCEPT='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+
+# Baseline: docs/evidence/2026-08-16-set2-connectors.md §7, measured 2026-08-16.
+# `moving` marks a tag the compose file itself does not pin — a change there is
+# R9 happening, not a fault. A change on a `version` tag is a re-push under a
+# tag the compose treats as immutable, which is a FAIL.
+BASELINE_ghcr_guardrails='sha256:57b345e0c8f6a6bf88690084f57fe863bd02882ade0e2c7b70002baa4c0e225b'
+BASELINE_ghcr_mcp='sha256:d37c997ea15c73c715cdc2b90ea01aa6a49dc34cb6897913ce1691d8d012cd53'
+BASELINE_aidboxone='sha256:42e4e8e10d9d42b54bf3f4602b3f584e06acc70738cdcf280ce7634bdb5e58b3'
+BASELINE_postgres='sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941'
+
+# The two supporting observations §7 recorded alongside the table. They are
+# re-read here rather than restated: a claim this script does not measure does
+# not belong in its output.
+BASELINE_TAGS='latest, v1.4.0, 1.5.0, 1.5, 1.6.0, 1.6, 1.7.0, 1.7, 1.8.0, 1.8, 1.9.0, 1.9, 1.10.0'
+
+fail=0
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; fail=1; }
+note() { printf '  \033[33mNOTE\033[0m %s\n' "$*"; }
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+die()  { printf '\n\033[31m%s\033[0m\n' "$*"; exit 2; }
+
+[ -f "$COMPOSE" ] || die "no compose file at ${COMPOSE} (run from the repo root)"
+
+printf 'image-pin-digests.sh\n'
+printf 'compose  %s\n' "$COMPOSE"
+printf 'date     %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+printf 'accept   %s\n' "$ACCEPT"
+printf 'baseline docs/evidence/2026-08-16-set2-connectors.md §7 (2026-08-16)\n'
+
+# --- registry plumbing ------------------------------------------------------
+
+# Anonymous pull token. Both registries hand one out for a public repository;
+# a failure here is a failure of the run, never a skipped row.
+registry_token() {
+  local host="$1" repo="$2" url
+  case "$host" in
+    ghcr.io)   url="https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" ;;
+    docker.io) url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" ;;
+    *)         return 1 ;;
+  esac
+  curl -sS --max-time 30 "$url" \
+    | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("token") or d.get("access_token") or "")' 2>/dev/null
+}
+
+registry_api() {
+  case "$1" in
+    ghcr.io)   echo "https://ghcr.io/v2" ;;
+    docker.io) echo "https://registry-1.docker.io/v2" ;;
+  esac
+}
+
+# Prints the manifest digest, or nothing. Never prints a digest it did not read
+# from a Docker-Content-Digest header.
+manifest_digest() {
+  local host="$1" repo="$2" ref="$3" tok
+  tok=$(registry_token "$host" "$repo") || return 1
+  [ -z "$tok" ] && return 1
+  curl -sSI --max-time 30 -H "Authorization: Bearer ${tok}" -H "Accept: ${ACCEPT}" \
+       "$(registry_api "$host")/${repo}/manifests/${ref}" 2>/dev/null \
+    | tr -d '\r' | awk 'tolower($1)=="docker-content-digest:"{print $2}'
+}
+
+tag_list() {
+  local host="$1" repo="$2" tok
+  tok=$(registry_token "$host" "$repo") || return 1
+  [ -z "$tok" ] && return 1
+  curl -sS --max-time 30 -H "Authorization: Bearer ${tok}" \
+       "$(registry_api "$host")/${repo}/tags/list?n=200" 2>/dev/null \
+    | python3 -c 'import sys,json;print(", ".join(json.load(sys.stdin).get("tags") or []))' 2>/dev/null
+}
+
+# `ghcr.io/aks129/x:1.10.0` -> host, repo, ref. Docker Hub short names get the
+# `library/` prefix the API needs.
+split_ref() {
+  python3 - "$1" <<'PY'
+import sys
+ref = sys.argv[1]
+name, _, tag = ref.rpartition(":")
+if "/" not in tag and name:
+    pass
+else:  # no tag at all
+    name, tag = ref, "latest"
+head, _, rest = name.partition("/")
+if "." in head or ":" in head or head == "localhost":
+    host, repo = head, rest
+else:
+    host, repo = "docker.io", name if "/" in name else f"library/{name}"
+print(host); print(repo); print(tag)
+PY
+}
+
+# --- the four rows ----------------------------------------------------------
+
+step "1. Manifest digests for every image the compose file names"
+
+images=$(grep -E '^[[:space:]]*image:[[:space:]]*' "$COMPOSE" | sed -E 's/^[[:space:]]*image:[[:space:]]*//' | tr -d '\042\047')
+[ -z "$images" ] && die "no image: lines in ${COMPOSE} — nothing was measured"
+
+printf '  %-52s %s\n' "image" "digest today"
+seen=0
+# Which of §7's four rows this run actually compared. Without this the script
+# passes vacuously when the compose file no longer names them: the first
+# version of it reported "no assertion failed" against a compose holding one
+# unrelated image, having compared nothing at all.
+compared=""
+for ref in $images; do
+  seen=$((seen + 1))
+  read -r host repo tag < <(split_ref "$ref" | paste -sd' ' -)
+  digest=$(manifest_digest "$host" "$repo" "$tag")
+  if [ -z "$digest" ]; then
+    printf '  %-52s %s\n' "$ref" "(no digest)"
+    bad "${ref}: the registry returned no Docker-Content-Digest. This run measured nothing for this row."
+    continue
+  fi
+  printf '  %-52s %s\n' "$ref" "$digest"
+
+  case "$ref" in
+    ghcr.io/aks129/healthclaw-guardrails:1.10.0)  base="$BASELINE_ghcr_guardrails"; kindof=version ;;
+    ghcr.io/aks129/healthclaw-mcp-server:1.10.0)  base="$BASELINE_ghcr_mcp";        kindof=version ;;
+    healthsamurai/aidboxone:edge)                 base="$BASELINE_aidboxone";       kindof=moving  ;;
+    postgres:18)                                  base="$BASELINE_postgres";        kindof=moving  ;;
+    *)                                            base="";                          kindof=new     ;;
+  esac
+
+  [ -n "$base" ] && compared="${compared} ${ref}"
+
+  if [ -z "$base" ]; then
+    note "${ref}: not in the 2026-08-16 table, so there is nothing to compare it to."
+  elif [ "$digest" = "$base" ]; then
+    if [ "$kindof" = version ]; then
+      ok "${ref}: same digest as 2026-08-16. The version tag was not re-pushed."
+    else
+      note "${ref}: same digest as 2026-08-16, which a moving tag is not obliged to be."
+    fi
+  else
+    if [ "$kindof" = version ]; then
+      bad "${ref}: MOVED since 2026-08-16 (${base} -> ${digest}). A version tag the compose treats as immutable was re-pushed."
+    else
+      note "${ref}: MOVED since 2026-08-16 (${base} -> ${digest}). This is R9: an unpinned tag, and \`pull_policy: always\` on one of them."
+    fi
+  fi
+done
+[ "$seen" -lt 1 ] && bad "no image rows were resolved at all"
+
+for want in \
+  'ghcr.io/aks129/healthclaw-guardrails:1.10.0' \
+  'ghcr.io/aks129/healthclaw-mcp-server:1.10.0' \
+  'healthsamurai/aidboxone:edge' \
+  'postgres:18'
+do
+  case "$compared" in
+    *" ${want}"*) ;;
+    *) bad "${want} is in §7's table but was not compared this run — ${COMPOSE} no longer names it, so §7's question went unanswered for that row." ;;
+  esac
+done
+
+# --- §7's two supporting observations --------------------------------------
+
+step "2. The two observations §7 recorded next to the table"
+
+for repo in aks129/healthclaw-guardrails aks129/healthclaw-mcp-server; do
+  tags=$(tag_list ghcr.io "$repo")
+  if [ -z "$tags" ]; then
+    bad "ghcr.io/${repo}: tag list unreadable — the '1.10 alias' observation was NOT measured this run."
+    continue
+  fi
+  printf '  ghcr.io/%s tags: %s\n' "$repo" "$tags"
+  if [ "$tags" = "$BASELINE_TAGS" ]; then
+    note "ghcr.io/${repo}: tag list identical to 2026-08-16."
+  else
+    note "ghcr.io/${repo}: tag list DIFFERS from 2026-08-16 ('${BASELINE_TAGS}')."
+  fi
+  case ", ${tags}," in
+    *", 1.10,"*) note "ghcr.io/${repo}: a 1.10 alias now exists; §7 recorded none." ;;
+    *)           note "ghcr.io/${repo}: still no 1.10 alias, unlike every prior minor." ;;
+  esac
+
+  latest=$(manifest_digest ghcr.io "$repo" latest)
+  pinned=$(manifest_digest ghcr.io "$repo" 1.10.0)
+  if [ -z "$latest" ] || [ -z "$pinned" ]; then
+    bad "ghcr.io/${repo}: could not read both latest and 1.10.0 — the 'latest == 1.10.0' observation was NOT measured this run."
+  elif [ "$latest" = "$pinned" ]; then
+    note "ghcr.io/${repo}: latest still resolves to the same digest as 1.10.0 (${latest})."
+  else
+    note "ghcr.io/${repo}: latest (${latest}) has DIVERGED from 1.10.0 (${pinned}) — the drift the compose comment describes."
+  fi
+done
+
+step "Result"
+if [ "$fail" -eq 0 ]; then
+  printf '  \033[32mno assertion failed\033[0m\n'
+  exit 0
+fi
+printf '  \033[31mat least one assertion failed\033[0m\n'
+exit 1

--- a/tests/test_set2_sections_5_to_7_evidence.py
+++ b/tests/test_set2_sections_5_to_7_evidence.py
@@ -1,0 +1,235 @@
+"""The three scripts behind §5, §6 and §7 of the set-2 pack, pinned.
+
+Issue #602: sections 5, 6 and 7 of `docs/evidence/2026-08-16-set2-connectors.md`
+rested on scripts that lived only in an uncommitted scratch directory. The
+directory is gone, so nobody could re-run the highest-severity finding of that
+pass (R5) or the half-configured-upstream finding (R1). #601 settled §3 and §4
+the same way; this is the rest.
+
+What this file guards, and what it deliberately does not:
+
+  * The scripts and their transcripts stay committed, and the documents that
+    cite them keep naming paths that exist. A document pointing at a deleted
+    script is the defect this whole thread is about.
+
+  * The scripts never print an absolute path. An operator's home-directory
+    name in an evidence pack merged to a public repository is the 2026-08-16
+    incident; the 2026-08-16 pack had to redact one. Fixed in the scripts
+    (`short()`), and this is what stops it coming back. Asserted by RUNNING
+    them, not by reading them for a string.
+
+  * The 2026-08-16 numbers the scripts compare against still match the pack.
+    Both scripts carry a hard-coded baseline so the comparison survives the
+    pack being edited; that is only safe while the two agree, and this is
+    where a disagreement surfaces.
+
+  * Each script refuses rather than reporting a pass when it cannot measure.
+    `smoke_medplum.py` scoring 7/8 against a Medplum that did not exist (pack
+    entry R2) is the failure mode.
+
+It does NOT re-pin what the connector registry does. `hapi` being AUTH_BASIC
+(#512), the misconfigured/degraded health state (#513) and refusing to boot on
+an unknown kind (#518) are already pinned by
+`tests/test_upstream_connector_registry.py` and `tests/test_fhir_proxy.py`. A
+second copy of a pin is a second thing to keep in step.
+
+Needs no Docker, no network and no FHIR server: every subprocess here is
+given input it must refuse before it reaches one.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK = ROOT / "docs" / "evidence" / "2026-08-16-set2-connectors.md"
+RERUN = ROOT / "docs" / "evidence" / "2026-09-04-set2-sections-5-7-rerun.md"
+TRANSCRIPTS = ROOT / "docs" / "evidence" / "2026-09-04-set2-rerun"
+
+REGISTRY_CONTRACT = ROOT / "scripts" / "connector-registry-contract.py"
+AUTH_PROBE = ROOT / "scripts" / "connector-auth-probe.py"
+IMAGE_PINS = ROOT / "scripts" / "image-pin-digests.sh"
+
+PYTHON_SCRIPTS = (REGISTRY_CONTRACT, AUTH_PROBE)
+
+TRANSCRIPT_NAMES = (
+    "registry-contract-run.txt",
+    "registry-contract-at-2b7872d-run.txt",
+    "mutation-registry-contract.txt",
+    "auth-probe-run.txt",
+    "auth-probe-at-2b7872d-run.txt",
+    "negative-control-auth-probe.txt",
+    "mutation-auth-probe.txt",
+    "image-pins-run.txt",
+    "negative-control-image-pins.txt",
+    "mutation-tests.txt",
+)
+
+
+def _run(argv, cwd=ROOT):
+    return subprocess.run(
+        argv, cwd=str(cwd), capture_output=True, text=True, timeout=120
+    )
+
+
+class TestTheEvidenceStaysCheckableByAStranger:
+    """#602's own property. A cited path that does not exist is the defect."""
+
+    @pytest.mark.parametrize(
+        "path", [REGISTRY_CONTRACT, AUTH_PROBE, IMAGE_PINS, RERUN, PACK]
+    )
+    def test_the_scripts_and_documents_are_committed(self, path):
+        assert path.exists(), (
+            f"{path.relative_to(ROOT)} is gone. §5, §6 and §7 of the set-2 "
+            "pack rest on it."
+        )
+
+    @pytest.mark.parametrize("name", TRANSCRIPT_NAMES)
+    def test_the_transcripts_are_committed(self, name):
+        assert (TRANSCRIPTS / name).exists(), (
+            f"{name} is gone. It is the raw output the re-run's findings are "
+            "read from; without it the findings are assertions again."
+        )
+
+    def test_the_rerun_document_names_only_paths_that_exist(self):
+        """Every repo path the write-up cites in backticks must resolve."""
+        cited = set()
+        for match in re.findall(r"`([^`\n]+)`", RERUN.read_text()):
+            candidate = re.sub(r":\d+$", "", match.strip()).rstrip(".")
+            if candidate.startswith(("scripts/", "docs/", "tests/", "r6/")):
+                cited.add(candidate)
+        assert cited, "the write-up cites no repository paths at all"
+        missing = sorted(p for p in cited if not (ROOT / p).exists())
+        assert not missing, f"the re-run write-up cites paths that do not exist: {missing}"
+
+    def test_the_correction_to_the_packs_stale_citation_is_itself_correct(self):
+        """The write-up says `is_proxy_enabled` moved. Check both halves.
+
+        MUTATION: point the write-up at a different line number -> red.
+        """
+        proxy = (ROOT / "r6" / "fhir_proxy.py").read_text().splitlines()
+        lines = [
+            n for n, text in enumerate(proxy, 1)
+            if text.startswith("def is_proxy_enabled(")
+        ]
+        assert len(lines) == 1, "is_proxy_enabled is not defined once in r6/fhir_proxy.py"
+        assert "def is_proxy_enabled(" not in (ROOT / "r6" / "routes.py").read_text(), (
+            "is_proxy_enabled is back in r6/routes.py; the write-up's correction "
+            "to the pack's citation is now wrong."
+        )
+        assert f"r6/fhir_proxy.py:{lines[0]}" in RERUN.read_text(), (
+            f"is_proxy_enabled is at r6/fhir_proxy.py:{lines[0]}, which is not "
+            "the line the write-up cites. A citation that has drifted is the "
+            "defect this whole thread is about."
+        )
+
+
+class TestNoOperatorUsernameReachesAnEvidencePack:
+    """The 2026-08-16 incident: a home-directory path in a public repo.
+
+    Asserted by running the scripts, not by grepping them for `short(`. The
+    string could survive a change that stops it being used.
+    """
+
+    @pytest.mark.parametrize("name", TRANSCRIPT_NAMES)
+    def test_the_committed_transcripts_carry_no_home_path(self, name):
+        text = (TRANSCRIPTS / name).read_text()
+        assert "/Users/" not in text and "/home/" not in text, (
+            f"{name} contains a home-directory path. An operator's OS "
+            "username in an evidence pack merged to a public repo is the "
+            "2026-08-16 incident."
+        )
+
+    @pytest.mark.parametrize("script", PYTHON_SCRIPTS, ids=lambda p: p.name)
+    def test_a_script_never_prints_an_absolute_checkout_path(self, script, tmp_path):
+        """The checkout it was pointed at comes back relative, always.
+
+        Absolute is the property under test, not "contains /Users/": the
+        temporary directory pytest hands this test is itself under a path
+        carrying the operator's name, and a relative path to it is correct
+        output from the script even so.
+
+        MUTATION: print `{repo}` instead of `{short(repo)}` -> red.
+        """
+        result = _run([sys.executable, str(script), "--repo", str(tmp_path)])
+        output = result.stdout + result.stderr
+        printed = re.search(r"no main\.py under (\S+)", output)
+        assert printed, (
+            f"{script.name} did not report the checkout it was given: {output[:200]!r}"
+        )
+        assert not printed.group(1).startswith("/"), (
+            f"{script.name} printed the absolute path {printed.group(1)!r}. "
+            "An absolute path here is the operator's home-directory name."
+        )
+
+
+class TestTheBaselinesStillMatchThePack:
+    """The scripts compare today against 2026-08-16 from a hard-coded copy.
+
+    Hard-coded on purpose — a baseline that follows the document it is checked
+    against cannot detect anything. The cost is that the two can drift apart
+    silently, which is what these tests are for.
+    """
+
+    def test_every_image_digest_the_script_compares_against_is_in_the_pack(self):
+        """MUTATION: change one hex digit in the script's baseline -> red."""
+        script = IMAGE_PINS.read_text()
+        digests = set(re.findall(r"BASELINE_\w+='(sha256:[0-9a-f]{64})'", script))
+        assert len(digests) == 4, (
+            f"expected §7's four baseline digests in {IMAGE_PINS.name}, "
+            f"found {len(digests)}"
+        )
+        pack = PACK.read_text()
+        missing = sorted(d for d in digests if d not in pack)
+        assert not missing, (
+            "image-pin-digests.sh compares against digests that §7 of the "
+            f"pack does not record: {missing}. One of the two moved."
+        )
+
+    def test_the_auth_probe_compares_against_what_section_6_recorded(self):
+        """MUTATION: flip the script's baseline to {'hapi': 'Basic'} -> red."""
+        script = AUTH_PROBE.read_text()
+        baseline = re.search(r"^BASELINE = (\{.*\})$", script, re.M)
+        assert baseline, "the auth probe no longer declares a 2026-08-16 baseline"
+        assert baseline.group(1) == '{"hapi": None, "generic": "Basic"}', (
+            "the auth probe's baseline changed. §6 recorded "
+            "`kind=hapi -> Authorization: None` and `kind=generic -> "
+            "Authorization: Basic`; a baseline that does not say that is "
+            "comparing against something other than the pack."
+        )
+        section6 = PACK.read_text().split("## 6.", 1)[-1].split("## 7.", 1)[0]
+        assert "kind=hapi     -> Authorization: None" in section6
+        assert "kind=generic  -> Authorization: Basic" in section6
+
+
+class TestAScriptRefusesRatherThanReportingAPass:
+    """R2's failure mode: 7 of 8 green against a server that did not exist."""
+
+    @pytest.mark.parametrize("script", PYTHON_SCRIPTS, ids=lambda p: p.name)
+    def test_a_checkout_with_no_app_is_refused(self, script, tmp_path):
+        result = _run([sys.executable, str(script), "--repo", str(tmp_path)])
+        assert result.returncode != 0, (
+            f"{script.name} exited 0 against a directory with no app in it. "
+            "A run that booted nothing must not read as a run that passed."
+        )
+        assert "PASS" not in result.stdout, (
+            f"{script.name} reported a PASS having booted nothing"
+        )
+
+    def test_a_compose_file_with_no_images_is_refused(self, tmp_path):
+        compose = tmp_path / "compose.yaml"
+        compose.write_text('services:\n  x:\n    ports:\n      - "1:1"\n')
+        result = _run(["bash", str(IMAGE_PINS), str(compose)])
+        assert result.returncode != 0, (
+            "image-pin-digests.sh exited 0 against a compose file naming no "
+            "images. §7's question went unanswered and the script said so."
+        )
+        assert "PASS" not in result.stdout
+
+    def test_a_missing_compose_file_is_refused(self, tmp_path):
+        result = _run(["bash", str(IMAGE_PINS), str(tmp_path / "nope.yaml")])
+        assert result.returncode != 0
+        assert "PASS" not in result.stdout

--- a/tests/test_set2_sections_5_to_7_evidence.py
+++ b/tests/test_set2_sections_5_to_7_evidence.py
@@ -189,6 +189,27 @@ class TestTheBaselinesStillMatchThePack:
             f"pack does not record: {missing}. One of the two moved."
         )
 
+    def test_every_digest_the_write_up_prints_was_actually_measured(self):
+        """A digest in the prose must appear in the transcript it cites.
+
+        Written after an abbreviated digest in the write-up's §7 was off by
+        one character — in the document whose subject is measurements being
+        restated wrongly. The abbreviation is gone; this is what stops the
+        next one.
+
+        MUTATION: change one hex digit in the write-up -> red.
+        """
+        transcript = (TRANSCRIPTS / "image-pins-run.txt").read_text()
+        quoted = set(re.findall(r"sha256:[0-9a-f]{64}", RERUN.read_text()))
+        assert len(quoted) == 6, (
+            f"expected §7's six digests in the write-up, found {len(quoted)}"
+        )
+        unmeasured = sorted(d for d in quoted if d not in transcript)
+        assert not unmeasured, (
+            "the write-up prints digests the run did not produce: "
+            f"{unmeasured}"
+        )
+
     def test_the_auth_probe_compares_against_what_section_6_recorded(self):
         """MUTATION: flip the script's baseline to {'hapi': 'Basic'} -> red."""
         script = AUTH_PROBE.read_text()


### PR DESCRIPTION
Issue #602, item 1. Continues #530 and the §3/§4 re-run in #601.

## The finding

**Every measurement §5 and §6 recorded reproduces exactly**, against `2b7872d`
— the tree the 2026-08-16 pack says its live runs used. R1's four lines come
back verbatim, down to `checks.upstream = 'not_configured'` and
`r6_resources Patient rows = 1`.

At `89b42fb` three of those measurements differ. Running the same script
against both trees is what makes "each difference is a fix" a measurement
rather than an assertion:

| what changed | fixed by |
|---|---|
| `hapi` sends the credential it used to drop (R5) | #512 |
| a half-configured upstream reports degraded, not healthy (R1) | #513 |
| an unknown kind refuses to boot instead of 500-ing per request (R6) | #518 |

`git diff --stat 2b7872d 89b42fb -- uv.lock pyproject.toml` is empty, and the
old tree was booted with this checkout's interpreter, so the only variable
between the two runs is source code. That is checked, not assumed.

## §7 is the different outcome

It named **no script**. It says only "resolved today via the registry HTTP
API", so there was no transcript to turn back into one — that is itself the
answer for that section. One was written from the section's own table instead,
and it answers the question §7 said could not be answered:

| image | §7 baseline | today | |
|---|---|---|---|
| `ghcr.io/aks129/healthclaw-guardrails:1.10.0` | `sha256:57b345e0…` | identical | not re-pushed |
| `ghcr.io/aks129/healthclaw-mcp-server:1.10.0` | `sha256:d37c997e…` | identical | not re-pushed |
| `healthsamurai/aidboxone:edge` | `sha256:42e4e8e1…` | `sha256:90c4e728…` | **moved** |
| `postgres:18` | `sha256:06cad38a…` | `sha256:4ef4dbc9…` | **moved** |

R9 measured rather than predicted. A manifest digest depends on the `Accept`
header, so the script prints the header it sent; the two identical rows
confirm it matches what 2026-08-16 must have used.

**One consequence, not fixed here.** The floating-tag exemption in
`tests/test_aidbox_example_tells_the_truth.py` justifies itself with "verified
end to end against `edge` as of 2026-08-16, and against nothing else". `edge`
no longer resolves to that image, so the exemption's own reason has expired.
That is a call for whoever owns it; no test was edited.

## The four-script framing is off by two

Both #602 and #601 say sections 5, 6 and 7 rest on four uncommitted scripts.
In fact `registry-contract.sh` and `halfconfig.sh` are §5, `auth_probe.py` is
§6, §7 had none, and `medplum-qa.sh` is **§2**. §2 is out of scope and stays
unverified: it needs a running Medplum and a client credential, and this
machine has neither. Corrected in the pack and above.

## Reachability, determined before anything ran

| Section | What a re-run needs | Reachable |
|---|---|---|
| §5 cases 1–2 | app booted locally; one read from `server.fire.ly` | yes |
| §5 case 3 (R1) | app booted locally, nothing else | yes |
| §6 | app booted locally, against a loopback recorder | yes |
| §7 | anonymous manifest reads from `ghcr.io` and Docker Hub | yes |
| §2 `medplum` | a running Medplum and client credentials | **no — not attempted** |

## What is now committed

- `scripts/connector-registry-contract.py` — §5, all three cases. One script
  where the pack had two: they boot the same app and ask the same endpoint,
  and two near-copies of one boot sequence is how the Aidbox walkthrough's
  status codes drifted from its own README (#499).
- `scripts/connector-auth-probe.py` — §6. The transcript does not say which
  request the proxy was made to send; the script sends the health check and
  records that as a reconstruction decision rather than leaving it implicit.
- `scripts/image-pin-digests.sh` — §7.
- `docs/evidence/2026-09-04-set2-rerun/*.txt` — transcripts, negative controls
  and mutation checks. Scanned for home-directory paths.
- `docs/evidence/2026-09-04-set2-sections-5-7-rerun.md` — the write-up.
- `tests/test_set2_sections_5_to_7_evidence.py` — 35 tests.

## Mutation, on both the scripts and the tests

Every guard was seen to fail. Each mutation transcript carries the `sed` that
made the mutant and a diff of the line it changed, so "mutation-checked" is
itself re-runnable.

Two of my own guards were wrong until a mutant found them:

- `image-pin-digests.sh` reported **"no assertion failed"** against a compose
  file naming none of §7's four images — a pass having compared nothing. It
  now fails when a baseline row is not reached.
- `connector-auth-probe.py` printed **"R5 STILL OPEN"** when the proxy never
  reached the recorder at all. "No header seen" and "no request happened" read
  the same; it now withholds the verdict instead.

`docs/evidence/2026-09-04-set2-rerun/mutation-tests.txt` is the same exercise
against the test file: seven mutations, each turning its named test red, and
the suite green again afterwards.

No unit pins were added for #512, #513 or #518 — `test_upstream_connector_registry.py`
and `test_fhir_proxy.py` already have them.

## Documents corrected

- The pack: notes at §5, §6, §7, and inside R1, R5, R6, R9. "Reproducing this"
  now names the committed paths and says what `medplum-qa.sh` actually backed.
  R1's `r6/routes.py:1980` citation is stale; `is_proxy_enabled` is in
  `r6/fhir_proxy.py` now, and a test pins the write-up's line number so the new
  citation cannot drift silently either.
- `docs/prd/02-connectors.md`: three of its four "defects fixed today" now have
  a run behind them, and the Aidbox exemption's expiry is recorded.

Nothing in the 2026-08-16 pack is rewritten. Its findings stand as its
findings.

## Merge order — read before rebasing

This branches from `main`, as instructed, but **#601 is not merged yet** and
touches the same two files.

- `docs/evidence/2026-08-16-set2-connectors.md` — "Reproducing this" **will
  conflict**; both PRs replace it. #601's version is the base to merge onto.
- #601's header note says "Sections 5, 6 and 7 have **not** been independently
  re-run" and its "Reproducing this" says "§5, §6 and R1 rest on them and have
  **not** been independently re-run". **Both become false when this merges.**
  They need editing at rebase; this PR cannot do it from `main`.
- `docs/prd/02-connectors.md` — my bullet sits four lines below #601's hunk and
  should merge cleanly.
- If #601 lands first, its `test_no_operator_username_in_the_transcripts` globs
  the same transcript directory as my per-file version. Collapsing them into
  one is fine; mine also runs the scripts to check the leak at its source.

## What this does NOT cover

- `aidbox` and `medplum`. Not attempted.
- **#602 item 2 — a connector against a server that requires a credential.**
  Untouched. §6 shows the header leaving the proxy against a loopback recorder;
  making that recorder demand the credential would not be the
  upstream-holds-a-credential property, so none was built rather than
  substituted. Still an owner item.
- The MCP step, the pinned images running, the `qa/demo.spec.ts` recording. No
  container was started; §7 read manifests and pulled nothing. The pack stays
  **EVIDENCE PARTIAL**.
- Any version string these runs did not read. The pack's HAPI and Firely build
  numbers and the app's own version are not repeated here.

## Footprint

Reads only, three hosts: `server.fire.ly/R4/metadata` (one per §5 case-1 boot),
one 404 from `hapi.fhir.org/oauth2/token` raised by a mutation, and manifest
and tag-list reads from `ghcr.io` and `registry-1.docker.io`. **Nothing created
on any public server, no image pulled, no container or deployment started or
stopped.** Case 3's synthetic Patient landed in a tempdir SQLite, deleted on
exit.

## Gates

```
uv run ruff check .   -> All checks passed!
uv run python -m pytest tests/ -q
  -> 3192 passed, 13 skipped, 1 xfailed, 2 warnings in 101.21s
uv run python -m pytest tests/test_guardrail_conformance.py -q
  -> 37 passed
```

No production code changed.

**Do not approve or enable auto-merge.** An approval here arms a merge that
fires on the next green check, and this one needs #601 to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Two corrections to my own write-up, after review (`de3d474`)

- **A digest in §7 of the write-up was off by one character.** `…c4c0e225b`
  where the measured digest ends `…a4c0e225b` — a transcription error, in the
  document whose subject is measurements being restated wrongly. The existing
  digest test compares the *script's* baseline against the pack, not the prose
  against the run, so nothing caught it. Abbreviation is gone (all six digests
  written out) and a new test requires every digest the write-up prints to
  appear in the transcript it cites. Mutation-checked; the transcript is
  appended to `mutation-tests.txt`.
- **"Verbatim" overclaimed.** R1's lines reproduce value for value, not
  character for character — this script also prints the HTTP status of the
  write and the read, which the pack's transcript does not show. Reworded.

Gates re-run after the fix: ruff clean, **3193 passed, 13 skipped, 1 xfailed**.

## One test worth a reviewer's opinion

`test_the_correction_to_the_packs_stale_citation_is_itself_correct` pins
`r6/fhir_proxy.py:775` — the line the write-up cites for `is_proxy_enabled`.
It has two halves. The durable one is "defined once in `fhir_proxy.py`, and not
in `routes.py`", which is the actual correction to the pack's stale citation.
The line-number half means **any unrelated edit above line 775 in
`fhir_proxy.py` turns this red and makes a developer edit an evidence
document.** That is deliberate — a citation that drifts silently is the defect
this thread is about — but it is a cost someone else pays, so it is called out
rather than left to be discovered in an unrelated CI run. Drop the line-number
assertion if you would rather not carry it; no finding depends on it.
