### PR TITLE
candidate: A5's own pin was a substring needle that missed 22 of 27 raw tenant reads

### DIFF
--- a/docs/defect-catalogue.md
+++ b/docs/defect-catalogue.md
@@ -294,6 +294,43 @@ both halves: no control at all on the read-only host, and no `<button>`,
 `onclick` or `fetch(` anywhere in the page body. Where a host genuinely cannot
 do the thing, say so in prose instead of offering a button that will 405.
 
+## 13. The instrument, not the thing it measures
+
+**Shape.** A ratchet or counter claims to measure a population — every call
+site of a pattern, every package with an unaudited write. It actually measures
+whatever narrower thing its detection technique happens to catch: one literal
+string shape, one file-level or package-level presence check. The number it
+reports is real and stable and wrong, and nothing about a passing test suite
+distinguishes "the population is small" from "the instrument is blind to most
+of it."
+
+**Evidence.**
+
+| What | Where | Cost |
+|---|---|---|
+| `_UNAUDITED_MUTATOR_PACKAGES` asked only "does this package contain any audit call at all?" — per the PR's own words, "one `audit()` call anywhere in `r6/agent_runs` would have emptied the set while thirteen endpoints stayed silent." | #595, 2026-09-04 | The B2 migration's own completeness pin could not tell "audited" from "one route out of fourteen is audited." |
+| `_RAW_TENANT_READS` matched one literal source-text needle — single-quoted, no default argument. Most call sites in the codebase are double-quoted or carry a default, and one is split across two lines, which no single-line text needle can match at any quoting. The pin read 5; an AST-based recount found 27, including the kernel spec's own open migration slice (`r6/agent_runs/routes.py:98`), invisible to the needle the entire time. | #618, 2026-09-04 | Council ruling D11 scheduled this ratchet as "5 → 0" — a number people plan sprints from. The real slice was 27 → 0, a 5x undercount, silently published in another PR's own evidence table (#562) before the instrument was checked. |
+
+**Why the tests did not catch it.** Both pins had a passing test — `13 passed`
+on every run, including runs where the true count was already climbing. A
+ratchet's own test suite proves the ratchet runs and returns a number; it does
+not prove the number is the population's size. Nothing short of independently
+re-deriving the count with a different technique (grep vs. AST, file-level vs.
+call-site) exposes the gap, because the pin and its test agree with each other
+by construction.
+
+**Guard.** Count structurally (AST) rather than by source text, and at the
+finest grain the property actually names (call site, not file; call site, not
+package). When a pin's own comment cites a number from when it was written
+("the 24 that existed when the migration started"), that number is a claim —
+verify it against the technique, not against the pin's own prior reading of
+itself.
+
+**Reviewer question:** for any ratchet or completeness count in this PR, could
+a change satisfy the check by touching one instance of many, or by matching
+one syntactic shape of several a mutation could legally take? If yes, re-derive
+the count with a broader technique before trusting the number.
+
 ## How to use this in review
 
 1. Read §0. Ask what in the PR *claims* to have been checked.

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -404,26 +404,64 @@ def test_the_god_module_only_shrinks():
 #: behaviour change, not a refactor. Check _is_exempt_discovery_path before
 #: moving a call site, per site — that is the whole reason this is 6 PRs and
 #: not one sed.
-_RAW_TENANT_READS = 5
+#:
+#: Corrected 2026-09-04: this was a single-quote, no-default-arg substring
+#: needle (`"request.headers.get('X-Tenant-Id')"` matched against the raw
+#: line) on a codebase where most call sites are double-quoted or carry a
+#: default — `request.headers.get("X-Tenant-Id")` and
+#: `request.headers.get('X-Tenant-Id', 'default')` both evaded it. The pin
+#: read 5; an AST-based recount (any quote style, with or without a
+#: default, plus the subscript form `request.headers['X-Tenant-Id']`) found
+#: 27, including r6/agent_runs/routes.py:98 — the kernel spec's own open
+#: slice 11j — and r6/wearables/routes.py:233, a call split across two
+#: lines that no single-line text needle could ever have matched regardless
+#: of quoting. This was decoration, not a ratchet: a migration touching
+#: only double-quoted single-line call sites could have lowered the count
+#: while the true number stayed flat.
+_RAW_TENANT_READS = 27
+
+
+def _is_tenant_header_read(node):
+    """`request.headers.get('X-Tenant-Id', ...)` or `request.headers['X-Tenant-Id']`.
+
+    Structural match, not source text: quote style and a default argument
+    are call-site style choices with no bearing on the property this pin
+    exists to hold — a handler reading the tenant header directly instead
+    of through the kernel. A needle that requires exact source text is a
+    guard that certifies whatever shape happened to exist when the needle
+    was written, and nothing else — see the correction above.
+    """
+    def is_request_headers(expr):
+        return (isinstance(expr, ast.Attribute) and expr.attr == 'headers'
+                and isinstance(expr.value, ast.Name) and expr.value.id == 'request')
+
+    if isinstance(node, ast.Call):
+        func = node.func
+        if (isinstance(func, ast.Attribute) and func.attr == 'get'
+                and is_request_headers(func.value) and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == 'X-Tenant-Id'):
+            return True
+    if isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
+        if is_request_headers(node.value):
+            key = node.slice
+            if isinstance(key, ast.Constant) and key.value == 'X-Tenant-Id':
+                return True
+    return False
 
 
 def test_raw_tenant_header_reads_only_decrease():
-    """MUTATION: add `request.headers.get('X-Tenant-Id')` to a handler -> red.
+    """MUTATION: add `request.headers.get("X-Tenant-Id")` to a handler -> red.
 
     The kernel is meant to be the one tenant reader (spec §1.1). Without a
-    pin, the 24 that existed when the migration started would quietly become
-    25 the next time someone needed a tenant in a hurry.
+    pin, the 27 that exist today would quietly become 28 the next time
+    someone needed a tenant in a hurry.
     """
-    root = pathlib.Path(__file__).resolve().parents[1]
-    needle = "request.headers.get('X-Tenant-Id')"
-    sites = []
-    for path in sorted(root.glob('r6/**/*.py')):
-        rel = path.relative_to(root).as_posix()
-        if rel == 'r6/access.py':
-            continue  # the kernel is where this read is supposed to live
-        for n, line in enumerate(path.read_text(encoding='utf-8').split('\n'), 1):
-            if needle in line and not line.lstrip().startswith('#'):
-                sites.append(f'{rel}:{n}')
+    def collect(tree, path):
+        return [f'{_rel(path)}:{node.lineno}' for node in ast.walk(tree)
+                if _is_tenant_header_read(node)]
+
+    sites, scanned = _scan(collect, skip=('r6/access.py',))
     assert len(sites) <= _RAW_TENANT_READS, _report(
         sites, _RAW_TENANT_READS,
         'Read the tenant through r6.access.tenant_from_request.')


### PR DESCRIPTION
## What

`tests/test_ratchets.py`'s `_RAW_TENANT_READS` pin used a single-quote,
no-default-arg substring needle — `"request.headers.get('X-Tenant-Id')"`
matched against raw line text — on a codebase where most call sites are
double-quoted or carry a default. Replaced with an AST-based structural
match (`_is_tenant_header_read`), consistent with every other pin in this
file (`_scan` + `ast.walk`); this was the one outlier still doing raw
text matching.

## Why

Property protected: the ratchet actually counts raw tenant-header reads
outside the kernel, not "reads written in the one source-text shape the
needle happened to be written against."

## Found doing

Auditing the F5/A5 pins for the presence-check-per-package shape a
reviewer found on the B2 (`_UNAUDITED_MUTATOR_PACKAGES`) pin — a
different failure mode, one level down: not aggregation scope, a literal
string match.

## Ran

`uv run python -m pytest tests/test_ratchets.py -q` — 13 passed, count
corrected 5 → 27. `uv run python -m pytest tests/ -q` — 3157 passed, 13
skipped, 1 xfailed, unchanged. `uv run ruff check tests/test_ratchets.py`
— clean.

## Mutation evidence

All four shapes that evaded the old needle, plus a negative control,
against a temporary addition to `r6/oauth.py` (reverted after each):

| Mutation | Old needle | New AST matcher |
|---|---|---|
| `request.headers.get("X-Tenant-Id")` (double-quoted) | missed | caught |
| `request.headers.get('X-Tenant-Id', 'default')` (single-quote + default) | missed | caught |
| `request.headers['X-Tenant-Id']` (subscript) | missed | caught |
| call split across two lines | missed | caught |
| different header name / plain dict / unrelated key (negative control) | — | stays green |

The multi-line case is not hypothetical: `r6/wearables/routes.py:233` is
exactly this shape in production code today and was invisible to the old
needle regardless of quoting.

## What was NOT run

Not run against the intake-read stack (#562–#594), which touches
`r6/sdc/routes.py` — one of the 27 sites this pin now counts. No
application code changed here; only the counter.

## Generalization check

The 27 sites named in the corrected count are read, not modified, by
this PR — they're the accurate baseline the next migration slice lowers,
not something this PR claims to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)