### PR TITLE
fix(deploy): the CareAgents VPS path is not live — retire it instead of documenting it (#264)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,11 +42,12 @@ Copy this into the release PR/issue and check items off.
       `https://app.healthclaw.io/r6/fhir/metadata` returns 200 post-deploy
 - [ ] **mcp-server does NOT auto-deploy** — staging-dir `railway up` (see
       [docs/development.md](docs/development.md) deploy notes), then verify `POST /mcp/rpc tools/list` returns the expected tool count
-- [ ] **CareAgents does NOT auto-deploy** — `./deploy/careagents/deploy.sh` (VPS) or a
-      staging-dir `railway up` (see [docs/development.md](docs/development.md) deploy
-      notes), then verify `GET /healthz` reports `build` = the released commit. Skipping
-      this is how both deployments ended up months behind `main` while every production
-      check was green (#258)
+- [ ] **CareAgents does NOT auto-deploy** — staging-dir `railway up` for the web *and*
+      worker service (see
+      [docs/runbooks/careagents-durable-worker.md](docs/runbooks/careagents-durable-worker.md)),
+      then verify `GET /healthz` reports `build` = the released commit. Skipping
+      this is how the deployments ended up months behind `main` while every production
+      check was green (#258). The old VPS script is retired and refuses to run
 - [ ] Re-seed `desktop-demo` if the release changed seed data: `POST /r6/fhir/internal/seed`
 
 ### 5. Announce (within 48h of the release)

--- a/careagents/_build.py
+++ b/careagents/_build.py
@@ -6,9 +6,9 @@ asked about could tell a current build from a stale one, because nothing the
 running process exposed said which build it was.
 
 `careagents/BUILD_SHA` answers that. It is written at deploy time
-(`deploy/careagents/deploy.sh`, or by hand before `railway up`) and travels
-with the tree, so it cannot drift from the code the way a service variable
-can. It is generated, never committed — a checked-in marker would go stale
+(`deploy/careagents/stamp_build.sh`, run against the stage before `railway
+up`) and travels with the tree, so it cannot drift from the code the way a
+service variable can. It is generated, never committed — a checked-in marker would go stale
 silently, which is the exact failure this exists to catch.
 
 Two lines:

--- a/deploy/careagents/deploy.sh
+++ b/deploy/careagents/deploy.sh
@@ -1,14 +1,40 @@
 #!/usr/bin/env bash
-# Deploy CareAgents to the careagents.cloud VPS.
+# RETIRED — this is not how CareAgents is deployed. It refuses to run.
 #
-#   ./deploy/careagents/deploy.sh [user@host]      # default root@187.77.4.50
+# It deployed CareAgents to the careagents.cloud VPS (187.77.4.50). That host
+# is no longer in front of any user: careagents.cloud is served by Railway,
+# careagents.cloud/healthz and careagents-production.up.railway.app/healthz
+# report the same build, and scripts/prod_watch.py watches only the Railway
+# name (#289). #264 (2026-08-02) called for exactly this — finish the DNS
+# cutover, keep one origin, retire this path — because two origins over one
+# account store break passkeys, which are bound to the origin they were
+# enrolled against. The cutover happened; the issue is still open.
 #
-# Idempotent: rsyncs the careagents package, (re)builds the venv, installs the
-# systemd unit, swaps nginx's `location /` from the static stub to the app
-# (leaving /gateway/, /telegram/, /hermes/, /health untouched), and restarts.
-# Secrets are NOT shipped by this script — /etc/careagents/careagents.env is
-# created once on the host (template printed if missing).
+# The live path is a staged `railway up` for the web and worker services:
+# docs/runbooks/careagents-durable-worker.md (## Railway).
+#
+# Kept rather than deleted so the retired path can still be read, and refusing
+# rather than warning because what it would do is the failure it was last
+# changed to catch: ship to a second origin that no monitor checks. Measured
+# 2026-09-04, that host is still serving CareAgents on its old vhost
+# (`curl --resolve careagents.cloud:443:187.77.4.50 https://careagents.cloud/healthz`)
+# and answers without `build`, `built_at` or `run_workers` — code from before
+# #257 and #258. Shutting it down is an owner action, not this script's.
+#
+# Everything below the refusal is the deploy as it last ran, on 2026-08-02.
 set -euo pipefail
+
+cat >&2 <<'RETIRED'
+deploy.sh is retired and did nothing.
+
+careagents.cloud is served by Railway. This script deploys to the VPS at
+187.77.4.50, which no user reaches and no monitor checks, against the same
+account store — a passkey enrolled there works on neither origin (#264).
+
+Deploy CareAgents with the staged `railway up` for BOTH services, per
+docs/runbooks/careagents-durable-worker.md (## Railway).
+RETIRED
+exit 1
 
 HOST="${1:-root@187.77.4.50}"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -165,8 +165,9 @@ auditor.
 - **The MCP server does not auto-deploy.** Pushing `main` deploys the Flask app
   (Railway) and site (Vercel), but MCP tool changes are live in the repo and
   *not* in Claude until a manual deploy runs.
-- **CareAgents deploys independently** to a shared prod VPS. That deploy needs
-  explicit authorization — don't roll it into unrelated work.
+- **CareAgents deploys independently** — a manual staged `railway up`, web and
+  worker. That deploy needs explicit authorization — don't roll it into
+  unrelated work. The VPS script it used before is retired and refuses to run.
 - **Playwright e2e is currently red on `main`** for environment reasons, so it
   gives no signal. Don't read a green/red Playwright result as evidence either
   way until that's fixed.

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,23 +119,29 @@ Flask/DB), report builders, and a `register_*_routes` function wired in
     && railway up --service mcp-server --detach
   ```
 
-- **CareAgents does NOT auto-deploy either.** Neither path is wired to a push:
-  the VPS path rsyncs the tree (`./deploy/careagents/deploy.sh`) and the Railway
-  path is `railway up` from a staging dir. Merged work therefore sits unshipped
-  until a human runs one of them — in #258 both deployments were serving code
-  months older than `main` while `scripts/prod_watch.py` reported 9/9 green,
-  because nothing it checked could tell the two apart.
+- **CareAgents does NOT auto-deploy either.** One path, not wired to a push:
+  `railway up` from a staging dir, for the web service *and* the worker. Merged
+  work therefore sits unshipped until a human runs it — in #258 the deployments
+  were serving code months older than `main` while `scripts/prod_watch.py`
+  reported 9/9 green, because nothing it checked could tell a current build from
+  a stale one. The full procedure is
+  [docs/runbooks/careagents-durable-worker.md](runbooks/careagents-durable-worker.md).
+
+  The VPS path (`./deploy/careagents/deploy.sh`) is **retired and refuses to
+  run.** careagents.cloud is served by Railway; the host that script deploys to
+  is reached by no user and checked by no monitor, and deploying a second origin
+  over the one account store is the passkey failure #264 exists to stop. It is
+  kept, refusing, so the retired path can still be read.
 
   Every deploy must stamp `careagents/BUILD_SHA`, the two-line marker
   (`<sha12>` / `<unix commit time>`) that `careagents/_build.py` reads once at
   import and `/healthz` reports as `build` / `built_at`. It is gitignored on
   purpose: a committed marker goes stale silently, which is the failure it
   exists to catch. `deploy/careagents/stamp_build.sh` is the only thing that
-  knows the format; both deploy paths call it, so they cannot drift apart.
-  `deploy.sh` runs it for you. On the Railway path, run it yourself against the
-  staging dir before `railway up` — it derives the repo from its own location,
-  so it works from anywhere and with a target outside the checkout, and it
-  refuses rather than writing nothing if you point it at the wrong directory:
+  knows the format. Nothing runs it for you: run it against every stage you
+  upload, before `railway up` — it derives the repo from its own location, so it
+  works from anywhere and with a target outside the checkout, and it refuses
+  rather than writing nothing if you point it at the wrong directory:
 
   ```bash
   # $STAGE = the directory `railway up` uploads

--- a/docs/healthcare-ai-advisors-roadmap.md
+++ b/docs/healthcare-ai-advisors-roadmap.md
@@ -298,8 +298,8 @@ Three different deploy models, and two are manual:
 
 - HealthClaw Flask app — auto-deploys on `main` (Railway)
 - MCP server — **manual** staging-dir deploy
-- CareAgents — **independent** VPS deploy; shared prod host, needs explicit
-  authorization
+- CareAgents — **independent** manual staged `railway up` (web and worker),
+  needs explicit authorization; the VPS path it once used is retired
 
 A change to MCP tools is live in the repo but not in Claude until the manual
 deploy runs. That gap has already bitten this project once.

--- a/tests/test_build_marker_stamp.py
+++ b/tests/test_build_marker_stamp.py
@@ -105,8 +105,8 @@ def test_an_uncommitted_tree_is_stamped_dirty(repo):
 
 
 def test_the_marker_itself_never_makes_the_tree_look_dirty(repo):
-    # deploy.sh stamps into the repo root and then rsyncs it. If the marker
-    # were not gitignored, the *second* deploy of an otherwise clean tree would
+    # A deploy stamps the tree it ships. If the marker were not gitignored,
+    # the *second* deploy of an otherwise clean tree would
     # stamp itself "-dirty" and the monitor would alarm on a correct release.
     _stamp(repo, repo)
     r = _stamp(repo, repo)

--- a/tests/test_careagents_vps_deploy_is_retired.py
+++ b/tests/test_careagents_vps_deploy_is_retired.py
@@ -1,0 +1,93 @@
+"""`deploy/careagents/deploy.sh` deploys to a host that is no longer production.
+
+The script rsyncs CareAgents to the careagents.cloud VPS (187.77.4.50) and
+points that host's nginx at the app. Users stopped landing there: careagents.cloud
+resolves to Railway's edge, it and `careagents-production.up.railway.app` report
+the same build, and `scripts/prod_watch.py` watches only the Railway host (#289).
+#264 asked for exactly that in August — one origin, VPS path retired — and the
+script was never told.
+
+Running it now would ship to an unwatched second origin against the same account
+store, which is #258's shape with a passkey failure on top. So it refuses, and
+these tests are what keep it refusing. They run the real script with `ssh`,
+`rsync` and `scp` stubbed on PATH and assert no stub is ever called — a refusal
+that happens after the first `ssh` is not a refusal — and that
+`careagents/BUILD_SHA` is untouched, because stamping is a write into the
+checkout that happens before the first remote call.
+
+What they do not prove: nothing here contacts the VPS, so these say what the
+script does, not what the host is running.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "deploy" / "careagents" / "deploy.sh"
+MARKER = REPO / "careagents" / "BUILD_SHA"
+
+# Every remote-side command the script reaches for. Each records its argv and
+# succeeds, so a script that got past the refusal would run to completion here
+# rather than dying on a missing binary and looking like a refusal.
+STUB = """#!/bin/sh
+printf '%s %s\\n' "$(basename "$0")" "$*" >> "$STUB_LOG"
+exit 0
+"""
+
+
+@pytest.fixture
+def stubs(tmp_path):
+    """`ssh`/`rsync`/`scp` on PATH that log instead of reaching a host."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    for name in ("ssh", "rsync", "scp"):
+        stub = bindir / name
+        stub.write_text(STUB)
+        stub.chmod(0o755)
+    return bindir, tmp_path / "stub.log"
+
+
+def _run(stubs, *args):
+    bindir, log = stubs
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    env["STUB_LOG"] = str(log)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=REPO, env=env, capture_output=True, text=True, timeout=60,
+    )
+
+
+def test_the_vps_deploy_refuses_and_reaches_no_host(stubs):
+    _, log = stubs
+    before = MARKER.read_bytes() if MARKER.exists() else None
+
+    r = _run(stubs)
+
+    assert r.returncode != 0, "the retired VPS deploy must not succeed"
+    assert not log.exists(), f"it contacted the host: {log.read_text()}"
+    after = MARKER.read_bytes() if MARKER.exists() else None
+    assert after == before, "it stamped BUILD_SHA into the checkout"
+
+
+def test_a_host_argument_does_not_re_enable_it(stubs):
+    # The script takes `[user@host]`, so a different target is the obvious way
+    # someone would try to keep using it. It is still the retired path.
+    _, log = stubs
+    r = _run(stubs, "root@example.invalid")
+    assert r.returncode != 0
+    assert not log.exists(), f"it contacted the host: {log.read_text()}"
+
+
+def test_the_refusal_names_the_live_path(stubs):
+    # A refusal that does not say what to run instead gets worked around.
+    r = _run(stubs)
+    said = r.stdout + r.stderr
+    assert "docs/runbooks/careagents-durable-worker.md" in said
+    assert "railway up" in said
+    assert "careagents.cloud" in said


### PR DESCRIPTION
## The question first

#553 adds `CAREAGENTS_CANONICAL_HOST`, `CARE_REAL_RECORDS` and
`CARE_REAL_RECORDS_ALLOWLIST`. `deploy/careagents/deploy.sh` writes an env
template and carries none of them. Before adding them: is that path live?

**It is not.** Measured 2026-09-04, over DoH and against the running services:

| Evidence | Result |
| --- | --- |
| `careagents.cloud` A record | `69.46.46.19` — not the `187.77.4.50` the script deploys to |
| `curl -I https://careagents.cloud/` | `server: railway-hikari`, `x-railway-edge: iad1` |
| `careagents.cloud/healthz` vs `careagents-production.up.railway.app/healthz` | identical: `build 89b42fbd0e66` = `main` at HEAD. One deployment |
| `scripts/prod_watch.py:60` | watches `careagents-production.up.railway.app` only (#289). Nothing watches the VPS |
| deploy history | `deploy.sh` last changed 2026-08-02; every deploy change since (Dockerfile, `CARE_ROLE`, runbook, prod-watch) is Railway |
| #264, 2026-08-02 | "finish the DNS cutover, keep `careagents.cloud` as the single `CARE_RP_ID`, and retire the VPS path" |

The cutover happened. The retirement never reached the script or the documents.
So this takes the second branch of the task: **do not add the three settings
here** — the runbook (#621) is the right and only place — and say so where the
path is still offered.

## What this does

- **`deploy/careagents/deploy.sh` refuses.** The exit is the first statement
  after `set -euo pipefail`, before `stamp_build.sh` writes `careagents/BUILD_SHA`
  into the checkout and before the first `ssh`. It names the host, why that host
  is wrong, and the staged `railway up` runbook to use instead. The body below
  it is untouched: running it would ship to an unwatched second origin over the
  one account store — #258's shape with #264's passkey break on top — but a
  retired path is easier to reason about present than deleted. No override flag:
  an escape hatch is the quiet path again, and editing the script is a
  deliberate act that shows in a diff.
- **The documents that presented it as a live option** now say what it is:
  `docs/development.md` (which described "two live paths" and claimed both stamp
  the build marker), `RELEASING.md` §4 release checklist, `docs/agent-task-guide.md`,
  `docs/healthcare-ai-advisors-roadmap.md` §4.4, and the `careagents/_build.py`
  docstring.
- **Test** (`tests/test_careagents_vps_deploy_is_retired.py`): runs the real
  script with `ssh`/`rsync`/`scp` stubbed on PATH, asserting a non-zero exit,
  zero stub invocations, `BUILD_SHA` untouched, a host argument not re-enabling
  it, and a refusal that names the live path. Before the change all three fail —
  the stubbed run prints `✓ deployed — verify: curl -s https://careagents.cloud/healthz`.

## For the owner — the VPS is still up, and still serving

Not fixed here; it is a host action.

```
curl --resolve careagents.cloud:443:187.77.4.50 https://careagents.cloud/healthz
{"accounts":true,"provider":"openai","status":"ok"}
```

No `build`, no `built_at`, no `run_workers` — that payload predates #257 and
#258 (2026-08-02). A CareAgents instance months behind `main`, holding an
accounts store and the mint secret, reachable by IP + SNI, watched by nothing.
DNS no longer sends anyone there, which is why it is quiet rather than urgent.
Decommissioning it (and rotating anything it shares with production) is a
founder/maintainer call.

## Ran

```
uv run ruff check .
All checks passed!

uv run python -m pytest tests/ -q -p no:cacheprovider
3160 passed, 13 skipped, 1 xfailed, 2 warnings in 109.82s (0:01:49)
```

## Noticed, deliberately not touched

- The 2026-07-14 design specs under `docs/superpowers/specs/` describe the VPS
  deployment. They are dated records of a decision that was true then; left as
  history.
- `docs/2026-08-16-system-topology.md` already describes CareAgents as Railway
  only — consistent, no change needed.
- No file conflicts with the open runbook PRs (#610, #621) or #605.

Refs #264, #289, #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
