### PR TITLE
chore(evidence): inventory every deployed surface, and what watches it (#624)

### DIFF
--- a/docs/evidence/2026-09-04-deployed-surface-inventory.md
+++ b/docs/evidence/2026-09-04-deployed-surface-inventory.md
@@ -8,6 +8,10 @@ repository names as deployed, read-only. `scripts/prod_watch.py` requests 4 of
 them. 16 answer and nothing checks them (4 ours, 12 third-party). 5 are named
 here and do not answer.
 
+Those are endpoint rows, and one host can carry two of them. Counted as
+distinct live hosts we own: 6, of which the monitor requests 4. The retired box
+in #624 is a 7th that no name resolves to.
+
 #624 (an abandoned CareAgents instance on an old VPS) was found by accident,
 when somebody asked whether a deploy script was still used. This exercise asks
 the question that accident raised: what else is out there? The answer includes
@@ -29,7 +33,8 @@ output directly.
 ### On the DNS answers
 
 Every name resolved twice, over DoH and through the system resolver, because
-this network answers port 53 from a stale cache (`CLAUDE.md`). The two agreed
+this network answers port 53 from a stale cache (operator notes, not published
+in this repository). The two agreed
 for every host except `healthclaw.io`, `mcp.healthclaw.io` and
 `shl.healthclaw.io`, where the address sets differ. All three sit behind
 Vercel, and both answers reached Vercel, so the likeliest cause is anycast or
@@ -159,10 +164,11 @@ decide what happens to the account data.
 `1.10.0`. Both deployments are therefore behind the source, by at least the
 change that raised the version.
 
-Three checks in `prod_watch` speak for these two hosts. All three pass. Two ask
-whether `/health` returns 200 and one asks whether the demo server answers an
-unauthenticated handshake. None reads the version field the response already
-carries, so all three are satisfied by any build at all. This is the #258 shape
+Four checks in `prod_watch` speak for these two hosts, and all four pass. Two
+ask whether `/health` returns 200. One asks whether the token-locked server
+refuses an unauthenticated caller with 401. One asks whether the demo server
+answers an unauthenticated handshake. None reads the version field the response
+already carries, so all four are satisfied by any build at all. This is the #258 shape
 exactly: the CareAgents build check exists because every other check was
 equally satisfied by a months-old build, and the same hole is still open on the
 MCP servers.
@@ -192,13 +198,16 @@ request from any check.
 Today the two return the same `build` and `built_at`, so `careagents.cloud` is
 a custom domain in front of the same Railway service rather than a second
 instance. That makes the gap narrow but not empty. This repository already
-records a Railway failure that breaks a custom domain while the container stays
-healthy. A domain pinned to the wrong target port answers "Application failed
-to respond" while the service serves normally (`CLAUDE.md`,
-`docs/2026-08-06-two-generators-three-laws.md`). Under that failure all four
+records a domain-level failure that a service-level check cannot see. On
+2026-08-06 a Vercel domain list omitted the hostname the project served, the
+serving project was deleted, and production went down
+(`docs/2026-08-06-two-generators-three-laws.md:41`). Operator notes carry a
+second one specific to Railway, where a custom domain pinned to the wrong
+target port answers "Application failed to respond" while the container serves
+normally; that note is not published here. Under either failure all four
 `careagents:` checks pass, the workflow stays green, and no user can sign in.
 
-`scripts/prod_watch.py:64` names the constant `CAREAGENTS` and sets it to the
+`scripts/prod_watch.py:60` names the constant `CAREAGENTS` and sets it to the
 platform hostname. Reading the constant name would have reproduced the error
 this inventory exists to catch.
 
@@ -255,11 +264,11 @@ dereference the URL. Both are claims our servers make that no longer resolve.
 Reported, not patched. QA does not edit production code.
 
 **6a. "all N checks passing" counts what ran, not what exists.**
-`scripts/prod_watch.py:396` prints `f"all {len(results)} checks passing"`, and
+`scripts/prod_watch.py:404` prints `f"all {len(results)} checks passing"`, and
 `results` is appended to at run time. The build check is only recorded when
 `--expect-sha` is given; in informational mode it prints through `report()` and
