### PR TITLE
fix(ci): the auto-merge comment mailed on every push, and said something untrue

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,6 +26,15 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  # One run at a time per PR. Two pushes minutes apart produce two runs, and
+  # the notification dedupe below reads back a comment the other run may not
+  # have posted yet — so both would see "nothing said yet" and both would say
+  # it. Queue instead of racing. `false`, not `true`: cancelling a run
+  # mid-flight would abandon the arming step half-done.
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 env:
   AUTO_MERGE_EXTERNAL: "false"
 
@@ -126,30 +135,93 @@ jobs:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -e
+          # This block decides ONE thing — the state the PR is in — and then
+          # reports it twice, differently. GitHub mails every comment; it
+          # mails nothing about a job summary. So the state always goes to the
+          # summary, and only a state the maintainer must know about or act on
+          # is allowed to become a comment.
+          #
+          # Keep this free of Actions expression syntax — every value it
+          # needs arrives through `env:` above — because
+          # tests/test_pr_review_notifications.py executes this block verbatim
+          # against a stub `gh`, and that is the only place the logic runs
+          # anywhere but a live PR.
+          STATE=""; HEADLINE=""
           # Tier 1: dependabot minor/patch -> full auto (merges when checks pass)
           if [ "$AUTHOR" = "dependabot[bot]" ]; then
             TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
             # minor/patch = the MAJOR version component is unchanged
             FROM_MAJ=$(printf '%s' "$TITLE" | sed -nE 's/.* from ([0-9]+)\..* to [0-9]+\..*/\1/p')
             TO_MAJ=$(printf '%s' "$TITLE" | sed -nE 's/.* from [0-9]+\..* to ([0-9]+)\..*/\1/p')
-            if [ -n "$FROM_MAJ" ] && [ "$FROM_MAJ" = "$TO_MAJ" ]; then
+            if [ -z "$FROM_MAJ" ]; then
+              # Half of this repo's dependabot PRs are grouped or multi-package
+              # bumps with no single "from X to Y" in the title. They are held
+              # for the same reason a major is, but for a different reason than
+              # a major, so they say so in their own words.
+              STATE="held-unparsed-bump"
+              HEADLINE="Not armed. This title carries no single from-X-to-Y version, so the minor/patch rule cannot be applied to it and nothing will merge on its own. A human has to review and merge it."
+            elif [ "$FROM_MAJ" = "$TO_MAJ" ]; then
               gh pr merge "$PR" --repo "$REPO" --squash --auto
-              echo "dependabot minor/patch: auto-merge armed"
+              STATE="armed-dependabot"
+              HEADLINE="Auto-merge is ARMED. Minor/patch bump, so it squash-merges by itself once the required checks are green, and no approval is asked for. To stop it: gh pr merge $PR -R $REPO --disable-auto"
             else
-              echo "dependabot MAJOR (or unparsable) bump — leaving for human review"
+              STATE="held-dependabot-major"
+              HEADLINE="Not armed. This is a MAJOR version bump ($FROM_MAJ to $TO_MAJ), which never merges on its own here. A human has to read the changelog and merge it."
             fi
