### PR TITLE
fix(caregaps): a row that could not pick an age band quoted one anyway (#616)

### DIFF
--- a/docs/clinical/care-gap-rule-register.md
+++ b/docs/clinical/care-gap-rule-register.md
@@ -208,6 +208,12 @@ what a verdict above means.
 **When something is unknown**
 
 - Unknown age on an age-gated rule → `indeterminate`, never a false "due".
+  On a rule whose cadence is banded by age, that row also carries **no
+  cadence at all** rather than the rule's default, because the default is
+  itself one band's figure — for `bp-screening`, the 40-and-over one. A row
+  that has said it does not know the person's age states no interval that
+  depends on it (#616), and the range covering both bands is not offered
+  either: it is still an answer to the question the row has just declined.
   **`diabetes-a1c` is the exception**: its diagnosis gate runs *before* the age
   gate, so with no date of birth on file it reports `not_applicable` — "no
   diabetes diagnosis found in your connected records" — rather than declining

--- a/r6/caregaps/evaluate.py
+++ b/r6/caregaps/evaluate.py
@@ -216,14 +216,22 @@ def _most_recent(resources, wanted_codes, as_of_date, cadence_months):
 
 
 def _cadence_for(rule, age):
-    """Months between screenings for a patient of `age` under this rule.
+    """Months between screenings for a patient of `age`, or None when this rule
+    has bands and there is no age to choose among them.
 
     A cadence may depend on age (USPSTF blood pressure: every 3-5 years at
-    18-39, annually at 40+). Only callable once the age gate has passed, since
-    without an age there is no band to pick — the rows that never get that far
-    report the rule's own `cadence_months`, which is also the fallback for any
-    age no band claims.
+    18-39, annually at 40+). With no age, a banded rule has NOTHING to report:
+    its own `cadence_months` is one band's figure — the 40+ one — so quoting it
+    on a row that has just said the date of birth is unknown asserts an age
+    band the row disclaims in the next field (#616). None is what that row
+    knows, and its `note` is what does the talking.
+
+    An age that no band claims is a different case and still gets
+    `cadence_months`: a band was consulted for this person and none applied,
+    which is a decision rather than an absence.
     """
+    if age is None:
+        return None if rule.get("cadence_bands") else rule["cadence_months"]
     for band in rule.get("cadence_bands") or ():
         if band["min_age"] <= age <= band["max_age"]:
             return band["cadence_months"]
@@ -254,7 +262,16 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
     results = []
     for rule in CARE_GAP_RULES:
         applies = rule["applies"]
-        cadence = _cadence_desc(rule["cadence_months"])
+        # Resolved with the patient's real age, ONCE, so that every row this
+        # loop can emit carries a cadence somebody chose for this person — or
+        # no cadence at all. It used to be `_cadence_desc(rule["cadence_months"])`
+        # here and the banded figure only after the age gate, which gave the
+        # rows that never reach the gate the 40+ figure by default (#616).
+        # `None` rather than a dropped key: the field is part of the row's
+        # shape for every consumer, exactly as `last_done` is.
+        cadence_months = _cadence_for(rule, age)
+        cadence = (_cadence_desc(cadence_months)
+                   if cadence_months is not None else None)
         base = {"rule_id": rule["id"], "title": rule["title"],
                 "cadence": cadence, "source": rule["source"],
                 "related_ecqm": rule["related_ecqm"],
@@ -296,16 +313,9 @@ def evaluate_care_gaps(patient, conditions=None, observations=None,
                             "note": "sex not recorded — cannot determine eligibility"})
             continue
 
-        # Applicable, and now old enough to have a cadence chosen for them.
-        # Resolved here rather than with `base` above because it needs an age:
-        # the not-applicable and indeterminate rows built before this point
-        # report the rule's default, which is the most that can be said when
-        # no age picked a band.
-        cadence_months = _cadence_for(rule, age)
-        cadence = _cadence_desc(cadence_months)
-        base = {**base, "cadence": cadence}
-
-        # Is there a satisfying record in the connected data?
+        # Is there a satisfying record in the connected data? `cadence_months`
+        # is never None below: the age gate above returns for `age is None`,
+        # and only a banded rule with no age has no cadence.
         last = _most_recent(by_resource[rule["satisfied_by"]["resource"]],
                             rule["satisfied_by"]["codes"], as_of_date,
                             cadence_months)

--- a/tests/test_caregaps_evaluate.py
+++ b/tests/test_caregaps_evaluate.py
@@ -5,7 +5,8 @@ enforced). 'Due' means no satisfying record was found in the CONNECTED data —
 never an assertion that the screening wasn't done elsewhere.
 """
 
-from r6.caregaps.evaluate import CARE_GAP_RULES, REFERENCES, evaluate_care_gaps
+from r6.caregaps.evaluate import (
+    CARE_GAP_RULES, REFERENCES, _cadence_desc, evaluate_care_gaps)
 
 
 def _patient(gender="female", birth="1968-05-01"):
@@ -336,3 +337,85 @@ def test_the_a1c_gate_reports_what_the_records_held_not_what_the_person_has():
     # The claim is bounded by where we looked.
     assert "connected records" in note
     assert "applies to patients" not in note
+
+
+# ─────────────────────────────────────────────
+# A row that could not pick a band must not quote one (#616)
+#
+# `base` was assembled at the top of the loop from `rule["cadence_months"]`,
+# before any gate ran, and the age-banded `_cadence_for` was consulted only
+# after the age gate passed. So the row for an unknown or missing date of
+# birth said "date of birth unknown — cannot determine eligibility" and
+# "yearly" in the same object: it admitted it did not know the age and then
+# asserted the cadence for one age band.
+#
+# The patient-facing filter drops that row (`_consumer_line` renders only
+# `applicable is True`), which is what made it look contained. It is not: the
+# operation's `detail` parameter is the raw unfiltered results
+# (r6/caregaps/routes.py) and the connector tool returns the whole Parameters
+# document unchanged (services/agent-orchestrator/src/tools.ts), so an agent
+# narrating the record can quote "yearly" as authoritative for someone who may
+# be twenty-five.
+#
+# Asserted as a property of every banded rule rather than against the string
+# "yearly", so it still holds when bands are added to a second rule.
+# ─────────────────────────────────────────────
+
+#: Inputs that leave `_age_years` with nothing to work from. Missing and
+#: unparseable are different journeys to the same row, and the row carries the
+#: same contradiction either way.
+_AGELESS = ({"resourceType": "Patient", "gender": "female"},
+            {"resourceType": "Patient", "gender": "female", "birthDate": ""},
+            {"resourceType": "Patient", "gender": "female",
+             "birthDate": "not-a-date"})
+
+
+def _band_figures(rule):
+    """Every cadence this rule can describe — its own and each band's.
+
+    The rule's own `cadence_months` is in here on purpose: for bp-screening it
+    IS a band's figure (the 40-and-over one), so "not a band's, just the
+    default" would print the same false claim.
+    """
+    months = {rule["cadence_months"]}
+    months |= {b["cadence_months"] for b in rule.get("cadence_bands") or ()}
+    return {_cadence_desc(m) for m in months}
+
+
+def test_a_row_that_never_picked_a_band_quotes_no_bands_figure():
+    """MUTATION: build `base` from `_cadence_desc(rule["cadence_months"])`
+    again -> red, the birth-date-unknown row reports "yearly".
+    """
+    banded = [r for r in CARE_GAP_RULES if r.get("cadence_bands")]
+    assert banded, (
+        "no rule carries cadence_bands — this test would assert nothing; "
+        "delete it or give it a rule to guard")
+    for patient in _AGELESS:
+        res = {r["rule_id"]: r for r in evaluate_care_gaps(
+            patient, as_of=_AS_OF)}
+        for rule in banded:
+            row = res[rule["id"]]
+            assert row["cadence"] not in _band_figures(rule), (
+                f"{rule['id']}: {row['cadence']!r} belongs to one age band, "
+                f"and this row has just said it does not know the age "
+                f"({row.get('indeterminate_reason') or row['note']})")
+            # Nothing else may stand in for it either: a range describing both
+            # bands is still an answer to the question the row has just
+            # declined to answer, and the note is what explains the silence.
+            assert row["cadence"] is None, row["cadence"]
+
+
+def test_an_unbanded_rule_still_states_its_one_cadence_with_no_age():
+    """The scope of the fix, pinned from the other side. A rule with a single
+    cadence for everyone it covers makes no age-dependent claim, so blanking
+    it would drop something true — and "consistency" is the reason someone
+    would.
+    """
+    unbanded = [r for r in CARE_GAP_RULES if not r.get("cadence_bands")]
+    assert unbanded, "every rule is banded — this test asserts nothing"
+    for patient in _AGELESS:
+        res = {r["rule_id"]: r for r in evaluate_care_gaps(
+            patient, as_of=_AS_OF)}
+        for rule in unbanded:
+            assert res[rule["id"]]["cadence"] == _cadence_desc(
+                rule["cadence_months"]), rule["id"]


### PR DESCRIPTION
Fixes #616. Based on `fix/542-436-caregaps-route-honesty` (#563) — merge that first.

## The row contradicted itself

`base` was assembled at the top of the rule loop in `r6/caregaps/evaluate.py`
from `_cadence_desc(rule["cadence_months"])`, before any gate ran. The
age-banded `_cadence_for` was consulted only after the age gate passed. So a
patient with an unknown or missing date of birth got:

```json
{"rule_id": "bp-screening",
 "status": "indeterminate",
 "indeterminate_reason": "birth-date-unknown",
 "note": "date of birth unknown — cannot determine eligibility",
 "cadence": "yearly"}
```

Two fields of one object disagreeing. `"yearly"` is the 40-and-over band's
figure, presented with nothing marking it as one of two.

## It is not contained by the consumer filter

`_consumer_line` renders only rows with `applicable is True`, so this one never
reaches the patient page — which is why it looked harmless. But `detail` on the
`$care-gaps` Parameters is the raw unfiltered results
(`r6/caregaps/routes.py:225`), and the connector's `care_gaps` tool returns the
whole document unchanged (`services/agent-orchestrator/src/tools.ts:1795-1806`
— nothing stripped, only `_meta.ui` added). An agent narrating the record can
quote "yearly" as authoritative for someone who may be twenty-five. Both
verified in the code, not assumed.

## The fix

Resolve the band once, at the top, with the patient's real age, and let
`_cadence_for` return `None` when a banded rule has no age to choose with. The
second resolution at the bottom of the loop goes away — one call site, one
value per row.

**Why omit rather than state the range.** A range is still an answer to the
question the row has just said it cannot answer, and the row already carries a
note explaining why it is undecided. That field does the talking.

**Why `null` rather than a dropped key.** `cadence` stays part of the row's
shape for every consumer, exactly as `last_done: None` already is. Nothing
reads it defensively today; nothing has to start.

After:

```
bp-screening        cadence: null            indeterminate
lipid-screening     cadence: every 5 years   indeterminate
diabetes-a1c        cadence: every 6 months  not_applicable
colorectal          cadence: every 10 years  indeterminate
cervical            cadence: every 3 years   indeterminate
mammography         cadence: every 2 years   indeterminate
flu-immunization    cadence: yearly          indeterminate
```

Scoped to banded rules on purpose. An unbanded rule states one cadence for
everyone it covers and makes no age-dependent claim, so blanking it would drop
something true.

## Is cadence the only field with this shape?

Yes, as of this rule table. `rule_id`, `title`, `source` and `related_ecqm` are
static attributes of the rule with no gate-dependent default; `last_done` and
`note` are filled per row after the gates. `cadence_bands` is the only key any
band can override, so `cadence` is the only projection of it. The test is
written so that changes to that answer are caught rather than reasoned about.

## Tests

Property, not string: for every rule carrying `cadence_bands`, a row built with
no age may carry **none** of the figures that rule can describe — the bands'
and its own default, which for `bp-screening` *is* a band's figure. Written
that way it still holds when someone adds bands to a second rule, and it fails
if a future default sneaks back in under another name.

- swept over three inputs that leave `_age_years` with nothing: `birthDate`
  absent, empty, and unparseable
- non-tautology guard: red if no rule carries bands
- positive boundary: an unbanded rule still states its one cadence with no age,
  so a later "consistency" pass cannot blank every indeterminate row

MUTATION verified: restoring `_cadence_desc(rule["cadence_months"])` in `base`
turns `test_a_row_that_never_picked_a_band_quotes_no_bands_figure` red with
`bp-screening: 'yearly' belongs to one age band, and this row has just said it
does not know the age (birth-date-unknown)`.

## Register

`docs/clinical/care-gap-rule-register.md` — the "when something is unknown"
bullet now says the banded row carries no cadence. That page is what a
clinician signs against, and this changes what the row asserts. The drift test
pins numbers, not prose, and stays green.

## Gates

```
3184 passed, 13 skipped, 1 xfailed, 2 warnings in 107.04s
All checks passed!          (uv run ruff check .)
50 passed                   (conformance + ratchets, run again on their own)
```

## Noticed, deliberately not touched

A `not_applicable`-by-age row — age known, outside every band, e.g. a
ten-year-old against `bp-screening` — still reports the rule's default. That is
a band consulted for this person and none applying, which is a decision rather
than an absence, and the row already says "recommended ages 18-120" beside it.
Changing it would move what the register states and is beyond this issue.

Do not approve or merge — #563 is the base, and standards-review reports
success without having run (#608).