-is never counted. The same fully-healthy production therefore reports two
-different totals:
+is never counted. The same stubbed deployment therefore reports two different
+totals:
 
 ```
 RESULT no --expect-sha        -> len(results) = 11

--- a/docs/evidence/2026-09-04-deployed-surface-inventory.md
+++ b/docs/evidence/2026-09-04-deployed-surface-inventory.md
@@ -1,0 +1,325 @@
+# Deployed-surface inventory
+
+**Date:** 2026-09-04 · **Measured at:** `89b42fbd0e66b0170e2e2d1248fcfeb8f91c9da5`
+(`89b42fb`, tip of `main`) · **Produced by:** `scripts/surface_inventory.py`
+
+**Result: we serve more than we watch.** The script probed 25 surfaces this
+repository names as deployed, read-only. `scripts/prod_watch.py` requests 4 of
+them. 16 answer and nothing checks them (4 ours, 12 third-party). 5 are named
+here and do not answer.
+
+#624 (an abandoned CareAgents instance on an old VPS) was found by accident,
+when somebody asked whether a deploy script was still used. This exercise asks
+the question that accident raised: what else is out there? The answer includes
+the #624 box, still serving today, and two surfaces we own that no monitor has
+ever requested.
+
+## Re-run it
+
+```bash
+uv run --with requests python scripts/surface_inventory.py \
+    --json-out /tmp/surface-inventory.json
+```
+
+One GET per endpoint. No retries, no credential, no method other than GET. The
+script reads the retired VPS address from `deploy/careagents/deploy.sh` at run
+time and scrubs it from every line it prints, so this document can quote the
+output directly.
+
+### On the DNS answers
+
+Every name resolved twice, over DoH and through the system resolver, because
+this network answers port 53 from a stale cache (`CLAUDE.md`). The two agreed
+for every host except `healthclaw.io`, `mcp.healthclaw.io` and
+`shl.healthclaw.io`, where the address sets differ. All three sit behind
+Vercel, and both answers reached Vercel, so the likeliest cause is anycast or
+per-resolver load balancing rather than a forged answer. This method cannot
+tell those apart, and none of the three findings turns on the difference. The
+one host where a wrong answer would flip a finding, `careagents.cloud`, is one
+where the two resolvers agree.
+
+## What the monitor actually watches
+
+Not read from `prod_watch`'s constants. The script imports that module,
+replaces its `get` and `post` with recorders, runs it with no network, and
+takes the URLs it requested:
+
+```
+https://app.healthclaw.io/r6/fhir/health
+https://app.healthclaw.io/r6/fhir/$conformance
+https://app.healthclaw.io/r6/fhir/Condition?_count=5
+https://app.healthclaw.io/r6/fhir/Patient?_count=200
+https://careagents-production.up.railway.app/healthz
+https://careagents-production.up.railway.app/
+https://careagents-production.up.railway.app/auth
+https://mcp-server-production-5112.up.railway.app/health
+https://mcp-server-production-5112.up.railway.app/mcp
+https://mcp-demo-production-ee2c.up.railway.app/health
+https://mcp-demo-production-ee2c.up.railway.app/mcp
+→ 4 hosts
+```
+
+Measuring rather than reading was the right call twice over. See findings 3 and
+6: a check named for one product measures a hostname no user ever types, and
+the count in the closing "all N checks passing" line is not a constant.
+
+## Group 1: live and watched (4)
+
+| Surface | Probe | Status | Running |
+|---|---|---|---|
+| healthclaw engine | `https://app.healthclaw.io/r6/fhir/health` | 200 | `version=1.10.0`, `fhirVersion=6.0.0-ballot3` |
+| CareAgents (platform host) | `https://careagents-production.up.railway.app/healthz` | 200 | `build=89b42fbd0e66`, `built_at=1788143223`, workers up |
+| MCP server (token-locked) | `https://mcp-server-production-5112.up.railway.app/health` | 200 | `version=1.9.0` |
+| MCP server (public demo) | `https://mcp-demo-production-ee2c.up.railway.app/health` | 200 | `version=1.9.0` |
+
+The CareAgents build matches the commit this document was measured at, so that
+deployment is current. The engine's `1.10.0` matches `pyproject.toml`. The two
+MCP servers do not match their source: see finding 2.
+
+## Group 2: live and unwatched (16)
+
+### Ours (4)
+
+| Surface | Probe | Status | Running |
+|---|---|---|---|
+| CareAgents VPS (address in `deploy/careagents/deploy.sh`) | `/healthz`, hostname presented to that address | 200 | `status=ok`, `accounts=true`, `provider=openai`. **No `build`, no `built_at`, no `run_workers`.** |
+| CareAgents consumer domain | `https://careagents.cloud/healthz` | 200 | `build=89b42fbd0e66`, `built_at=1788143223`, workers up |
+| HealthClaw public site | `https://healthclaw.io/` | 200 | `Server: Vercel`. No build marker is served. |
+| Agent-skills discovery document | `https://healthclaw.io/.well-known/agent-skills/index.json` | 200 | `Server: Vercel` |
+
+### Upstreams and partner surfaces (12)
+
+Third-party services this code or these documents call. Unwatched is the
+expected state for all of them, and none is a finding. They are listed so the
+next reader does not have to rediscover which ones still answer.
+
+| Surface | Probe | Status |
+|---|---|---|
+| HAPI FHIR public R4 | `https://hapi.fhir.org/baseR4/metadata` | 200 (nginx/1.28.3) |
+| SMART Health IT R4 | `https://r4.smarthealthit.org/metadata` | 200 (nginx/1.10.3) |
+| Firely public server | `https://server.fire.ly/R4/metadata` | 200 |
+| Medplum hosted API | `https://api.medplum.com/fhir/R4/metadata` | 200 |
+| tx.fhir.org terminology | `https://tx.fhir.org/r4/metadata` | 200 |
+| Fasten Connect API | `https://api.connect.fastenhealth.com/v1` | 404 (host answers) |
+| MEDENT FHIR | `https://fhir.medent.com/fhir/R4/metadata` | 301 (Apache) |
+| HealthEx MCP | `https://api.healthex.io/mcp` | 404 (host answers) |
+| Health Bank One MCP | `https://mcp.app.healthbankone.com/mcp` | 401 (istio-envoy) |
+| Health Bank One OAuth | `https://oauth.app.healthbankone.com/` | 404 (host answers) |
+| PromptOpinion marketplace | `https://app.promptopinion.ai/marketplace` | 200 (Kestrel) |
+| ClawHub skill listing | `https://clawhub.ai/aks129/skills/fhir-r6-guardrails` | 200 |
+
+## Group 3: referenced but dead (5)
+
+| Surface | Probe | Result | Named at |
+|---|---|---|---|
+| `shl.healthclaw.io` | `/` | 404 from Vercel | `skills/share-health-qr/SKILL.md:214,215,226,230` |
+| `healthclaw.up.railway.app` | `/r6/fhir/health` | 404, `Application not found` (railway-hikari) | `skills/personal-health-records/SKILL.md:108,132,158,171`; `scripts/build_quickstart_pdf.py:485` |
+| `mcp.healthclaw.io` | `/mcp` | 404 from Vercel | `docs/specs/2026-08-16-mcp-authorization.md:128,130,549,746` |
+| `schemas.agentskills.io` | `/discovery/0.2.0/schema.json` | NXDOMAIN | `app.py:339`; `tests/test_wellknown_skills.py:21` |
+| `sharponmcp.com` | `/` | NXDOMAIN | `services/agent-orchestrator/src/index.ts:230,259,704`; `templates/wiki.html:562`; `templates/faq.html:328` |
+
+`mcp.healthclaw.io` is already written up in
+`docs/specs/2026-08-16-mcp-authorization.md` §9.6 as a dangling record. The
+other four were not tracked anywhere before this document.
+
+## Findings
+
+### 1. The #624 box is still serving (owner decision)
+
+```
+$ curl --resolve careagents.cloud:443:<address in deploy/careagents/deploy.sh> \
+       https://careagents.cloud/healthz
+{"accounts":true,"provider":"openai","status":"ok"}
+```
+
+Identical to the payload in #624, including what is missing. No `build`, no
+`built_at`, no `run_workers`. Those three fields are present on both live
+CareAgents deployments, so this box predates the build stamping added in #258
+and the worker readiness added since. It still holds an accounts store.
+
+Public DNS for `careagents.cloud` does not point at it (confirmed over DoH and
+through the system resolver, which agree), so no user is routed there. Reaching
+it needs the address and the hostname together.
+
+This is the finding #624 already carries. #624 was filed on 2026-09-04, the
+same day as this sweep, so this is not an aged report: it is the same fact
+reached from the other direction, by enumeration rather than by accident. That
+is the only claim it supports. PR #623, which retires the deploy path, is still
+open, so `deploy/careagents/deploy.sh` on `main` still defaults to that host.
+
+Nothing here can be fixed in the repository. The decisions are the ones #624
+lists: shut it down or watch it, rotate anything it shares with production, and
+decide what happens to the account data.
+
+### 2. Both MCP deployments run an older build than `main`, and no check asks
+
+`/health` on both MCP servers reports `version: 1.9.0`. That field is
+`SERVER_VERSION`, read from `services/agent-orchestrator/package.json`
+(`services/agent-orchestrator/src/index.ts:32`). That file on `main` says
+`1.10.0`. Both deployments are therefore behind the source, by at least the
+change that raised the version.
+
+Three checks in `prod_watch` speak for these two hosts. All three pass. Two ask
+whether `/health` returns 200 and one asks whether the demo server answers an
+unauthenticated handshake. None reads the version field the response already
+carries, so all three are satisfied by any build at all. This is the #258 shape
+exactly: the CareAgents build check exists because every other check was
+equally satisfied by a months-old build, and the same hole is still open on the
+MCP servers.
+
+A third number disagrees with both. `server.json:9` declares `1.8.0` to the MCP
+registry while the package it describes is at `1.10.0`.
+
+What this does not establish: whether `1.9.0` is materially different from
+`1.10.0`, or whether anything is broken. The MCP deployments are manual and
+need explicit authorization, so a lag is expected. The finding is that the lag
+is invisible, not that it is harmful.
+
+**Reproduction:**
+
+```bash
+curl -s https://mcp-demo-production-ee2c.up.railway.app/health
+grep '"version"' services/agent-orchestrator/package.json
+```
+
+### 3. `careagents.cloud` is the host users type, and nothing checks it
+
+Every check named `careagents:` in `scripts/prod_watch.py` requests
+`careagents-production.up.railway.app`. The domain in `CARE_ORIGIN` and
+`CARE_RP_ID`, the one a person's browser shows and WebAuthn binds to, gets no
+request from any check.
+
+Today the two return the same `build` and `built_at`, so `careagents.cloud` is
+a custom domain in front of the same Railway service rather than a second
+instance. That makes the gap narrow but not empty. This repository already
+records a Railway failure that breaks a custom domain while the container stays
+healthy. A domain pinned to the wrong target port answers "Application failed
+to respond" while the service serves normally (`CLAUDE.md`,
+`docs/2026-08-06-two-generators-three-laws.md`). Under that failure all four
+`careagents:` checks pass, the workflow stays green, and no user can sign in.
+
+`scripts/prod_watch.py:64` names the constant `CAREAGENTS` and sets it to the
+platform hostname. Reading the constant name would have reproduced the error
+this inventory exists to catch.
+
+**Reproduction:**
+
+```bash
+uv run --with requests python scripts/surface_inventory.py | grep careagents
+```
+
+The consumer domain appears under LIVE AND UNWATCHED; the platform host appears
+under LIVE AND WATCHED.
+
+### 4. `healthclaw.io` is a first-class host in the code and unwatched
+
+`deployment.py:1-20` describes two hosts that "are not interchangeable" and
+names `healthclaw.io` as the second. It serves the public site, the skills
+catalogue, and the `r6-dashboard` the README sends visitors to. It answers 200.
+No check requests it.
+
+Its Vercel purpose is recorded as an open owner decision in
+`docs/2026-08-16-system-topology.md` ("purpose unsettled"). Unwatched is a
+defensible answer for a host nobody has decided to keep. It is not a defensible
+answer by default, which is what it is today.
+
+### 5. Four dead names are still published, two of them by running code
+
+Two are documentation and cost a reader their time:
+
+- `skills/share-health-qr/SKILL.md` shows `shl.healthclaw.io` viewer and manage
+  links as the output of the skill. The host 404s.
+- `skills/personal-health-records/SKILL.md` and
+  `scripts/build_quickstart_pdf.py` tell readers to configure
+  `https://healthclaw.up.railway.app/mcp`. Railway answers
+  `Application not found`. `SKILL.md:158` also gives a `curl -X POST` against
+  that host, so a reader following it writes nothing anywhere.
+
+Two are served by running code, which is worse, because the reader is a machine:
+
+- `app.py:339` puts `https://schemas.agentskills.io/discovery/0.2.0/schema.json`
+  in the `$schema` field of the live discovery document at
+  `https://healthclaw.io/.well-known/agent-skills/index.json`. That hostname is
+  NXDOMAIN. The parent zone `agentskills.io` resolves; the `schemas` label does
+  not. `tests/test_wellknown_skills.py:21` asserts the prefix, so the test
+  passes on a URL that cannot be fetched.
+- `services/agent-orchestrator/src/index.ts:259,704` returns
+  `spec: "https://sharponmcp.com"` in the MCP `initialize` response. That domain
+  is NXDOMAIN at the registry level.
+
+Neither of those is a security problem and neither breaks a client that does not
+dereference the URL. Both are claims our servers make that no longer resolve.
+
+### 6. Two honesty defects in `scripts/prod_watch.py`
+
+Reported, not patched. QA does not edit production code.
+
+**6a. "all N checks passing" counts what ran, not what exists.**
+`scripts/prod_watch.py:396` prints `f"all {len(results)} checks passing"`, and
+`results` is appended to at run time. The build check is only recorded when
+`--expect-sha` is given; in informational mode it prints through `report()` and
+is never counted. The same fully-healthy production therefore reports two
+different totals:
+
+```
+RESULT no --expect-sha        -> len(results) = 11
+RESULT --expect-sha given     -> len(results) = 12
+```
+
+Reproduction: `docs/evidence/2026-09-04-surface-inventory-check-count.py`
+(committed alongside this document) stubs `get`/`post` with a healthy response
+and runs `prod_watch.run` twice. Severity is low, because the run that omits the
+build check is the run that already failed the readiness check next to it. It is
+still a completeness claim derived from whatever ran, in the one script whose
+stated purpose is that it verified every line it prints.
+
+**6b. Check names carry a product, targets carry a hostname.** Finding 3 above.
+
+## What was excluded, and why
+
+The repository names roughly 300 distinct hostnames. These classes were left
+out on purpose, so the omissions are visible rather than silent:
+
+| Class | Examples | Why |
+|---|---|---|
+| Code system identifiers | `hl7.org`, `loinc.org`, `snomed.info`, `unitsofmeasure.org`, `dicom.nema.org` | `system` values in FHIR codings. They are namespaces, not endpoints we depend on. |
+| Package registries and CDNs | `files.pythonhosted.org`, `registry.npmjs.org`, `cdnjs.cloudflare.com` | Build-time dependencies, covered by the lockfiles. |
+| Documentation and badge links | `github.com`, `img.shields.io`, `opencollective.com`, `keepachangelog.com` | Link-outs. A dead one costs a click. |
+| Reserved and example names | `example.com`, `*.example`, `*.invalid`, `*.test`, `evil.com`, `self.hosted.example` | Cannot resolve by design. |
+| Loopback and container names | `localhost:*`, `127.0.0.1:*`, `aidbox:8080`, `db.internal:5432`, `open-wearables:8000` | Local or compose-internal. Not deployed surfaces. |
+| Provider APIs called with a key | `api.anthropic.com`, `api.openai.com`, `api.resend.com`, `api.telegram.org`, `api.twilio.com`, `api.bland.ai` | Probing them without a credential proves nothing, and this exercise sends no credential. |
+
+## What this did NOT cover
+
+- **Anything behind authentication.** Every probe was unauthenticated. The
+  signed-in journey (sign up, email code, connect, chat, approve) is untested
+  here, exactly as `prod_watch` states for itself.
+- **Ports.** Only 443 was contacted, on names this repository writes down. A
+  service on another port, or on a host nobody wrote down, is invisible to this
+  method. That is the residual #624 risk and this document does not close it.
+- **The Mac mini relay.** `deploy/careagents/imessage_relay.py` runs on a
+  machine with no public name in this repository. It holds a mint secret. It was
+  not probed and is not in any group above.
+- **The Telegram surface.** The bot handle comes from `CARE_TELEGRAM_BOT`, which
+  is empty in the repository, so there is no fixed `t.me` name to probe.
+- **Whether a live surface is correct.** The build markers say which artifact is
+  deployed. They do not say it works. Only CareAgents reports a commit; the
+  engine and the two MCP servers report a package version, so for those three
+  "current" means "matches the version declared in the source", which is a
+  weaker claim. A rebuild that forgets to raise the version is invisible to it.
+- **Anything Vercel serves under a preview URL.** No `*.vercel.app` name appears
+  in the repository, so none was probed.
+
+## Follow-ups filed
+
+| Finding | Tracked in |
+|---|---|
+| 1. The #624 box still serves | **#624** (existing). Confirmed independently on 2026-09-04. Owner decision: shut down or watch, rotate the shared credential, decide what happens to the account data. |
+| 2. MCP builds behind `main` | **#625** |
+| 3. `careagents.cloud` unwatched | **#625** |
+| 4. `healthclaw.io` unwatched | **#625** |
+| 5. Four dead published names | **#626** |
+| 6. Monitor honesty defects | **#625** |
+
+Nothing in findings 2 to 6 was fixed here. Each is a decision with a cost
+attached, and this document reports rather than patches.