+          else
+            # Tier 2: external/human code — arm only if a maintainer approved
+            # (or AUTO_MERGE_EXTERNAL flips the policy)
+            APPROVED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
+              --jq '[.reviews[] | select(.state=="APPROVED") | select(.authorAssociation=="OWNER" or .authorAssociation=="MEMBER" or .authorAssociation=="COLLABORATOR")] | length')
+            if [ "$APPROVED" -gt 0 ] || [ "${AUTO_MERGE_EXTERNAL}" = "true" ]; then
+              gh pr merge "$PR" --repo "$REPO" --squash --auto
+              STATE="armed-approved"
+              HEADLINE="Auto-merge is ARMED. This PR squash-merges by itself the moment the last required check goes green — including a check that is red now and gets fixed later, and including mid-review. To stop it: gh pr merge $PR -R $REPO --disable-auto"
+            else
+              STATE="waiting-approval"
+              # The wording this replaced said the PR would merge "the moment a
+              # maintainer approves". It cannot: this workflow has no trigger
+              # on reviews, so an approval on its own runs nothing. The trigger
+              # list quoted here is pinned by
+              # test_the_wording_matches_the_triggers_it_describes.
+              HEADLINE="Not armed. Waiting for a maintainer approval. Approving alone arms nothing, because this workflow runs on opened, synchronize, reopened and ready_for_review and has no trigger on reviews — it arms on the next push, reopen or ready-for-review that happens after an approval exists."
+            fi
+          fi
+
+          # Always. A job summary notifies nobody, which is precisely why the
+          # states that need no action end here and nowhere else.
+          printf '### auto-merge: %s\n\n%s\n' "$STATE" "$HEADLINE" \
+            >> "$GITHUB_STEP_SUMMARY"
+          echo "$STATE: $HEADLINE"
+
+          # Only a state the maintainer must know about or act on is mailed.
+          # "Everything passed, waiting for you" is not one — they can see the
+          # PR is waiting. This job runs on every push, and that sentence was
+          # mailed 65 times across the 25 most recent PRs, six times on one of
+          # them, four minutes apart on another.
+          case "$STATE" in
+            armed-*|held-*) ;;
+            *) exit 0 ;;
+          esac
+
+          # ...and only when it CHANGES, or five pushes send five identical
+          # mails. The previous state is read back out of the marker in our own
+          # last comment: no external storage, and it survives a re-run. The
+          # alternative — editing one comment in place — is silent, but it is
+          # silent at the state change too, and the state change is the only
+          # moment worth a mail. So: post on change, say nothing otherwise.
+          #
+          # `grep` matching nothing does not trip `set -e` here: a pipeline's
+          # status is its LAST command's, and `sed` succeeds on empty input.
+          PREV=$(gh pr view "$PR" --repo "$REPO" --json comments \
+                   --jq '.comments[].body' \
+                 | grep -o 'automerge-state: [a-z-]*' | tail -n1 | sed 's/.*: //')
+          if [ "$PREV" = "$STATE" ]; then
+            echo "state unchanged since the last comment — not mailing it again"
             exit 0
           fi
-          # Tier 2: external/human code — arm only if a maintainer approved
-          # (or AUTO_MERGE_EXTERNAL flips the policy)
-          APPROVED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
-            --jq '[.reviews[] | select(.state=="APPROVED") | select(.authorAssociation=="OWNER" or .authorAssociation=="MEMBER" or .authorAssociation=="COLLABORATOR")] | length')
-          if [ "$APPROVED" -gt 0 ] || [ "${AUTO_MERGE_EXTERNAL}" = "true" ]; then
-            gh pr merge "$PR" --repo "$REPO" --squash --auto
-            echo "auto-merge armed (maintainer-approved)"
-          else
-            gh pr comment "$PR" --repo "$REPO" --body \
-              "✅ Standards review passed (claude:approve) and auto-merge is staged — this PR will merge automatically the moment a maintainer approves and CI is green." \
-              || true
-            echo "awaiting maintainer approval before arming auto-merge"
-          fi
+          # No `|| true`: a comment that failed to post is a notification that
+          # did not happen, and this repository has paid for silence that
+          # cannot be told from success (defect catalogue section 5).
+          gh pr comment "$PR" --repo "$REPO" --body \
+            "$(printf '%s\n\n<!-- automerge-state: %s -->\n' "$HEADLINE" "$STATE")"

