### PR TITLE
test(guards): four #630 guards that pin the property, each mutated both ways

### DIFF
--- a/tests/test_actions_routes.py
+++ b/tests/test_actions_routes.py
@@ -122,6 +122,63 @@ def test_status_shows_payload_with_step_up(client, tenant_headers, auth_headers)
     assert 'payload' in resp.get_json()
 
 
+def _assert_summary_only(resp, action_id):
+    """The PHI-safe summary, asserted as a property rather than a shape.
+
+    Same three facts as test_status_hides_payload_without_step_up, factored
+    out so the unprivileged branch is checked identically however the caller
+    failed to prove itself.
+    """
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert 'payload' not in d
+    blob = json.dumps(d)
+    assert '617-555-0100' not in blob   # phone
+    assert 'metformin' not in blob      # message body
+    assert d['id'] == action_id
+
+
+def test_status_hides_payload_with_a_malformed_step_up_token(client,
+                                                             tenant_headers):
+    """H4, the branch nothing reached: token PRESENT but not valid.
+
+    The pair above tests header-absent and header-present-and-valid, so a
+    route that stopped validating and merely checked for the header's
+    presence stayed green. Presenting a garbage token is the only way to
+    tell "a valid token" from "a token".
+
+    MUTATION: r6/actions/routes.py, `privileged = valid` ->
+    `privileged = bool(step_up)` (equivalently, collapse the three-line
+    check to `privileged = bool(step_up)`) -> red. Executed 2026-09-04.
+    """
+    action_id = _propose(client, tenant_headers)
+    headers = dict(tenant_headers)
+    headers['X-Step-Up-Token'] = 'not-a-real-token'
+    resp = client.get(f'/r6/actions/{action_id}', headers=headers)
+    _assert_summary_only(resp, action_id)
+
+
+def test_status_hides_payload_from_another_tenants_step_up_token(
+        client, tenant_headers):
+    """A well-formed, correctly-signed token issued to a DIFFERENT tenant.
+
+    Distinct from the malformed case: this one survives signature checking
+    and is refused only because the route passes `tenant_id` to the
+    validator. It is what pins the tenant binding the route comment claims —
+    dropping the argument would leave the malformed test green.
+
+    MUTATION: r6/stepup.py, drop the tenant-binding check
+    (`if payload.get('tid') != tenant_id: return False, ...`) -> red, while
+    the malformed-token test above stays green. Executed 2026-09-04.
+    """
+    from r6.stepup import generate_step_up_token
+    action_id = _propose(client, tenant_headers)
+    headers = dict(tenant_headers)
+    headers['X-Step-Up-Token'] = generate_step_up_token('some-other-tenant')
+    resp = client.get(f'/r6/actions/{action_id}', headers=headers)
+    _assert_summary_only(resp, action_id)
+
+
 def test_commit_requires_step_up(client, tenant_headers):
     action_id = _propose(client, tenant_headers)
     resp = client.post('/r6/actions/%s/commit' % action_id,

--- a/tests/test_command_center_writes_are_audited.py
+++ b/tests/test_command_center_writes_are_audited.py
@@ -19,6 +19,7 @@ whole contract is that it holds no PHI.
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
@@ -79,17 +80,36 @@ def test_the_conversation_audit_never_carries_the_message(app, client, step_up):
     PHI-free, and chat transcripts are PHI-adjacent.
 
     MUTATION: put `text` (or any slice of it) into the detail -> red.
+    Executed 2026-09-04 as `preview={text[:10]}`. Before the two additions
+    below it was NOT red: `text[:10]` is "Quintaviou", which contains none of
+    the five whole words, and the POST's status was never asserted, so a
+    refusal would have satisfied the loop with an empty trail.
     """
     _clear(app)
-    client.post("/command-center/api/conversations",
-                headers={"X-Step-Up-Token": step_up},
-                json={"tenant_id": _TENANT, "role": "user",
-                      "text": _SECRET_TEXT, "agent_id": "a1"})
+    resp = client.post("/command-center/api/conversations",
+                       headers={"X-Step-Up-Token": step_up},
+                       json={"tenant_id": _TENANT, "role": "user",
+                             "text": _SECRET_TEXT, "agent_id": "a1"})
+
+    # Non-vacuity. Without this the write could 4xx and the absence check
+    # below would be reporting on a trail that was never written.
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+    events = _events(app, "ConversationMessage")
+    assert len(events) == 1, events
 
     blob = json.dumps(_events(app))
     for token in ("Quintavious", "Zzyzxbarton", "A1c", "8.1", "scared"):
         assert token not in blob, (
             f"the audit trail carries {token!r} out of the message body")
+
+    # The property, rather than a list of phrases that happen not to appear:
+    # the detail is exactly these four ids-and-counts fields and nothing
+    # else. A blocklist can only refuse what it was told about; a fullmatch
+    # refuses everything it was not. Any appended slice of the turn — any
+    # appended anything — fails here.
+    assert re.fullmatch(
+        r"conversation=\S+ role=\S+ channel=\S+ chars=\d+",
+        events[0]["detail"]), events[0]["detail"]
 
 
 def test_an_idempotent_replay_does_not_audit_a_second_write(app, client, step_up):
@@ -138,18 +158,28 @@ def test_creating_and_updating_a_task_are_both_audited(app, client, step_up):
 def test_the_task_audit_never_carries_the_title(app, client, step_up):
     """A task title is caller-supplied free text and may name a condition.
 
-    MUTATION: put `title` into the create detail -> red.
+    MUTATION: put `title` into the create detail -> red. Executed 2026-09-04
+    as `title={title[:10]}` — the same slice-shaped leak as the conversation
+    case, and the same result: green before the additions below, red after.
+    This docstring had never been run.
     """
     _clear(app)
-    client.post("/command-center/api/tasks",
-                headers={"X-Step-Up-Token": step_up},
-                json={"tenant_id": _TENANT, "agent_id": "joe",
-                      "title": _SECRET_TEXT})
+    resp = client.post("/command-center/api/tasks",
+                       headers={"X-Step-Up-Token": step_up},
+                       json={"tenant_id": _TENANT, "agent_id": "joe",
+                             "title": _SECRET_TEXT})
+
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+    events = _events(app, "AgentTask")
+    assert len(events) == 1, events
 
     blob = json.dumps(_events(app, "AgentTask"))
     for token in ("Quintavious", "Zzyzxbarton", "A1c", "scared"):
         assert token not in blob, (
             f"the audit trail carries {token!r} out of a task title")
+
+    assert re.fullmatch(r"priority=\S+ title_chars=\d+",
+                        events[0]["detail"]), events[0]["detail"]
 
 
 # --- the gap this file closes, stated as a property -------------------------

--- a/tests/test_oauth_tenant_binding.py
+++ b/tests/test_oauth_tenant_binding.py
@@ -46,3 +46,116 @@ def test_authorize_allows_public_tenant_when_read_auth_on(client, monkeypatch):
     resp = _authorize(client, client_id, 'desktop-demo')
     assert resp.status_code == 200
     assert 'code' in resp.get_json()
+
+
+# --- What the code is BOUND to, not merely that one was issued ---------------
+#
+# The two tests above stop at the status code, and the third at `'code' in
+# body`. A code exists either way, so the tenant a granted code carries was
+# never read back by anything. These do read it back — once out of the token
+# the code buys, and once out of the behaviour that token then has.
+
+
+def _challenge_pair():
+    """(verifier, challenge). The helper above discards the verifier, which
+    is exactly what a token exchange needs."""
+    verifier = secrets.token_urlsafe(32)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).rstrip(b'=').decode()
+    return verifier, challenge
+
+
+def _authorize_claiming(client, client_id, header_tenant, challenge,
+                        **extra_query):
+    """Authorize as `header_tenant`, smuggling `extra_query` into the URL."""
+    query = ''.join(f'&{k}={v}' for k, v in extra_query.items())
+    return client.get(
+        f'/r6/fhir/oauth/authorize?client_id={client_id}'
+        f'&redirect_uri=http://localhost/cb'
+        f'&code_challenge={challenge}&code_challenge_method=S256{query}',
+        headers={'X-Tenant-Id': header_tenant})
+
+
+def _exchange(client, client_id, code, verifier):
+    resp = client.post('/r6/fhir/oauth/token', data={
+        'grant_type': 'authorization_code',
+        'code': code,
+        'code_verifier': verifier,
+        'client_id': client_id,
+        'redirect_uri': 'http://localhost/cb',
+    })
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    return resp.get_json()['access_token']
+
+
+def test_the_granted_code_is_bound_to_the_header_tenant_not_a_query_param(
+        client, monkeypatch):
+    """H3, read back: the tenant on the minted grant is the one the gate saw.
+
+    The gate above checks `X-Tenant-Id` against PUBLIC_TENANTS. If the code
+    is then bound from anywhere else — a query parameter, a body field — the
+    403 is decorative: pass the gate as the public tenant, receive a grant
+    for someone else.
+
+    MUTATION: r6/oauth.py, `'tenant_id': requested_tenant` ->
+    `'tenant_id': request.args.get('tenant_id', requested_tenant)` -> red.
+    Executed 2026-09-04.
+    """
+    from r6.oauth import validate_bearer_token
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    client_id = _register(client, {'X-Tenant-Id': 'desktop-demo'})
+    verifier, challenge = _challenge_pair()
+
+    resp = _authorize_claiming(client, client_id, 'desktop-demo', challenge,
+                               tenant_id='victim-tenant')
+    assert resp.status_code == 200
+    token = _exchange(client, client_id, resp.get_json()['code'], verifier)
+
+    # Destructured, never truthiness-tested — validate_bearer_token returns
+    # a tuple whose first element is the answer.
+    ok, info = validate_bearer_token(token)
+    assert ok, info
+    assert info['tenant_id'] == 'desktop-demo', (
+        f"the grant is bound to {info['tenant_id']!r}, which is not the "
+        "tenant the auto-approve gate authorized")
+
+
+def test_a_code_granted_to_a_public_tenant_cannot_read_a_private_one(
+        client, monkeypatch):
+    """The same property stated as behaviour rather than as a stored field.
+
+    Structure can be right and still not matter; this is the read the H3
+    escape was worth making. Same mutation, same direction.
+
+    MUTATION: r6/oauth.py, `'tenant_id': requested_tenant` ->
+    `'tenant_id': request.args.get('tenant_id', requested_tenant)` -> red.
+    Executed 2026-09-04.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    client_id = _register(client, {'X-Tenant-Id': 'desktop-demo'})
+    verifier, challenge = _challenge_pair()
+
+    resp = _authorize_claiming(client, client_id, 'desktop-demo', challenge,
+                               tenant_id='victim-tenant')
+    token = _exchange(client, client_id, resp.get_json()['code'], verifier)
+
+    read = client.get('/r6/fhir/Patient?_summary=count', headers={
+        'X-Tenant-Id': 'victim-tenant',
+        'Authorization': f'Bearer {token}',
+    })
+    assert read.status_code == 401, read.get_data(as_text=True)
+    assert read.get_json()['issue'][0]['code'] == 'security'
+
+    # Non-vacuity, and only that: the route answers 200 for the tenant the
+    # grant was authorized against, so the 401 above is not a route that
+    # refuses everybody. It does NOT show the bearer is live — desktop-demo
+    # is in PUBLIC_TENANTS, so authorize_tenant_read returns before it ever
+    # looks at the Authorization header. The read-back in the sibling test
+    # is what establishes the token is real and bound.
+    own = client.get('/r6/fhir/Patient?_summary=count', headers={
+        'X-Tenant-Id': 'desktop-demo',
+        'Authorization': f'Bearer {token}',
+    })
+    assert own.status_code == 200

--- a/tests/test_read_auth.py
+++ b/tests/test_read_auth.py
@@ -333,3 +333,130 @@ def test_read_flag_on_oauth_bearer_no_read_scope_401(client, monkeypatch):
         'Authorization': f'Bearer {tok}',
     })
     assert resp.status_code == 401
