### PR TITLE
docs(runbooks): four operator steps that no longer do what they say (#605)

### DIFF
--- a/docs/runbooks/agent-run-control-plane.md
+++ b/docs/runbooks/agent-run-control-plane.md
@@ -63,7 +63,10 @@ leases at `deadline_at` and atomically enforce the same deadline invariant.
 
 All paths are under `/command-center/api/runs`:
 
-- `POST /` — idempotently create from `{tenant_id, message_id}`.
+- `POST` on the base path itself — idempotently create from
+  `{tenant_id, message_id}`. Post to `/command-center/api/runs`, **not**
+  `/command-center/api/runs/`; the route carries no trailing slash and the
+  slashed form is a 404, not a redirect.
 - `GET /<id>` — PHI-redacted run/tool projection.
 - `GET /<id>/events?after=<cursor>` — ordered durable replay.
 - `POST /<id>/cancel` — durable cancellation request.

--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -220,13 +220,21 @@ If it refuses, it names what it found and nothing was created. **`cannot build
 a reference for: MY-VAR`** — Railway holds a name that `${{web.NAME}}` cannot
 express. Either rename it on the web service, or, if the worker does not need
 it, add it to the exclusion pattern beside `PORT` and `CARE_ROLE`.
-**`enumeration is missing CARE_ENV`** — you are reading the wrong service or
-project; check `railway status` before retrying. In both cases `$STAGE` is
-intact and you can re-run the block as-is.
+**`enumeration is missing CARE_ENV`** — usually you are reading the wrong
+service or project; check `railway status` before retrying. Check the variable
+names too before you go looking for a misconfigured project: the block names
+`CARE_ENV` and the two `*_API_KEY`s exactly, while `careagents/config.py` reads
+`CARE_ENV` **or** `APP_ENV` for the production switch and accepts
+`ANTHROPIC_OAUTH_TOKEN` as a third LLM credential. A service configured through
+either of those spellings is correct and still trips this block. The refusal is
+deliberate in that direction — it fails closed and creates nothing — but the
+diagnosis above is then the wrong one. In every case `$STAGE` is intact and you
+can re-run the block as-is.
 
 A reference resolves at deploy time, so rotating the web service's secret
 rotates the worker's with it and no secret is ever pasted into a second field.
-At the time of writing the web service carries 17 of them: `CARE_DATABASE_URL`,
+As enumerated on 2026-08-02 (#273) and not re-read against Railway since, the
+web service carries 17 of them: `CARE_DATABASE_URL`,
 `CARE_EMAIL_FROM`, `CARE_ENV`, `CARE_IMESSAGE_HANDLE`, `CARE_MODEL`,
 `CARE_OPENAI_MODEL`, `CARE_ORIGIN`, `CARE_RP_ID`, `CARE_RP_NAME`,
 `CARE_SESSION_SECRET`, `CARE_TELEGRAM_BOT`, `FASTEN_PUBLIC_KEY`,

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -18,13 +18,10 @@ uv run alembic check
 ```
 
 `alembic current` must name the same revision as `alembic heads` and print
-`(head)` beside it — `0007_agent_worker_presence` when this was last checked
-(2026-09-04). **Compare the two commands rather than trusting this literal.**
-Every new revision moves it: this line read `0002_current_contract` from
-2026-07-12 until 2026-09-04, though `0003_audit_outcome_detail` landed on
-2026-07-16 and four more followed it, so an operator verifying against the
-printed name saw a mismatch and had no way to tell a stale document from a
-migration that had not run.
+`(head)` beside it — `0007_agent_worker_presence` when last checked
+(2026-09-04). **Compare the two commands rather than trusting that literal**,
+which every new revision moves; a name pinned here once went stale four days
+after it was written and stayed wrong for seven weeks.
 
 `alembic check` must print `No new upgrade operations detected.`
 

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -17,8 +17,16 @@ uv run alembic current
 uv run alembic check
 ```
 
-Expected current revision: `0002_current_contract (head)`. `alembic check`
-must print `No new upgrade operations detected.`
+`alembic current` must name the same revision as `alembic heads` and print
+`(head)` beside it — `0007_agent_worker_presence` when this was last checked
+(2026-09-04). **Compare the two commands rather than trusting this literal.**
+Every new revision moves it: this line read `0002_current_contract` from
+2026-07-12 until 2026-09-04, though `0003_audit_outcome_detail` landed on
+2026-07-16 and four more followed it, so an operator verifying against the
+printed name saw a mismatch and had no way to tell a stale document from a
+migration that had not run.
+
+`alembic check` must print `No new upgrade operations detected.`
 
 ## Existing v1.8.0 database (first Alembic deployment)
 

--- a/docs/runbooks/resource-identity-migration.md
+++ b/docs/runbooks/resource-identity-migration.md
@@ -131,6 +131,15 @@ curl -s -H "X-Tenant-Id: desktop-demo" \
   https://<prod-host>/r6/fhir/Patient | python -m json.tool | head
 ```
 
+**A bare tenant header only reads a tenant named in `PUBLIC_TENANTS`.** Read
+auth arrived after this runbook was written: `authorize_tenant_read` in
+`r6/read_auth.py` refuses a credential-free read whenever `READ_AUTH_ENABLED`
+is set and the tenant is not public. If the target host has read auth on and
+`desktop-demo` is not in its `PUBLIC_TENANTS`, this returns 401 — which during
+a migration reads like the migration broke reads. Mint a step-up token and send
+`X-Step-Up-Token` instead, and confirm the 401 is absent *before* the migration
+so the comparison means something. Not verified against production here.
+
 Then watch one Fasten ingest complete with `failed=0` where the old
 cross-tenant collisions used to show up as nonzero `failed` counts.
 

--- a/docs/runbooks/resource-identity-migration.md
+++ b/docs/runbooks/resource-identity-migration.md
@@ -137,8 +137,10 @@ auth arrived after this runbook was written: `authorize_tenant_read` in
 is set and the tenant is not public. If the target host has read auth on and
 `desktop-demo` is not in its `PUBLIC_TENANTS`, this returns 401 — which during
 a migration reads like the migration broke reads. Mint a step-up token and send
-`X-Step-Up-Token` instead, and confirm the 401 is absent *before* the migration
-so the comparison means something. Not verified against production here.
+`X-Step-Up-Token` instead — note that minting one for a non-public tenant is
+itself gated, and needs `X-Internal-Secret` matching `INTERNAL_TOKEN_MINT_SECRET`
+— and confirm the 401 is absent *before* the migration so the comparison means
+something. Not verified against production here.
 
 Then watch one Fasten ingest complete with `failed=0` where the old
 cross-tenant collisions used to show up as nonzero `failed` counts.


### PR DESCRIPTION
#605 named the runbooks as the expensive remaining gap: their claims are
operator commands, and settling one means running it rather than pattern-matching
it. This reads **all six** against a booted HealthClaw, a real schema, and the
live upstream. (#605 estimated eight; there are six in `docs/runbooks/`.)

Four corrections, each reproduced before it was written. Everything else I
checked is listed below as holding, with the commands, so the next sweep does
not re-derive it.

## Corrections

### 1. The migration runbook pinned a head that has been wrong for seven weeks

`database-migrations.md:20` told the operator to expect
`0002_current_contract (head)`. The head is `0007_agent_worker_presence`.

```
$ uv run alembic current
0007_agent_worker_presence (head)
```

Written 2026-07-12 (#103); `0003_audit_outcome_detail` broke it 2026-07-16
(#122), and four more revisions followed. So the document's own verification
step has printed a mismatch since four days after it was written, and an
operator has no way to tell a stale document from a migration that did not run
— on the one page whose whole job is to say whether the migration ran.
`tests/test_database_migrations.py:199` already asserts the true head, so the
repo contradicted itself.

Fixed by comparing `alembic current` against `alembic heads` rather than a
literal, so the next revision cannot re-stale it, and dated.

The rest of the section verified clean, end to end, against a scratch database:

```
$ uv run alembic history            # chain 0001..0007, no branches
$ uv run flask --app main init-db   # "Database upgraded to Alembic revision 0007_agent_worker_presence."
$ uv run alembic check              # "No new upgrade operations detected."
$ uv run alembic heads              # 0007_agent_worker_presence (head)
```

`alembic heads` is run above because the fix introduces it: the correction tells
the operator to compare `current` against `heads`, and a runbook sweep that
shipped an unrun command would be the defect it audits.

### 2. `POST /` on the control plane is a 404

`agent-run-control-plane.md:66` listed `POST /` under "All paths are under
`/command-center/api/runs`". Every other entry concatenates correctly
(`GET /<id>`); this one gives `/command-center/api/runs/`, and the route is
`post("")` — Flask does not redirect toward the unslashed form.

```
POST /command-center/api/runs   -> 401   (route matched, auth refused)
POST /command-center/api/runs/  -> 404
```

### 3. The identity-migration smoke read predates read auth

`resource-identity-migration.md:129-131` verifies a completed production
migration with a bare `X-Tenant-Id` header. `authorize_tenant_read`
(`r6/read_auth.py:44`) refuses a credential-free read whenever
`READ_AUTH_ENABLED` is set and the tenant is not in `PUBLIC_TENANTS`. Where
that holds, the step returns 401 — which, read mid-migration, looks like the
migration broke reads, at exactly the point the operator is deciding whether to
restore the snapshot.

**Marked, not guessed.** Whether production sets those two variables needs
production access I do not have; the note names the condition and says it was
not verified there. (Locally both tenants return 200 because `READ_AUTH_ENABLED`
is unset — which is why reading this one off a dev box would have been wrong.)
The note also says that minting the replacement step-up token is itself gated by
`X-Internal-Secret` for a non-public tenant, which the original half-instruction
omitted.

### 4. A failure message in the worker runbook gives the wrong diagnosis

`careagents-durable-worker.md:223` says `enumeration is missing CARE_ENV` means
"you are reading the wrong service or project". The pasted block names
`CARE_ENV` and the two `*_API_KEY`s exactly, while `careagents/config.py:32`
reads `CARE_ENV` **or** `APP_ENV`, and `:151` accepts `ANTHROPIC_OAUTH_TOKEN` as
a third LLM credential. A service configured through either spelling is correct
and still trips the block, sending the operator to audit a project that is fine.

It fails closed and creates nothing, so **the check is left exactly as written**
and only the diagnosis is corrected. Also dated the 17-variable list (production
state enumerated 2026-08-02, #273), which is the "true when written, nothing
dates it" shape the sweep asked for.

## Verified against a running stack — holds, no change

Booted per `docs/development.md` (`init-db`, then `PORT=5099
STEP_UP_SECRET=… python main.py`).

- **All 10 operator SQL statements execute** against a schema built by the
  documented `init-db` — the three in `agent-run-control-plane.md:99-107`, the
  two in `conversation-identity.md:49-55`, the five in
  `careagents-durable-worker.md:332-350`. `passed=10 failed=0`. Every column
  they name exists (`lease_expires_at`, `last_seen_at`, `tool_name`,
  `error_class`, `event_type`, `attempt`).
- **Auth boundaries refuse as documented.** `/workers/health` 403s without
  `X-Internal-Secret` and with a wrong one; 503s fail-closed with no fresh
  presence. On reconcile, the **worker secret 403s and a tenant step-up token
  403s** — only `X-Reconciliation-Secret` passes (then 404s on an unknown run).
  That is `agent-run-control-plane.md:29-33` demonstrated rather than asserted.
- **The conversation contract holds in full** (`conversation-identity.md:13-20`):
  201 on a new claim; 200 with `idempotent_replay: true` **and the original
  message id** on replay; 409 on agent mismatch; **404 on tenant mismatch**
  (`create_run` scopes the message lookup by tenant and raises `LookupError`).
  `surface` is a real accepted field (`routes.py:379` reads `surface` before
  `channel`). I nearly filed the 404 as a defect off a cross-tenant *auth*
  failure returning 401; the documented claim is about an existing conversation
  and is correct.
- **`cc_conversations` is genuinely the cross-process mutex** — `with_for_update`
  on the conversation row inside `claim_next` (`r6/agent_runs/service.py:456-465`).
  Worth stating because #605 found `careagents/conversation_locks.py` deleted in
  #471 and flagged the prose as suspect; the lock moved into HealthClaw's claim
  path, and both runbooks describe where it is now.
- **Every `CARE_RUN_*` name and default matches `careagents/config.py:107-118`**
  (all seven). `lease_seconds / 3` confirms "heartbeated every third". The
  production `_require` set and the 32-char minimum match. The Dockerfile
  dispatches on `CARE_ROLE` and exits 2 on an unknown value. `stamp_build.sh`,
  both systemd units, `careagents/BUILD_SHA` in `.gitignore`, and the compose
  `careagents` profile with both services all exist. Issue #255 is still open,
  so that pointer is live.
- **The Medplum runbook's upstream still matches**: the compose URL is 200 and
  still defines `medplum-server`, `redis` with password `medplum`, port 8103,
  and the recaptcha test keys the override exists to blank. `smoke_medplum.py`
  takes the three documented flags and records exactly **8** results, so `8/8`
  is right — and its gate/check split means a partial run can no longer print a
  flattering fraction. The `/r6/fhir/health` keys (`mode`,
  `checks.upstream.{software,status,upstream_url}`) match `fhir_proxy.py:427-430`,
  and the token endpoint really derives to `<origin>/oauth2/token` (`:76`). §3's
  pivot also holds: the three `MEDPLUM_*` exports **alone** put the app into
  upstream mode, with no `FHIR_UPSTREAM_URL` — booted against an unreachable
  base URL, `/r6/fhir/health` returns `"mode": "upstream"` with
  `"status": "unreachable"`, so an operator following §3 does not land on
  `mode: local` and conclude Medplum is unwired. (`software` appears only on
  the connected branch, so §3's sample JSON is the connected shape.)
- Migration-script strings all present: `current PK:`, `pre-checks passed`,
  `--dry-run verdict: safe to migrate`, `already migrated`,
  `pk_r6_resources_identity`, and the `--dry-run` flag. `varchar(255)` widening
  and the composite PK are both in `0002`. Every cited test path and doc path
  exists.
- `railway.toml` runs `init-db && seed-demo` as one `preDeployCommand` and
  compose has the one-shot `migrate` service, as
  `database-migrations.md:52-56` describes. The "application imports never
  create tables" claim holds and is guarded:
  `test_legacy_environment_flag_cannot_run_ddl_during_factory`. Boot-time
  seeding needs an explicit `flask legacy-boot`, so "omit that seed command" is
  complete advice, not half a control.
- No runbook points at a switched-off channel; there is no dead notification
  step in this directory.

## PR #580 — read, not collided with

#580 rewrites `:303-307` (the `/healthz` JSON gains `run_workers_state`) and
inserts the three-state health table before `## Compose`. **I changed nothing in
that region.** My two edits there are at `:223` and `:229`, both well above it,
and I left the finish-line check at `:289-291` alone — #580's new text speaks to
it and should own it. #580 has no auto-merge armed.

Trial-merged rather than assumed, at this branch's tip:

```
git merge --no-commit --no-ff pr580
  -> Auto-merging docs/runbooks/careagents-durable-worker.md
     Automatic merge went well; stopped before committing as requested
  -> 0 conflicts
```

## What I did NOT cover

- **Anything needing production or Railway.** The 17-variable list, whether
  `ANTHROPIC_API_KEY` is unset, `/healthz` returning `provider: openai`, the
  `railway link/add/up` sequence, and whether production's `PUBLIC_TENANTS`
  contains `desktop-demo` (correction 3 turns on exactly this). Dated or marked,
  not guessed.
- **No live Medplum, no Docker.** §1-2 of the Medplum runbook — the bootstrap
  PKCE sequence and the Redis rate-limiter reset — are read against the upstream
  compose, not executed. The `8/8` is a count of the script's recorded results,
  not an observed run.
- **No live Postgres.** The 10 SQL statements ran against SQLite built by the
  same `init-db`. They are schema-valid; `FOR UPDATE SKIP LOCKED` concurrency
  behaviour is not exercised.
- **The legacy `resource-identity-migration.md` procedure was not executed.**
  Strings and paths verified statically. It also uses bare `python`, not
  `uv run python`, throughout — left alone as it is explicitly the legacy
  document, but it is the one remaining inconsistency I noticed and did not fix.

## Guard — proposed, not built

Per the brief I am not building a second overlapping guard. The one that would
have caught the most consequential finding here is narrow and cheap: **assert
that `database-migrations.md` names the current Alembic head**, comparing the
document against `ScriptDirectory.get_current_head()`. It is one file, one
string, no heuristics, and it fails exactly when a new revision lands — which is
the moment the line goes stale.

I would **not** generalise it. The other three findings needed a booted app, a
404-vs-redirect distinction, and reading `config.py` against pasted shell — none
is mechanically checkable, and a guard that appeared to cover runbooks while
catching only one of four would be worse than none. #605's own conclusion.

## Gates

```
uv run ruff check .                                  -> All checks passed!
uv run python -m pytest tests/ -q
  -> 3157 passed, 13 skipped, 1 xfailed, 2 warnings in 109.71s
uv run python -m pytest tests/test_guardrail_conformance.py -q
  -> 37 passed                     (grade subset: 5 passed, Grade A intact)
```

No production code changed; no security invariant touched.

**Do not approve or enable auto-merge.** An approval here arms a merge that
fires on the next green check. Note also that the standards-review check reports
success without having run (#608) — it is not a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