--- a/tests/test_pr_review_notifications.py
+++ b/tests/test_pr_review_notifications.py
@@ -1,0 +1,306 @@
+"""What the PR-review workflow is allowed to mail, and what it is not.
+
+Every comment a workflow posts is an email. `auto-merge-when-satisfied` runs
+on `synchronize`, so it ran on every push, and until this file existed it
+commented on every one of those runs: "standards review passed, auto-merge is
+staged". Measured on 2026-09-04 over the 25 most recent pull requests — 65 of
+those comments, on 23 of the 25, six on one and two four minutes apart on
+another. None of them named anything the maintainer could act on.
+
+The rule the workflow now follows: a comment is for a state the maintainer
+must know about or act on; every other state goes to the job summary, which
+notifies nobody. And a state that has not changed is not news, so it is not
+sent twice.
+
+The behavioural tests here run the workflow's real shell block — extracted
+from the YAML, not paraphrased — against a stub `gh` that records calls and
+lets a posted comment be read back by the next run. A sequence of runs is
+therefore a real sequence, which is the only way to ask the question that
+matters: does pushing five times send five mails?
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "claude-pr-review.yml"
+WORKFLOW_TEXT = WORKFLOW_PATH.read_text(encoding="utf-8")
+WORKFLOW = yaml.safe_load(WORKFLOW_TEXT)
+
+# YAML 1.1 reads a bare `on:` as the boolean True, which is why this is not
+# WORKFLOW["on"].
+TRIGGERS = WORKFLOW[True]
+
+
+def _arming_step() -> str:
+    """The shell block of the auto-merge job, verbatim."""
+    steps = WORKFLOW["jobs"]["auto-merge"]["steps"]
+    blocks = [s["run"] for s in steps if "run" in s]
+    assert len(blocks) == 1, f"expected one shell step, found {len(blocks)}"
+    return blocks[0]
+
+
+def _arming_code() -> str:
+    """The same block with its comments stripped — the part that executes.
+
+    Written after `test_a_failed_comment_is_not_swallowed` went red on the
+    comment explaining why there is no `|| true`. A guard that cannot tell
+    code from prose about the code reports on the wrong thing.
+    """
+    return "\n".join(line for line in _arming_step().splitlines()
+                      if not line.lstrip().startswith("#"))
+
+
+# A stand-in for `gh`. It logs the verb of every call, answers the three reads
+# the step makes, and — the part that makes a sequence of runs real — appends a
+# posted comment to the same store the next run reads its previous state from.
+GH_STUB = r"""#!/bin/bash
+echo "$1 $2" >> "$GH_LOG"
+case "$1 $2" in
+  "pr view")
+    case "$*" in
+      *"--json title"*)    printf '%s\n' "$FAKE_TITLE" ;;
+      *"--json reviews"*)  printf '%s\n' "${FAKE_APPROVED:-0}" ;;
+      *"--json comments"*) cat "$FAKE_COMMENTS" ;;
+    esac ;;
+  "pr comment")
+    for a in "$@"; do last="$a"; done
+    printf '%s\n' "$last" >> "$FAKE_COMMENTS" ;;
+esac
+exit 0
+"""
+
+
+class _PullRequest:
+    """One pull request, across as many workflow runs as a test wants."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.dir = tmp_path
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir()
+        gh = self.bin / "gh"
+        gh.write_text(GH_STUB)
+        gh.chmod(0o755)
+        self.comments = tmp_path / "comments.txt"
+        self.log = tmp_path / "gh.log"
+        self.summary = tmp_path / "summary.md"
+        for f in (self.comments, self.log, self.summary):
+            f.write_text("")
+
+    def push(self, *, author: str = "contributor", approved: int = 0,
+             title: str = "") -> subprocess.CompletedProcess:
+        """One run of the workflow, as a push to this PR would trigger it."""
+        before = len(self.calls())
+        env = {
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "HOME": str(self.dir),
+            "GH_TOKEN": "stub",
+            "PR": "7",
+            "REPO": "owner/repo",
+            "AUTHOR": author,
+            # Read from the workflow, not hard-coded: flipping it there is a
+            # policy change this test should follow rather than mask.
+            "AUTO_MERGE_EXTERNAL": WORKFLOW["env"]["AUTO_MERGE_EXTERNAL"],
+            "GITHUB_STEP_SUMMARY": str(self.summary),
+            "GH_LOG": str(self.log),
+            "FAKE_COMMENTS": str(self.comments),
+            "FAKE_APPROVED": str(approved),
+            "FAKE_TITLE": title,
+        }
+        proc = subprocess.run(["bash", "-c", _arming_step()], env=env,
+                              capture_output=True, text=True, cwd=self.dir)
+        assert proc.returncode == 0, proc.stderr
+        # Catalogue §0: a harness that drove nothing must not read as a pass.
+        # Every path makes at least one `gh pr view`, so no new calls means
+        # the block exited before doing anything and every count below would
+        # be zero for the wrong reason.
+        assert len(self.calls()) > before, (
+            f"the step made no gh call at all:\n{proc.stdout}{proc.stderr}")
+        return proc
+
+    def calls(self) -> list[str]:
+        return [ln for ln in self.log.read_text().splitlines() if ln.strip()]
+
+    def count(self, verb: str) -> int:
+        return self.calls().count(verb)
+
+    def comment_text(self) -> str:
+        return self.comments.read_text()
+
+
+@pytest.fixture()
+def pr(tmp_path: Path) -> _PullRequest:
+    return _PullRequest(tmp_path)
+
+
+# --- the block has to be runnable at all ------------------------------------
+
+def test_the_arming_step_is_plain_shell_so_this_file_runs_the_real_thing():
+    """MUTATION: put an Actions expression in the block -> red.
+
+    The tests below execute this block outside Actions. One `${{ ... }}` in it
+    and they would be running something that cannot be substituted — and,
+    worse, an empty expression is a workflow syntax error, so the file would
+    fail to parse in production while every test here stayed green.
+    """
+    step = _arming_step()
+    assert "${{" not in step, "the block is no longer executable outside Actions"
+    assert "gh pr merge" in step and "gh pr comment" in step, (
+        "the extracted block is not the arming step")
+
+
+# --- what earns a mail ------------------------------------------------------
+
+def test_a_pull_request_merely_waiting_for_the_maintainer_is_never_mailed(pr):
+    """The offender. Five pushes, no approval, and nothing to act on.
+
+    MUTATION: restore the `gh pr comment` in the waiting branch -> red.
+    """
+    for _ in range(5):
+        pr.push()
+    assert pr.count("pr comment") == 0
+    assert pr.count("pr merge") == 0
+    assert "waiting-approval" in pr.summary.read_text(), (
+        "a state nobody is mailed about must still be recorded somewhere")
+
+
+def test_an_armed_auto_merge_is_mailed_once_however_many_pushes(pr):
+    """A pending merge is worth knowing about. It is worth knowing once.
+
+    MUTATION: delete the PREV check -> red at the second push.
+    """
+    for _ in range(5):
+        pr.push(approved=1)
+    assert pr.count("pr merge") == 5, (
+        "arming is idempotent and must keep running on every push — it is the "
+        "notification that is deduplicated, not the arming")
+    assert pr.count("pr comment") == 1
+
+
+def test_the_mail_goes_at_the_state_change_and_not_before(pr):
+    """Two silent pushes, then an approval, then silence again."""
+    pr.push()
+    pr.push()
+    assert pr.count("pr comment") == 0
+    pr.push(approved=1)
+    assert pr.count("pr comment") == 1, "arming is the news"
+    pr.push(approved=1)
+    assert pr.count("pr comment") == 1, "and it is only news once"
+
+
+@pytest.mark.parametrize("title,state,merges", [
+    ("chore(deps): bump actions/checkout from 4.1.1 to 4.2.0",
+     "armed-dependabot", 3),
+    ("chore(deps): bump actions/checkout from 4.1.1 to 5.0.0",
+     "held-dependabot-major", 0),
+    # Half of this repo's dependabot pull requests look like this one: a
+    # grouped or multi-package bump with no single from-X-to-Y in the title.
+    ("chore(deps-dev): bump jest and @types/jest in /services/agent-orchestrator",
+     "held-unparsed-bump", 0),
+])
+def test_each_dependabot_outcome_is_stated_once_and_only_once(pr, title, state,
+                                                              merges):
+    for _ in range(3):
+        pr.push(author="dependabot[bot]", title=title)
+    assert pr.count("pr merge") == merges
+    assert pr.count("pr comment") == 1
+    # The marker is what the dedupe reads back. A comment posted without one
+    # would notify every run and nothing else here would notice.
+    assert pr.comment_text().count(f"automerge-state: {state}") == 1
+
+
+def test_a_held_bump_and_an_armed_one_are_different_news(pr):
+    """The dedupe key is the state, not "have we ever commented".
+
+    MUTATION: collapse the three dependabot states into one -> red.
+    """
+    pr.push(author="dependabot[bot]",
+            title="chore(deps): bump x from 1.0.0 to 2.0.0")
+    pr.push(author="dependabot[bot]",
+            title="chore(deps): bump x from 1.0.0 to 1.1.0")
+    assert pr.count("pr comment") == 2
+    assert "automerge-state: held-dependabot-major" in pr.comment_text()
+    assert "automerge-state: armed-dependabot" in pr.comment_text()
+
+
+def test_every_run_records_its_state_in_the_job_summary(pr):
+    """The summary is where the quiet states go, so it must always be written."""
+    pr.push()
+    pr.push(approved=1)
+    summary = pr.summary.read_text()
+    assert "### auto-merge: waiting-approval" in summary
+    assert "### auto-merge: armed-approved" in summary
+
+
+# --- what the wording is allowed to claim -----------------------------------
+
+def test_the_wording_matches_the_triggers_it_describes():
+    """The removed comment said the PR merges "the moment a maintainer
+    approves and CI is green". It does not: there is no trigger on reviews, so
+    an approval on its own runs nothing at all — the merge arms on the next
+    push, reopen or ready-for-review after an approval exists.
+
+    The replacement says that instead, which makes it a claim about this
+    trigger list. Add `pull_request_review` here and the sentence becomes
+    wrong, so this test goes red and the wording has to move with it.
+
+    MUTATION: add `pull_request_review:` to the triggers -> red.
+    """
+    assert "the moment a maintainer approves" not in WORKFLOW_TEXT
+    assert "auto-merge is staged" not in WORKFLOW_TEXT
+
+    assert set(TRIGGERS) == {"pull_request_target"}, (
+        "a new trigger changes when auto-merge arms, which the waiting-state "
+        "wording describes verbatim")
+    assert TRIGGERS["pull_request_target"]["types"] == [
+        "opened", "synchronize", "reopened", "ready_for_review"]
+
+    step = _arming_step()
+    assert "has no trigger on reviews" in step
+    assert "next push, reopen or ready-for-review" in step
+
+
+def test_the_arming_step_does_not_claim_a_review_verdict_it_cannot_see():
+    """Measured on 2026-09-04: with ANTHROPIC_API_KEY unset, both the review
+    step and the verdict gate are skipped, the job succeeds, and auto-merge
+    runs anyway. Three sampled pull requests carried the "Standards review
+    passed (claude:approve)" comment and no `claude:approve` label, because no
+    review had run. This job has no way to tell the two apart, so it is not
+    allowed to speak for the reviewer at all.
+
+    MUTATION: put "standards review passed" back in the headline -> red.
+    """
+    code = _arming_code().lower()
+    assert "review passed" not in code
+    assert "claude:approve" not in code
+
+
+def test_a_failed_comment_is_not_swallowed():
+    """Catalogue §5. A notification that did not post must fail the run, not
+    return zero quietly.
+
+    MUTATION: append `|| true` to the `gh pr comment` -> red.
+    """
+    assert "|| true" not in _arming_code()
+
+
+def test_runs_on_one_pull_request_are_serialised():
+    """The dedupe reads a comment the other run may not have posted yet.
+
+    Two pushes four minutes apart is what was observed; two close enough to
+    overlap is what breaks read-then-write with no concurrency group.
+
+    MUTATION: delete the concurrency stanza -> red.
+    """
+    concurrency = WORKFLOW["concurrency"]
+    assert "pull_request.number" in concurrency["group"], (
+        "the group must be per pull request, or every PR queues behind every "
+        "other one")
+    assert concurrency["cancel-in-progress"] is False, (
+        "cancelling mid-run would abandon the arming step half-done")


