### PR TITLE
fix(prod-watch): declare the checks instead of counting the ones that ran

### DIFF
--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -132,6 +132,21 @@ jobs:
             // observed pass may close one.
             const buildResolved = status?.build?.asserted === true
                                   && status?.build?.ok === true;
+            // The third condition, and not a variant of the first: "the watch
+            // did not run every check it declares" is a defect in
+            // scripts/prod_watch.py, and its remedy is a code change, not a
+            // deploy or a redeploy. Filed as an outage it would send whoever
+            // reads it at 03:00 to the wrong dashboard; folded into the
+            // outage alarm's silence it would be exactly the failure it
+            // reports — a summary line that reads complete because the
+            // denominator shrank.
+            //
+            // Belt and braces for the same reason the stale alarm has it:
+            // exit 3 has one meaning, and it keeps firing if the verdict file
+            // is absent, truncated, or schema-drifted (rename `complete` and
+            // the JSON-only predicate silently never fires again).
+            const incomplete = exit === '3' || status?.complete === false;
+            const complete = status?.complete === true;
             // WHAT is wrong, reduced to a comparable value. A comment is a
             // notification; an edit is not. So the issue body is refreshed
             // every run (always current, silent) and a comment is posted only
@@ -159,6 +174,11 @@ jobs:
             const outageFp = status ? `checks:${failingNames}` : unknown;
             const staleFp = status?.build?.deployed
               ? `build:${status.build.deployed}` : unknown;
+            // WHICH checks vanished, so a second one going missing comments
+            // and the same one every six hours does not.
+            const gone = [...(status?.missing ?? []),
+                          ...(status?.unreadable ?? [])].sort().join('|');
+            const incompleteFp = status ? `missing:${gone}` : unknown;
 
             const MARK = (fp) => `<!-- prod-watch-fingerprint: ${fp} -->`;
             const FP_RE = /<!-- prod-watch-fingerprint: (.*?) -->/;
@@ -169,6 +189,15 @@ jobs:
               ['prod-watch: deployed build is stale', staleFiring, buildResolved,
                'Production is healthy, but it is not running the build we expect.',
                staleFp],