--- a/docs/evidence/2026-09-04-surface-inventory-check-count.py
+++ b/docs/evidence/2026-09-04-surface-inventory-check-count.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reproduction for finding 5a of the 2026-09-04 deployed-surface inventory.
+
+    uv run python docs/evidence/2026-09-04-surface-inventory-check-count.py
+
+`scripts/prod_watch.py` closes a passing run with `all {len(results)} checks
+passing`. `results` is appended to at run time, and the build check is appended
+only when `--expect-sha` is given. So the same fully-healthy production reports
+two different totals depending on how it was called.
+
+This stubs both HTTP helpers with one healthy response and runs the monitor
+twice, changing nothing but the expected-sha argument. It asserts nothing and
+gates nothing; it prints the two counts so the claim in the evidence document
+can be re-checked rather than trusted.
+
+Not a test on purpose. A test asserting the current behaviour would pin the
+defect as a specification, and a test asserting the fix would fail until the
+fix lands. QA reports this one; the change belongs to whoever owns the monitor.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import prod_watch  # noqa: E402  (the path insert above must come first)
+
+
+class HealthyEverything:
+    """One response that satisfies every check the monitor makes.
+
+    Grade A, an 8-digit code input, a sign-in link, a stamped build, and an
+    empty bundle. The Patient check wants an exact set and gets an empty one,
+    so it fails; that does not matter here, because the count is taken from
+    `results`, which records passes and failures alike.
+    """
+    status_code = 200
+    text = '<a href="/auth"></a> <input maxlength="8">'
+
+    def json(self) -> dict:
+        return {"grade": "A", "accounts": True, "build": "deadbeefcafe",
+                "built_at": 1788143223, "result": {}, "entry": []}
+
+
+def count(expect_sha: list[str]) -> int:
+    prod_watch.results.clear()
+    prod_watch.get = lambda url, timeout, **kw: HealthyEverything()
+    prod_watch.post = lambda url, timeout, **kw: HealthyEverything()
+    prod_watch.run(1.0, expect_sha)
+    return len(prod_watch.results)
+
+
+def main() -> int:
+    informational = count([])
+    asserted = count(["deadbeefcafe0000000000000000000000000000"])
+    print()
+    print("prod_watch.run(), same stubbed healthy deployment both times:")
+    print(f"  no --expect-sha     -> 'all {informational} checks passing'")
+    print(f"  --expect-sha given  -> 'all {asserted} checks passing'")
+    print()
+    print("The total is a property of the invocation, not of the surface.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/surface_inventory.py
+++ b/scripts/surface_inventory.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Deployed-surface inventory — what is out there, and is anything watching it?
+
+    uv run --with requests python scripts/surface_inventory.py
+    uv run --with requests python scripts/surface_inventory.py --json-out out.json
+
+Why this exists
+---------------
+#624 was an abandoned CareAgents instance still serving on an old VPS: months
+behind `main`, holding an accounts store, holding a working credential to the
+engine, and watched by nothing. It was found because somebody happened to ask
+whether a deploy script was still used. Nothing in this repository could have
+answered "what else is like that?" — so this does.
+
+It enumerates every host this repository names as a *deployed surface*, probes
+each one read-only, and sorts the answers into three groups:
+
+  * **live and watched**   — answering, and `scripts/prod_watch.py` requests it
+  * **live and unwatched** — answering, and nothing requests it (the #624 shape)
+  * **referenced but dead** — named here, not answering (a stale reference)
+
+Two rules it follows, both learned the hard way
+----------------------------------------------
+**Watched is measured, not assumed.** The watched set is not a copy of
+prod_watch's constants. This imports that module, replaces its `get`/`post`
+with recorders, runs it offline, and takes the URLs it actually requested. A
+constant named `CAREAGENTS` proves nothing about which host a check named
+"careagents:" measures — and in fact it measures the platform hostname, never
+the domain users type. Reading names would have reproduced that error.
+
+**DNS on a developer machine is not evidence.** This LAN answers port 53 from
+a stale cache (`docs/development.md`, CLAUDE.md). Every name here is resolved
+over DoH *and* through the system resolver, and a disagreement is reported
+rather than silently picked. It matters most for the one host where a wrong
+answer flips the finding: if `careagents.cloud` still pointed at the retired
+VPS, a probe of the name would be a probe of the abandoned box.
+
+What it deliberately does NOT do
+--------------------------------
+No credential is ever sent, no method other than GET is used, no endpoint is
+retried, and one request is made per endpoint. Several of these hosts belong
+to other people. A non-answer is recorded as a non-answer.
+
+It therefore cannot see anything behind authentication, cannot see a surface
+this repository does not name, and cannot see a port nobody wrote down. Those
+gaps are stated in the evidence document rather than papered over: a monitor
+that quietly checks less than it appears to is worse than one with a narrow,
+stated scope.
+
+Redaction
+---------
+The retired VPS is addressed by IP in `deploy/careagents/deploy.sh`. That
+address is read at runtime and **never printed** — every string this script
+emits passes through `_scrub()`, which replaces it with a placeholder. The
+report says whether a name resolves to it, which is the finding, without
+restating it.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import ipaddress
+import json
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+UA = "healthclaw-surface-inventory/1.0 (+https://github.com/aks129/HealthClawGuardrails)"
+
+G, R, Y, B, D, X = ("\033[92m", "\033[91m", "\033[93m", "\033[94m",
+                    "\033[2m", "\033[0m")
+
+# --- groups ------------------------------------------------------------------
+OURS = "ours"          # we deploy it, or we own the name
+UPSTREAM = "upstream"  # someone else's service this code or these docs call
+
+LIVE_WATCHED = "live and watched"
+LIVE_UNWATCHED = "live and unwatched"
+DEAD = "referenced but dead"
+
+#: Every surface this repository names as deployed, with the reason it is in
+#: scope. `probe` is the single endpoint this script GETs — one per surface.
+#:
+#: An entry earns its place by being a thing that answers on the network. Code
+#: identifier URIs (hl7.org, loinc.org, snomed.info, unitsofmeasure.org),
+#: package registries and CDNs, badge and link-out hosts, and every
+#: example/invalid/localhost/docker name are excluded on purpose; the exclusion
+#: list is in the evidence document so the omissions are visible rather than
+#: silent.
+SURFACES: tuple[dict, ...] = (
+    # --- ours ---------------------------------------------------------------
+    {"name": "healthclaw engine (stateful)", "group": OURS,
+     "probe": "https://app.healthclaw.io/r6/fhir/health",
+     "why": "the guardrail engine; deployment.py STATEFUL_HOST"},
+    {"name": "healthclaw public site / demo", "group": OURS,
+     "probe": "https://healthclaw.io/",
+     "why": "Vercel read-only copy; app.py PUBLIC_SITE_URL default"},
+    {"name": "healthclaw MCP subdomain", "group": OURS,
+     "probe": "https://mcp.healthclaw.io/mcp",
+     "why": "proposed hosted MCP name, docs/specs/2026-08-16-mcp-authorization.md"},
+    {"name": "smart health links viewer", "group": OURS,
+     "probe": "https://shl.healthclaw.io/",
+     "why": "viewer/manage links published by skills/share-health-qr"},
+    {"name": "healthclaw legacy railway name", "group": OURS,
+     "probe": "https://healthclaw.up.railway.app/r6/fhir/health",
+     "why": "MCP url in skills/personal-health-records and the quickstart PDF"},
+    {"name": "agent-skills discovery document", "group": OURS,
+     "probe": "https://healthclaw.io/.well-known/agent-skills/index.json",
+     "why": "RFC 8615 skill catalogue app.py serves to any spec client"},
+    {"name": "careagents consumer domain", "group": OURS,
+     "probe": "https://careagents.cloud/healthz",
+     "why": "CARE_ORIGIN / CARE_RP_ID — the host a person's browser sees"},
+    {"name": "careagents platform host", "group": OURS,
+     "probe": "https://careagents-production.up.railway.app/healthz",
+     "why": "the CareAgents deployment prod_watch measures"},
+    {"name": "mcp server (token-locked)", "group": OURS,
+     "probe": "https://mcp-server-production-5112.up.railway.app/health",
+     "why": "server.json remote; production tool surface"},
+    {"name": "mcp server (public demo)", "group": OURS,
+     "probe": "https://mcp-demo-production-ee2c.up.railway.app/health",
+     "why": "server.json remote, gemini-extension.json, every quickstart"},
+    # --- upstreams and partner surfaces -------------------------------------
+    {"name": "HAPI FHIR public R4", "group": UPSTREAM,
+     "probe": "https://hapi.fhir.org/baseR4/metadata?_summary=true",
+     "why": "FHIR_UPSTREAM_URL example throughout README/INTEGRATION"},
+    {"name": "SMART Health IT R4", "group": UPSTREAM,
+     "probe": "https://r4.smarthealthit.org/metadata?_summary=true",
+     "why": "documented upstream, r6/fhir_proxy.py"},
+    {"name": "Firely public server", "group": UPSTREAM,
+     "probe": "https://server.fire.ly/R4/metadata?_summary=true",
+     "why": "the `generic` connector's proven-live server (set-2 evidence)"},
+    {"name": "Medplum hosted API", "group": UPSTREAM,
+     "probe": "https://api.medplum.com/fhir/R4/metadata?_summary=true",
+     "why": "_MEDPLUM_HOSTED_TOKEN_ENDPOINT, r6/fhir_proxy.py:50"},
+    {"name": "tx.fhir.org terminology", "group": UPSTREAM,
+     "probe": "https://tx.fhir.org/r4/metadata?_summary=true",
+     "why": "TX_FHIR_ORG, r6/curatr.py:29"},
+    {"name": "Fasten Connect API", "group": UPSTREAM,
+     "probe": "https://api.connect.fastenhealth.com/v1",
+     "why": "FASTEN_API_BASE default, r6/fasten/api.py:19"},
+    {"name": "MEDENT FHIR", "group": UPSTREAM,
+     "probe": "https://fhir.medent.com/fhir/R4/metadata?_summary=true",
+     "why": "_MEDENT_FHIR_BASE, scripts/export_medent_fhir.py:28"},
+    {"name": "HealthEx MCP", "group": UPSTREAM,
+     "probe": "https://api.healthex.io/mcp",
+     "why": "HEALTHEX_MCP_URL default, scripts/export_healthex_legacy.py"},
+    {"name": "Health Bank One MCP", "group": UPSTREAM,
+     "probe": "https://mcp.app.healthbankone.com/mcp",
+     "why": "HBO_MCP_URL default, openclaw/bot.py:109; .mcp.json"},
+    {"name": "Health Bank One OAuth", "group": UPSTREAM,
+     "probe": "https://oauth.app.healthbankone.com/",
+     "why": "scripts/healthbankone_oauth.py"},
+    {"name": "PromptOpinion marketplace", "group": UPSTREAM,
+     "probe": "https://app.promptopinion.ai/marketplace",
+     "why": "listing linked from templates/index.html, faq.html, wiki.html"},
+    {"name": "SHARP-on-MCP spec site", "group": UPSTREAM,
+     "probe": "https://sharponmcp.com/",
+     "why": "the contract the MCP server advertises conformance to"},
+    {"name": "ClawHub skill listing", "group": UPSTREAM,
+     "probe": "https://clawhub.ai/aks129/skills/fhir-r6-guardrails",
+     "why": "README distribution channel for 14 skills"},
+    {"name": "agentskills.io schema host", "group": UPSTREAM,
+     "probe": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+     "why": "_SKILLS_DISCOVERY_SCHEMA, app.py:339 — served in our own JSON"},
+)
+
+# The retired VPS. Addressed by IP in the deploy script, so the address is read
+# from there at runtime and scrubbed out of everything printed. Probed by
+# presenting the hostname to that address, which is exactly how #624 reached it.
+VPS_DEPLOY_SCRIPT = REPO_ROOT / "deploy" / "careagents" / "deploy.sh"
+VPS_SNI_HOST = "careagents.cloud"
+VPS_PLACEHOLDER = "<vps-address-redacted>"
+
+_IPV4 = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+def vps_address() -> str | None:
+    """The default host in the CareAgents VPS deploy script, if it is still there.
+
+    Returned only so the probe can dial it and the DNS comparison can test
+    against it. It must not reach any output stream — `_scrub` enforces that.
+    """
+    if not VPS_DEPLOY_SCRIPT.is_file():
+        return None
+    text = VPS_DEPLOY_SCRIPT.read_text(encoding="utf-8", errors="ignore")
+    match = re.search(r'HOST="\$\{1:-[^@"]*@([^"}]+)\}"', text)
+    if not match:
+        return None
+    candidate = match.group(1).strip()
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        # A hostname rather than an address is not a secret, but it is also not
+        # what this branch is for; treat only literal addresses as the target.
+        return None
+    return candidate
+
+
+_SECRET_ADDRESS = vps_address()
+
+
+def _scrub(text: str) -> str:
+    """Remove the retired box's address from anything on its way out.
+
+    Deliberately blunt: the address, and any address at all in a probe body we
+    do not control. The cost of over-redacting a report is a reader running one
+    more command; the cost of under-redacting is publishing an operator's
+    infrastructure into a public repository, which this repo has done before.
+    """
+    if not text:
+        return text
+    if _SECRET_ADDRESS:
+        text = text.replace(_SECRET_ADDRESS, VPS_PLACEHOLDER)
+    return text
+
+
+def out(line: str = "") -> None:
+    print(_scrub(line))
+
+
+# --- probing -----------------------------------------------------------------
+
+def probe(url: str, timeout: float) -> dict:
+    """One GET. No redirect following, no retry, no credential.
+
+    `allow_redirects=False` because a 301 to a parking page is a different
+    finding from a 200, and following it would erase the difference.
+    """
+    try:
+        r = requests.get(url, timeout=timeout, allow_redirects=False,
+                         headers={"User-Agent": UA, "Accept": "*/*"})
+    except requests.RequestException as exc:
+        return {"reached": False, "error": type(exc).__name__,
+                "status": None, "server": None, "location": None, "body": ""}
+    return {
+        "reached": True,
+        "error": None,
+        "status": r.status_code,
+        "server": r.headers.get("Server") or r.headers.get("server"),
+        "location": r.headers.get("Location"),
+        "body": (r.text or "")[:600],
+    }
+
+
+def answering(result: dict) -> bool:
+    """Is something serving here?
+
+    A 401/403/404 from a server is a server. Only a transport failure, or a
+    platform's own "this deployment does not exist" page, counts as dead —
+    the second because a Vercel 404 for an unclaimed name is served by Vercel,
+    not by us, and calling that "live" would hide exactly the stale reference
+    this exercise is looking for.
+    """
+    if not result.get("reached"):
+        return False
+    body = result.get("body") or ""
+    if "DEPLOYMENT_NOT_FOUND" in body or "Application not found" in body:
+        return False
+    if "Application failed to respond" in body:
+        return False
+    return True
+
+
+# --- what does the monitor actually request? ---------------------------------
+
+def watched_urls() -> list[str]:
+    """The URLs `scripts/prod_watch.py` requests, observed rather than read.
+
+    Imports the monitor, swaps its two HTTP helpers for recorders, and runs it
+    with no network. The stub returns a string, so every `getattr(r,
+    "status_code", None)` in that module yields None and the run completes and
+    reports failures — which is fine, the verdicts are discarded. Only the URLs
+    matter.
+
+    This is the whole reason the inventory can be trusted about "watched": the
+    module's constants are named for products, and a check named "careagents:"
+    turns out to request a hostname no user ever types.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    import prod_watch  # noqa: E402  (deliberate: the stub must precede the run)
+
+    seen: list[str] = []
+
+    def recorder(url, timeout, **kw):
+        seen.append(url)
+        return "surface-inventory-stub"
+
+    original_get, original_post = prod_watch.get, prod_watch.post
+    try:
+        prod_watch.get = recorder
+        prod_watch.post = recorder
+        # Never mind the exit code; a run with no network fails every check.
+        # Its report is swallowed rather than printed: eleven FAIL lines at the
+        # top of an inventory read as the inventory failing, and they are an
+        # artefact of stubbing the network, not a finding about production.
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            prod_watch.run(1.0, [])
+    finally:
+        prod_watch.get, prod_watch.post = original_get, original_post
+    return seen
+
+
+def host_of(url: str) -> str:
+    return (urlsplit(url).hostname or "").lower()
+
+
+# --- DNS, over a resolver that is not this network's -------------------------
+
+def doh(name: str, rrtype: str) -> list[str]:
+    try:
+        r = requests.get("https://dns.google/resolve", timeout=10,
+                         params={"name": name, "type": rrtype},
+                         headers={"User-Agent": UA})
+        payload = r.json()
+    except (requests.RequestException, ValueError):
+        return []
+    return [a.get("data", "") for a in (payload.get("Answer") or [])
+            if a.get("type") in (1, 5)]
+
+
+def nameservers(name: str) -> list[str]:
+    """Who is authoritative — the cheapest honest label for 'which platform'."""
+    labels = name.split(".")
+    for start in range(len(labels) - 1):
+        zone = ".".join(labels[start:])
+        try:
+            r = requests.get("https://dns.google/resolve", timeout=10,
+                             params={"name": zone, "type": "NS"},
+                             headers={"User-Agent": UA})
+            payload = r.json()
+        except (requests.RequestException, ValueError):
+            return []
+        answers = [a.get("data", "").rstrip(".")
+                   for a in (payload.get("Answer") or []) if a.get("type") == 2]
+        if answers:
+            return sorted(answers)
+    return []
+
+
+def system_addresses(name: str) -> list[str]:
+    try:
+        info = socket.getaddrinfo(name, 443, proto=socket.IPPROTO_TCP)
+    except OSError:
+        return []
+    return sorted({i[4][0] for i in info})
+
+
+def dns_facts(name: str) -> dict:
+    """Both resolvers, compared, with no address in the result.
+
+    Addresses are compared and then dropped. What a reader needs is (a) do the
+    two resolvers agree, (b) does this name point at the retired box, and (c)
+    who runs the zone. An address list adds none of that and is the one class
+    of string this report must not carry.
+    """
+    doh_a = sorted({a for a in doh(name, "A")
+                    if _IPV4.fullmatch(a or "")})
+    sys_a = sorted(set(system_addresses(name)))
+    return {
+        "resolves": bool(doh_a),
+        "resolvers_agree": (set(doh_a) == set(sys_a)) if (doh_a and sys_a)
+                           else None,
+        "points_at_retired_vps": (
+            None if not (doh_a and _SECRET_ADDRESS)
+            else _SECRET_ADDRESS in doh_a),
+        "nameservers": nameservers(name),
+    }
+
+
+# --- build evidence ----------------------------------------------------------
+
+def build_evidence(url: str, result: dict) -> str:
+    """Anything the surface says about WHICH build it is.
+
+    "Answering" and "current" are different findings and #624 was the second:
+    the box answered perfectly while running code from months earlier. A
+    payload with no build marker at all is itself evidence — it predates the
+    stamping this repo added in #258.
+    """
+    if not result.get("reached"):
+        return ""
+    body = result.get("body") or ""
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict):
+        bits = []
+        for key in ("build", "built_at", "version", "software", "fhirVersion",
+                    "status", "grade", "accounts", "run_workers", "provider",
+                    "database"):
+            if key in payload:
+                bits.append(f"{key}={payload[key]!r}")
+        if bits:
+            return "; ".join(bits)
+    server = result.get("server")
+    return f"Server: {server}" if server else "no build marker in the response"
+
+
+# --- reference scan ----------------------------------------------------------
+
+_SKIP_DIRS = {"node_modules", ".git", "dist", "__pycache__", ".venv",
+              ".ruff_cache", ".pytest_cache", "build", ".claude"}
+_SCAN_SUFFIXES = {".py", ".ts", ".js", ".md", ".json", ".yml", ".yaml",
+                  ".html", ".toml", ".sh", ".service", ".txt", ".example"}
+
+
+def references(host: str, limit: int = 4) -> list[str]:
+    """Where the repository names this host, as file:line.
+
+    Computed at run time rather than written down, so the inventory cannot
+    drift from the tree the way a hand-maintained list does.
+    """
+    hits: list[str] = []
+    for path in sorted(REPO_ROOT.rglob("*")):
+        if not path.is_file():
+            continue
+        # Relative parts, not absolute. An absolute comparison silently
+        # matched every file when the repo itself sits under a skipped name
+        # (a `.claude/worktrees/...` checkout), so this returned nothing at
+        # all and the "computed at run time" claim was empty.
+        if _SKIP_DIRS & set(path.relative_to(REPO_ROOT).parts):
+            continue
+        if path.suffix.lower() not in _SCAN_SUFFIXES:
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError:
+            continue
+        for index, line in enumerate(lines, 1):
+            if host in line:
+                hits.append(f"{path.relative_to(REPO_ROOT)}:{index}")
+                break
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+# --- the retired VPS ---------------------------------------------------------
+
+def probe_retired_vps(timeout: float) -> dict | None:
+    """One GET to the address in the deploy script, presenting the hostname.
+
+    Uses curl's `--resolve` rather than the system resolver, because the point
+    is to reach that specific box regardless of where the name currently
+    points. Read-only, single request, no credential.
+    """
+    if not _SECRET_ADDRESS:
+        return None
+    cmd = ["curl", "-sS", "--max-time", str(int(timeout)),
+           "--resolve", f"{VPS_SNI_HOST}:443:{_SECRET_ADDRESS}",
+           "-o", "-", "-w", "\n__STATUS__%{http_code}",
+           "-A", UA, f"https://{VPS_SNI_HOST}/healthz"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=timeout + 5)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"reached": False, "error": type(exc).__name__, "status": None,
+                "server": None, "location": None, "body": ""}
+    raw = proc.stdout or ""
+    status = None
+    body = raw
+    if "__STATUS__" in raw:
+        body, _, code = raw.rpartition("__STATUS__")
+        status = int(code.strip()) if code.strip().isdigit() else None
+    if not status:
+        return {"reached": False,
+                "error": (proc.stderr or "curl failed").strip()[:120],
+                "status": None, "server": None, "location": None, "body": ""}
+    return {"reached": True, "error": None, "status": status, "server": None,
+            "location": None, "body": body.strip()[:600]}
+
+
+# --- main --------------------------------------------------------------------
+
+def classify(result: dict, watched: bool) -> str:
+    if not answering(result):
+        return DEAD
+    return LIVE_WATCHED if watched else LIVE_UNWATCHED
+
+
+def run(timeout: float) -> dict:
+    watched_list = watched_urls()
+    watched_hosts = {host_of(u) for u in watched_list}
+
+    out(f"{B}What scripts/prod_watch.py actually requests{X} "
+        f"{D}(observed, not read from its constants){X}")
+    for url in watched_list:
+        out(f"  {url}")
+    out(f"  {D}→ {len(watched_hosts)} host(s): "
+        f"{', '.join(sorted(watched_hosts))}{X}")
+    out()
+
+    rows: list[dict] = []
+    for surface in SURFACES:
+        url = surface["probe"]
+        host = host_of(url)
+        result = probe(url, timeout)
+        is_watched = host in watched_hosts
+        row = {
+            "name": surface["name"],
+            "group": surface["group"],
+            "host": host,
+            "probe": url,
+            "why": surface["why"],
+            "status": result["status"],
+            "error": result["error"],
+            "location": _scrub(result["location"] or ""),
+            "answering": answering(result),
+            "watched": is_watched,
+            "verdict": classify(result, is_watched),
+            "build": _scrub(build_evidence(url, result)),
+            "references": references(host),
+        }
+        # DNS for everything we own, and for anything that did not answer:
+        # "the name does not exist" and "the name exists and refused" are
+        # different stale references with different owners.
+        if surface["group"] == OURS or not row["answering"]:
+            row["dns"] = dns_facts(host)
+        rows.append(row)
+
+    # The retired VPS, addressed rather than named.
+    vps = probe_retired_vps(timeout)
+    if vps is not None:
+        rows.append({
+            "name": "careagents VPS (address from deploy/careagents/deploy.sh)",
+            "group": OURS,
+            "host": VPS_PLACEHOLDER,
+            "probe": f"https://{VPS_SNI_HOST}/healthz via --resolve "
+                     f"{VPS_PLACEHOLDER}",
+            "why": "the #624 box; deploy/careagents/deploy.sh still defaults to it",
+            "status": vps["status"],
+            "error": _scrub(vps["error"] or ""),
+            "location": "",
+            "answering": answering(vps),
+            "watched": False,
+            "verdict": classify(vps, False),
+            "build": _scrub(build_evidence("", vps)),
+            "references": ["deploy/careagents/deploy.sh"],
+            "dns": None,
+        })
+
+    for verdict, colour in ((LIVE_UNWATCHED, R), (LIVE_WATCHED, G), (DEAD, Y)):
+        group = [r for r in rows if r["verdict"] == verdict]
+        out(f"{colour}{verdict.upper()} — {len(group)}{X}")
+        for row in group:
+            code = row["status"] if row["status"] is not None else row["error"]
+            out(f"  [{row['group']}] {row['name']}")
+            out(f"      {row['probe']} -> {code}")
+            if row["build"]:
+                out(f"      {D}{row['build']}{X}")
+            if row.get("dns"):
+                dns = row["dns"]
+                out(f"      {D}dns: resolves={dns['resolves']} "
+                    f"resolvers_agree={dns['resolvers_agree']} "
+                    f"retired_vps={dns['points_at_retired_vps']} "
+                    f"ns={','.join(dns['nameservers']) or '—'}{X}")
+            if row["references"]:
+                out(f"      {D}referenced: "
+                    f"{', '.join(row['references'])}{X}")
+        out()
+
+    counts = {v: len([r for r in rows if r["verdict"] == v])
+              for v in (LIVE_WATCHED, LIVE_UNWATCHED, DEAD)}
+    out(f"{B}{len(rows)} surface(s) probed{X}: "
+        + ", ".join(f"{n} {v}" for v, n in counts.items()))
+    return {"watched_urls": watched_list,
+            "watched_hosts": sorted(watched_hosts),
+            "surfaces": rows,
+            "counts": counts}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--timeout", type=float, default=10.0)
+    ap.add_argument("--json-out", metavar="PATH",
+                    help="write the same findings as JSON")
+    args = ap.parse_args()
+    payload = run(args.timeout)
+    if args.json_out:
+        Path(args.json_out).write_text(
+            _scrub(json.dumps(payload, indent=2)) + "\n", encoding="utf-8")
+    # Always 0: this reports, it does not gate. An inventory that fails a build
+    # because a third party's demo server is down would be turned off in a week.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/surface_inventory.py
+++ b/scripts/surface_inventory.py
@@ -29,7 +29,7 @@ constant named `CAREAGENTS` proves nothing about which host a check named
 the domain users type. Reading names would have reproduced that error.
 
 **DNS on a developer machine is not evidence.** This LAN answers port 53 from
-a stale cache (`docs/development.md`, CLAUDE.md). Every name here is resolved
+a stale cache (operator notes, not published here). Every name here is resolved
 over DoH *and* through the system resolver, and a disagreement is reported
 rather than silently picked. It matters most for the one host where a wrong
 answer flips the finding: if `careagents.cloud` still pointed at the retired

--- a/tests/test_surface_inventory.py
+++ b/tests/test_surface_inventory.py
@@ -1,0 +1,149 @@
+"""Guards on the deployed-surface inventory tool itself.
+
+`scripts/surface_inventory.py` exists because #624 (an abandoned deployment
+nobody watched) was found by accident. A tool that answers "what else is out
+there?" is only worth having if its own claims hold, so these pin the three
+that a reader would otherwise have to take on trust:
+
+  * the reference scan really scans (it silently scanned nothing, once);
+  * the retired VPS address never reaches an output stream;
+  * the watched set comes from what the monitor requests, not from its
+    constants.
+
+Every test here runs offline. None of them makes a network request.
+"""
+
+from __future__ import annotations
+
+import io
+import contextlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+surface_inventory = pytest.importorskip(
+    "surface_inventory", reason="requires requests")
+
+
+def test_reference_scan_finds_a_host_it_should_find():
+    """The scan returns real file:line hits, not an empty list.
+
+    This failed silently and completely: `_SKIP_DIRS` was compared against the
+    ABSOLUTE path parts, so a checkout living under any skipped name (a
+    `.claude/worktrees/...` worktree, a `build/` directory) matched on every
+    file and the scanner returned nothing for every host. The report still
+    rendered, with the evidence column simply blank, which is the failure mode
+    worth a test: a tool that reports nothing looks the same as a tool that
+    found nothing.
+    """
+    hits = surface_inventory.references("careagents.cloud")
+
+    assert hits, (
+        "the reference scan found no file naming careagents.cloud, which "
+        "cannot be true — careagents/config.py and README.md both do. The "
+        "scanner is skipping everything."
+    )
+    for hit in hits:
+        path, _, line = hit.rpartition(":")
+        assert (REPO_ROOT / path).is_file(), f"{hit} is not a real file"
+        assert line.isdigit(), f"{hit} has no line number"
+
+
+def test_reference_scan_reports_paths_relative_to_the_repo():
+    """A hit must be quotable into a document as-is.
+
+    An absolute path leaks the operator's home directory, which this repo has
+    published into a public evidence pack before.
+    """
+    for hit in surface_inventory.references("careagents.cloud"):
+        assert not hit.startswith("/"), f"absolute path in a report: {hit}"
+        assert "Users" not in hit, f"home directory in a report: {hit}"
+
+
+def test_the_retired_vps_address_is_scrubbed():
+    """The one string this tool must never print.
+
+    `deploy/careagents/deploy.sh` addresses the retired box by IP. The report
+    says whether a name resolves to it; it must not restate it.
+    """
+    address = surface_inventory.vps_address()
+    if address is None:
+        pytest.skip("the deploy script no longer carries a literal address")
+
+    scrubbed = surface_inventory._scrub(f"connecting to {address}/healthz")
+
+    assert address not in scrubbed
+    assert surface_inventory.VPS_PLACEHOLDER in scrubbed
+
+
+def test_scrub_survives_empty_and_missing_input():
+    assert surface_inventory._scrub("") == ""
+    assert surface_inventory._scrub(None) is None
+
+
+def test_watched_set_is_observed_rather_than_read():
+    """The watched URLs come from prod_watch's requests, not its constants.
+
+    The distinction is the whole point. `prod_watch.CAREAGENTS` is named for a
+    product and set to a platform hostname, so a set built by reading names
+    would claim the consumer domain is watched when no check ever requests it.
+    """
+    urls = surface_inventory.watched_urls()
+
+    assert urls, "prod_watch made no requests at all"
+    hosts = {surface_inventory.host_of(u) for u in urls}
+    assert "careagents-production.up.railway.app" in hosts, (
+        "the observed set lost the CareAgents platform host")
+    assert "careagents.cloud" not in hosts, (
+        "prod_watch does not request careagents.cloud; if it now does, the "
+        "inventory's finding 3 is fixed and this test should say so")
+
+
+def test_the_stub_run_prints_nothing():
+    """Deriving the watched set must not spray prod_watch's report at a reader.
+
+    The stub gives every check a non-response, so an unguarded call prints
+    eleven FAIL lines at the top of the inventory. They are an artefact of
+    stubbing the network, and a reader reasonably reads them as the inventory
+    failing.
+    """
+    captured_out, captured_err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(captured_out), \
+            contextlib.redirect_stderr(captured_err):
+        surface_inventory.watched_urls()
+
+    assert captured_out.getvalue() == ""
+    assert captured_err.getvalue() == ""
+
+
+def test_every_surface_is_probed_over_https_with_a_reason():
+    """No plaintext probe, and no entry without a stated reason for being here.
+
+    The exclusion argument in the evidence document only holds if every
+    inclusion is justified in the table itself.
+    """
+    for surface in surface_inventory.SURFACES:
+        assert surface["probe"].startswith("https://"), surface
+        assert surface["why"].strip(), surface
+        assert surface["group"] in (surface_inventory.OURS,
+                                    surface_inventory.UPSTREAM), surface
+
+
+def test_a_platform_not_found_page_is_not_a_live_surface():
+    """Railway and Vercel answer for names that host nothing.
+
+    Counting those as live would hide exactly the stale reference this tool
+    looks for: the host answers, the deployment does not exist.
+    """
+    not_found = {"reached": True, "status": 404, "body":
+                 '{"status":"error","code":404,"message":"Application not found"}'}
+    real_404 = {"reached": True, "status": 404, "body": '{"detail":"no route"}'}
+    unreachable = {"reached": False, "status": None, "body": ""}
+
+    assert surface_inventory.answering(not_found) is False
+    assert surface_inventory.answering(real_404) is True
+    assert surface_inventory.answering(unreachable) is False

--- a/tests/test_surface_inventory.py
+++ b/tests/test_surface_inventory.py
@@ -98,9 +98,11 @@ def test_watched_set_is_observed_rather_than_read():
     hosts = {surface_inventory.host_of(u) for u in urls}
     assert "careagents-production.up.railway.app" in hosts, (
         "the observed set lost the CareAgents platform host")
-    assert "careagents.cloud" not in hosts, (
-        "prod_watch does not request careagents.cloud; if it now does, the "
-        "inventory's finding 3 is fixed and this test should say so")
+    # Deliberately no assertion that careagents.cloud is absent. It is absent
+    # today and that is finding 3 of the 2026-09-04 inventory, but pinning it
+    # here would turn CI red the moment somebody fixes #625 by adding the
+    # consumer domain. A test that fails on the fix is a test that argues for
+    # the defect.
 
 
 def test_the_stub_run_prints_nothing():


### PR DESCRIPTION
Generalises #624. That issue was an abandoned CareAgents instance still serving
on an old VPS: months behind `main`, holding an accounts store, watched by
nothing. It surfaced because somebody happened to ask whether a deploy script
was still used. Nothing in this repository could answer "what else is like
that?", so this adds the thing that can, and runs it once.

## What is here

- `scripts/surface_inventory.py` — enumerates every host the repository names
  as a deployed surface, probes each one read-only, and sorts them into **live
  and watched**, **live and unwatched**, and **referenced but dead**.
- `docs/evidence/2026-09-04-deployed-surface-inventory.md` — the run, dated and
  pinned to a commit, with the exclusion list and the coverage gaps stated.
- `docs/evidence/2026-09-04-surface-inventory-check-count.py` — the
  reproduction for one finding about the monitor.
- `tests/test_surface_inventory.py` — guards on the tool's own claims.

## Two rules it follows rather than assumes

**The watched set is measured.** It imports `scripts/prod_watch.py`, replaces
`get`/`post` with recorders, runs it offline, and takes the URLs it actually
requested. Reading the constants would have reproduced the error it went
looking for: the checks named `careagents:` measure a platform hostname, never
the domain users type.

**DNS is resolved twice.** Over DoH and through the system resolver, with any
disagreement reported. This network answers port 53 from a stale cache, and for
`careagents.cloud` a wrong answer would have flipped the #624 finding in either
direction.

## What the run found

Measured 2026-09-04 at `89b42fb`. 25 endpoint rows: 4 watched, 16 live and
unwatched (4 ours, 12 third-party), 5 dead. Counted as distinct live hosts we
own, that is 6, of which the monitor requests 4, plus the retired #624 box that
no name resolves to.

1. **The #624 box still answers**, with an accounts store and no build marker.
   Confirmed from the other direction, by enumeration rather than by accident.
   Owner decision, unchanged: #624.
2. **Both MCP servers run `1.9.0`; their `package.json` on `main` says
   `1.10.0`.** Four checks cover those two hosts and all four pass, because
   none reads the version field the response already carries. The #258 shape,
   still open on a different pair of deployments. → #625
3. **`careagents.cloud` is unwatched.** It is `CARE_ORIGIN` and `CARE_RP_ID`,
   the host a browser shows and WebAuthn binds to. Today it fronts the same
   Railway service as the watched hostname, so the gap is narrow. The 08-06
   incident is the shape that opens it: a domain list omitted the hostname the
   project served and production went down while the service was fine. Under
   that, all four `careagents:` checks pass while nobody can sign in. → #625
4. **`healthclaw.io` is unwatched**, while `deployment.py` treats it as one of
   two hosts that "are not interchangeable". → #625
5. **Four published hostnames do not answer**, two of them served by running
   code: the `$schema` in our live agent-skills discovery document, and the
   `spec` URL in the MCP `initialize` response. → #626
6. **Two honesty defects in `prod_watch`.** `all {len(results)} checks passing`
   counts what ran, so the same stubbed deployment reports 11 or 12 depending
   on the flag. And check names carry a product while targets carry a hostname.
   → #625

## Scope

No production code is changed and no finding is patched. Each is a decision
with a cost: watching `healthclaw.io` means deciding to keep it, and asserting
an MCP version means deciding the accepted set for a deployment that is manual
by design. Evidence and reproductions are in the document and the issues.

## Probe discipline

One GET per endpoint, `allow_redirects=False`, no retries, no credential sent,
no method other than GET. 14 of the 25 rows are other people's servers.

## Redaction

The retired VPS is addressed by IP in `deploy/careagents/deploy.sh`. The script
reads that address at run time and scrubs it from every line it prints, so the
report can say whether a name resolves to it without restating it. The diff
carries no address, credential, or local path; `tests/test_surface_inventory.py`
pins the scrub.

## Gates

```
uv run ruff check .          All checks passed!
uv run python -m pytest tests/ -q
                            3165 passed, 13 skipped, 1 xfailed
```

Both new tests fail without their fixes (verified by reverting each): the
reference scan silently scanned nothing when the checkout sat under a skipped
directory name, and deriving the watched set printed the monitor's own eleven
stubbed failures at the top of the report.

A second commit on this branch corrects five claims that did not survive
review: a check miscounted three as four, two `prod_watch` line numbers that
were estimates rather than `grep -n` output, three citations to a gitignored
file, an overstated reproduction, and a test that asserted a defect as
specification. Its message says what each was.

## Known gaps, stated rather than papered over

Only port 443, only names this repository writes down, nothing behind
authentication. A service on another port or on a host nobody wrote down is
invisible to this method. That is the residual #624 risk and this PR does not
close it. The Mac mini iMessage relay holds a mint secret and has no public
name here; it was not probed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
