### PR TITLE
docs(conformance): the scorecard's own count did not match its transcript (#605)

### DIFF
--- a/docs/2026-08-16-hard-truths.md
+++ b/docs/2026-08-16-hard-truths.md
@@ -57,7 +57,7 @@ This is the uncomfortable pattern, and it is consistent:
 
 | Artifact | The claim | The reality |
 |---|---|---|
-| `$conformance`, the flagship | a grade a partner can trust | graded **F, 1/7** against a real HAPI, with **four of six failures blaming the guardrails** — the probe was creating a constant Patient and the server rejected the duplicate |
+| `$conformance`, the flagship | a grade a partner can trust | graded **F, 1/7** against a real HAPI, with **five of six failures caused by the probe and two of them blaming a gate by name** — the probe was creating a constant Patient and the server rejected the duplicate. *(Count corrected 2026-09-04, #605: this cell read "four of six failures blaming the guardrails"; no count in the run's transcript yields four.)* |
 | `SECURITY.md`, the policy doc | "HIPAA Safe Harbor … redaction" | redaction **truncates** identifiers to their last four characters; Safe Harbor requires SSNs removed |
 | the connector registry summary | "add `CLIENT_ID`/`_SECRET` for a HAPI behind Basic" | `AUTH_NONE` — the credentials were read, accepted and **dropped** |
 | `smoke_medplum.py`, the QA script | "7/8 guardrail checks passed" | there was **no Medplum**; two of the seven passed on the body of a 401 |

--- a/docs/evidence/2026-08-16-set2-connectors.md
+++ b/docs/evidence/2026-08-16-set2-connectors.md
@@ -235,9 +235,21 @@ Two failures, neither of which is a guardrail failure:
 Docker is down. Reported as red because nothing ran, which is the correct
 report.
 
+> **Count corrected 2026-09-04 (#605).** The sentence below read "Four of the
+> six failing properties report a gate that is working as broken" from
+> 2026-08-16 until today, and register entry R4 said the same. **No count in
+> the transcript beneath it yields four.** The harness names six failing
+> properties; the walkthrough asserts on five, excluding `error_fidelity` (the
+> known #498 failure, which fails against Firely too); five FAIL blocks are
+> printed; and **two** of them carry `on_failure` text blaming a gate. This
+> was wrong on the day rather than overtaken since. The finding it supports is
+> unchanged and slightly stronger — five of the six failures were the
+> collision, not the guardrails. The transcript below is not edited.
+
 **Step 4's Grade F is caused by the harness, not the guardrails**, and the
-mechanism was traced to the end rather than assumed. Four of the six failing
-properties report a gate that is working as broken:
+mechanism was traced to the end rather than assumed. Five of the six failing
+properties are this collision rather than a defect, and two of them report a
+gate that is working as broken in so many words:
 
 ```
 ### FAIL step_up_enforcement
@@ -512,13 +524,18 @@ the script cannot pass at all against a deployment with read auth on — which
 production has.
 
 **R4 — `$conformance` cannot be re-run against an upstream with duplicate
-detection, and misattributes the failure to the guardrails. No issue yet.**
+detection, and misattributes the failure to the guardrails. FIXED by #514;
+re-measured 2026-09-04 (#601). Count corrected 2026-09-04 (#605): this entry
+read "Four properties then fail with `on_failure` text naming the gate" —
+**two** do.** The finding as written on 2026-08-16, with that one count
+corrected in place:
 Measured in §3. `_synthetic_patient()` in `r6/conformance/probes.py` returns a
 constant body; HAPI answers the second and later creates with 412 `HAPI-2840`.
-Four properties then fail with `on_failure` text naming the gate ("the gate
-refuses authorized writes too, so its 401s prove nothing") when the gate was
-never reached. Grade F against a deployment whose guardrails were, in the same
-session, observed to hold. The code comment on `_synthetic_observation` records
+Five of the six graded properties then fail for that reason rather than a
+defect, and **two** of them fail with `on_failure` text naming the gate ("the
+gate refuses authorized writes too, so its 401s prove nothing") when the gate
+was never reached. Grade F against a deployment whose guardrails were, in the
+same session, observed to hold. The code comment on `_synthetic_observation` records
 the same class of misattribution happening before against Aidbox (422, dangling
 reference), so this is the second instance of one shape. Suggested change (not
 made): give the synthetic identifier a per-run nonce — `uuid` is already

--- a/docs/specs/guardrail-spec-0.1.0-draft.md
+++ b/docs/specs/guardrail-spec-0.1.0-draft.md
@@ -752,12 +752,17 @@ own referential-integrity rules, and its own free text.
 - **A create echoes the caller's upstream `display` back unredacted**
   ([#380](https://github.com/aks129/HealthClawGuardrails/issues/380)).
 - **Upstream referential integrity changes what a probe means.** A probe whose
-  subject the upstream rejected can score a pass on the failure of a guardrail
-  that was working. That happened: a constant Patient body, a server that
-  refuses duplicates, and a scorecard reading **Grade F, 1/7, with four of six
-  failures blaming the guardrails**. The synthetic subject is now unique per run
-  and clinical probes bind to a real subject where one can be created. Any
-  implementation of this suite MUST do the same.
+  subject the upstream rejected scores a FAILURE against a guardrail that was
+  working, and names it. That happened on 2026-08-16: a constant Patient body,
+  a server that refuses duplicates, and a scorecard reading **Grade F, 1/7 —
+  five of its six failing properties caused by that collision rather than by a
+  defect, two of them blaming a gate in the failure text**. The synthetic
+  subject is now unique per run and clinical probes bind to a real subject
+  where one can be created; the same deployment re-measured **B, 6/7** on
+  2026-09-04. Any implementation of this suite MUST do the same. (Count
+  corrected 2026-09-04, #605: this read "four of six" and the transcript
+  supports no such count. The inverted "score a pass on the failure" was
+  corrected with it.)
 - **MCP error paths beyond the read path forward raw backend text**
   ([#153](https://github.com/aks129/HealthClawGuardrails/issues/153)).
 

--- a/r6/conformance/probes.py
+++ b/r6/conformance/probes.py
@@ -128,10 +128,18 @@ def _synthetic_patient():
 
     So the FIRST conformance run against a HAPI deployment passed and every
     run after it failed — and failed in the worst possible way, because the
-    dependent Observation then 400s on a dangling subject reference and the
-    scorecard blames the GUARDRAILS. Measured: Grade F, 1/7, with four of the
-    six failures naming gates that were working. A report that accuses the
-    thing it is meant to certify is worse than no report.
+    dependent Observation then 400'd on a dangling subject reference and the
+    scorecard blamed the GUARDRAILS rather than the probe. Measured
+    2026-08-16 against hapi.fhir.org: Grade F, 1/7, where five of the six
+    failing properties were this collision and not a defect (only
+    `error_fidelity`, #498, was real), and two of those named a gate the same
+    session had just watched work. A report that accuses the thing it is
+    meant to certify is worse than no report.
+
+    Fixed 2026-08-16 by the marker identifier below (#514); the same
+    deployment re-measured Grade B, 6/7 on 2026-09-04. None of the above is
+    current behaviour — it is why the marker exists. Transcript:
+    `docs/evidence/2026-08-16-set2-connectors.md` §3.
 
     The uniqueness lives in a marker identifier rather than in the five
     values the redaction checks look for. Those stay constant on purpose: a

--- a/tests/test_conformance_probe_can_run_twice.py
+++ b/tests/test_conformance_probe_can_run_twice.py
@@ -10,14 +10,22 @@ does. Reproduced against hapi.fhir.org directly:
 
 So the first `$conformance` run against a HAPI deployment passed and every
 run after it failed. It failed in the worst available way: the Patient create
-returns no id, the dependent Observation then 400s on a dangling subject
-reference, and the scorecard attributes both to the guardrails. Measured on a
-live run: **Grade F, 1/7, four of the six failures naming gates that were
-working.**
+returned no id, the dependent Observation then 400'd on a dangling subject
+reference, and the scorecard attributed both to the guardrails. Measured on a
+live run, 2026-08-16 against hapi.fhir.org: **Grade F, 1/7 — five of the six
+failing properties were the collision and not a defect (only `error_fidelity`,
+#498, was real), and two of those named a gate the same session had just
+watched work.**
 
 That is the flagship artifact accusing the thing it exists to certify, in
 front of whoever ran it against their own server. The grade is published, and
 a partner evaluating us reruns it — which is precisely the second run.
+
+The F expired the day it was measured: #514 is this fix, and the same
+deployment re-measured **Grade B, 6/7** on 2026-09-04. The transcript of the
+F is `docs/evidence/2026-08-16-set2-connectors.md` §3. The count above read
+"four of the six" here and in four other places until 2026-09-04; no count in
+that transcript yields four (#605).
 
 TWO PROPERTIES, and the second is why this file is not one assertion:
 

--- a/tests/test_scorecard_count_matches_its_transcript.py
+++ b/tests/test_scorecard_count_matches_its_transcript.py
@@ -154,13 +154,17 @@ def test_the_docstring_does_not_present_the_f_as_current():
     """The F was measured on 2026-08-16 and fixed the same day by #514.
 
     A grade in a present-tense docstring is read as today's grade. This pins
-    only that the fix is named in the same docstring as the failure — not
-    how either is worded.
+    only that a stated F is dated and carries its fix — NOT that the F must
+    be stated at all. Deleting an expired grade from production code is the
+    tidiest possible improvement to this docstring, and a test that forced
+    the number to stay would be the same defect one level up: a guard
+    demanding that an out-of-date claim remain in the tree.
     """
     source = PROBES.read_text(encoding="utf-8")
     doc = re.search(r'def _synthetic_patient\(\):\n    """(.*?)"""', source, re.DOTALL)
     assert doc, "_synthetic_patient lost its docstring"
     body = doc.group(1)
-    assert "Grade F, 1/7" in body
+    if "Grade F" not in body:
+        pytest.skip("the docstring no longer states the grade; nothing to date")
     assert "#514" in body, "the docstring states the F without saying it was fixed"
     assert "2026-08-16" in body, "the F is stated without the date it was measured"

--- a/tests/test_scorecard_count_matches_its_transcript.py
+++ b/tests/test_scorecard_count_matches_its_transcript.py
@@ -1,0 +1,166 @@
+"""A count restated from a transcript must equal what the transcript shows.
+
+The 2026-08-16 set-2 pack measured `$conformance` at Grade F, 1/7 against a
+live HAPI and explained that the F came from the probe rather than from the
+guardrails. That explanation carried a count — "four of the six failures
+naming gates that were working" — and the count was copied into five places,
+including a docstring in `r6/conformance/probes.py`. It was never true. The
+transcript printed directly beneath the sentence shows five FAIL blocks, two
+of which carry `on_failure` text blaming a gate. Six, five and two are all
+findable in that transcript; four is not.
+
+The defect is not the arithmetic. It is that a number describing a transcript
+sat next to the transcript for three weeks, in production code and in the
+spec other implementers are told to follow, with nothing comparing the two.
+This file is that comparison.
+
+Deliberately NOT pinned: the wording of either docstring. Prose about a
+measurement should be free to improve. What is pinned is the transcript's own
+counts, the two `on_failure` strings in the probe source that the prose
+describes, and that no document restates the count that was wrong.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PACK = REPO / "docs" / "evidence" / "2026-08-16-set2-connectors.md"
+PROBES = REPO / "r6" / "conformance" / "probes.py"
+
+#: The count that was wrong, in the forms it was written in. Kept narrow on
+#: purpose: "Four of the six feature sets have never been run end to end"
+#: (hard-truths) and "Four of the six sets are unmeasured" (prd/README) are
+#: different, correct claims about something else, and a looser pattern would
+#: fail on them and teach the next person to delete this test.
+WRONG_COUNT = re.compile(
+    r"[Ff]our of (?:the )?six (?:failures|failing)"
+    r"|[Ff]our properties then fail"
+    r"|[Ff]our of the six failures naming",
+)
+
+
+def _fail_block_transcript() -> str:
+    """The fenced block in the pack that lists the failing properties."""
+    text = PACK.read_text(encoding="utf-8")
+    blocks = re.findall(r"```\n(.*?)```", text, re.DOTALL)
+    matching = [b for b in blocks if "### FAIL " in b]
+    assert len(matching) == 1, (
+        f"expected exactly one FAIL-block transcript in {PACK.name}, "
+        f"found {len(matching)}"
+    )
+    return matching[0]
+
+
+def test_the_transcript_shows_five_fail_blocks_and_two_gate_blames():
+    """The two numbers the corrected prose claims, read off the transcript."""
+    block = _fail_block_transcript()
+
+    fail_blocks = re.findall(r"^### FAIL (\w+)$", block, re.MULTILINE)
+    assert len(fail_blocks) == 5, fail_blocks
+
+    # A gate blame is `on_failure` text asserting the gate itself is broken.
+    # Both read "...so its NNNs prove nothing", which is the phrasing that
+    # turns a probe-setup failure into an accusation against the product.
+    gate_blames = re.findall(r"on_failure: the gate .*prove nothing", block)
+    assert len(gate_blames) == 2, gate_blames
+
+    # Four is not any of them, and is not the harness's six either.
+    assert not WRONG_COUNT.search(block), "the transcript itself must not be edited"
+
+
+def test_the_harness_named_six_failing_properties_not_five():
+    """Why "six" was defensible while "four" never was.
+
+    The harness grades seven properties and named six as failing. The
+    walkthrough asserted on five of those, excluding `error_fidelity` — the
+    known #498 failure, which fails against Firely too and so is not the
+    collision. Both numbers are real and describe different things; a
+    correction that flattened them into one would lose that.
+    """
+    text = PACK.read_text(encoding="utf-8")
+    listed = re.search(
+        r"failing properties: \[(.*?)\]", text, re.DOTALL,
+    )
+    assert listed, "the step-4 failing-properties list is gone from the pack"
+    names = re.findall(r"'(\w+)'", listed.group(1))
+    assert len(names) == 6, names
+    assert "error_fidelity" in names
+
+    # And the walkthrough's own assertion line names the other five.
+    asserted = re.search(
+        r"properties that should hold did not: (.*?)\n", text,
+    )
+    assert asserted
+    assert "error_fidelity" not in asserted.group(1)
+
+
+def test_exactly_two_probe_checks_blame_the_gate_in_their_failure_text():
+    """The prose count, checked against the code that produces it.
+
+    Written against string literals rather than by running the probes: the
+    point is that the number in the docstring above them is the number of
+    accusing strings below it, and that stays checkable with no server.
+    """
+    source = PROBES.read_text(encoding="utf-8")
+    # Strip the module's own explanatory comments and docstrings' quoted
+    # examples would be caught too, so count only the literals that are
+    # passed as `on_failure=`.
+    on_failure_args = re.findall(
+        r"on_failure=\(?\s*((?:\"[^\"]*\"\s*)+)", source,
+    )
+    blaming = [a for a in on_failure_args if "prove nothing" in a]
+    assert len(blaming) == 2, blaming
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "r6/conformance/probes.py",
+        "tests/test_conformance_probe_can_run_twice.py",
+        "docs/evidence/2026-08-16-set2-connectors.md",
+        "docs/specs/guardrail-spec-0.1.0-draft.md",
+        "docs/2026-08-16-hard-truths.md",
+    ],
+)
+def test_the_wrong_count_is_not_restated(relative):
+    """All five sites it was copied to.
+
+    Listed by name rather than swept repo-wide: a sweep would go green the
+    day someone writes the number in a sixth file this list does not know
+    about, and would give a false sense that the class is guarded. It is not
+    — only these five are.
+    """
+    # Whitespace-normalised, NOT line by line. In `probes.py` the original
+    # read "...with four of the\n    six failures naming gates...", so every
+    # line-oriented check goes green on the exact text this test exists to
+    # catch. That was this file's first version, and it passed against the
+    # unfixed docstring.
+    flat = re.sub(r"\s+", " ", (REPO / relative).read_text(encoding="utf-8"))
+
+    hits = []
+    for m in WRONG_COUNT.finditer(flat):
+        context = flat[max(0, m.start() - 220):m.end() + 60]
+        # A dated correction note has to quote the count it is correcting.
+        # `Count corrected` is the marker; anything else is a live restatement.
+        if "Count corrected" in context:
+            continue
+        hits.append(context)
+    assert not hits, hits
+
+
+def test_the_docstring_does_not_present_the_f_as_current():
+    """The F was measured on 2026-08-16 and fixed the same day by #514.
+
+    A grade in a present-tense docstring is read as today's grade. This pins
+    only that the fix is named in the same docstring as the failure — not
+    how either is worded.
+    """
+    source = PROBES.read_text(encoding="utf-8")
+    doc = re.search(r'def _synthetic_patient\(\):\n    """(.*?)"""', source, re.DOTALL)
+    assert doc, "_synthetic_patient lost its docstring"
+    body = doc.group(1)
+    assert "Grade F, 1/7" in body
+    assert "#514" in body, "the docstring states the F without saying it was fixed"
+    assert "2026-08-16" in body, "the F is stated without the date it was measured"


### PR DESCRIPTION
Settles the item #605 verified and deferred: *"This is a Dev item — I do not edit
production code."* The edit to `r6/conformance/probes.py` is **inside a docstring;
no executable line changes** (`git diff r6/conformance/probes.py` is one hunk, all
of it prose).

## The count was wrong, and it was wrong on the day

`r6/conformance/probes.py:132` told the next person in that file:

> Measured: Grade F, 1/7, with four of the six failures naming gates that were working.

Read off the transcript in `docs/evidence/2026-08-16-set2-connectors.md` §3 rather
than off any prose about it:

| what the transcript shows | count |
|---|---|
| failing properties the harness names (`failing properties: [...]`) | **6** |
| properties the walkthrough asserts on (`error_fidelity` excluded — the known #498 failure) | **5** |
| `### FAIL` blocks printed | **5** |
| blocks carrying `on_failure` text blaming a gate | **2** |

**Four is not any of them.** Six, five and two are all findable; four is not.
`grep -c "prove nothing" r6/conformance/probes.py` returns 3 — the two `on_failure=`
literals plus one comment quoting one of them.

Repro: `sed -n '241,268p' docs/evidence/2026-08-16-set2-connectors.md`

One number in this PR is **inference, not transcript**: that **five** of the six
failures were the collision rather than a defect. The 2026-08-16 transcript alone
shows the setup failures and the 412/400 codes; attributing `audit_trail` to the
collision needs the source (`pid` is `None`, so no read happens to be audited).
What proves the five is the **pair** of runs — change only the probe and five
clear, with `error_fidelity` left standing. That is stronger evidence than one
transcript, and it is why the pair matters.

Where "six" came from is worth keeping, because it is why the six was defensible
while the four never was: the harness graded six properties as failing, and the
walkthrough asserted on five of them, excluding `error_fidelity` — which is a real
failure (#498) and fails against Firely too, so it is not the collision.

## Wrong vs expired, separated

The repo distinguishes these and both are here.

- **Wrong when written:** the count. Corrected in place at all five sites, each
  with a dated note saying what it read before.
- **Expired since:** the grade. **F, 1/7** was true on 2026-08-16 against `2b7872d`.
  #514 (`d68c012`) fixed the duplicate-body collision the same day, and the same
  deployment re-measured **B, 6/7** on 2026-09-04. Dated, not deleted.

The B 6/7 is read from the transcript, not from a PR description:
`docs/evidence/2026-09-04-set2-rerun/hapi-run.txt` on #601's branch —
`grade B (6/7)` / `failing properties: error_fidelity`. **#601 is unmerged**, so
the docstring cites the pack (which exists on `main`) and names the re-run by date
rather than by a path that is not in the tree yet.

## The docstring: corrected in place, not shortened

Judgment called for in the task. The arithmetic was the broken part. The reason the
paragraph exists — *a report that accuses the thing it is meant to certify is worse
than no report* — is what stops the next person "simplifying" the marker identifier
away, and it survives intact. It is **stronger** with the right numbers: five of the
six failures were the probe, not the guardrails.

Two changes beyond the count:

- **Tense.** "the dependent Observation then 400s ... and the scorecard blames the
  GUARDRAILS" is past-tensed. A grade in a present-tense comment is read as today's
  grade, and this one has been fixed for three weeks.
- **The fix is named in the same paragraph**, so the F cannot be read as current.

## Five sites, one number

| file | what changed |
|---|---|
| `r6/conformance/probes.py:132` | count, tense, dated, fix named. Docstring only. |
| `tests/test_conformance_probe_can_run_twice.py:15` | identical correction — these two must agree |
| `docs/evidence/2026-08-16-set2-connectors.md` §3 | dated correction note; prose count fixed |
| `…set2-connectors.md` R4 | "Four properties then fail with `on_failure` text naming the gate" — **two** do |
| `docs/specs/guardrail-spec-0.1.0-draft.md:757` | count; also the inverted "can score a pass on the failure of a guardrail that was working" |
| `docs/2026-08-16-hard-truths.md:60` | table cell, with the prior wording quoted |

**The pack is annotated, not rewritten** — the form #601 and #603 use. The transcript
block itself is untouched.

Not touched: `docs/2026-08-16-hard-truths.md:14` ("Four of the six feature sets have
never been run end to end") and `docs/prd/README.md:20` ("Four of the six sets are
unmeasured"). Different claims, both correct.

## The guard

`tests/test_scorecard_count_matches_its_transcript.py`, 9 tests. It compares the
prose to the transcript, which nothing did for three weeks.

**Its first version was green against the exact text it exists to catch.** The
original spanned a line break — `"...with four of the\n    six failures naming..."` —
so every line-oriented check misses it. It now reads whitespace-normalised text.
That is written into the test, because the next person will reach for `splitlines()`.

Mutation-checked, five mutations, each turning its named test red and the suite green
again after:

| mutation | test turned red |
|---|---|
| restore the real pre-fix `probes.py` from `HEAD` | `…wrong_count_is_not_restated[probes.py]` + `…does_not_present_the_f_as_current` |
| delete one `### FAIL` block from the transcript | `…shows_five_fail_blocks_and_two_gate_blames` |
| drop `error_fidelity` from the failing-properties list | `…named_six_failing_properties_not_five` |
| soften one probe `on_failure` off "prove nothing" | `…two_probe_checks_blame_the_gate…` |
| restate the count with no correction marker | `…wrong_count_is_not_restated[hard-truths]` |
| delete the grade sentence entirely (the tidy improvement) | **none — skips.** Added in `592ecbe`; the guard must not force an expired number to stay |

Deliberately not pinned: the wording of either docstring. Prose about a measurement
should be free to improve. The five sites are listed **by name, not swept repo-wide** —
a sweep goes green the day someone writes the number in a sixth file and would imply
a coverage this does not have.

## Merge order and collisions

`autoMergeRequest` is null on this PR and I have not approved anything.

**All three trial merges are clean and green**, run at `9464b04`:

```
git merge --no-commit --no-ff origin/qa/530-…  (#601) -> clean
  + test_public_walkthrough_tells_the_truth.py     -> 26 passed
git merge --no-commit --no-ff origin/qa/602-…  (#603) -> clean
  + test_set2_sections_5_to_7_evidence.py          -> 45 passed
git merge --no-commit --no-ff pr605            (#605) -> clean
  + test_docs_cite_paths_that_exist.py             -> 21 passed
```

`git merge-tree --write-tree` exits 0 against both #601 and #603. My hunks in the
pack are at §3 (~line 238) and R4 (~line 520); #601's are the header, R8 and
"Reproducing this"; #603's are §5, §6, §7, R1, R5, R6, R9 and "Reproducing this".
No overlap.

**One semantic collision the textual merge does not catch.** #601 adds, under the
hard-truths table:

> The rows stay as written because they are what was true on 2026-08-16 …

After this merges, **row 1 no longer stays as written** — its count was corrected
because it was never true on 2026-08-16. Whichever of us lands second should soften
that clause to the other four rows. I cannot do it from `main`; flagging it the way
#603 flagged the equivalent for #601.

## What this does NOT cover

- **No live conformance run.** The B 6/7 is #601's measurement, read from its
  transcript. I did not re-run `$conformance` against `hapi.fhir.org` — that creates
  resources on a public server, and #601 already did it on 2026-09-04.
- **The audit_trail rendering gap, unexplained and not chased.** `probe_audit_trail`
  at `2b7872d` (byte-identical to today) gives its read check `on_failure` text, and
  the pack's transcript prints that block with no `on_failure:` line. Either the
  uncommitted walkthrough script did not render it or it was trimmed. It does not
  change any count — that text ("no AuditEvent with action=R references the resource
  …") is descriptive, not accusatory, so it would not be a third gate blame. Recorded
  as an observation.
- **Only the five sites named above.** #605's sweep hand-read five documents;
  runbooks, PRDs and quickstarts are unread by both of us.
- No production behaviour, no guardrail, no test assertion elsewhere was changed.

## Gates

```
uv run ruff check .   -> All checks passed!
uv run python -m pytest tests/ -q
  -> 3166 passed, 13 skipped, 1 xfailed, 2 warnings in 110.51s
uv run python -m pytest tests/test_guardrail_conformance.py \
      tests/test_conformance_probe_can_run_twice.py -q
  -> 40 passed
```

3166 is below the 3169 #605 quotes, so: that is #605's own branch with its own new
tests, not `main`'s baseline. `main` collects **3171**; this branch collects **3180**;
the delta is **exactly the 9 tests added here**. The only other test file touched
changed its module docstring and nothing else.

**Do not approve or enable auto-merge.** An approval here arms a merge that fires on
the next green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

