### PR TITLE
fix(skills): the discovery $schema URI is an identifier, not an address (#626)

### DIFF
--- a/app.py
+++ b/app.py
@@ -341,10 +341,11 @@ def skills_index():
 # match it against known schema URIs and states it "does not need to be
 # resolvable"; a client that does not recognise the exact string SHOULD NOT
 # process the index, and one that finds no $schema at all reads the index as
-# v0.1.0, a format we do not serve. `schemas.agentskills.io` is NXDOMAIN and
-# that is the specified state — repointing this at a host that answers, or
-# dropping the field, breaks every conformant client. Change it only to adopt
-# a later spec version, byte-for-byte as that version defines it.
+# v0.1.0, a format we do not serve. `schemas.agentskills.io` does not resolve
+# today and the spec permits that; whether it resolves is simply not a property
+# of this value. Repointing this at a host that answers, or dropping the field,
+# breaks every conformant client. Change it only to adopt a later spec
+# version, byte-for-byte as that version defines it.
 _SKILLS_DISCOVERY_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
 _SKILL_NAME_RE = re.compile(r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$")
 

--- a/app.py
+++ b/app.py
@@ -336,6 +336,15 @@ def skills_index():
 # (type "skill-md"); digests are SHA-256 of the artifact, computed at import.
 # The /.well-known/skills/ alias serves v0.1 clients.
 # ---------------------------------------------------------------------------
+# The $schema value is an opaque version identifier, not an address. The RFC
+# (github.com/cloudflare/agent-skills-discovery-rfc, "Versioning") has clients
+# match it against known schema URIs and states it "does not need to be
+# resolvable"; a client that does not recognise the exact string SHOULD NOT
+# process the index, and one that finds no $schema at all reads the index as
+# v0.1.0, a format we do not serve. `schemas.agentskills.io` is NXDOMAIN and
+# that is the specified state — repointing this at a host that answers, or
+# dropping the field, breaks every conformant client. Change it only to adopt
+# a later spec version, byte-for-byte as that version defines it.
 _SKILLS_DISCOVERY_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
 _SKILL_NAME_RE = re.compile(r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$")
 

--- a/tests/test_wellknown_skills.py
+++ b/tests/test_wellknown_skills.py
@@ -13,12 +13,18 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 NAME_RE = re.compile(r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$")
 
+#: Pinned exactly, not by prefix. The spec makes this an opaque identifier that
+#: clients match against known schema URIs, so any other string — a later
+#: version we do not serve, or a host chosen because it resolves — reads to a
+#: conformant client as an index it SHOULD NOT process.
+DISCOVERY_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+
 
 def test_index_serves_all_repo_skills(client):
     r = client.get("/.well-known/agent-skills/index.json")
     assert r.status_code == 200
     body = r.get_json()
-    assert body["$schema"].startswith("https://schemas.agentskills.io/discovery/")
+    assert body["$schema"] == DISCOVERY_SCHEMA
     names = {s["name"] for s in body["skills"]}
     on_disk = {p.parent.name for p in ROOT.glob("skills/*/SKILL.md")}
     assert names == on_disk


### PR DESCRIPTION
Refs #626. Deliberately not `Closes`: this PR settles one of the four hostnames
in that issue and leaves the other three, with the reasons below.

## The reported URL is correct. The fix is the reasoning, not a new address.

#626 lists the `$schema` in our live agent-skills discovery document
(`app.py:339`) as a published hostname that does not resolve, on the stated
theory that "a conformant client may try to fetch it". The spec this endpoint
implements says the opposite. From the Cloudflare Agent Skills Discovery RFC
v0.2.0, section Versioning
([README.md:175](https://github.com/cloudflare/agent-skills-discovery-rfc/blob/main/README.md)):

> The `$schema` URI is an **opaque identifier**. Clients MUST match it against
> known schema URIs to determine how to process the index. The URI does not
> need to be resolvable, though it MAY point to a JSON Schema document that
> describes the index format.

The same section names the exact string, and it is the one we serve. So
`schemas.agentskills.io` returning NXDOMAIN is the specified state, not a
defect, and the two obvious repairs both break clients:

- Repoint it at a host that answers, and a conformant client no longer
  recognises the URI. RFC line 177: it SHOULD warn the user and SHOULD NOT
  process the index.
- Drop the field, and a client reads the index as v0.1.0, which used `files`
  paths and no digests. We do not serve that format.

Nothing this PR does changes a byte of what
`https://healthclaw.io/.well-known/agent-skills/index.json` returns.

## What changed

- `app.py:339`. A comment above the constant carrying the citation and the two
  consequences above, so the next surface sweep does not re-file this and
  nobody repairs the URL into something that resolves.
- `tests/test_wellknown_skills.py:21`. The assertion was a prefix,
  `.startswith("https://schemas.agentskills.io/discovery/")`, which passes on
  any version string in that path. Clients match the whole URI, so the whole
  URI is the contract. Now pinned exactly, with the reasoning on the constant.

That test change is the guard #626 asks for, and it needs no network. Mutation:
set the served version to `0.3.0` and `test_index_serves_all_repo_skills`
fails on the exact string; the prefix assertion it replaces passes on that same
mutation.

## `sharponmcp.com` is not registered, which is worse than dead

#626 records the host as NXDOMAIN. Measured today, it is also unregistered:

```
$ whois sharponmcp.com
No match for domain "SHARPONMCP.COM".
```

NXDOMAIN confirmed through two DoH resolvers, Google and Cloudflare, each
answering with the `.com` SOA in the authority section rather than from cache.
The Wayback Machine has a 200 for `sharponmcp.com` on 2026-06-17, and an https
snapshot on 2026-06-13, so the domain lapsed between then and now.

`services/agent-orchestrator/src/index.ts:259` puts that URL in the `sharp`
block of the MCP `initialize` response and `:704` repeats it in `/health`.
Both MCP deployments serve it today, measured for this PR:

```
$ curl -s https://mcp-demo-production-ee2c.up.railway.app/health
version=1.9.0  sharp.spec=https://sharponmcp.com
$ curl -s https://mcp-server-production-5112.up.railway.app/health
version=1.9.0  sharp.spec=https://sharponmcp.com
```

An unregistered name is available to anyone. Whoever registers it inherits a
URL that our own servers label as the protocol specification.

That raises the priority of the second half. It does not change who decides it.

## Why the second half is not in this PR

Three reasons, any one of which is sufficient:

1. `index.ts` is claimed by #556, which ships phase 1 of the MCP authorization
   spec behind `MCP_CANONICAL_RESOURCE` and carries its own owner-only deploy
   checklist. There is nothing to write in that file today except a comment,
   which is not worth a conflict with it.
2. No replacement address is establishable. The GitHub search finds
   implementations that call themselves SHARP-compliant, not a spec home. The
   Wayback root snapshot is a 1.7KB JavaScript shell with no outbound links,
   and `sharponmcp.com/getting-started` has no snapshot at all. Substituting
   the PromptOpinion extension doc, which is live, would be a vendor URL in
   place of a vendor-neutral spec, and false in a different way.
3. #626 says this one is "a question for whoever owns the SHARP relationship
   rather than a find-and-replace". That reading is right.

`templates/wiki.html:562` and `templates/faq.html:328` link the same host and
are not claimed by #556, so they could land now. They wait on purpose. Those
are the two places a human clicks, and both repairs available today, plain text
or a different address, still state something about SHARP's status that no
source establishes.

The two skills in #626, `share-health-qr` and `personal-health-records`, are
also untouched. `personal-health-records` needs more than a substitution: it
uses one dead host for both `/mcp` and `/r6/fhir`, which are two different
services in `server.json` and `deployment.py`, and whether `desktop-demo` and
`/r6/fhir/internal/seed` answer on the replacement is a live measurement rather
than a file edit.

All four are tracked in #626, which stays open.

## One thing for #627

`scripts/surface_inventory.py` lives on that unmerged branch, so this PR cannot
touch it. Its "referenced but dead" class is the right answer for three of the
rows and the wrong one for `schemas.agentskills.io`, which is an identifier
rather than an address. Without a distinction there, the next sweep re-files
this issue. Posted as a comment on #627 with the citation.

## Gates

```
uv run ruff check .          All checks passed!
uv run python -m pytest tests/ -q
                             3157 passed, 13 skipped, 1 xfailed in 112.45s
```

The connector suite was not run. No TypeScript changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
