### PR TITLE
docs(runbook): the beta batch's three settings, and the one that fails open (#553)

### DIFF
--- a/docs/runbooks/careagents-durable-worker.md
+++ b/docs/runbooks/careagents-durable-worker.md
@@ -78,6 +78,47 @@ CareAgents identity store use shared databases. The claim path is PostgreSQL
 safe (`FOR UPDATE SKIP LOCKED`); SQLite remains development-only for multiple
 hosts.
 
+## Application settings
+
+Both roles build the same `Config()` (`careagents/config.py`), so these are read
+whichever way the process was started — systemd, Railway or Compose. They change
+what the site does rather than how fast the queue drains:
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `CAREAGENTS_CANONICAL_HOST` | unset | The site's only public hostname. A request arriving under any other `Host` is answered 308 to the same path and query there; `/healthz` is exempt |
+| `CARE_REAL_RECORDS` | `off` | Whether an account may **start** a Fasten, wearable or direct-upload connection. One of `off`, `allowlist`, `on` |
+| `CARE_REAL_RECORDS_ALLOWLIST` | empty | The account emails `allowlist` mode admits — comma-separated, case-insensitive |
+
+What each does when it is **absent** is the part worth reading:
+
+- **`CAREAGENTS_CANONICAL_HOST` unset installs no redirect**, and it is the one
+  of the three that does not fail safe. The service then answers on the
+  platform's own `*.up.railway.app` name as well as on `careagents.cloud`, which
+  is the pair of origins #264 exists to remove. WebAuthn binds a passkey to the
+  origin it was created on and `CARE_RP_ID`/`CARE_ORIGIN` name
+  `careagents.cloud`, so whoever lands on the other name cannot register or
+  present a credential the server will accept. It reaches you as "I can't sign
+  in", from a tester unlikely to have noticed which hostname they used, and
+  nothing in the logs names this variable. Set it to a bare hostname:
+  `careagents.cloud`, with no scheme, port, path or whitespace. Any of those
+  raises `ConfigError` at start-up and both roles crash-loop, deliberately —
+  `https://careagents.cloud` would otherwise 308 every request to
+  `https://https//careagents.cloud/...`, and since `/healthz` is exempt the
+  platform would go on reporting a healthy deploy over a dead site.
+- **`CARE_REAL_RECORDS` unset is `off`**, which renders the Fasten, wearable and
+  direct-upload tiles "coming soon" and answers the connect POST 503. That is
+  the intended beta posture, so a deploy that omits the variable arrives at it
+  by accident rather than by decision — set it explicitly and the next operator
+  can tell the two apart. It gates **new** connections only: refresh, poll,
+  upload and delete on a connection that already exists never consult it. A
+  value outside `off`, `allowlist`, `on` raises `ConfigError`.
+- **`CARE_REAL_RECORDS_ALLOWLIST` is read only in `allowlist` mode.** Unset
+  there, the set is empty and no account qualifies, so the mode closes rather
+  than opens. Entries are account emails, comma-separated; surrounding
+  whitespace and case are ignored. `off` and `on` ignore the variable outright,
+  so it is never a way around `off`.
+
 ## Railway
 
 Two services built from one image. The only configuration that differs is
@@ -246,6 +287,22 @@ you an empty value — a boot refusal if it was the only credential, or worse, a
 worker that claims runs and fails every one at inference while readiness reports
 green.
 
+That enumeration was read once, on 2026-08-02, and predates the three settings
+under [Application settings](#application-settings). Set those on the **web**
+service before deploying a build that contains them, and the enumeration then
+forwards whichever of the three you set alongside the original 17. How many
+that is depends on the posture you chose — `CARE_REAL_RECORDS_ALLOWLIST` means
+nothing outside `allowlist` mode — so check the names, not the total.
+
+A worker service created before they existed does not gain them on its next
+deploy: a reference is written per name at `railway add` time. It does not need
+them either — the worker builds `Config()` but never `create_app()`, so it
+serves no HTTP and starts no connections, and neither setting reaches anything
+it runs. This is the one place the mirror-everything rule has an exception, and
+it is safe only in that direction: add the three references to keep the two
+services identical if you prefer, in the same `${{careagents.NAME}}` form used
+above.
+
 Give the worker **no healthcheck path and no public domain**. It serves no
 HTTP, so Railway's default (no path configured, which is what the web service
 also runs with) is correct; a healthcheck path copied across from the web
