### PR TITLE
test(docs): every cited path must exist, checked by shape rather than by name (#601, #603)

### DIFF
--- a/docs/2026-08-03-access-kernel-spec.md
+++ b/docs/2026-08-03-access-kernel-spec.md
@@ -11,6 +11,16 @@ two design objections that blocked the kernel as originally specified.
 
 Every file:line below was verified against `origin/main` at `516cf5b`.
 
+> **Anchors re-checked 2026-09-04 (#604).** They have drifted. Three
+> citations into `r6/read_auth.py` — two at lines 88-93 and one at 262 —
+> pointed past the end of a file that is now 86 lines: `a58e2df` (#431) moved
+> that code out to break the auth-stack import cycles, and `_PUBLIC_REASONS`
+> now lives in `r6/access.py`, the kernel this document specifies. Those three
+> now name the function rather than a line, so they survive the next move.
+> **The rest of the file:line anchors below were not re-verified** and should
+> be read as of `516cf5b`, not of today. This slice order is still the live
+> contract for migration PRs; its line numbers are not.
+
 ---
 
 ## 0. Blocking precondition: the safety net is red
@@ -149,7 +159,7 @@ class Scope(Enum):
     rejects one. The names say what the check does, not what the caller
     wishes it did — the exact mistake behind _RESOURCE_ID_PATTERN.
     """
-    TENANT_BOUND = "tenant-bound"   # r6/read_auth.py:88-93 needs this
+    TENANT_BOUND = "tenant-bound"   # authorize_tenant_read() needs this
     WRITE        = "write"          # every write gate today
 
 
@@ -603,7 +613,7 @@ characterization test written first — which by rule 2 is a separate PR.
 | 5 | `r6/actions/routes.py:256-265`, `:354`, `:464-471`, `r6/actions/review.py:66` | Exercises `also_bearer`, `audience`, `operation`, `consume_nonce`. Four matrix rows. Note the matrix already found a site the audit's line list missed (`commit`, `routes.py:354`) — migrate from the matrix, not from the plan. |
 | 6 | `r6/routes.py:464-472` (create), `:629-637` (update), `:3370-3382` (share-bundle) | Three rows, all 401, all `parses_body_before_step_up` pinned. |
 | 7 | `r6/routes.py:1215-1231` (`$ingest-context`), `:2976-2994` + `:3010-3023` (curatr) | The flag-conditional gate (S-3) and the 403 dialect with a two-phase nonce consume. Migrate the SHAPE only. S-3's fail-open stays fail-open in this PR and is fixed in its own, so the diff shows one thing. |
-| 8 | `r6/read_auth.py:88-93` → `Scope.TENANT_BOUND` | **Last, deliberately.** It is called from the `before_request` hook at `r6/routes.py:269-270` on every GET and from `authenticate_tenant_read` at `:250`. Widest blast radius in the file. It is also the site that proved `require_write_grant` needed a scope parameter: `require_scope=None` here is load-bearing, and `tests/test_patient_connect_token.py:126-130` goes red if a write-grant replaces it. |
+| 8 | `authorize_tenant_read` in `r6/read_auth.py` → `Scope.TENANT_BOUND` | **Last, deliberately.** It is called from the `before_request` hook in `r6/routes.py` on every GET and from `authenticate_tenant_read`. Widest blast radius in the file. It is also the site that proved `require_write_grant` needed a scope parameter: `require_scope=None` here is load-bearing, and `tests/test_patient_connect_token.py:126-130` goes red if a write-grant replaces it. |
 
 Deferred out of this group with a reason: `r6/agent_runs/routes.py:53`
 (`validate_step_up_token(...)[0]`, S-5) and
@@ -884,7 +894,7 @@ Protect it.
   mismatch` describes a credential belonging to someone else: it confirms
   the token is valid and merely issued elsewhere, which is the distinction a
   caller probing with a token they should not have is trying to draw.
-  `r6/read_auth.py:262` withholds it for the same reason.
+  The tenant-read path withholds it for the same reason.
 
   Implemented as an allowlist (`_PUBLIC_REASONS`) with the withheld case
   documented beside it (`_WITHHELD_REASONS`), so a reason added to

--- a/docs/2026-08-03-access-kernel-spec.md
+++ b/docs/2026-08-03-access-kernel-spec.md
@@ -11,7 +11,7 @@ two design objections that blocked the kernel as originally specified.
 
 Every file:line below was verified against `origin/main` at `516cf5b`.
 
-> **Anchors re-checked 2026-09-04 (#604).** They have drifted. Three
+> **Anchors re-checked 2026-09-04 (#605).** They have drifted. Three
 > citations into `r6/read_auth.py` — two at lines 88-93 and one at 262 —
 > pointed past the end of a file that is now 86 lines: `a58e2df` (#431) moved
 > that code out to break the auth-stack import cycles, and `_PUBLIC_REASONS`

--- a/docs/2026-08-05-graph-and-scaling-review.md
+++ b/docs/2026-08-05-graph-and-scaling-review.md
@@ -351,7 +351,7 @@ scheduled in Phase 0/1 of the playbook.
   half-landed).
 - `r6/schema_sync.py` is dead code with zero production callers,
   contradicted by its own test suite. Delete it.
-  > **Done, 2026-09-04 (#604).** `a66b33f` (#471) deleted it. The path above
+  > **Done, 2026-09-04 (#605).** `a66b33f` (#471) deleted it. The path above
   > no longer resolves; it is kept as the record of why, not as a pointer.
 
 ## 7. Measured against healthcare/FHIR practice

--- a/docs/2026-08-05-graph-and-scaling-review.md
+++ b/docs/2026-08-05-graph-and-scaling-review.md
@@ -351,6 +351,8 @@ scheduled in Phase 0/1 of the playbook.
   half-landed).
 - `r6/schema_sync.py` is dead code with zero production callers,
   contradicted by its own test suite. Delete it.
+  > **Done, 2026-09-04 (#604).** `a66b33f` (#471) deleted it. The path above
+  > no longer resolves; it is kept as the record of why, not as a pointer.
 
 ## 7. Measured against healthcare/FHIR practice
 

--- a/docs/2026-08-05-pattern-first-architecture-review.md
+++ b/docs/2026-08-05-pattern-first-architecture-review.md
@@ -505,7 +505,7 @@ that exists or a risk that is live.
 
 **Delete now** (code documenting promises nothing keeps):
 
-> **Status checked 2026-09-04 (#604).** Three of the four landed in `a66b33f`
+> **Status checked 2026-09-04 (#605).** Three of the four landed in `a66b33f`
 > (#471): `r6/schema_sync.py`, `careagents/conversation_locks.py` and the two
 > `careagents/app.py` constants are all gone, so those paths no longer
 > resolve. **`scripts/export_healthex_legacy.py` is still in the tree** — that

--- a/docs/2026-08-05-pattern-first-architecture-review.md
+++ b/docs/2026-08-05-pattern-first-architecture-review.md
@@ -505,6 +505,12 @@ that exists or a risk that is live.
 
 **Delete now** (code documenting promises nothing keeps):
 
+> **Status checked 2026-09-04 (#604).** Three of the four landed in `a66b33f`
+> (#471): `r6/schema_sync.py`, `careagents/conversation_locks.py` and the two
+> `careagents/app.py` constants are all gone, so those paths no longer
+> resolve. **`scripts/export_healthex_legacy.py` is still in the tree** — that
+> item was not carried out and is still open.
+
 - `r6/schema_sync.py` — zero production callers; contradicted by its own
   test suite.
 - `careagents/conversation_locks.py` (85 LOC) — imported only by a test;

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -77,16 +77,17 @@ which was never true of either set.
 
 **50,429 lines of test code guard 29,508 lines of engine — 1.7 to 1.**
 
-> **Engine LOC re-measured 2026-09-04 (#604).** This document gave the engine
-> two different sizes and cited a command for neither: 29,446 in the component
-> table above, 29,508 here. Neither is reproducible as written, and they
-> cannot both be right. Measured today at `89b42fb` with
-> `git ls-files 'r6/*.py' 'r6/**/*.py' | xargs wc -l` → **29,537**. The 1.7:1
-> ratio survives; the two figures above are left as written, dated, rather
-> than silently reconciled. The other LOC rows in the table were not
-> re-measured except `services/agent-orchestrator`, which reads 7,899 above
-> and measures **7,640** tracked `.ts` lines today.
 **3,153** tests pass, 13 skip, 1 xfails.
+
+> **The component table disagrees with this block (#604, 2026-09-04).** The
+> engine is 29,508 LOC here and **29,446 LOC** in the component table near the
+> top of this document — one document, one metric, two numbers, and no command
+> cited for either. Measured at `89b42fb` with
+> `git ls-files 'r6/*.py' 'r6/**/*.py' | xargs wc -l` → **29,537**. Both
+> figures are left as written and dated rather than silently reconciled; the
+> table row is the one still uncorrected. Of the table's other sizes only
+> `services/agent-orchestrator` was re-checked: it reads 7,899 and measures
+> **7,640** tracked `.ts` lines today. The rest were not re-measured.
 
 Measured at `4cb3771`, which is this document's branch point, with
 `git ls-files 'r6/**/*.py' 'r6/*.py' | xargs wc -l` and the same over

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -79,7 +79,7 @@ which was never true of either set.
 
 **3,153** tests pass, 13 skip, 1 xfails.
 
-> **The component table disagrees with this block (#604, 2026-09-04).** The
+> **The component table disagrees with this block (#605, 2026-09-04).** The
 > engine is 29,508 LOC here and **29,446 LOC** in the component table near the
 > top of this document — one document, one metric, two numbers, and no command
 > cited for either. Measured at `89b42fb` with

--- a/docs/2026-08-16-system-topology.md
+++ b/docs/2026-08-16-system-topology.md
@@ -30,7 +30,7 @@ problem it was written to solve.
 
 | Component | Size | State |
 |---|---|---|
-| `r6/` — the guardrail engine | 29,446 LOC, 11 blueprints | Conformance **Grade A 7/7 local**, measured today. Proxy mode **not measured** since 2026-08-16 morning. |
+| `r6/` — the guardrail engine | 29,446 LOC (see note), 11 blueprints | Conformance **Grade A 7/7 local**, measured today. Proxy mode **not measured** since 2026-08-16 morning. |
 | `r6/routes.py` — the god module | **3,924 lines, 39 routes** | Ratcheted; shrinking. Decomposition (#56) has not started. |
 | `r6/access.py` — the access kernel | one module | Adopted by 9 modules. `require_grant` + `has_grant` (#506). |
 | `careagents/` — consumer app | 5,311 LOC | On Railway + Postgres. **Deployed build is stale** (#427). Stores no PHI. |
@@ -76,6 +76,16 @@ which was never true of either set.
 ## The two numbers that explain why this document exists
 
 **50,429 lines of test code guard 29,508 lines of engine — 1.7 to 1.**
+
+> **Engine LOC re-measured 2026-09-04 (#604).** This document gave the engine
+> two different sizes and cited a command for neither: 29,446 in the component
+> table above, 29,508 here. Neither is reproducible as written, and they
+> cannot both be right. Measured today at `89b42fb` with
+> `git ls-files 'r6/*.py' 'r6/**/*.py' | xargs wc -l` → **29,537**. The 1.7:1
+> ratio survives; the two figures above are left as written, dated, rather
+> than silently reconciled. The other LOC rows in the table were not
+> re-measured except `services/agent-orchestrator`, which reads 7,899 above
+> and measures **7,640** tracked `.ts` lines today.
 **3,153** tests pass, 13 skip, 1 xfails.
 
 Measured at `4cb3771`, which is this document's branch point, with

--- a/docs/evidence/2026-08-16-set1-guardrail-core.md
+++ b/docs/evidence/2026-08-16-set1-guardrail-core.md
@@ -228,7 +228,7 @@ refused by the guardrail with a corrective `OperationOutcome`) is documented in
 `examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh` step 4.
 **I did not execute it this run**, so it is cited, not asserted as measured.
 
-> **Citation corrected 2026-09-04 (#604).** This line elided the middle of
+> **Citation corrected 2026-09-04 (#605).** This line elided the middle of
 > the path to an ellipsis, which no reader could follow and no check could
 > resolve; the full path is above. The claim behind it was checked at the same
 > time and **holds** — the comment at step 4 of that script describes the
@@ -484,7 +484,7 @@ Stated plainly, because scope stated honestly beats coverage implied.
    compose project up, and re-run §1 (`$conformance` live), §3, §4, §5 against
    `localhost:5099` with
    `examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh`.
-   (Path corrected 2026-09-04 (#604): this read `scripts/walkthrough.sh`,
+   (Path corrected 2026-09-04 (#605): this read `scripts/walkthrough.sh`,
    which does not exist at the repository root. The script is real; the
    citation was relative to the example directory without saying so.)
 2. Answer §2 for proxy mode: for each property the live endpoint reports PASSED,

--- a/docs/evidence/2026-08-16-set1-guardrail-core.md
+++ b/docs/evidence/2026-08-16-set1-guardrail-core.md
@@ -224,8 +224,15 @@ harness is explicit about that rather than rounding it up.
 
 The mechanism itself (unknown search parameters forwarded to Aidbox instead of
 refused by the guardrail with a corrective `OperationOutcome`) is documented in
-**#498** and in the code comment at `examples/.../scripts/walkthrough.sh` step 4.
+**#498** and in the code comment at
+`examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh` step 4.
 **I did not execute it this run**, so it is cited, not asserted as measured.
+
+> **Citation corrected 2026-09-04 (#604).** This line elided the middle of
+> the path to an ellipsis, which no reader could follow and no check could
+> resolve; the full path is above. The claim behind it was checked at the same
+> time and **holds** — the comment at step 4 of that script describes the
+> unknown-parameter forwarding and names #498. Only the path was wrong.
 
 ---
 
@@ -475,7 +482,11 @@ Stated plainly, because scope stated honestly beats coverage implied.
 
 1. Restore `examples/aidbox-healthclaw-guardrails/.env` (**R-1**), bring the
    compose project up, and re-run §1 (`$conformance` live), §3, §4, §5 against
-   `localhost:5099` with `scripts/walkthrough.sh`.
+   `localhost:5099` with
+   `examples/aidbox-healthclaw-guardrails/scripts/walkthrough.sh`.
+   (Path corrected 2026-09-04 (#604): this read `scripts/walkthrough.sh`,
+   which does not exist at the repository root. The script is real; the
+   citation was relative to the example directory without saying so.)
 2. Answer §2 for proxy mode: for each property the live endpoint reports PASSED,
    confirm the subject exists **in Aidbox** (**R-2**).
 3. Run `qa/demo.spec.ts` to produce the asserting recording.

--- a/tests/test_docs_cite_paths_that_exist.py
+++ b/tests/test_docs_cite_paths_that_exist.py
@@ -151,7 +151,11 @@ def _tree_files() -> dict[str, list[Path]]:
             ['git', 'ls-files', '-z'], cwd=REPO_ROOT,
             capture_output=True, text=True, timeout=60, check=True).stdout
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
-        pytest.skip(f'git is required to index the tree: {exc}')
+        # This runs at import time. Without allow_module_level, pytest turns a
+        # module-level skip into a collection *error*, which reads as the
+        # guard being broken rather than as git being unavailable.
+        pytest.skip(f'git is required to index the tree: {exc}',
+                    allow_module_level=True)
     for rel in listing.split('\0'):
         if rel:
             path = REPO_ROOT / rel

--- a/tests/test_docs_cite_paths_that_exist.py
+++ b/tests/test_docs_cite_paths_that_exist.py
@@ -75,8 +75,11 @@ DOCS = REPO_ROOT / 'docs'
 
 # Document kinds whose paths describe intent rather than the tree.
 _PROPOSAL_DIRS = frozenset({'superpowers', 'specs', 'design'})
+# Case-insensitive on purpose: `docs/ROADMAP.md` is the same kind of document
+# as `docs/x-roadmap.md`, and excluding one but not the other is the sort of
+# accident that makes a guard fire on a document it was never meant to police.
 _PROPOSAL_SUFFIX = re.compile(
-    r'(?:-design|-plan|-review|-playbook|-refactor-plan|roadmap)\.md$')
+    r'(?:-design|-plan|-review|-playbook|-refactor-plan|roadmap)\.md$', re.I)
 
 # Extensions that make a slashed token a claim about a file rather than a
 # route, a package name, or a sentence containing a slash.
@@ -133,13 +136,26 @@ def _git_ignores(path: str) -> bool:
 
 
 def _tree_files() -> dict[str, list[Path]]:
+    """Index the tracked tree, via git rather than a filesystem walk.
+
+    "In the repository" is literally the property under test, so the index has
+    to be the repository and not the working directory. A walk also picks up
+    `.venv` and — on the primary checkout — `.claude/worktrees/*`, which hold
+    whole copies of this repo. Every filename would then have two or more
+    matches, the unique-suffix step would stop resolving, and a citation that
+    is fine would go red on one machine and green in CI.
+    """
     index: dict[str, list[Path]] = {}
-    for p in REPO_ROOT.rglob('*'):
-        parts = p.parts
-        if '.git' in parts or 'node_modules' in parts or '.venv' in parts:
-            continue
-        if p.is_file():
-            index.setdefault(p.name, []).append(p)
+    try:
+        listing = subprocess.run(
+            ['git', 'ls-files', '-z'], cwd=REPO_ROOT,
+            capture_output=True, text=True, timeout=60, check=True).stdout
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
+        pytest.skip(f'git is required to index the tree: {exc}')
+    for rel in listing.split('\0'):
+        if rel:
+            path = REPO_ROOT / rel
+            index.setdefault(path.name, []).append(path)
     return index
 
 
@@ -194,6 +210,14 @@ def test_the_scan_reaches_the_directories_it_exists_for():
         assert required in reached, (
             'docs/%s/ is not being scanned, and it is a directory whose '
             'documents cite scripts as backing for claims' % required)
+
+
+def test_the_evidence_pack_parametrisation_is_not_empty():
+    """Parametrising over an empty glob collects zero tests and reports green."""
+    packs = sorted((DOCS / 'evidence').glob('*.md'))
+    assert len(packs) >= 2, (
+        'docs/evidence/ has %d pack(s); the per-pack test would be vacuous'
+        % len(packs))
 
 
 def test_the_extractor_actually_finds_citations():
@@ -300,18 +324,21 @@ def test_no_published_document_cites_a_line_past_the_end_of_a_file():
         + '\n'.join(offenders))
 
 
-@pytest.mark.parametrize('doc_name', [
-    '2026-08-16-set1-guardrail-core.md',
-    '2026-08-16-set2-connectors.md',
-])
-def test_every_evidence_pack_citation_resolves(doc_name):
+@pytest.mark.parametrize(
+    'pack',
+    sorted((DOCS / 'evidence').glob('*.md')),
+    ids=lambda p: p.name,
+)
+def test_every_evidence_pack_citation_resolves(pack):
     """The evidence packs are the most quoted artifacts this repo produces.
 
     Stated separately from the sweep above so that a pack failing is reported
     as a pack failing, rather than as one line in a list of every document.
+
+    Discovered by glob, not listed: #601 and #603 each add a pack, and a
+    hardcoded pair would cover neither. Listing filenames here is the exact
+    narrowness this file exists to avoid.
     """
-    pack = DOCS / 'evidence' / doc_name
-    assert pack.exists(), f'{doc_name} has been renamed or removed'
     unresolved = [
         '%s:%d -> %s' % (pack.name, line_no, token)
         for line_no, token in _citations(pack)

--- a/tests/test_docs_cite_paths_that_exist.py
+++ b/tests/test_docs_cite_paths_that_exist.py
@@ -258,6 +258,48 @@ def test_no_published_document_cites_a_path_that_does_not_exist():
         'cannot be followed is not.\n\n' + '\n'.join(offenders))
 
 
+_LINE_CITE = re.compile(
+    r'((?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.(?:py|ts|tsx|js|sh|html|yaml|yml)'
+    r'):(\d+)')
+
+
+def test_no_published_document_cites_a_line_past_the_end_of_a_file():
+    """The one half of "the path exists but says something else" a machine can see.
+
+    A citation of `foo.py:900` in an 86-line file is not drift — no reading of
+    the file supports it. Ordinary drift (the line moved, the claim still
+    roughly holds) is deliberately NOT flagged: pinning exact line numbers
+    makes an unrelated edit above the line turn an evidence document red, and
+    the cost of that lands on someone who did nothing wrong.
+    """
+    offenders = []
+    for doc in _scanned_docs():
+        for line_no, line in enumerate(
+                doc.read_text(encoding='utf-8').splitlines(), 1):
+            for match in _LINE_CITE.finditer(line):
+                token, cited = match.group(1), int(match.group(2))
+                target = REPO_ROOT / token
+                if not target.exists():
+                    tail = token.split('/')[-1]
+                    found = [c for c in _TREE.get(tail, ())
+                             if str(c.relative_to(REPO_ROOT)).endswith(token)]
+                    if len(found) != 1:
+                        continue  # the path check above owns this case
+                    target = found[0]
+                length = len(target.read_text(
+                    encoding='utf-8', errors='replace').splitlines())
+                if cited > length:
+                    offenders.append(
+                        '%s:%d cites %s:%d, but that file ends at line %d'
+                        % (doc.relative_to(REPO_ROOT), line_no, token,
+                           cited, length))
+
+    assert not offenders, (
+        'A published document cites a line that cannot exist. The file has '
+        'shrunk past the citation, so the claim has no anchor at all.\n\n'
+        + '\n'.join(offenders))
+
+
 @pytest.mark.parametrize('doc_name', [
     '2026-08-16-set1-guardrail-core.md',
     '2026-08-16-set2-connectors.md',

--- a/tests/test_docs_cite_paths_that_exist.py
+++ b/tests/test_docs_cite_paths_that_exist.py
@@ -1,0 +1,278 @@
+"""A published document must not cite a path that does not exist.
+
+Twice now a document has asserted a measured claim and named a script as the
+backing for it, and the script was not in the repository — #601 and #603.
+Both times the claim happened to survive re-running, so nothing broke; both
+times it was found by a person stumbling over it. That is the detection
+method this file replaces.
+
+#601 added the idea in a form keyed to its own evidence file: "every document
+citing *this* evidence still names a path that exists". The property is not
+about that evidence file. It is: **anywhere in `docs/`, a path offered as
+backing for a claim resolves to something in the tree.** A guard written
+against today's filenames does not fire for the document added next week,
+which is the one nobody has read.
+
+So the scan is defined by shape, not by a list:
+
+* every `docs/**/*.md`, discovered at run time — a new evidence pack in a new
+  subdirectory is covered the moment it lands, with nothing to remember;
+* a citation is a token rooted at a real top-level directory of this
+  repository (also read at run time) carrying a known source extension;
+* a citation fails only when four ways of resolving it all miss.
+
+## What is deliberately NOT scanned, and why
+
+**Design, plan, review, spec and playbook documents.** Their paths are
+proposals — `docs/2026-08-02-architecture-audit-and-refactor-plan.md` names
+`r6/http/crud.py` as a module the refactor would *create*. Requiring those to
+exist would mean a plan could not be written before the code, so this guard
+would be deleted rather than obeyed. They are excluded by *kind*
+(`_PROPOSAL_DIRS` / `_PROPOSAL_SUFFIX`), never by filename, so a new review
+document is excluded on the same rule and a new evidence pack is not.
+
+The cost is a real gap: a spec that says "as `tests/x.py` already pins" is a
+claim about the present tense and goes unchecked here. Narrowing that needs
+prose classification, not a path check.
+
+**A cited path inside a fenced command block in an excluded document** is also
+unchecked. `git add r6/actions/rails/ …` in a plan is a command for a tree
+that does not exist yet, so checking fences everywhere trades this guard's
+false-negative for false positives in exactly the documents that legitimately
+name unbuilt paths.
+
+**Extensionless tokens.** `r6/shc/medent/callback` in
+`docs/healthcare-ai-advisors-roadmap.md` is a URL route, and "isolated
+skills/personas" is prose. Neither is a file. Requiring an extension is what
+separates a citation from a slash in a sentence; the price is that a citation
+of a bare *directory* that has been deleted does not fire.
+
+**There is no opt-out marker, and that has a cost.** A note explaining a
+citation this guard rejected cannot quote the rejected path — writing the
+correction in the set-1 pack turned this file red until the note described the
+broken form instead of reproducing it. That is the right trade: a suppression
+comment is a hole, and whoever adds the next dead citation would reach for it.
+Describe the bad path, do not paste it.
+
+**Category 2 and 3 are out of reach of any path check.** A path that exists
+but no longer does what the prose says (`r6/schema_sync.py` was described in
+the present tense as dead code after #471 deleted it) resolves fine here. A
+measurement with no citation at all — the shape #601 and #603 actually found
+— has no path to check. Both were swept by hand in the PR that added this
+file; neither is guarded.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / 'docs'
+
+# Document kinds whose paths describe intent rather than the tree.
+_PROPOSAL_DIRS = frozenset({'superpowers', 'specs', 'design'})
+_PROPOSAL_SUFFIX = re.compile(
+    r'(?:-design|-plan|-review|-playbook|-refactor-plan|roadmap)\.md$')
+
+# Extensions that make a slashed token a claim about a file rather than a
+# route, a package name, or a sentence containing a slash.
+_SOURCE_EXTS = (
+    'py', 'sh', 'ts', 'tsx', 'js', 'mjs', 'md', 'json', 'yml', 'yaml',
+    'toml', 'html', 'css', 'sql', 'txt', 'cfg', 'ini', 'lock',
+)
+
+# Extensions tried when a citation drops the suffix (`r6/access`).
+_IMPLIED_EXTS = ('.py', '.sh', '.ts', '.tsx', '.js', '.md', '.yaml', '.yml',
+                 '.json', '.html')
+
+
+def _repo_roots() -> list[str]:
+    """Top-level directories, read from the tree rather than hardcoded."""
+    return sorted(
+        p.name for p in REPO_ROOT.iterdir()
+        if p.is_dir() and not p.name.startswith('.') and p.name != 'node_modules'
+    )
+
+
+def _citation_re() -> re.Pattern[str]:
+    roots = '|'.join(re.escape(d) for d in _repo_roots())
+    exts = '|'.join(_SOURCE_EXTS)
+    return re.compile(
+        r'(?<![\w/.-])((?:' + roots + r')/[A-Za-z0-9_./-]*'
+        r'[A-Za-z0-9_-]\.(?:' + exts + r'))(?![A-Za-z0-9])')
+
+
+def _is_proposal(doc: Path) -> bool:
+    rel = doc.relative_to(REPO_ROOT)
+    if _PROPOSAL_DIRS.intersection(rel.parts):
+        return True
+    return bool(_PROPOSAL_SUFFIX.search(rel.name))
+
+
+def _scanned_docs() -> list[Path]:
+    return [p for p in sorted(DOCS.rglob('*.md')) if not _is_proposal(p)]
+
+
+def _git_ignores(path: str) -> bool:
+    """A citation of a file that is absent *by policy* is not a dead citation.
+
+    `examples/aidbox-healthclaw-guardrails/.env` and `careagents/BUILD_SHA`
+    are cited correctly and are supposed to be missing from a clean checkout.
+    """
+    try:
+        return subprocess.run(
+            ['git', 'check-ignore', '-q', path],
+            cwd=REPO_ROOT, capture_output=True, timeout=30,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover
+        return False
+
+
+def _tree_files() -> dict[str, list[Path]]:
+    index: dict[str, list[Path]] = {}
+    for p in REPO_ROOT.rglob('*'):
+        parts = p.parts
+        if '.git' in parts or 'node_modules' in parts or '.venv' in parts:
+            continue
+        if p.is_file():
+            index.setdefault(p.name, []).append(p)
+    return index
+
+
+_TREE = _tree_files()
+
+
+def resolve_citation(token: str) -> str | None:
+    """Return how `token` resolves, or None if nothing in the tree matches.
+
+    Four ways, cheapest first. A citation that is merely *imprecise* — the
+    set-1 pack writes `scripts/walkthrough.sh` for a script that lives under
+    `examples/` — still names something real, and correcting the prose is the
+    sweep's job, not a reason to keep CI red.
+    """
+    if (REPO_ROOT / token).exists():
+        return 'exact'
+    if _git_ignores(token):
+        return 'gitignored'
+    for ext in _IMPLIED_EXTS:
+        if (REPO_ROOT / (token + ext)).exists():
+            return 'implied-extension'
+    tail = token.split('/')[-1]
+    matches = [c for c in _TREE.get(tail, ())
+               if str(c.relative_to(REPO_ROOT)).endswith(token)]
+    if len(matches) == 1:
+        return 'unique-suffix'
+    return None
+
+
+def _citations(doc: Path) -> list[tuple[int, str]]:
+    pattern = _citation_re()
+    found = []
+    for line_no, line in enumerate(doc.read_text(encoding='utf-8').splitlines(), 1):
+        for match in pattern.finditer(line):
+            found.append((line_no, match.group(1)))
+    return found
+
+
+# --------------------------------------------------------------------------
+# Guard the guard. A scan that quietly covers nothing passes forever, which is
+# how the narrow version of this check would have failed to generalise.
+# --------------------------------------------------------------------------
+
+def test_the_scan_reaches_the_directories_it_exists_for():
+    scanned = _scanned_docs()
+    assert len(scanned) >= 40, (
+        'the docs scan collapsed to %d file(s) — check _PROPOSAL_SUFFIX'
+        % len(scanned))
+
+    reached = {p.parent.name for p in scanned}
+    for required in ('evidence', 'runbooks', 'prd', 'quickstarts'):
+        assert required in reached, (
+            'docs/%s/ is not being scanned, and it is a directory whose '
+            'documents cite scripts as backing for claims' % required)
+
+
+def test_the_extractor_actually_finds_citations():
+    """If the regex stops matching, every other test here passes vacuously."""
+    total = sum(len(_citations(doc)) for doc in _scanned_docs())
+    assert total >= 100, (
+        'only %d path citations found across docs/ — the extractor is broken, '
+        'not the documents' % total)
+
+
+def test_the_extractor_finds_a_citation_it_must_find():
+    """A concrete anchor, so a regex that matches only noise is caught."""
+    pack = DOCS / 'evidence' / '2026-08-16-set1-guardrail-core.md'
+    cited = {token for _, token in _citations(pack)}
+    assert any(t.startswith('examples/aidbox-healthclaw-guardrails/')
+               for t in cited), (
+        'the set-1 evidence pack cites paths under examples/, and the '
+        'extractor found none of them')
+
+
+def test_proposal_documents_are_excluded_by_kind_not_by_name():
+    excluded = [p for p in sorted(DOCS.rglob('*.md')) if _is_proposal(p)]
+    assert len(excluded) >= 10, 'the proposal exclusion stopped matching'
+    # The exclusion must be a rule about kinds, so a document that is neither
+    # in a proposal directory nor named like one is never excluded.
+    for doc in excluded:
+        rel = doc.relative_to(REPO_ROOT)
+        assert (_PROPOSAL_DIRS.intersection(rel.parts)
+                or _PROPOSAL_SUFFIX.search(rel.name)), rel
+
+
+def test_resolution_accepts_a_path_that_plainly_exists():
+    assert resolve_citation('r6/access.py') == 'exact'
+
+
+def test_resolution_accepts_a_file_that_is_absent_by_policy():
+    assert resolve_citation('careagents/BUILD_SHA') == 'gitignored'
+
+
+def test_resolution_rejects_a_path_that_is_simply_not_there():
+    assert resolve_citation('scripts/this_script_was_never_committed.sh') is None
+
+
+# --------------------------------------------------------------------------
+# The property.
+# --------------------------------------------------------------------------
+
+def test_no_published_document_cites_a_path_that_does_not_exist():
+    offenders = []
+    for doc in _scanned_docs():
+        for line_no, token in _citations(doc):
+            if resolve_citation(token) is None:
+                offenders.append(
+                    '%s:%d cites %s, which is not in the tree'
+                    % (doc.relative_to(REPO_ROOT), line_no, token))
+
+    assert not offenders, (
+        'A published document offers a path as the backing for a claim, and '
+        'the path is not in this repository. Either commit the thing it '
+        'names, or mark the claim as resting on something uncommitted — an '
+        'unverifiable claim labelled as such is useful, a citation that '
+        'cannot be followed is not.\n\n' + '\n'.join(offenders))
+
+
+@pytest.mark.parametrize('doc_name', [
+    '2026-08-16-set1-guardrail-core.md',
+    '2026-08-16-set2-connectors.md',
+])
+def test_every_evidence_pack_citation_resolves(doc_name):
+    """The evidence packs are the most quoted artifacts this repo produces.
+
+    Stated separately from the sweep above so that a pack failing is reported
+    as a pack failing, rather than as one line in a list of every document.
+    """
+    pack = DOCS / 'evidence' / doc_name
+    assert pack.exists(), f'{doc_name} has been renamed or removed'
+    unresolved = [
+        '%s:%d -> %s' % (pack.name, line_no, token)
+        for line_no, token in _citations(pack)
+        if resolve_citation(token) is None
+    ]
+    assert not unresolved, '\n'.join(unresolved)


### PR DESCRIPTION
Generalises what #601 and #603 each found by hand: a document asserting a
measured claim and naming a script that was not in the repository.

## The guard would not have caught either motivating finding

Worth saying first, because a reviewer will work it out in thirty seconds
otherwise. #603's missing scripts are bare filenames in a sentence that
already says "Not committed" — no path shape to check. #601's was a number
with no citation at all. **This guard catches the shape the sweep asked for —
a document pointing at a path that is not there — and neither of the two cases
that motivated it.** Those are categories 2 and 3 below; both were swept by
hand here, and neither is guarded.

## The guard

`tests/test_docs_cite_paths_that_exist.py`, 12 tests (13 once #601 lands its
pack — the per-pack case is parametrised over a glob).

Every `docs/**/*.md`, discovered at run time. A citation is a token rooted at
a real top-level directory of this repo (also read at run time) carrying a
source extension. It fails only when four resolutions all miss: exact path →
`git check-ignore` → implied extension (`r6/access` → `r6/access.py`) →
unique suffix match (`scripts/walkthrough.sh` → the copy under `examples/`).
Imprecise-but-existing is the sweep's job to correct, not the guard's to fail.

**Nothing is keyed to a filename.** A new evidence pack in a new subdirectory
is covered the moment it lands. That is the property, and it is what the
narrow version could not do.

**Excluded by kind, never by name:** design, plan, review, spec, playbook and
roadmap documents. `docs/2026-08-02-architecture-audit-and-refactor-plan.md`
names `r6/http/crud.py` as a module the refactor would *create*; requiring
those to exist would mean a plan could not be written before the code, and the
guard would be deleted rather than obeyed. 25 excluded, 53 scanned.

A second test, `test_no_published_document_cites_a_line_past_the_end_of_a_file`,
reaches the one mechanically-checkable half of category 2. Ordinary drift is
deliberately not flagged — pinning exact line numbers turns an evidence
document red on an unrelated edit above the line, and that cost lands on
someone who did nothing wrong.

### Mutation-checked

| mutation | expected | result |
|---|---|---|
| bogus path in a new file in a **new** `docs/` subdirectory | red | red |
| bogus path in a `*-review.md` | green | green |
| citation of a gitignored path (`r6/__pycache__/*.py`) | green | green |
| `path.py:99999` in a new doc | red | red |

The gitignore row was wrong on the first attempt and is worth flagging: the
probe was `examples/…/.env`, which carries no source extension, so the
extractor never looked at it and the green meant nothing. Re-run with a path
that is ignored *and* extractable.

### Trial-merged against both open PRs

Both merge clean and stay green. Re-run at this branch's tip, `ae7afb0`:

```
git merge --no-commit --no-ff pr601 -> clean
  test_docs_cite_paths_that_exist.py + test_public_walkthrough_tells_the_truth.py
    -> 27 passed   (13 + 14; the guard gains a case from #601's new pack via the glob)
git merge --no-commit --no-ff pr603 -> clean
  test_docs_cite_paths_that_exist.py + test_set2_sections_5_to_7_evidence.py
    -> 49 passed
```

The per-pack test globs `docs/evidence/*.md` rather than listing names, which
is why #601's pack is covered on arrival with no edit.

## Category 1 — a cited path that is simply gone

Swept mechanically across all 78 documents. **241 distinct path-shaped tokens:
208 resolve exactly, 2 are gitignored by policy, 4 drop an extension, 2 are
example-relative** — 216 accounted for. The remaining 25 tokens appear at 32
citation sites: 30 in proposal documents, where they are proposals, and 2
real. Both real ones are in the set-1 pack, both corrected:

- `docs/evidence/2026-08-16-set1-guardrail-core.md:227` elided the middle of a
  path to an ellipsis — unfollowable and unresolvable. **The claim behind it
  was checked and holds**: step 4 of that script does describe the
  unknown-parameter forwarding and does name #498. Only the citation was wrong.
- `…:478` cited `scripts/walkthrough.sh`, which does not exist at the
  repository root; the script is real and lives under `examples/`.

## Category 2 — the path exists, the prose no longer holds

Three found by the past-EOF check, all in
`docs/2026-08-03-access-kernel-spec.md`, which CLAUDE.md names as the live
contract migration PRs follow. Slice 8 pointed at `r6/read_auth.py:88-93`, and
the reason-withholding logic at `:262`, in a file that is now 86 lines:
`a58e2df` (#431) moved that code out to break the auth-stack import cycles,
and `_PUBLIC_REASONS` now lives in `r6/access.py` — the kernel the document
specifies. **A developer working slice 8 would have found nothing at those
lines.** Corrected to name functions, which survive the next move. The
document's header claimed every file:line in it was verified at `516cf5b`;
it now says which anchors were re-checked and that the rest were not.

Also corrected, from the same class:

- `docs/2026-08-05-graph-and-scaling-review.md` and
  `…-pattern-first-architecture-review.md` describe `r6/schema_sync.py` and
  `careagents/conversation_locks.py` in the present tense. `a66b33f` (#471)
  deleted both. Annotated, not rewritten.
- The same "Delete now" list has four items. Three landed; the fourth,
  `scripts/export_healthex_legacy.py`, **is still in the tree and still open.**

## Category 3 — a measurement with no citation

The shape both earlier findings actually took, and invisible to a path check.
Hand-read across five documents. One correction made here; the rest are in
files #601/#603 are rewriting and are listed below rather than edited.

`docs/2026-08-16-system-topology.md` gives the engine two different sizes —
29,446 in the component table, 29,508 in "the two numbers that explain why
this document exists" — with no command cited for either. Measured at
`89b42fb`: **29,537**. Both left as written and dated; the table row is the
one still uncorrected after #601. `services/agent-orchestrator` reads 7,899
and measures 7,640.

## Findings I verified but did NOT edit — contested files

`docs/evidence/2026-08-16-set2-connectors.md`, `…-hard-truths.md` and
`…-tester-program.md` are being rewritten by #601 and #603, which already
conflict with each other. Editing them adds a third party to that conflict.
**Verified by me, against the repo:**

- **set2:241-268 — "four of the six failing properties report a gate that is
  working as broken."** The transcript printed directly beneath that sentence
  shows **five** FAIL blocks, of which **two** carry gate-blame `on_failure`
  text. `grep "prove nothing" r6/conformance/probes.py` returns 2. **The
  "four" is restated in production code** at `r6/conformance/probes.py:132`.
  Repro: `sed -n '241,268p' docs/evidence/2026-08-16-set2-connectors.md`.
  This is a Dev item — I do not edit production code.
- **set2:428 — "A repo-wide search for `sha256:` in yaml/yml/md/txt returns
  one unrelated hit."** Present tense, no command cited. True when written;
  **false the moment the document saved**, because the table four lines above
  it records four digests. Today: 6 hits in 2 files, 5 of them in this
  document. Repro: `grep -rn "sha256:" docs/ skills/`.
- **topology:33 vs :78** — above.
- **topology:37** 7,899 vs 7,640 measured; **topology:110** 10,998 vs 12,648
  measured (`git ls-files 'scripts/*' | xargs wc -l`).

## Reported, not verified by me

A subagent read the five priority documents for category 3 and produced a
larger table. **I independently checked only the five items above.** The rest
is unverified and must be treated as a lead, not a finding — most consequential
being its claim that six of the packs' own highest-severity register entries
(set2 R1/R4/R5, hard-truths' `SECURITY.md` and `form_fill.py`,
tester-program's #525) are already fixed in-tree while the documents still
read as live. #601 and #603 already annotate several of those.

## Coverage — what I did NOT do

- **Mechanical checks cover all 78 documents.** Hand-reading for categories 2
  and 3 covered **five**: the two evidence packs, hard-truths, system-topology,
  tester-program.
- **Not hand-read:** PRDs, runbooks, quickstarts, blog, recipes. The runbooks
  are the expensive gap — each cites operator commands, and settling one means
  reading the script against the prose. Rough cost: half a day for the eight
  runbooks, more if any needs a live run.
- **Known guard gaps**, beyond those in the docstring: an elided path with no
  extension is invisible to it — `docs/2026-08-16-system-topology.md:42` writes
  `examples/aidbox-…/qa/` with a Unicode ellipsis, which is unfollowable and
  uncaught. Not edited: it is in #601's file. `.github/` is not a
  scanned root; a comma-list citation (`r6/routes.py:218,297,…`) checks only
  the first number; and `docs/2026-08-02-architecture-audit-and-refactor-plan.md:153`
  cites `r6/read_auth.py:89` past EOF but is unflagged because its kind is
  excluded.
- **Link rot, report-only.** `docs/beta-program.md` writes issue links as
  `../../../issues/N` and `docs/healthcare-ai-advisors-roadmap.md` as
  `../../issues/N`, 12 of them. One form is wrong on github.com; settling
  which needs a fetch of the rendered page, which I did not do. Deliberately
  out of the guard — these point at an issue tracker, not at backing for a
  claim.
- **There is no opt-out marker, by design.** A note explaining a rejected
  citation cannot quote the rejected path — writing the set-1 correction
  turned this file red until the note described the broken form instead of
  pasting it. A suppression comment is a hole, and whoever adds the next dead
  citation would reach for it.

## Gates

```
uv run ruff check .   -> All checks passed!
uv run python -m pytest tests/ -q
  -> 3169 passed, 13 skipped, 1 xfailed, 2 warnings in 126.13s
uv run python -m pytest tests/test_guardrail_conformance.py -q
  -> 37 passed
```

No production code changed.

## Merge order

Branches from `main`. Touches `docs/2026-08-16-system-topology.md`, which
#601 also touches — my note is at the "two numbers" block, #601's only hunk is
lines 44-57, and the trial merge above is clean. No other file overlaps either
PR.

**Do not approve or enable auto-merge.** An approval here arms a merge that
fires on the next green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