### PR DESCRIPTION
## What & why

`auto-merge-when-satisfied` runs on `synchronize`, and it commented on every
run:

> ✅ Standards review passed (claude:approve) and auto-merge is staged — this PR
> will merge automatically the moment a maintainer approves and CI is green.

GitHub emails every comment, so that is mail. It names nothing the maintainer
can act on — the PR is waiting for them, which they can already see — and it is
untrue twice over.

**It cannot merge "the moment a maintainer approves."** This workflow has no
trigger on reviews. An approval on its own runs nothing; the merge arms on the
next push, reopen or ready-for-review *after* an approval exists.

**It spoke for a review that had not run.** With `ANTHROPIC_API_KEY` unset, the
review step and the verdict gate are both skipped, the job succeeds anyway, and
this comment claims the verdict. Run `33868870495` (2026-09-04) records
`Claude standards review=skipped`, `Gate on verdict label=skipped`, both jobs
`success`. PRs #605, #579 and #566 each carry that sentence and have **no
`claude:approve` label**, because no review ever applied one. The arming job
cannot see the verdict, so it no longer speaks for it at all.

### The volume, measured

25 most recent PRs, comment bodies read on 2026-09-04:

| | |
|---|---|
| copies of that comment | **65** |
| PRs carrying at least one | 23 of 25 |
| most on one PR | 6 (#579) |
| PRs carrying it, all time | 285 |

## What changed

A comment is for a state the maintainer must know about or act on. Every other
state goes to the job summary, which notifies nobody.

| state | comment | why |
|---|---|---|
| `armed-approved` | yes | a merge is now pending and can fire on the next green check |
| `armed-dependabot` | yes | same, and nobody will be asked to approve it |
| `held-dependabot-major` | yes | it will not merge on its own; a human has to |
| `held-unparsed-bump` | yes | same, and for a reason worth naming separately |
| `waiting-approval` | **no** | "everything passed, waiting for you" |

**Repetition.** Posting on the state change, not updating one comment in place.
Both were on the table; the deciding argument is that an edit is silent *at the
state change too*, and the state change is the only moment worth a mail. The
previous state is read back from an HTML marker in our own last comment — no
external storage, survives a re-run. Five pushes send one mail.

**`concurrency`, added.** The dedupe is a read-then-write, and two pushes close
together produce two runs; without a group they can both read "nothing said
yet" and both say it. `cancel-in-progress: false`, because cancelling would
abandon the arming step half-done.

**Dependabot mail goes up, deliberately.** Those PRs are silent today. At the
observed rate (44 dependabot PRs in ~14 weeks: 16 single minor/patch, 6 single
major, 22 grouped or multi-package) this adds roughly 3 comments a week, one
per dependabot PR, never more. It follows the "an armed auto-merge is worth a
notification" rule and the 2026-08-16 incident behind it. One word vetoes it.

## Observed vs reasoned

**Observed — the change cannot be tested through a pull request, and I checked
rather than assumed.** I opened a throwaway PR (#606, now closed) stacked on
this branch, expecting `pull_request_target` to run this branch's workflow.
It ran **main's**: runs `33870594715` and `33870620151` echo the *old* script
verbatim in their logs and posted two copies of the old comment. The base
branch had the new file at the time (`050a014`, pushed two minutes earlier), so
this is not a staleness artefact. Had I read the check result instead of the
log, I would have reported this change as verified on a live PR. It was not.

**Observed — the real block, the real `gh`, against a live PR.** So instead I
extracted this branch's shell block from the YAML and ran it directly against
#606 with the live `gh` and the real GitHub API:

| run | state | result |
|---|---|---|
| author `aks129`, unapproved | `waiting-approval` | exit 0, summary written, **comment count unchanged at 3** |
| author `dependabot[bot]` | `held-unparsed-bump` | one comment posted (`#issuecomment-5540145967`), count 3 → 4 |
| identical re-run | `held-unparsed-bump` | `state unchanged since the last comment — not mailing it again`, count stays 4 |
| title changed to a major bump | `held-dependabot-major` | new comment posted, count 4 → 5 |

That exercises what a stub cannot: the `--json comments --jq` read, the marker
read-back through real comment bodies (including the two legacy comments with
no marker, which correctly read as "nothing said yet"), and the posting itself.
`gh pr merge` was never reached on any path — #606 ended with
`autoMergeRequest: null`.

**Observed — the suite.** `tests/test_pr_review_notifications.py` executes the
same block against a stub `gh` that lets a posted comment be read back by the
next run, so a sequence of pushes is a real sequence. 13 pass.
Full suite: `3170 passed, 13 skipped, 1 xfailed`. `ruff check .`: clean.

**Reasoned, not observed.** That the merged workflow behaves this way on a real
PR event — the only remaining gap, and it closes on merge. First
unapproved PR to land afterwards should show zero auto-merge comments and
`### auto-merge: waiting-approval` in the job summary. If it does not, the
observations above say the fault is in the wiring, not the logic.

**Reasoned.** `actionlint` is not installed here and is not in CI, so the YAML
is validated by `yaml.safe_load` and by GitHub having parsed and run the file
on #606 — including the new `concurrency` stanza, which came from main's copy
in that run and therefore is *not* covered. Worth a glance on the first run
after merge.

## Mutations run

Each applied to the workflow, suite re-run, then reverted
(harness: 9 mutations, 9 red, none unnoticed):

- drop the mail gate so `waiting-approval` comments again → **RED**
  (`test_a_pull_request_merely_waiting_for_the_maintainer_is_never_mailed`)
- delete the `PREV` check → **RED** (`..._mailed_once_however_many_pushes`)
- remove the marker from the comment body → **RED** (same test — the dedupe
  reads the marker, so a comment without one notifies every run)
- collapse the three dependabot states into one → **RED**
  (`test_each_dependabot_outcome_is_stated_once_and_only_once`)
- add a `pull_request_review` trigger without updating the wording → **RED**
  (`test_the_wording_matches_the_triggers_it_describes`)
- delete the `concurrency` stanza → **RED**
  (`test_runs_on_one_pull_request_are_serialised`)
- append `|| true` to the `gh pr comment` → **RED**
- let an Actions expression into the block → **RED**
- put "Standards review passed (claude:approve)" back in a headline → **RED**
  (`test_the_arming_step_does_not_claim_a_review_verdict_it_cannot_see`)

One of these guards was wrong first: `test_a_failed_comment_is_not_swallowed`
went red on the *comment* explaining why there is no `|| true`. It now strips
comment lines before looking, which is catalogue §4 found inside the guard for
it.

## Checklist

- [x] Tests added/updated and `uv run python -m pytest tests/ -q` passes
- [x] `uv run ruff check .` passes
- [x] No PHI in code, tests, fixtures, or logs
- [x] Touches auth/audit/redaction/tenancy? **No.** CI notification policy only;
      the trust tiers and the arming conditions are byte-for-byte unchanged.
- [x] Node changes: none
- [x] Read against `docs/defect-catalogue.md` — §0 (the harness asserts it made
      a `gh` call before any count is trusted), §1 (the removed sentence *was*
      a reassuring word doing a check's job), §5 (no `|| true` on the post)
- [x] New guards mutation-tested, results above
- [x] Anything deliberately left undone is named below

## Found while there, deliberately not fixed

1. **The verdict gate is not a gate when the reviewer is unconfigured.** With
   no `ANTHROPIC_API_KEY`, both steps skip, `claude-standards-review` reports
   success, and `auto-merge` arms on a maintainer approval having run no
   standards review at all. This is why the old comment could claim a verdict
   that did not exist. Fixing it means deciding whether an unconfigured
   reviewer should block merges — an owner call, not a notification change.
   Worth an issue.
2. **The workflow still has no trigger on reviews.** The new wording is honest
   about it instead of hiding it, but an approval genuinely does nothing until
   the next push. Adding `pull_request_review` would make approval arm the
   merge directly; it would also re-run the review job on every review event.
   `test_the_wording_matches_the_triggers_it_describes` goes red if the trigger
   list changes, so the wording cannot drift away from whatever is decided.
3. **The AI reviewer posts nothing today,** so "a review that found problems is
   worth a notification" is currently vacuous — the prompt's instruction 1 has
   never run. When the key is set it will comment once per push, which is new
   code each time rather than repetition, so I left it alone. If it turns out
   to be noise: on `claude:approve`, post nothing and let the label be the
   verdict; comment only on `request-changes`.
4. **`prod-watch.yml` is already fixed** (#502): fingerprinted issue body,
   edited silently every run, comment only when the failing set changes. Two
   residuals, both deliberate, neither touched here — an unreadable
   `status.json` fingerprints as `unverified-run-<runId>`, so a firing alarm
   with no verdict file comments every 6h (documented as preferable to
   silence); and an alarm issue closed by a human while the condition persists
   is re-filed as a *new* issue next run, since the search is `is:open`.
5. #585 (CI never runs on stacked PRs) is confirmed in passing: #606 ran the
   review and auto-merge jobs and no test job.