@@ -296,12 +353,21 @@ visible. Readiness flips only once a worker's presence is fresh:
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' https://careagents.cloud/healthz   # 200
 curl -s https://careagents.cloud/healthz                                    # "run_workers": true
+curl -sI -o /dev/null -w '%{http_code}\n' https://<web-public-domain>/      # 308
 ```
 
 `200` with `"run_workers": true` and a `build` matching the commit you staged is
 the finish line. If it stays 503, the worker is not running: check its deploy
 logs for a `ConfigError`, and check presence directly with the
 `agent_worker_presence` query under [Operations](#operations).
+
+The third call checks what the first two cannot. `careagents.cloud` is already
+the canonical host and `/healthz` is exempt from the redirect, so both of those
+pass identically whether or not `CAREAGENTS_CANONICAL_HOST` is set. Put the web
+service's own `RAILWAY_PUBLIC_DOMAIN` in `<web-public-domain>`: `308` is the
+redirect working, and `200` means the site is still answering on a second
+origin — where a tester can create a passkey that will not work on
+`careagents.cloud`.
 
 ### A deployment with only the web service
 

--- a/tests/test_careagents_runbook_railway_qa.py
+++ b/tests/test_careagents_runbook_railway_qa.py
@@ -48,10 +48,13 @@ case "$1" in
     for a in "$@"; do
       if [ "$a" = "--json" ]; then
         cat <<'JSON'
-{"CARE_DATABASE_URL":"postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway",
+{"CAREAGENTS_CANONICAL_HOST":"careagents.cloud",
+ "CARE_DATABASE_URL":"postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway",
  "CARE_EMAIL_FROM":"CareAgents <hello@careagents.cloud>","CARE_ENV":"production",
  "CARE_IMESSAGE_HANDLE":"+15550100","CARE_MODEL":"claude-sonnet-5",
  "CARE_OPENAI_MODEL":"gpt-4o-mini","CARE_ORIGIN":"https://careagents.cloud",
+ "CARE_REAL_RECORDS":"allowlist",
+ "CARE_REAL_RECORDS_ALLOWLIST":"first.tester@example.com,second.tester@example.com",
  "CARE_RP_ID":"careagents.cloud","CARE_RP_NAME":"CareAgents",
  "CARE_SESSION_SECRET":"RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3=",
  "CARE_TELEGRAM_BOT":"example_bot",
@@ -70,6 +73,7 @@ JSON
       fi
     done
     cat <<'VARS'
+CAREAGENTS_CANONICAL_HOST=careagents.cloud
 CARE_DATABASE_URL=postgresql://care:S3cr3tPassw0rd@postgres-bfs.railway.internal:5432/railway
 CARE_EMAIL_FROM=CareAgents <hello@careagents.cloud>
 CARE_ENV=production
@@ -77,6 +81,8 @@ CARE_IMESSAGE_HANDLE=+15550100
 CARE_MODEL=claude-sonnet-5
 CARE_OPENAI_MODEL=gpt-4o-mini
 CARE_ORIGIN=https://careagents.cloud
+CARE_REAL_RECORDS=allowlist
+CARE_REAL_RECORDS_ALLOWLIST=first.tester@example.com,second.tester@example.com
 CARE_RP_ID=careagents.cloud
 CARE_RP_NAME=CareAgents
 CARE_SESSION_SECRET=RtQm9xPLv2eWs7YbKd4NfHj6Uz1AoCg3=
@@ -103,11 +109,17 @@ esac
 """
 
 # Every name the snippet must forward: the stub's list minus RAILWAY_*, PORT
-# and CARE_ROLE. These are exactly the 17 the live web service carries, and
-# they include the two whose absence crash-loops the worker.
+# and CARE_ROLE. It is the set the runbook documents, not a reading of Railway
+# — the module docstring is explicit that these tests cannot see the live
+# service — and it includes the two whose absence crash-loops the worker. The
+# order is the stub's JSON order, because that is the order the argv comes out
+# in. The last three arrived with the beta batch (#553) and are described under
+# "Application settings" in the runbook.
 EXPECTED_NAMES = [
+    "CAREAGENTS_CANONICAL_HOST",
     "CARE_DATABASE_URL", "CARE_EMAIL_FROM", "CARE_ENV", "CARE_IMESSAGE_HANDLE",
-    "CARE_MODEL", "CARE_OPENAI_MODEL", "CARE_ORIGIN", "CARE_RP_ID",
+    "CARE_MODEL", "CARE_OPENAI_MODEL", "CARE_ORIGIN", "CARE_REAL_RECORDS",
+    "CARE_REAL_RECORDS_ALLOWLIST", "CARE_RP_ID",
     "CARE_RP_NAME", "CARE_SESSION_SECRET", "CARE_TELEGRAM_BOT",
     "FASTEN_PUBLIC_KEY", "HEALTHCLAW_BASE", "HEALTHCLAW_MINT_SECRET",
     "OPENAI_API_KEY", "OPENAI_BASE_URL", "RESEND_API_KEY",
@@ -126,6 +138,10 @@ SECRET_FRAGMENTS = [
     # the snippet actually calls. Without this the leak assertion would not
     # cover the value shape that motivated switching away from `--kv` at all.
     "QUFAKEKEYQAFAKEKEYQAFAKEKEYQAFAKEKEY",
+    # Not a secret, but CARE_REAL_RECORDS_ALLOWLIST holds tester email
+    # addresses, and the reference form is what keeps them out of the argv and
+    # the shell history along with everything else.
+    "second.tester@example.com",
 ]
 
 # The block is fenced ```bash and uses bash/zsh arrays and a herestring, so it