+
+
+# --- Read-shaped POST operations -------------------------------------------
+#
+# The before_request hook above only gates GET ("Only reads. Writes ... are
+# gated elsewhere"), so every read-shaped POST — a FHIR $operation that reads
+# rather than writes — has to call authenticate_tenant_read for itself. Each
+# such call is therefore the ONLY thing standing between an unauthenticated
+# caller and that tenant's data, and until now four of them had no test.
+#
+# Each test below asserts the status AND the OperationOutcome, because under
+# the mutation these routes do not return 200 uniformly — $populate 404s on an
+# unresolvable questionnaire — and "not 200" is a weaker claim than "401
+# security", which is the one the gate makes.
+#
+# The other two read-shaped POSTs are already pinned, next to their own
+# routes rather than here: QuestionnaireResponse/$extract in
+# tests/test_sdc_routes.py and Measure/$evaluate-measure in
+# tests/test_quality_routes.py. Named so the next reader does not re-add them.
+
+def _assert_read_refused(resp):
+    assert resp.status_code == 401, resp.get_data(as_text=True)
+    body = resp.get_json()
+    assert body['resourceType'] == 'OperationOutcome'
+    assert body['issue'][0]['code'] == 'security'
+
+
+def test_read_flag_on_interpret_post_no_token_401(client, monkeypatch):
+    """POST Observation/$interpret returns interpreted labs for the tenant.
+
+    MUTATION: r6/labs/routes.py, delete the authenticate_tenant_read call in
+    interpret_labs (or null its result) -> red. Executed 2026-09-04.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', '')
+    resp = client.post('/r6/fhir/Observation/$interpret',
+                       json={'resourceType': 'Parameters', 'parameter': []},
+                       headers={'X-Tenant-Id': 'private-tenant'})
+    _assert_read_refused(resp)
+
+
+def test_read_flag_on_care_gaps_post_no_token_401(client, monkeypatch):
+    """Patient/$care-gaps is registered for GET *and* POST. The GET is caught
+    by the before_request hook; the POST is caught by nothing but the
+    in-handler call, so the POST is the one worth pinning.
+
+    MUTATION: r6/caregaps/routes.py, delete the authenticate_tenant_read call
+    in care_gaps (or null its result) -> red. Executed 2026-09-04.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', '')
+    resp = client.post('/r6/fhir/Patient/$care-gaps',
+                       json={'resourceType': 'Parameters', 'parameter': []},
+                       headers={'X-Tenant-Id': 'private-tenant'})
+    _assert_read_refused(resp)
+
+
+def test_read_flag_on_populate_post_no_token_401(client, monkeypatch):
+    """POST Questionnaire/$populate fills a form from the tenant's record.
+
+    The gate must fire BEFORE questionnaire resolution, or the refusal
+    degrades into a 404 that reports whether the questionnaire exists.
+
+    MUTATION: r6/sdc/routes.py, delete the authenticate_tenant_read call in
+    sdc_populate (or null its result) -> red (404, not 401). Executed
+    2026-09-04.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', '')
+    resp = client.post('/r6/fhir/Questionnaire/$populate',
+                       json={'resourceType': 'Parameters', 'parameter': []},
+                       headers={'X-Tenant-Id': 'private-tenant'})
+    _assert_read_refused(resp)
+
+
+
+def test_read_flag_on_these_operations_answer_for_a_public_tenant(
+        client, monkeypatch):
+    """Non-vacuity for the three above.
+
+    Each asserts a 401. A route that 401s for every caller — or that stopped
+    being registered at all — would satisfy every one of them. With the flag
+    on and the tenant public, the same three calls must NOT be 401.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    body = {'resourceType': 'Parameters', 'parameter': []}
+    headers = {'X-Tenant-Id': 'desktop-demo'}
+    for path in ('/r6/fhir/Observation/$interpret',
+                 '/r6/fhir/Patient/$care-gaps',
+                 '/r6/fhir/Questionnaire/$populate'):
+        resp = client.post(path, json=body, headers=headers)
+        assert resp.status_code != 401, (
+            f'{path} refuses a public tenant, so its 401 test proves nothing')
+
+
+def test_read_flag_on_appointment_brief_no_token_401(client, monkeypatch):
+    """/AppointmentBrief had no read-auth test at all; now it has one.
+
+    Stated carefully, because the obvious mutation does NOT turn this red.
+    The brief is a GET, so it is gated twice: by the `authenticate_read`
+    before_request hook AND by its own `authenticate_tenant_read` call.
+    Either one alone refuses — verified by nulling each in turn, both times
+    still 401. So this test pins the property (no token, no brief) and
+    notices only the loss of the LAST gate, not the first.
+
+    MUTATION: null r6/brief/routes.py's authenticate_tenant_read call ->
+    still green (defence in depth). Null the `request.method != 'GET'` early
+    return in r6/routes.py's authenticate_read as well -> red. Both executed
+    2026-09-04. #630 lists this route alongside the read-shaped POSTs; it is
+    a GET, and the single-call mutation it names does not turn a guard red.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', '')
+    resp = client.get('/r6/fhir/AppointmentBrief',
+                      headers={'X-Tenant-Id': 'private-tenant'})
+    _assert_read_refused(resp)
+
+
+def test_read_flag_on_appointment_brief_answers_a_public_tenant(
+        client, monkeypatch):
+    """Non-vacuity for the brief: public tenant, flag on, not a 401."""
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    resp = client.get('/r6/fhir/AppointmentBrief',
+                      headers={'X-Tenant-Id': 'desktop-demo'})
+    assert resp.status_code != 401, resp.get_data(as_text=True)


### PR DESCRIPTION
Closes the four unclaimed rows of #630: F3, F4, F5, F7. F8 is out of scope
(`tests/test_ratchets.py` is contended by #618, #595, #562).

Production code is unchanged. Every line of the diff is a test.

## The rule this PR is built around

#630's finding is that `MUTATION: … -> red` docstrings decayed into claims
because nobody re-ran them. So every mutation named in a docstring here was
executed, in both directions, and the transcript is below. One guard turned
out to pass under its own mutation; it is shipped with a docstring that says
so rather than a claim that it does not.

Method: pure pytest — edit source, run, revert — with the replacement count
asserted at 1 before each edit. See the stale-bytecode note at the bottom;
"pure pytest sidesteps the stale-process trap" turned out not to be true.

## Evidence

Every row is a real run. `clean` is the same selection on unmutated code.

| Mutation | File | Clean | Mutated |
|---|---|---|---|
| `privileged = valid` → `privileged = bool(step_up)` | `r6/actions/routes.py` | 4 passed | **2 failed**, 2 passed |
| drop the `tid != tenant_id` check | `r6/stepup.py` | 4 passed | **1 failed**, 3 passed |
| `'tenant_id': requested_tenant` → `request.args.get('tenant_id', …)` | `r6/oauth.py` | 4 passed | **2 failed**, 2 passed |
| null `authenticate_tenant_read` | `r6/labs/routes.py` | 1 passed | **1 failed** |
| null `authenticate_tenant_read` | `r6/caregaps/routes.py` | 1 passed | **1 failed** |
| null `authenticate_tenant_read` in `sdc_populate` | `r6/sdc/routes.py` | 1 passed | **1 failed** |
| append `preview={text[:10]}` to the detail | `r6/command_center/routes.py` | 1 passed | **1 failed** |
| append `title={title[:10]}` to the detail | `r6/command_center/routes.py` | 1 passed | **1 failed** |
| `_authz_write` always refuses (vacuity probe) | `r6/command_center/routes.py` | 2 passed | **2 failed** |

In the F3 and F4 rows the "2 passed" under the mutation are the pre-existing
tests. They are green while the record leaks, which is #630's claim,
reproduced.

### The same three F7 mutations against the pre-repair tests

`git show HEAD:tests/test_command_center_writes_are_audited.py` run as a
separate file, so the before/after is a controlled comparison:

| Mutation | Pre-repair test |
|---|---|
| `preview={text[:10]}` | **passed** (not caught) |
| `title={title[:10]}` | **passed** (not caught) |
| `_authz_write` always refuses | **passed** (not caught) |

`title={title[:10]}` is the one #630 flagged as never executed. It was
equally blind. Confirmed, not cleared.

## What each guard now pins

**F3 — `tests/test_actions_routes.py`.** Two tests. A malformed token
(`not-a-real-token`) and a correctly-signed token issued to another tenant
must both get the PHI-safe summary. The second is the one that pins the
tenant argument: it is the only test in the file that goes red when the
binding check is dropped — run against the whole file, not a selection:
23 passed clean, 1 failed mutated.

**F4 — `tests/test_oauth_tenant_binding.py`.** The grant is exchanged for a
token and the token's tenant is read back, then the same bearer is refused
against the tenant it was not granted for and accepted for the one it was.
The mutation is #630's exact H3 escape: pass the public-tenant gate,
smuggle `?tenant_id=victim-tenant`.

**F5 — `tests/test_read_auth.py`.** Three read-shaped POST operations, each
asserting 401 *and* `issue[0].code == "security"`, because under the
mutation `$populate` returns 404 rather than 200 and "not 200" is a weaker
claim than the one the gate makes. One test calls all three as a public
tenant and asserts none is 401, so a route that refuses everybody cannot
satisfy them.

The first draft of this PR also covered `$extract` (dry run) and
`$evaluate-measure`. Those are the two of six that #630 records as already
covered — `tests/test_sdc_routes.py:152` and `tests/test_quality_routes.py:130`
pin them next to their own routes, in the same shape. The duplicates were
removed and a comment names their locations instead. #630's count was right
and this PR's first draft was wrong.

**F7 — `tests/test_command_center_writes_are_audited.py`.** The existing
blocklists are kept and joined by a `re.fullmatch` on the detail. A
blocklist refuses only what it was told about; a fullmatch refuses
everything it was not, which is the shape #630 praised in
`r6/conformance/probes.py`. Plus a status assertion and an event count, so
a refused write can no longer satisfy an absence check.

## Two corrections to #630

**The `/AppointmentBrief` row is wrong.** It is listed with the read-shaped
POSTs. It is a `GET`, so the `authenticate_read` before_request hook gates
it as well as its own in-handler call. Verified three ways:

- null the handler call → still 401 (**not caught**)
- null the hook's `request.method != 'GET'` early return → still 401 (**not caught**)
- null both → **red**

So the census's mutation for this row does not turn a guard red, and the
route is not uncovered in the way the row implies. It genuinely had no
read-auth test, so one is shipped — with a docstring that states the two-gate
fact and names the double mutation, rather than a `-> red` line that would be
false.

**The denominator is off.** `authenticate_tenant_read` has ten call sites,
not six. This PR covers five of the uncovered ones; `r6/smbp/routes.py:139`,
`r6/smbp/trend_routes.py:95`, `r6/smbp/scheduler_routes.py:56` and
`r6/actions/routes.py:684` were not examined.

## A trap worth recording

#630 says the pure-pytest method "sidesteps the stale-process trap recorded
in CLAUDE.md entirely". It does not.

The vacuity mutation replaces `valid` with `False` — same length. Restored
by `git checkout --` inside the same clock second, the source's mtime and
size are both unchanged, so CPython accepts the cached `.pyc` and the next
run executes code that is no longer on disk. It cost about twenty minutes
here: a full-suite run came back `51 failed` against a working tree `git
status` reported clean, and the failures reproduced at `HEAD` with the diff
stashed. `find . -name __pycache__ -delete` fixed it with no source change.

The fix in the harness is `PYTHONDONTWRITEBYTECODE=1` plus a cache purge
before every run. Every result in the tables above was re-run under it; the
verdicts did not change, which is the point of re-running them.

## Runs

```
uv run python -m pytest tests/ -q
3167 passed, 13 skipped, 1 xfailed, 2 warnings in 111.62s

uv run ruff check .
All checks passed!
```

#630's baseline is 3157 passed; this adds 10 tests and repairs 2 in place.
`test_prod_watch_build.py::test_a_dirty_build_is_never_accepted`, which #630
records as an order-dependent full-suite failure, passed in this full-suite
run.

## Not touched

- `tests/test_ratchets.py` (F8) — contended by #618, #595, #562.
- `r6/actions/routes.py:713` still calls `validate_step_up_token` raw where
  CLAUDE.md points to `require_grant`. It destructures correctly; migrating
  it is not this PR's remit, and the new tests would cover the migration.
- No existing assertion was weakened or removed. The F7 changes are
  additive to tests whose bodies otherwise stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