+              ['prod-watch: the watch is not running every check it declares',
+               incomplete, complete,
+               'This run decided fewer checks than scripts/prod_watch.py ' +
+               'declares. Every OK line below is still true; the run as a ' +
+               'whole is not a verdict on production, because part of the ' +
+               'harness did not execute. Fix the script — this is not a ' +
+               'deployment problem, and the outage alarm stays open until a ' +
+               'complete run observes production passing.',
+               incompleteFp],
             ];
             for (const [title, firing, resolved, lead, fingerprint] of alarms) {
               const { data: found } = await github.rest.search.issuesAndPullRequests({

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -110,7 +110,7 @@ def _human():
     return sys.stderr if _human_to_stderr else sys.stdout
 
 # The build check's verdict, kept separately from `results`, because an exit
-# code is one scalar and the two alarms it drives are not. Without this the
+# code is one scalar and the alarms it drives are not. Without this the
 # workflow had to infer "is the build stale?" from a code an unrelated outage
 # also sets, and closed a live stale-build alarm with "passing again" during an
 # outage — the same unverified green #258 exists to eliminate.

--- a/scripts/prod_watch.py
+++ b/scripts/prod_watch.py
@@ -14,9 +14,15 @@ Exit codes, so a scheduled job can open the right issue:
     0  everything passing
     1  hard failure — a deployment is down, degraded, or a guardrail regressed
     2  the deployment is healthy but is running a build we did not expect
+    3  the run did not decide every check this script declares — a defect in
+       this script, not a verdict on production
 
 Those are different alarms with different remedies, and a stale build holding
-the outage issue open would destroy the meaning of the outage issue.
+the outage issue open would destroy the meaning of the outage issue. 3 is the
+same argument once more: "the harness is broken" and "production is broken"
+send different people to different places, and the first used to be reported
+as the second's absence — `all N checks passing`, with N derived from whatever
+happened to run.
 
 Why this exists
 ---------------
@@ -47,10 +53,12 @@ artifact works — a broken build carrying the right sha still passes it.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 import requests
 
@@ -85,6 +93,10 @@ BUILD_CHECK = "careagents: running the current build"
 _SHA_RE = re.compile(r"[0-9a-f]{7,40}")
 
 results: list[tuple[str, bool, str]] = []
+#: Names decided WITHOUT an assertion — see `report`. Kept because a check that
+#: said "not asserted, and here is why" ran, and one that said nothing did not.
+#: The completeness guard in `run` has to be able to tell those apart.
+reported: list[str] = []
 
 # Where the human report goes. `--json` moves it to stderr so stdout carries
 # the payload and nothing else — the flag was documented as machine-readable
@@ -107,8 +119,75 @@ def _human():
 build_info: dict = {"deployed": None, "built_at": None, "built": None,
                     "asserted": False, "ok": None}
 
+# Whether the run decided everything it declares, kept apart from `results` for
+# the same reason build_info is: this is a claim about the RUN, not about
+# production, and it drives a third alarm whose remedy is "fix this script".
+# False until a run proves otherwise — not-yet-known is not complete.
+completeness: dict = {"complete": False, "missing": [], "unreadable": []}
+
+
+def _declared_checks(source: str | None = None):
+    """The check names this file declares, and the call sites it cannot read.
+
+    Every `check(NAME, ...)` here is a declaration that the run will decide
+    NAME. Reading them back out of the source is what keeps the expectation in
+    the same place as the checks: there is no list beside them to update, so
+    there is none to forget, and two branches that each add a check cannot
+    disagree about a total. Adding a check adds its expectation.
+
+    A name is readable when it is a string literal or a module-level string
+    constant (BUILD_CHECK is one). Anything else — an f-string, a name built at
+    run time — comes back as unreadable rather than being skipped: a call site
+    this cannot see is a check the guard cannot miss, which is the whole hole.
+
+    `report` sites are NOT declarations. report is how a declared name says
+    "not asserted this run", so a name that only ever reports asserts nothing
+    and must not be demanded of a run that had no reason to say it.
+    """
+    if source is None:
+        source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    consts: dict[str, str] = {}
+    for node in tree.body:
+        if (isinstance(node, ast.Assign)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+
+    names: set[str] = set()
+    unreadable: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == "check"):
+            continue
+        arg = node.args[0] if node.args else None
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            names.add(arg.value)
+        elif isinstance(arg, ast.Name) and arg.id in consts:
+            names.add(consts[arg.id])
+        else:
+            unreadable.append(
+                f"the check on line {node.lineno} does not name itself with a "
+                "literal or a module constant, so a run cannot tell whether "
+                "it ran")
+    return frozenset(names), unreadable
+
 
 def check(name: str, ok: bool, detail: str = "") -> bool:
+    """Assert something, and record the verdict under `name`.
+
+    The name is a promise. Every `check(...)` call site in this file is read
+    back out of the source as a declaration that the run will DECIDE that name
+    — asserted here, or reported under the same name when there is honestly
+    nothing to assert (#272). A run that does neither has quietly checked less
+    than this script says it checks, and `run` fails it rather than counting
+    what happened to run.
+
+    So a name has to stay statically readable: a literal, or a module constant
+    like BUILD_CHECK. `_declared_checks` refuses anything it cannot read.
+    """
     results.append((name, ok, detail))
     mark = f"{G} OK {X}" if ok else f"{R}FAIL{X}"
     print(f"{mark} {name}" + (f" {D}— {detail}{X}" if detail else ""),
@@ -120,8 +199,12 @@ def report(name: str, detail: str) -> None:
     """Print a fact without asserting anything about it.
 
     Deliberately NOT recorded as a passing check: this script's whole claim is
-    that every line it prints was actually verified.
+    that every line it prints was actually verified. It IS recorded as decided,
+    because a check that says "not asserted, and here is why" has run — the
+    completeness guard must not report it as vanished, and a silence must not
+    borrow its cover.
     """
+    reported.append(name)
     print(f"{Y}INFO{X} {name} {D}— {detail}{X}", file=_human())
 
 
@@ -161,7 +244,13 @@ def post(url: str, timeout: float, **kw):
         return type(exc).__name__
 
 
-def run(timeout: float, expect_sha: list[str]) -> int:
+def _run_checks(timeout: float, expect_sha: list[str]) -> bool:
+    """Run every check; return whether the build check found a stale build.
+
+    Split out of `run` so the summary and the completeness guard cannot be
+    skipped by anything added in here — including an early `return`, which is
+    one of the ways a check stops running in the first place.
+    """
     # Reset, because this is module state and a stale verdict is worse than no
     # verdict: a second run in informational mode would otherwise inherit the
     # first run's `asserted=True, ok=True` and let the workflow close a live
@@ -169,6 +258,12 @@ def run(timeout: float, expect_sha: list[str]) -> int:
     # process happens today; that is a property of main(), not of run().
     build_info.update(deployed=None, built_at=None, built=None,
                       asserted=False, ok=None)
+    # Both registers, together. The completeness guard reads them as "what
+    # THIS run decided"; a name left behind by an earlier run would answer for
+    # a check this one skipped, which is the guard being fooled by exactly the
+    # stale module state the reset above exists for.
+    results.clear()
+    reported.clear()
 
     # --- the guardrail engine ------------------------------------------------
     r = get(f"{HEALTHCLAW}/r6/fhir/health", timeout)
@@ -389,19 +484,72 @@ def run(timeout: float, expect_sha: list[str]) -> int:
           f"keyless initialize -> {code}"
           + ("" if served else " (no JSON-RPC result)"))
 
+    return stale
+
+
+def run(timeout: float, expect_sha: list[str]) -> int:
+    stale = _run_checks(timeout, expect_sha)
+
+    # Did this run actually run? `all N checks passing` counted what happened
+    # to execute, so a check that stopped running — moved inside a condition
+    # that no longer fires, lost in a merge, skipped by an early return — shrank
+    # N and the line still read as complete. That is the demo-tenant lesson one
+    # level up: a count answers "has something broken" and cannot answer "is
+    # this all of it". So compare the SET of names decided against the set this
+    # file declares, and name what is absent.
+    #
+    # The distinction this guard draws, because the script makes both kinds of
+    # claim: an assertion about a RESPONSE may be computed from the response —
+    # that is what checking is. A claim about how much of the HARNESS ran may
+    # not be computed from the harness.
+    try:
+        declared, unreadable = _declared_checks()
+    except (OSError, SyntaxError) as exc:
+        # Not knowing what we should have run IS the failure this guard is
+        # about, so it takes this guard's exit code. Raising here would exit 1
+        # and file the outage issue about a script that never reached
+        # production.
+        declared, unreadable = frozenset(), [
+            f"this script's own source could not be read ({type(exc).__name__}"
+            f": {exc}), so nothing knows what this run should have decided"]
+    missing = sorted(declared - ({n for n, _, _ in results} | set(reported)))
+    completeness.update(complete=not missing and not unreadable,
+                        missing=missing, unreadable=unreadable)
+
     failed = [n for n, ok, _ in results if not ok]
     hard = [n for n in failed if n != BUILD_CHECK]
     print(file=_human())
     if failed:
         print(f"{R}{len(failed)} check(s) failing:{X} " + ", ".join(failed),
               file=_human())
+    if missing:
+        print(f"{R}{len(missing)} declared check(s) never ran:{X} "
+              + ", ".join(missing), file=_human())
+    for why in unreadable:
+        print(f"{R}this run cannot say what it should have decided:{X} {why}",
+              file=_human())
+    if missing or unreadable:
+        print(f"{D}Each line above is still true; this run as a whole is not a "
+              f"verdict on production. The defect is in scripts/prod_watch.py, "
+              f"not in the deployment.{X}", file=_human())
+
     # A stale build is not an outage. Reporting it as one would train the
-    # reader to ignore the outage alarm.
+    # reader to ignore the outage alarm. An incomplete run is neither of those:
+    # it says nothing about production at all, so it must not be able to close
+    # either alarm, and it outranks the stale one — a build verdict from a run
+    # that skipped checks is not worth acting on. An outage still outranks it,
+    # because a real outage is the more urgent of the two things to be told.
     if hard:
         return 1
+    if missing or unreadable:
+        return 3
     if stale:
         return 2
-    print(f"{G}all {len(results)} checks passing{X}", file=_human())
+    print(f"{G}all {len(results)} checks passing{X} "
+          f"{D}— {len(declared)} declared, all accounted for"
+          + (f" ({len(reported)} reported without assertion)"
+             if reported else "")
+          + f"{X}", file=_human())
     return 0
 
 
@@ -415,9 +563,9 @@ def main() -> int:
     ap.add_argument("--json-out", metavar="PATH",
                     help="write the same machine-readable results to PATH. "
                          "stdout keeps the human report unless --json is also "
-                         "given. The scheduled run uses this to drive its two "
-                         "alarms from the checks themselves rather than from "
-                         "one exit code.")
+                         "given. The scheduled run uses this to drive its "
+                         "three alarms from the checks themselves rather than "
+                         "from one exit code.")
     ap.add_argument("--expect-sha", action="append", default=[], metavar="SHA",
                     help="full commit sha the CareAgents build may have been "
                          "built from; repeatable or comma-separated. The "
@@ -455,9 +603,23 @@ def main() -> int:
                # manual CareAgents redeploy. That is the normal state of this
                # repo, not an edge case, and it is the exact meaning-destruction
                # the two-alarm split exists to prevent.
-               "hard_ok": code != 1,
+               # `and complete`: a run that skipped a check has not observed
+               # production, so it must not be able to close the outage issue.
+               # `!hardFailing` was already rejected in the workflow for
+               # exactly this reason — the absence of a failure is not an
+               # observation — and a shrunken denominator is that same absence
+               # arriving from inside the script instead of from the runner.
+               "hard_ok": code != 1 and completeness["complete"],
                "checks": [{"name": n, "ok": o, "detail": d}
                           for n, o, d in results],
+               # What this run DECLARES it decides, against what it decided.
+               # The scheduled job raises its third alarm from these and can
+               # name the check that vanished; `reported` is what accounts for
+               # the gap between `checks` and the declaration on an honest run.
+               "complete": completeness["complete"],
+               "missing": list(completeness["missing"]),
+               "unreadable": list(completeness["unreadable"]),
+               "reported": list(reported),
                # Separate from `checks` on purpose: in informational mode the
                # build is reported without being counted, so folding it in
                # would inflate the count. Omitting it entirely left --json as

--- a/tests/test_prod_watch_completeness.py
+++ b/tests/test_prod_watch_completeness.py
@@ -1,0 +1,302 @@
+"""prod-watch's completeness guard: did this run run what it says it runs?
+
+`all N checks passing` was a completeness claim derived from whatever happened
+to execute. A check that stopped running — moved under a condition that no
+longer fires, lost in a merge, skipped by an early return — shrank N, and the
+line still read as complete. The scheduled production run
+(`.github/workflows/prod-watch.yml`) invokes the script directly and never
+pytest, so the counts pinned elsewhere in this suite were no backstop for the
+one run that watches production.
+
+The expectation is now read out of the script's own `check(...)` call sites, so
+adding a check adds its expectation in the same edit and there is no total for
+two branches to disagree about. These tests pin that it is derived rather than
+written down, that a declared name nobody decided fails the run under its own
+exit code, and that the failure can be told apart from an outage.
+
+No network: `prod_watch.get` and `prod_watch.post` are replaced wholesale, and
+`requests.get`/`requests.post` are tripwired under them so a test that reaches
+production fails loudly instead of passing on production's say-so (#433).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import prod_watch  # noqa: E402
+
+TIP = "4f2a91cbeef1a9d3c05e7b21fd8460ac9e13d7f5"
+# The name of a check that exists in the declaration and never runs. Standing
+# in for the real thing — a call site that stopped executing — because the real
+# thing cannot be produced without editing the file under test.
+PHANTOM = "careagents: a check that stopped running"
+
+# Captured before any test replaces it, so the phantom declarations below can
+# build on the real reading instead of recursing into their own replacement.
+_REAL_DECLARED = prod_watch._declared_checks
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status_code = status
+        self.text = text
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+def _fake_get(grade="A"):
+    def get(url, timeout, **kw):
+        if "$conformance" in url:
+            return _Resp(200, {"grade": grade})
+        if "Patient" in url:
+            return _Resp(200, {"entry": [
+                {"resource": {"resourceType": "Patient", "id": i}}
+                for i in prod_watch.DEMO_PATIENTS]})
+        if "Condition" in url:
+            return _Resp(200, {"entry": [{"resource": {
+                "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
+        if url.endswith("/healthz"):
+            return _Resp(200, {"status": "ok", "accounts": True,
+                               "build": "4f2a91cbeef1",
+                               "built_at": 1754056800})
+        if url.endswith("/auth"):
+            return _Resp(200, text='<input maxlength="8">')
+        if url.endswith("/mcp"):
+            return _Resp(401)
+        if url.endswith("/health"):
+            return _Resp(200)
+        return _Resp(200, text='<a href="/auth">start</a>')
+    return get
+
+
+def _fake_post(url, timeout, **kw):
+    # The public demo's keyless `initialize` — the one POST in the script.
+    return _Resp(200, {"jsonrpc": "2.0", "id": 1, "result": {}})
+
+
+def _no_network(url, *a, **kw):
+    # Not a RequestException on purpose: prod_watch.get/post swallow those into
+    # a status string, which is how a real request hid here once before (#433).
+    raise AssertionError(f"a test in this file reached the network: {url}")
+
+
+_FRESH_BUILD_INFO = {"deployed": None, "built_at": None, "built": None,
+                     "asserted": False, "ok": None}
+_FRESH_COMPLETENESS = {"complete": False, "missing": [], "unreadable": []}
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    prod_watch.results.clear()
+    prod_watch.reported.clear()
+    prod_watch.build_info.update(_FRESH_BUILD_INFO)
+    prod_watch.completeness.update(_FRESH_COMPLETENESS)
+    monkeypatch.setattr(prod_watch, "_human_to_stderr", False)
+    monkeypatch.setattr(prod_watch, "get", _fake_get())
+    monkeypatch.setattr(prod_watch, "post", _fake_post)
+    monkeypatch.setattr(requests, "get", _no_network)
+    monkeypatch.setattr(requests, "post", _no_network)
+    yield
+    prod_watch.results.clear()
+    prod_watch.reported.clear()
+    prod_watch.build_info.update(_FRESH_BUILD_INFO)
+    prod_watch.completeness.update(_FRESH_COMPLETENESS)
+
+
+def _declares_a_phantom(source=None):
+    declared, unreadable = _REAL_DECLARED(source)
+    return frozenset(declared | {PHANTOM}), unreadable
+
+
+def _decided():
+    return {n for n, _, _ in prod_watch.results} | set(prod_watch.reported)
+
+
+# --- the declaration itself -------------------------------------------------
+
+def test_every_check_name_in_the_script_can_be_read_statically():
+    # The backstop for the backstop. A name assembled at run time — an
+    # f-string, a variable — cannot be declared, so the guard would either miss
+    # it or demand it forever; either way the scheduled run stops meaning what
+    # it says. Catching that here is the difference between a red test and
+    # every production run exiting 3.
+    _, unreadable = prod_watch._declared_checks()
+    assert unreadable == [], "\n".join(unreadable)
+
+
+def test_a_module_constant_is_read_as_the_name_it_holds():
+    declared, _ = prod_watch._declared_checks()
+    assert prod_watch.BUILD_CHECK in declared
+    assert "healthclaw: alive" in declared
+
+
+def test_a_name_the_guard_cannot_read_is_reported_not_skipped():
+    declared, unreadable = prod_watch._declared_checks(
+        'def f(x):\n    check(f"careagents: {x}", True)\n')
+    assert declared == frozenset()
+    assert len(unreadable) == 1 and "line 2" in unreadable[0]
+
+
+def test_a_name_that_only_ever_reports_is_never_demanded():
+    # `report` asserts nothing, so a name with no `check` call site is not a
+    # promise this run has to keep. Demanding it would make an honest
+    # informational line into a missing check.
+    declared, unreadable = prod_watch._declared_checks(
+        'def f():\n    report("just a fact", "detail")\n')
+    assert declared == frozenset() and unreadable == []
+
+
+def test_adding_a_check_adds_its_expectation():
+    # The property the whole design rests on: there is no second place to
+    # update, so a branch that adds a check cannot forget the number, and two
+    # branches that each add one cannot disagree about it.
+    before, _ = prod_watch._declared_checks('def f():\n    check("a", True)\n')
+    after, _ = prod_watch._declared_checks(
+        'def f():\n    check("a", True)\n    check("b", True)\n')
+    assert before == {"a"} and after == {"a", "b"}
+
+
+# --- what a run does with it ------------------------------------------------
+
+def test_a_healthy_run_decides_every_name_it_declares():
+    assert prod_watch.run(1.0, [TIP]) == 0
+    declared, unreadable = prod_watch._declared_checks()
+    assert unreadable == []
+    assert declared == _decided(), (
+        f"declared but never decided: {sorted(declared - _decided())}")
+
+
+def test_an_unasserted_check_counts_as_decided_not_as_missing(capsys):
+    # Informational mode: the build check reports instead of asserting (#272).
+    # That is a decision, not a silence, so the run stays complete — and the
+    # summary says so rather than quietly counting one check fewer.
+    assert prod_watch.run(1.0, []) == 0
+    assert prod_watch.BUILD_CHECK in prod_watch.reported
+    assert prod_watch.BUILD_CHECK not in {n for n, _, _ in prod_watch.results}
+    out = capsys.readouterr().out
+    assert "1 reported without assertion" in out
+    assert "all accounted for" in out
+
+
+def test_a_declared_check_that_never_runs_fails_the_run(capsys, monkeypatch):
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    code = prod_watch.run(1.0, [TIP])
+    out = capsys.readouterr().out
+    assert code == 3, "a vanished check must fail the run, not shrink the count"
+    assert "1 declared check(s) never ran" in out and PHANTOM in out
+
+
+def test_an_incomplete_run_never_reports_itself_as_complete(capsys,
+                                                            monkeypatch):
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    prod_watch.run(1.0, [TIP])
+    out = capsys.readouterr().out
+    # The exact line the guard exists for. Every check that ran did pass, so
+    # the old summary printed and read as a verdict on production.
+    assert "checks passing" not in out
+    assert "not a verdict on production" in out
+
+
+def test_an_incomplete_run_is_not_reported_as_an_outage(monkeypatch):
+    # Exit 3, not 1: nothing here says production is down, and filing this as
+    # an outage sends whoever reads it at 03:00 to the wrong dashboard.
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    assert prod_watch.run(1.0, [TIP]) == 3
+
+
+def test_an_incomplete_run_outranks_a_stale_build(monkeypatch):
+    # A build verdict from a run that skipped checks is not worth acting on.
+    # The stale alarm still fires from the JSON, which carries build.asserted.
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    assert prod_watch.run(1.0, ["0" * 40]) == 3
+    assert prod_watch.build_info["asserted"] is True
+    assert prod_watch.build_info["ok"] is False
+
+
+def test_an_outage_outranks_an_incomplete_run(monkeypatch):
+    # A real outage is the more urgent of the two, and the third alarm reads
+    # the JSON rather than the exit code, so it still fires alongside.
+    monkeypatch.setattr(prod_watch, "get", _fake_get(grade="B"))
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    assert prod_watch.run(1.0, [TIP]) == 1
+    assert prod_watch.completeness["complete"] is False
+
+
+def test_a_run_decides_only_for_itself():
+    # The guard reads "what this run decided". A name left in the registers by
+    # an earlier run would answer for a check this one skipped — the guard
+    # fooled by the same stale module state the build verdict is reset for.
+    prod_watch.results.append(("a check from an earlier run", True, ""))
+    prod_watch.reported.append("a name from an earlier run")
+    assert prod_watch.run(1.0, [TIP]) == 0
+    assert "a check from an earlier run" not in _decided()
+    assert "a name from an earlier run" not in _decided()
+
+
+def test_a_source_it_cannot_read_fails_the_run(capsys, monkeypatch):
+    def boom(source=None):
+        raise OSError("no such file")
+    monkeypatch.setattr(prod_watch, "_declared_checks", boom)
+    code = prod_watch.run(1.0, [TIP])
+    out = capsys.readouterr().out
+    # Not a traceback: that exits 1 and files the outage issue about a script
+    # that never reached production.
+    assert code == 3
+    assert "cannot say what it should have decided" in out
+
+
+# --- what the scheduled job reads -------------------------------------------
+
+def _payload(monkeypatch, tmp_path, argv):
+    out = tmp_path / "status.json"
+    monkeypatch.setattr(sys, "argv",
+                        ["prod_watch.py", "--json-out", str(out)] + argv)
+    code = prod_watch.main()
+    return code, json.loads(out.read_text())
+
+
+def test_the_payload_names_the_checks_that_vanished(monkeypatch, tmp_path):
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    code, payload = _payload(monkeypatch, tmp_path, ["--expect-sha", TIP])
+    assert code == 3
+    assert payload["complete"] is False
+    # The alarm has to name what is wrong, not only that something is.
+    assert payload["missing"] == [PHANTOM]
+    assert payload["unreadable"] == []
+
+
+def test_an_incomplete_run_cannot_close_the_outage_alarm(monkeypatch,
+                                                         tmp_path):
+    # `hard_ok` is what closes the outage issue, and closing needs a positive
+    # observation. A run that skipped a check has not observed production.
+    monkeypatch.setattr(prod_watch, "_declared_checks", _declares_a_phantom)
+    _, payload = _payload(monkeypatch, tmp_path, ["--expect-sha", TIP])
+    assert payload["hard_ok"] is False and payload["ok"] is False
+
+
+def test_a_complete_run_still_closes_it(monkeypatch, tmp_path):
+    code, payload = _payload(monkeypatch, tmp_path, ["--expect-sha", TIP])
+    assert code == 0
+    assert payload["complete"] is True and payload["hard_ok"] is True
+    assert payload["missing"] == [] and payload["reported"] == []
+
+
+def test_a_stale_build_alone_still_closes_the_outage_alarm(monkeypatch,
+                                                           tmp_path):
+    # The property the two-alarm split exists for, re-pinned because `hard_ok`
+    # gained a second term: a healthy deployment on a stale build must not pin
+    # the outage issue open.
+    code, payload = _payload(monkeypatch, tmp_path, ["--expect-sha", "0" * 40])
+    assert code == 2
+    assert payload["complete"] is True and payload["hard_ok"] is True

--- a/tests/test_prod_watch_completeness.py
+++ b/tests/test_prod_watch_completeness.py
@@ -67,7 +67,14 @@ def _fake_get(grade="A"):
             return _Resp(200, {"entry": [{"resource": {
                 "resourceType": "Condition", "code": {"text": "Asthma"}}}]})
         if url.endswith("/healthz"):
+            # `run_workers`/`run_workers_state` are inert until #219 lands and
+            # prod_watch reads them. They are here so this file's idea of a
+            # HEALTHY deployment does not go stale the moment it does: a check
+            # that fails on the fake turns every exit code asserted below into
+            # 1, and these tests are about the codes.
             return _Resp(200, {"status": "ok", "accounts": True,
+                               "run_workers": True,
+                               "run_workers_state": "ready",
                                "build": "4f2a91cbeef1",
                                "built_at": 1754056800})
         if url.endswith("/auth"):


### PR DESCRIPTION
`scripts/prod_watch.py:404` printed `all {len(results)} checks passing` — a completeness claim derived from whatever ran. A check that silently stopped running shrank the denominator and the line still read as complete. The only declared expectation was a pinned count in `tests/test_build_marker_stamp.py`, and `.github/workflows/prod-watch.yml` invokes the script directly on a schedule against production, never pytest. The scheduled run had no backstop.

## What changed

The expectation is read out of the script's own `check(...)` call sites. Every call site declares that the run will **decide** that name — asserted, or reported under the same name when there is honestly nothing to assert (#272). A declared name nobody decided fails the run and is printed by name.

```
all 12 checks passing — 12 declared, all accounted for
all 11 checks passing — 12 declared, all accounted for (1 reported without assertion)
```

versus, when a call site stops executing:

```
1 declared check(s) never ran: careagents: landing renders
Each line above is still true; this run as a whole is not a verdict on
production. The defect is in scripts/prod_watch.py, not in the deployment.
```

## Why derived rather than written down

The task asked for the expectation to come from a check registry if the structure allows, so adding a check updates it by construction. There is no registry: the checks are inline and share state — the `/healthz` body feeds the build check, and #549's Telegram check reads the landing body fetched two checks earlier. Refactoring `run()` into a registry of functions would collide with both open PRs and is a much larger change than this defect warrants.

A hand-kept list beside the checks was the other option, and it is what the task warns against: #549 and #580 would each append to it, giving a three-way conflict on top of the two-way conflict already on the pinned counts. Reading the call sites means adding a check adds its expectation in the same edit — no total to agree about, and **no line either open PR touches**. This is also the established idiom here (`tests/test_ratchets.py`, `scripts/check_table_stakes.py`).

A name the reader cannot resolve statically — an f-string, a name assembled at run time — is reported as unreadable rather than skipped, since a call site it cannot see is a check it cannot miss. `test_every_check_name_in_the_script_can_be_read_statically` is the CI backstop that keeps that from ever reaching a production run.

## The exit code, and what an operator sees

A short count and a failing check are different conditions with different remedies, so:

- **exit 3**, its own code and its own alarm: *the watch is not running every check it declares*. The remedy is a code change, not a deploy. Filed as an outage it would send whoever reads it at 03:00 to the wrong dashboard.
- **`hard_ok: false`** on an incomplete run. Closing an alarm needs a positive observation, and a run that skipped a check has not observed production — the same argument already made in the workflow against `!hardFailing`.
- **An outage still outranks it** (exit 1 wins); a stale build no longer does, because a build verdict from a partial run is not worth acting on. The stale alarm keeps firing from the JSON either way.
- The workflow's third alarm fires on `exit === '3' || status?.complete === false`, fingerprinted on *which* checks vanished, mirroring the stale alarm's belt-and-braces exactly.

The summary and the guard moved out of the check body into `run`, so nothing added to `_run_checks` can skip them — including an early `return`, which is one of the ways a check stops running in the first place.

## Merge order

Nothing here touches `tests/test_build_marker_stamp.py` or `tests/test_prod_watch_build.py`, and the `all {N} checks passing` substring is preserved, so the counts #549 and #580 move are untouched by this branch. Their new checks pick up their expectations by construction. The pre-existing 12→14 / 12→13 conflict between those two is unchanged, not worsened.

Source isolation is not the whole story, though, and the second commit here is the rest of it: a new test file carries its own idea of a *healthy* deployment, and #580's check reads a `/healthz` field this file's fake did not serve. Simulated locally, ten of the eighteen tests went red on it — not on the check, on every exit code they assert, because a check failing against the fake turns 0, 2 and 3 into 1. The fake now serves `run_workers`/`run_workers_state`; both are inert until #580 lands. #549 was checked the same way and needs nothing: `/home` falls through to the landing default with no Telegram copy, and `_answered_elsewhere` sees no `url` on the fake response.

## The rest of the script

Audited for the same defect. `{labelled}/{total} labelled` and the `len(expect_sha)` detail are assertions and descriptions of response data and inputs, which is what checking is; `DEMO_PATIENTS` was already the right shape (a declared set, not a count). The remaining computed claim about the harness was the summary line this PR replaces.

## Verification

- `uv run python -m pytest tests/ -q` — 3175 passed, 13 skipped, 1 xfailed
- `uv run ruff check .` — All checks passed
- Read-only against production, the way the workflow invokes it: exit 0, `all 12 checks passing — 12 declared, all accounted for`; without `--expect-sha`, `all 11 checks passing — 12 declared, all accounted for (1 reported without assertion)`.

Not merging or approving — #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