@@ -427,3 +443,20 @@ def test_the_runbook_does_not_send_the_operator_back_to_a_repo_build():
     assert "Do not create the service from the GitHub repo" in railway_section
     assert "railway.toml" in railway_section
     assert "--repo" not in railway_section
+
+
+def test_the_runbook_documents_the_settings_that_change_what_the_site_does():
+    # These three shipped in #553 with no entry on the page an operator deploys
+    # from. Two fail safe when omitted — CARE_REAL_RECORDS defaults to `off`
+    # and closes the record tiles, which is the beta posture anyway. The
+    # canonical host does not: unset, no redirect is installed, the platform's
+    # own *.up.railway.app name stays a second origin, and the WebAuthn failure
+    # that follows reaches an operator as "testers cannot sign in" — a symptom
+    # that points nowhere near a missing variable.
+    text = RUNBOOK.read_text()
+    assert "## Application settings" in text
+    for name in ("CAREAGENTS_CANONICAL_HOST", "CARE_REAL_RECORDS",
+                 "CARE_REAL_RECORDS_ALLOWLIST"):
+        assert f"`{name}`" in text, (
+            f"careagents/config.py reads {name}, but the deploy runbook never "
+            f"mentions it")


### PR DESCRIPTION
Branches from and targets `feat/careagents-beta-batch` (#553).

## What was missing

#553 introduces `CAREAGENTS_CANONICAL_HOST`, `CARE_REAL_RECORDS` and
`CARE_REAL_RECORDS_ALLOWLIST`. Grepping every `.md`, `.toml`, `.yml` and
Dockerfile in the repo finds none of the three — including in
`docs/runbooks/careagents-durable-worker.md`, which is the page an operator
deploys CareAgents from.

Two of them fail safe. `CARE_REAL_RECORDS` defaults to `off`
(`careagents/config.py`) and closes the Fasten, wearable and direct-upload
tiles, so a deploy that omits it lands on the intended beta posture by
accident. `CAREAGENTS_CANONICAL_HOST` does not. Unset, `_enforce_canonical_host`
returns immediately, no redirect is installed, and the service keeps answering
on the platform's own `*.up.railway.app` name as well as on `careagents.cloud`
— the two origins #264 exists to remove. `CARE_RP_ID`/`CARE_ORIGIN` name
`careagents.cloud`, so a tester who reaches the other name cannot create or use
a passkey. That surfaces as "I can't sign in", from someone who has no idea
which hostname they used, with nothing in the logs naming the variable.

## What this adds

- An **Application settings** section between `## systemd` and `## Railway`, in
  the same `| Variable | Default | Purpose |` table the page already uses, plus
  prose for each on what its absence does and which values it constrains. It
  sits before the Railway section because both roles build the same `Config()`
  whatever started them, and because the canonical-host failure is a Railway
  failure.
- A paragraph after the 17-name enumeration recording that the snapshot
  predates all three and that they belong on the **web** service. It tells the
  operator to check the names rather than a total, because how many of the
  three apply depends on the posture — `CARE_REAL_RECORDS_ALLOWLIST` means
  nothing outside `allowlist` mode, so a beta deploy sets two, not three. A
  worker created before them neither gains them on redeploy (a reference is
  written per name at `railway add` time) nor needs them: `careagents/worker.py`
  builds `Config()` and never `create_app()`, so it serves no HTTP and starts no
  connections and neither setting reaches anything it runs. That is the one
  exception to the mirror-everything rule, and the paragraph says why it is safe
  in that direction only.

  The 2026-08-02 date in that paragraph is measured, not copied from #610:
  `git log -S'carries 17 of them'` on the file returns exactly `9493be3`
  (2026-08-02, #273), and no later commit touches the list.
- A third call in **Deploy and confirm it worked**. This is the staleness the
  three settings caused beyond their own absence: the existing finish line is
  `curl https://careagents.cloud/healthz`, and *both* of its checks pass
  identically whether or not the canonical host is set — `careagents.cloud` is
  already canonical, and `/healthz` is exempt from the redirect by design. A
  `308` against the platform domain's root is the only check here that can see
  the failure.

## The pinned list: contents, not a count

`tests/test_careagents_runbook_railway_qa.py` pins the enumerated variable set,
and it is **not** the count-shaped guard found in four others today. The
assertion is `names == EXPECTED_NAMES` — ordered contents. The count lives only
in the failure message, and in a comment. So the list was moved with the change
rather than around it: the stub service and `EXPECTED_NAMES` go 17 → 20, in
matching order (argv order is the stub's JSON order), and the snippet is still
proved to forward every name as a `${{careagents.NAME}}` reference and to drop
none silently.

Two smaller notes on that file:

- The comment "these are exactly the 17 the live web service carries" **was**
  count-shaped, and it claimed live Railway state the tests explicitly cannot
  see (the module docstring says so). Rewritten to say it is the set the
  runbook documents.
- `CARE_REAL_RECORDS_ALLOWLIST` holds tester email addresses. Its stub value
  joins `SECRET_FRAGMENTS`, so the existing "nothing reaches the argv or the
  terminal" guarantee covers the PII this release adds, not only secrets.

One new test asserts the runbook mentions all three by name. That is beyond the
literal ask; it is the guard that would have caught this, and it fails on the
pre-change runbook.

## Collision with #610

**#610 touches the lines this needs, so I did not.** Its hunk is old lines
220–232 and it rewrites

> `At the time of writing the web service carries 17 of them: \`CARE_DATABASE_URL\`,`

into an "As enumerated on 2026-08-02 … and not re-read against Railway since"
form. Inserting `CAREAGENTS_CANONICAL_HOST` into that list alphabetically —
it sorts first, ahead of every `CARE_*` name — would have conflicted. This PR
leaves 229–239 untouched and adds a following paragraph instead, outside that
hunk and its context.

Worth stating plainly, since #610 is an audit: it **dated** this list without
checking it against the code, and the three names were already missing when it
did. Dating a list is not checking it.

## Deliberately not touched

- `deploy/careagents/deploy.sh` writes the systemd env template and is a third
  list carrying none of the three. That is a code change on the systemd path,
  not documentation, and out of scope here.
- `CARE_TELEGRAM_BOT` stays in the enumeration. #553 stops the hub emitting it,
  but `careagents/app.py:1212` still reads it for the deep link, so the
  snapshot is not wrong and the runbook says nothing about Telegram to go
  stale.
- Whether the three are set on live Railway right now. I have not read the
  service, and the runbook is now explicit that the 17-name snapshot is a dated
  reading rather than current state.

## Gates

```
3179 passed, 13 skipped, 1 xfailed, 2 warnings in 101.50s
All checks passed!          (uv run ruff check .)
```

Do not merge or approve — approval arms a merge that fires on the next push,
and the standards-review check reports success without having run (#608).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

