### PR TITLE
test(guards): #630 F1, F2 and F6 — each mutation run in both directions

### DIFF
--- a/tests/test_no_raw_step_up_reason_reaches_a_caller.py
+++ b/tests/test_no_raw_step_up_reason_reaches_a_caller.py
@@ -19,11 +19,53 @@ r6/command_center/routes.py were never in that diff and still carried it
 (#508). A leak that comes back after its issue is closed is a leak with no
 guard on it, so this file is the guard rather than another fix.
 
-THE RULE, in one sentence: the name bound to the error half of
-`validate_step_up_token`'s tuple may be passed to a logger or to
-`r6.access.public_step_up_reason`, and to nothing else.
+THE RULE, in one sentence: the error half of `validate_step_up_token`'s tuple
+may be passed to a logger or to `r6.access.public_step_up_reason`, and to
+nothing else — however the caller gets hold of it.
 
-MUTATION: interpolate the raw reason into any response anywhere -> red.
+## The word "anywhere" was not true (#630 F6)
+
+This docstring used to end `MUTATION: interpolate the raw reason into any
+response anywhere -> red`, and that line had never been executed. The scanner
+recognised exactly ONE shape — a two-element TUPLE ASSIGNMENT whose value is a
+direct `validate_step_up_token(...)` call — so the same leak written as
+
+    res = validate_step_up_token(token, tenant_id)
+    if res[0]:
+        return None
+    return jsonify({"error": f"step-up token rejected: {res[1]}"}), 401
+
+walked straight past it. Applied to `_authz_write` in
+`r6/command_center/routes.py` that mutation put a *token tenant mismatch* back
+on the wire and the whole suite stayed green: 3157 passed, byte-identical to
+baseline (2026-09-04). #508, undetected, in the file this guard was written
+for.
+
+The shape is not hypothetical bad style. `res = validate_step_up_token(...)`
+is one keystroke from `if res:` — the truthiness test on the tuple that
+CLAUDE.md names as a silent auth bypass, since a 2-tuple is always truthy.
+A guard that cannot see the binding cannot see either failure.
+
+THE SHAPES RECOGNISED, so a reader knows the boundary rather than trusting
+the word "anywhere":
+
+  1. `valid, err = validate_step_up_token(...)` -> reads of `err`
+     (`_reason_names` + `_guarded_uses`)
+  2. `res = validate_step_up_token(...)`        -> reads of `res[1]`, and
+     bare reads of `res` (which carry both halves, and cover `if res:`).
+     `res[0]` is the boolean and is always allowed.
+     (`_tuple_names` + `_guarded_tuple_uses`)
+  3. `validate_step_up_token(...)[1]` with no name at all
+     (`_direct_reason_subscripts`)
+
+NOT recognised, and deliberately left rather than guessed at: a reason that
+travels through another function's return value, a dict, or `*rest`
+unpacking. `test_a_token_for_another_tenant_is_refused_without_naming_why`
+below is the backstop that does not care about syntax at all — it drives the
+two #508 sites over the wire.
+
+MUTATION (run 2026-09-04, both directions, see PR): rewrite either
+command_center site to bind the tuple and interpolate `res[1]` -> red.
 """
 
 import ast
@@ -80,14 +122,34 @@ def _reason_names(func):
     return names
 
 
-def _guarded_uses(func, name):
-    """Line numbers where `name` is read somewhere other than an allowed sink.
+def _tuple_names(func):
+    """Names bound to the WHOLE tuple: `res = validate_step_up_token(...)`.
 
-    A read is allowed when its nearest enclosing Call is a logger method or
-    the classifier. Everything else — an f-string in a response, a dict value,
-    a `.format` argument, a bare return — is a use that can reach a caller.
+    Shape 2 of the three in the module docstring. `_reason_names` above is
+    blind to it, which is what #630 F6 found.
     """
-    allowed_lines = set()
+    names = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target, value = node.targets[0], node.value
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
+            continue
+        called = (getattr(value.func, 'id', None)
+                  or getattr(value.func, 'attr', None))
+        if called == 'validate_step_up_token':
+            names.add(target.id)
+    return names
+
+
+def _sink_positions(func, predicate):
+    """(lineno, col_offset) of every node inside an allowed sink call.
+
+    Position rather than identity because `ast.walk` visits a node once per
+    walk and the two passes below need to agree on which reads were already
+    accounted for.
+    """
+    positions = set()
     for node in ast.walk(func):
         if not isinstance(node, ast.Call):
             continue
@@ -95,9 +157,71 @@ def _guarded_uses(func, name):
                   or getattr(node.func, 'attr', None))
         if called not in _ALLOWED_SINKS:
             continue
-        for arg in ast.walk(node):
-            if isinstance(arg, ast.Name) and arg.id == name:
-                allowed_lines.add((arg.lineno, arg.col_offset))
+        for inner in ast.walk(node):
+            if predicate(inner):
+                positions.add((inner.lineno, inner.col_offset))
+    return positions
+
+
+def _guarded_tuple_uses(func, name):
+    """Line numbers where the tuple bound to `name` can carry the reason out.
+
+    `name[0]` is the boolean half — always fine. `name[1]` is the raw reason
+    and is fine only inside an allowed sink. A bare read of `name` is
+    reported because it carries both halves, which also makes this the check
+    that catches `if name:` — the truthiness test on the tuple that CLAUDE.md
+    calls a silent auth bypass.
+    """
+    allowed_lines = _sink_positions(
+        func, lambda n: isinstance(n, ast.Name) and n.id == name)
+
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Subscript):
+            continue
+        inner = node.value
+        if (isinstance(inner, ast.Name) and inner.id == name
+                and isinstance(node.slice, ast.Constant)
+                and node.slice.value == 0):
+            allowed_lines.add((inner.lineno, inner.col_offset))
+
+    return [node.lineno for node in ast.walk(func)
+            if isinstance(node, ast.Name) and node.id == name
+            and isinstance(node.ctx, ast.Load)
+            and (node.lineno, node.col_offset) not in allowed_lines]
+
+
+def _direct_reason_subscripts(func):
+    """Line numbers of `validate_step_up_token(...)[1]` — shape 3, no name."""
+    allowed = _sink_positions(func, lambda n: isinstance(n, ast.Subscript))
+
+    bad = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Subscript):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        called = (getattr(call.func, 'id', None)
+                  or getattr(call.func, 'attr', None))
+        if called != 'validate_step_up_token':
+            continue
+        if not (isinstance(node.slice, ast.Constant) and node.slice.value == 1):
+            continue
+        if (node.lineno, node.col_offset) in allowed:
+            continue
+        bad.append(node.lineno)
+    return bad
+
+
+def _guarded_uses(func, name):
+    """Line numbers where `name` is read somewhere other than an allowed sink.
+
+    A read is allowed when its nearest enclosing Call is a logger method or
+    the classifier. Everything else — an f-string in a response, a dict value,
+    a `.format` argument, a bare return — is a use that can reach a caller.
+    """
+    allowed_lines = _sink_positions(
+        func, lambda n: isinstance(n, ast.Name) and n.id == name)
 
     bad = []
     for node in ast.walk(func):
@@ -116,11 +240,23 @@ def _leaks():
         for func in ast.walk(tree):
             if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
+            where = path.relative_to(REPO_ROOT)
             for name in _reason_names(func):
                 for lineno in _guarded_uses(func, name):
-                    yield (f'{path.relative_to(REPO_ROOT)}:{lineno}',
+                    yield (f'{where}:{lineno}',
                            f'{func.name}() reads `{name}` outside a logger '
                            'or public_step_up_reason')
+            for name in _tuple_names(func):
+                for lineno in _guarded_tuple_uses(func, name):
+                    yield (f'{where}:{lineno}',
+                           f'{func.name}() reads the validator tuple `{name}` '
+                           'outside a logger or public_step_up_reason '
+                           f'(`{name}[0]` is the only free read)')
+            for lineno in _direct_reason_subscripts(func):
+                yield (f'{where}:{lineno}',
+                       f'{func.name}() subscripts '
+                       'validate_step_up_token(...)[1] outside a logger or '
+                       'public_step_up_reason')
     assert scanned > 100, f'the leak scan only walked {scanned} files'
 
 
@@ -161,6 +297,62 @@ def test_the_leak_detector_actually_detects_the_leak():
     assert _guarded_uses(func, 'err') == []
 
 
+def _only_function(source):
+    return next(n for n in ast.walk(ast.parse(source))
+                if isinstance(n, ast.FunctionDef))
+
+
+def test_the_leak_detector_sees_the_tuple_reached_by_index_too():
+    """#630 F6: the shape the scanner could not see, proven visible.
+
+    Each case states what the OLD detector returned as well, because "the new
+    helper finds it" is only half the claim being repaired — the other half is
+    that the old one did not, which is why the census row exists.
+    """
+    indexed = _only_function(
+        'def handler():\n'
+        '    res = validate_step_up_token(t, tid)\n'
+        '    if res[0]:\n'
+        '        return None\n'
+        '    return jsonify({"error": f"rejected: {res[1]}"}), 401\n')
+    assert _reason_names(indexed) == set(), (
+        'the tuple-unpack detector was never blind to this; if it sees it '
+        'now, the #630 F6 premise changed and this repair needs re-deriving')
+    assert _tuple_names(indexed) == {'res'}
+    assert _guarded_tuple_uses(indexed, 'res') == [5]
+
+    classified = _only_function(
+        'def handler():\n'
+        '    res = validate_step_up_token(t, tid)\n'
+        '    if res[0]:\n'
+        '        return None\n'
+        '    logger.info("refused: %s", res[1])\n'
+        '    return jsonify({"error": public_step_up_reason(res[1])}), 401\n')
+    assert _guarded_tuple_uses(classified, 'res') == [], (
+        'the classified spelling of the same shape must stay green, or the '
+        'guard forces callers away from the one safe way to write it')
+
+    truthy = _only_function(
+        'def handler():\n'
+        '    res = validate_step_up_token(t, tid)\n'
+        '    if res:\n'
+        '        return None\n')
+    assert _guarded_tuple_uses(truthy, 'res') == [3], (
+        'a bare read of the tuple is the CLAUDE.md non-negotiable — a 2-tuple '
+        'is always truthy, so `if res:` authorizes every caller')
+
+    direct = _only_function(
+        'def handler():\n'
+        '    return jsonify(\n'
+        '        {"error": validate_step_up_token(t, tid)[1]}), 401\n')
+    assert _direct_reason_subscripts(direct) == [3]
+
+    sunk = _only_function(
+        'def handler():\n'
+        '    logger.info("refused: %s", validate_step_up_token(t, tid)[1])\n')
+    assert _direct_reason_subscripts(sunk) == []
+
+
 # --- the wire behaviour, both sides of the ruling -------------------------
 
 @pytest.mark.parametrize('reason', [
@@ -182,3 +374,61 @@ def test_a_reason_about_the_callers_own_token_still_reaches_them(reason):
 
 def test_the_one_reason_about_someone_elses_credential_does_not():
     assert public_step_up_reason('Token tenant mismatch') == _DENIED_REJECTED
+
+
+# --- the backstop that does not read source at all ------------------------
+
+#: Neither row may use the `tenant_id` fixture: `test-tenant` is in
+#: PUBLIC_TENANTS under the test config, and `/api/generate-link` skips the
+#: step-up branch entirely for a public tenant (200, a minted link). That is
+#: the documented demo carve-out, not a defect — but a probe pointed at a
+#: public tenant would have measured nothing.
+_PRIVATE_TENANT = 'probe-private-tenant'
+
+
+@pytest.mark.parametrize('path, payload', [
+    ('/command-center/api/conversations',
+     {'role': 'user', 'text': 'hello'}),
+    ('/command-center/api/generate-link', {}),
+])
+def test_a_token_for_another_tenant_is_refused_without_naming_why(
+        client, path, payload):
+    """The two #508 sites, driven over the wire.
+
+    Every other row in this file reads Python source, so all of them share one
+    failure mode: a leak spelled in a syntax the scanner does not model stays
+    invisible no matter how many shapes get added. This row cares only about
+    the bytes on the wire. It is the reason the scanner may honestly say which
+    three shapes it recognises instead of claiming "anywhere".
+
+    A token that is real, unexpired and correctly signed — but minted for a
+    DIFFERENT tenant — must come back as the generic refusal. Telling this
+    caller the token is merely issued elsewhere is the one carve-out in the
+    owner's 2026-08-10 ruling, and it is what #508 put back on the wire.
+
+    MUTATION (run 2026-09-04): bind the validator's tuple in `_authz_write`
+    and interpolate `res[1]` -> red, on the conversations row, with
+    'Token tenant mismatch' in the body.
+    """
+    from r6.command_center import access
+    from r6.stepup import generate_step_up_token
+    assert not access.is_public(_PRIVATE_TENANT), (
+        '%s is in PUBLIC_TENANTS, so generate-link never reaches the step-up '
+        'branch and this row measures nothing' % _PRIVATE_TENANT)
+    other = generate_step_up_token('a-different-tenant-entirely')
+
+    response = client.post(path,
+                           json={'tenant_id': _PRIVATE_TENANT, **payload},
+                           headers={'X-Step-Up-Token': other})
+
+    assert response.status_code == 401, (
+        'the refusal this row measures did not happen, so the assertions '
+        'below prove nothing: %s %s'
+        % (response.status_code, response.get_data(as_text=True)[:200]))
+    body = response.get_data(as_text=True)
+    assert 'mismatch' not in body.lower(), (
+        'the raw validator reason reached the caller: ' + body[:200])
+    assert _DENIED_REJECTED in body, (
+        'the refusal should carry the classified sentence; a different '
+        'refusal means this row stopped measuring the step-up gate: '
+        + body[:200])

--- a/tests/test_no_raw_step_up_reason_reaches_a_caller.py
+++ b/tests/test_no_raw_step_up_reason_reaches_a_caller.py
@@ -65,7 +65,10 @@ below is the backstop that does not care about syntax at all — it drives the
 two #508 sites over the wire.
 
 MUTATION (run 2026-09-04, both directions, see PR): rewrite either
-command_center site to bind the tuple and interpolate `res[1]` -> red.
+command_center site to bind the tuple and interpolate `res[1]` -> red. Run
+on BOTH — `_authz_write` and `api_generate_link` — rather than one and an
+assumption about the other, since "either" is the kind of word this file now
+exists to stop anyone from writing untested.
 """
 
 import ast
@@ -406,8 +409,10 @@ def test_a_token_for_another_tenant_is_refused_without_naming_why(
     caller the token is merely issued elsewhere is the one carve-out in the
     owner's 2026-08-10 ruling, and it is what #508 put back on the wire.
 
-    MUTATION (run 2026-09-04): bind the validator's tuple in `_authz_write`
-    and interpolate `res[1]` -> red, on the conversations row, with
+    MUTATION (run 2026-09-04): bind the validator's tuple and interpolate
+    `res[1]` -> red. Run separately against each site: mutating
+    `_authz_write` reddens the conversations row, mutating
+    `api_generate_link` reddens the generate-link row, each with
     'Token tenant mismatch' in the body.
     """
     from r6.command_center import access

--- a/tests/test_recursive_redaction.py
+++ b/tests/test_recursive_redaction.py
@@ -1,4 +1,29 @@
-"""PHI redaction must cover nested FHIR structures, not only Patient roots."""
+"""PHI redaction must cover nested FHIR structures, not only Patient roots.
+
+## The name branch had no observer (#630 F2)
+
+The canary loop in the first test below is the whole measurement, and until
+2026-09 no canary in it could see a name. Its contained RelatedPerson is
+`{"family": "Secret", "given": ["Janet"]}` and the canary is `"Jane Secret"` —
+two strings that are never adjacent in the serialized JSON, so the name branch
+of `_redact_fields` was unobserved by the file whose one-line summary is that
+names below the root get redacted.
+
+Scoping that branch to the root Patient —
+
+    if resource.get('resourceType') == 'Patient' and 'name' in resource ...
+
+— hands back contained RelatedPerson and Practitioner names in full, and the
+whole suite stays green: 3157 passed, byte-identical to baseline
+(2026-09-04). Deleting the branch outright IS caught, seven tests over; the
+half-measure was not, which is the more likely edit.
+
+`test_names_below_the_root_are_truncated_too` and
+`test_a_root_resource_that_is_not_a_patient_is_redacted_too` below are the
+observers. They assert the truncated SHAPE, not the absence of a phrase: an
+absence assertion passes just as happily when the field was dropped, renamed,
+or never reached.
+"""
 
 import json
 
@@ -72,6 +97,80 @@ def test_recursive_redaction_removes_nested_phi_and_preserves_clinical_values():
     assert output["valueQuantity"] == {"value": 126, "unit": "mg/dL"}
     assert output["subject"]["reference"] == "Patient/patient-1"
     assert output["extension"][2]["valueDate"] == "1984"
+
+
+def test_names_below_the_root_are_truncated_too():
+    """A contained RelatedPerson and Practitioner are people, and named.
+
+    `_redact_recursive` walks into `contained[]` and calls `_redact_fields`
+    on each entry, so a nested person's name is truncated exactly like the
+    root's. This row is what notices if that stops being true.
+
+    MUTATION (run 2026-09-04, both directions, see PR): scope the
+    name-truncation block in `r6/redaction.py::_redact_fields` to
+    `resource.get('resourceType') == 'Patient'` -> red, both names in full.
+    """
+    resource = {
+        "resourceType": "Observation",
+        "id": "obs-contained-names",
+        "status": "final",
+        "code": {"coding": [{"system": "http://loinc.org", "code": "2339-0"}]},
+        "subject": {"reference": "Patient/patient-1"},
+        "contained": [{
+            "resourceType": "RelatedPerson",
+            "id": "rp-1",
+            "name": [{"family": "Marguerite", "given": ["Josephine"]}],
+        }, {
+            "resourceType": "Practitioner",
+            "id": "prac-1",
+            "name": [{"family": "Quintaviou", "given": ["Bartholomew"]}],
+        }],
+        "valueQuantity": {"value": 126, "unit": "mg/dL"},
+    }
+
+    output = apply_redaction(resource)
+    contained = output.get("contained") or []
+
+    # Non-vacuity: the entries and their name arrays must still be there. An
+    # absence check over a tree that dropped `contained` proves nothing.
+    assert [c.get("resourceType") for c in contained] == [
+        "RelatedPerson", "Practitioner"]
+    assert all(c.get("name") for c in contained), (
+        "a contained name array vanished, so the truncation assertions below "
+        "would pass without measuring truncation: " + json.dumps(contained))
+
+    assert contained[0]["name"][0] == {"family": "M.", "given": ["J."]}
+    assert contained[1]["name"][0] == {"family": "Q.", "given": ["B."]}
+
+    serialized = json.dumps(output)
+    for canary in ("Marguerite", "Josephine", "Quintaviou", "Bartholomew"):
+        assert canary not in serialized, (
+            "a contained resource's name survived redaction: " + canary)
+
+
+def test_a_root_resource_that_is_not_a_patient_is_redacted_too():
+    """The same rule one level up: a Practitioner ROOT is a person too.
+
+    Scoping the name branch to Patient de-redacts this as well as the
+    contained case above, and a reader of #630 F2 would only look at
+    `contained`. Pinned here so the blast radius has an observer of its own.
+    """
+    output = apply_redaction({
+        "resourceType": "Practitioner",
+        "id": "prac-root-1",
+        "name": [{"family": "Vasilakopoulos", "given": ["Anastasia"],
+                  "text": "Dr Anastasia Vasilakopoulos"}],
+        "birthDate": "1971-11-02",
+    })
+
+    assert output.get("name"), (
+        "the name array is gone, so an absence check would be vacuous: "
+        + json.dumps(output))
+    assert output["name"][0] == {"family": "V.", "given": ["A."]}
+
+    serialized = json.dumps(output)
+    for canary in ("Vasilakopoulos", "Anastasia"):
+        assert canary not in serialized
 
 
 def test_deidentification_preview_recurses_through_nested_fhir_values():

--- a/tests/test_recursive_redaction.py
+++ b/tests/test_recursive_redaction.py
@@ -15,8 +15,14 @@ Scoping that branch to the root Patient —
 
 — hands back contained RelatedPerson and Practitioner names in full, and the
 whole suite stays green: 3157 passed, byte-identical to baseline
-(2026-09-04). Deleting the branch outright IS caught, seven tests over; the
-half-measure was not, which is the more likely edit.
+(2026-09-04).
+
+Deleting the branch OUTRIGHT is caught loudly: 15 existing tests go red,
+across conformance, the read path, ingest read-back and the coverage
+inventory (measured 2026-09-04; #630 said seven, which undercounts). So the
+suite is well defended against removing the control and was defended by
+nothing against narrowing it — and narrowing is the likelier edit, since it
+is what someone does to make a nested resource "readable".
 
 `test_names_below_the_root_are_truncated_too` and
 `test_a_root_resource_that_is_not_a_patient_is_redacted_too` below are the

--- a/tests/test_redaction_probes_multistep.py
+++ b/tests/test_redaction_probes_multistep.py
@@ -579,12 +579,14 @@ def test_persist_intake_document_return_value_reaches_no_caller():
     assert len(id_subscripts) == 1, (
         "expected exactly one docref['id'] read; found %d, so the shape this "
         "row measures changed" % len(id_subscripts))
+    # getsource() starts at the `def`, so an AST lineno is an offset into it.
+    offset = form_fill.FormFillExecutor.execute.__code__.co_firstlineno - 1
     assert len(loads) == 1, (
         "`docref` is read %d times in execute() but subscripted for 'id' "
         "once — the dict itself is being passed somewhere, and every field "
         "persist_intake_document built (including the base64 PDF) travels "
-        "with it. Lines: %s"
-        % (len(loads), sorted({n.lineno for n in loads})))
+        "with it. form_fill.py lines: %s"
+        % (len(loads), sorted({n.lineno + offset for n in loads})))
 
 
 def test_document_reference_read_drops_the_embedded_pdf(

--- a/tests/test_redaction_probes_multistep.py
+++ b/tests/test_redaction_probes_multistep.py
@@ -76,9 +76,11 @@ reached the code it names.
 
 from __future__ import annotations
 
+import ast
 import base64
 import json
 import re
+import textwrap
 import zlib
 from urllib.parse import parse_qs, urlparse
 
@@ -279,14 +281,19 @@ def test_the_pdf_text_extractor_actually_reads_text():
 # is the whole credential.
 # ---------------------------------------------------------------------------
 
-def _download_the_form(client, app, tenant_headers, auth_headers):
-    """propose -> commit -> review -> confirm -> GET the signed link.
+def _confirm_the_form(client, tenant_headers, auth_headers):
+    """propose -> commit -> review -> confirm.
 
-    Returns (docref_id, pdf_bytes). Asserts each hop, because a 4xx anywhere
-    would leave the caller asserting markers against an error page.
+    Returns (action_id, confirm_response). Split out of `_download_the_form`
+    because the confirm response is an exit in its own right: a completed
+    action is answered with `ProposedAction.to_dict()`
+    (r6/actions/routes.py:169), which carries `outcome_summary` verbatim —
+    so whatever the executor puts in its outcome goes on the wire.
+
+    Asserts each hop, because a 4xx anywhere would leave the caller asserting
+    markers against an error page.
     """
     from r6.actions.confirmations import ACTION_APPROVAL_AUDIENCE
-    from r6.actions.models import ProposedAction
     from r6.stepup import generate_step_up_token
     tenant = tenant_headers["X-Tenant-Id"]
 
@@ -318,6 +325,17 @@ def _download_the_form(client, app, tenant_headers, auth_headers):
     assert confirm.status_code == 200, confirm.get_data(as_text=True)
     assert confirm.get_json()["status"] == "completed", \
         confirm.get_data(as_text=True)
+    return action_id, confirm
+
+
+def _download_the_form(client, app, tenant_headers, auth_headers):
+    """`_confirm_the_form`, then GET the signed link.
+
+    Returns (docref_id, pdf_bytes).
+    """
+    from r6.actions.models import ProposedAction
+    action_id, _confirm = _confirm_the_form(client, tenant_headers,
+                                            auth_headers)
 
     with app.app_context():
         row = db.session.get(ProposedAction, action_id)
@@ -401,13 +419,143 @@ def test_form_fill_pdf_carries_only_the_reviewed_answers_and_the_name(
 # where its content can leave.
 # ---------------------------------------------------------------------------
 
+def _strings_in(value):
+    """Every string anywhere in a parsed JSON value, nested JSON included.
+
+    `outcome_summary` is a JSON document stored as a string inside another
+    JSON document, so a walker that stops at the first string never reaches
+    the outcome's own fields.
+    """
+    if isinstance(value, str):
+        yield value
+        try:
+            nested = json.loads(value)
+        except (TypeError, ValueError):
+            return
+        if isinstance(nested, (dict, list)):
+            yield from _strings_in(nested)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _strings_in(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _strings_in(item)
+
+
+def _decoded_pdfs(value):
+    """Every base64 string anywhere in `value` that decodes to a PDF.
+
+    A property, not a phrase: it does not care which key carried the bytes,
+    what that key is called, or how deep the JSON is nested. It also cannot
+    be defeated by the thing that defeats a marker search — reportlab writes
+    Flate streams, so the patient's name is not present as text in the base64
+    OR in the decoded bytes until `pdf_text` decompresses them.
+    """
+    for text in _strings_in(value):
+        if len(text) < 64:
+            continue
+        try:
+            blob = base64.b64decode(text, validate=True)
+        except Exception:  # noqa: BLE001 — not base64; nothing to decode
+            continue
+        if blob[:4] == b"%PDF":
+            yield blob
+
+
+def test_the_document_detector_finds_a_base64_pdf():
+    """Control for the probe below, in the exact shape of its mutation.
+
+    `_decoded_pdfs` has to reach through JSON-inside-JSON and then through
+    Flate compression. If it cannot, "no document in the confirm response" is
+    a false negative, which is the defect class this whole file is about.
+    """
+    from r6.sdc.pdf import render_questionnaire_response_pdf
+    rendered = render_questionnaire_response_pdf(
+        {"resourceType": "QuestionnaireResponse", "status": "completed",
+         "item": []},
+        subject_label=SUBJECT_LABEL_MARKER)
+    body = {"id": "act-1", "status": "completed",
+            "outcome_summary": json.dumps({
+                "document_reference_id": "doc-1",
+                "document": {"resourceType": "DocumentReference",
+                             "content": [{"attachment": {
+                                 "contentType": "application/pdf",
+                                 "data": base64.b64encode(rendered).decode(),
+                             }}]}})}
+
+    assert SUBJECT_LABEL_MARKER not in json.dumps(body), (
+        "the marker is readable as text in the response, so this control "
+        "cannot distinguish a working detector from a marker search")
+    found = list(_decoded_pdfs(body))
+    assert len(found) == 1, (
+        "the detector did not find the embedded PDF; every 'no document "
+        "left' assertion below is unmeasured")
+    assert SUBJECT_LABEL_MARKER in pdf_text(found[0])
+
+
+def test_the_confirm_response_carries_no_rendered_document(
+        client, app, tenant_headers, auth_headers, action_registry,
+        form_fill_ready):
+    """The exit `persist_intake_document`'s return value would leave by.
+
+    form_fill hands the executor's `outcome` dict to the state machine, which
+    stores it as `outcome_summary` and answers the confirm POST with
+    `to_dict()` — outcome included. So "the return value reaches nobody"
+    holds only while the outcome carries ids, not the object.
+
+    Two assertions, deliberately different in kind:
+      (a) the PROPERTY — nothing anywhere in the response body decodes to a
+          PDF, whatever key it arrives under;
+      (b) the named pin — the outcome's key set, exactly, so a new field of
+          any kind has to be added here on purpose.
+
+    MUTATION (run 2026-09-04, both directions, see PR): add
+    `'document': docref,` to the success outcome in
+    `r6/actions/rails/form_fill.py` -> red on both. Under it this route
+    answers 200 with a base64 PDF whose title is the patient's name.
+    """
+    _action_id, confirm = _confirm_the_form(client, tenant_headers,
+                                            auth_headers)
+    body = confirm.get_json()
+
+    # Non-vacuity: the flow really completed and really produced a document.
+    assert body["status"] == "completed", confirm.get_data(as_text=True)[:300]
+    outcome = json.loads(body["outcome_summary"])
+    assert outcome.get("document_reference_id"), (
+        "no document was persisted, so 'the document did not leave' is not a "
+        "measurement: " + json.dumps(outcome)[:300])
+
+    leaked = [pdf_text(blob) for blob in _decoded_pdfs(body)]
+    assert not leaked, (
+        "the rendered intake PDF left through the confirm response; it "
+        "carries the patient's name and date of birth. markers found: %s"
+        % sorted({m for text in leaked for m in _markers_in(text)}))
+
+    assert set(outcome) == {"document_reference_id", "delivery_link",
+                            "questionnaire_response_id"}, (
+        "the form-fill outcome grew a field (%s). Everything in it goes on "
+        "the wire in the confirm response — add it here deliberately, with a "
+        "probe for whatever it carries" % sorted(outcome))
+
+    assert _markers_in(confirm.get_data(as_text=True)) == set()
+
+
 def test_persist_intake_document_return_value_reaches_no_caller():
-    """Evidence, not assertion: the call chain from the read to a response.
+    """The static half: form_fill touches nothing but the id.
 
     `grep -rn persist_intake_document --include='*.py'` finds exactly one
-    production caller. This pins that caller's use of the returned dict, so
-    the "nothing escapes" claim above stops being true loudly rather than
-    silently if someone starts returning more of it.
+    production caller, and this pins what that caller does with the returned
+    dict.
+
+    #630 F1 found the docstring here claiming the "nothing escapes"
+    statement above "stops being true loudly". It did not. The assertion was
+    a regex for `docref[...]` subscripts, so passing the whole dict BY NAME —
+    `outcome={'document': docref, ...}` — added no subscript and the row
+    stayed green, along with the rest of the suite. The AST assertion below
+    is the repair: it counts every LOAD of the name, not every subscript of
+    it. `test_the_confirm_response_carries_no_rendered_document` above is the
+    behavioural half, and is the one that would survive the function being
+    rewritten.
     """
     import inspect
     from r6.actions.rails import form_fill
@@ -417,6 +565,26 @@ def test_persist_intake_document_return_value_reaches_no_caller():
         "form_fill now reads more than the id off persist_intake_document's "
         "return value (%s); documents.py:72 may now be an exit point and "
         "needs its own probe" % sorted(uses))
+
+    tree = ast.parse(textwrap.dedent(source))
+    loads = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Name) and n.id == "docref"
+             and isinstance(n.ctx, ast.Load)]
+    id_subscripts = [n for n in ast.walk(tree)
+                     if isinstance(n, ast.Subscript)
+                     and isinstance(n.value, ast.Name)
+                     and n.value.id == "docref"
+                     and isinstance(n.slice, ast.Constant)
+                     and n.slice.value == "id"]
+    assert len(id_subscripts) == 1, (
+        "expected exactly one docref['id'] read; found %d, so the shape this "
+        "row measures changed" % len(id_subscripts))
+    assert len(loads) == 1, (
+        "`docref` is read %d times in execute() but subscripted for 'id' "
+        "once — the dict itself is being passed somewhere, and every field "
+        "persist_intake_document built (including the base64 PDF) travels "
+        "with it. Lines: %s"
+        % (len(loads), sorted({n.lineno for n in loads})))
 
 
 def test_document_reference_read_drops_the_embedded_pdf(


### PR DESCRIPTION
Closes the three rows of #630 left after #631: **F1**, **F2**, **F6**. Test-only.

The defect in each is the same: a `MUTATION: … -> red` line nobody had executed. So the rule here was that no such line ships unless it has been run. Every claim below is a command that was run in this worktree.

## Harness

Per #630's own correction, pure pytest is not free of the stale-code trap — CPython invalidates a `.pyc` on `(mtime, size)`, so a same-length edit inside the same clock second is served from stale bytecode. Every run in this PR went through one script that:

- asserts the anchor string occurs **exactly once** before editing,
- re-reads the file from disk and asserts the mutated text is present and the anchor is gone,
- purges every `__pycache__` before and after,
- runs pytest with `PYTHONDONTWRITEBYTECODE=1`,
- restores by writing the saved original **bytes** back, never `git checkout --`,
- asserts `git status --porcelain` is empty afterwards.

## First: all three census claims reproduced

Baseline on `origin/main`, before any test was written:

```
3157 passed, 13 skipped, 1 xfailed, 2 warnings in 137.72s
```

Each mutation applied to production code, **full** suite re-run:

| mutation | full-suite result |
|---|---|
| F1 — `'document': docref,` added to form_fill's success outcome | `3157 passed, 13 skipped, 1 xfailed in 132.35s` |
| F2 — name truncation scoped to `resourceType == 'Patient'` | `3157 passed, 13 skipped, 1 xfailed in 134.69s` |
| F6 — `res = validate_step_up_token(...)`, `res[0]`, `res[1]` | `3157 passed, 13 skipped, 1 xfailed in 132.51s` |

Byte-identical to baseline in all three. The census was right on every row.

## F1 — `tests/test_redaction_probes_multistep.py`

The old assertion was `re.findall(r"docref\[([^\]]+)\]", source) == {"'id'"}`. Passing the dict **by name** adds no subscript, so it stayed green.

Repaired in two independent ways.

**Behavioural** — `test_the_confirm_response_carries_no_rendered_document`. `_resolve_from_executing` answers a completed action with `ProposedAction.to_dict()`, which carries `outcome_summary` verbatim, so the confirm response is an exit in its own right. The probe walks every string in the body (parsing JSON-inside-JSON, since `outcome_summary` is a JSON document stored as a string), base64-decodes each candidate, and fails on anything starting with `%PDF` — it does not care what key carried the bytes. A marker search would not have worked: reportlab writes Flate streams, so the name is not readable text in the base64 or in the decoded bytes. `test_the_document_detector_finds_a_base64_pdf` is the control for exactly that, in the mutation's own shape.

**Static** — the existing regex assertion is untouched; an AST assertion is added alongside that counts every `Load` of `docref`, not every subscript of it.

Red under the mutation:

```
E  AssertionError: the rendered intake PDF left through the confirm response;
   it carries the patient's name and date of birth. markers found:
   ['Marguerite', 'PHIALLERGYTEXTMARKER', 'PHIMEDTEXTMARKER', 'PHISUBJECTLABELMARKER']
E  assert not ['HealthClaw Standard Intake \227 PHISUBJECTLABELMARKER Demographics
   First name:  Josephine Last name:  Marguerite Da...']

E  AssertionError: `docref` is read 2 times in execute() but subscripted for 'id'
   once — the dict itself is being passed somewhere, and every field
   persist_intake_document built (including the base64 PDF) travels with it.
   form_fill.py lines: [102, 115]

2 failed, 14 passed
```

Green on clean code: `16 passed in 2.10s`.

`_download_the_form` is split into `_confirm_the_form` + `_download_the_form` so the confirm response can be asserted on without re-driving the download; its signature and return value are unchanged for its existing callers.

## F2 — `tests/test_recursive_redaction.py`

Canary `"Jane Secret"` against a contained RelatedPerson of `{"family": "Secret", "given": ["Janet"]}` — never adjacent in the serialized JSON, so the name branch had no observer.

**Test-only, as asked**: `r6/redaction.py` is claimed by #615. Two new tests assert the truncated **shape** rather than the absence of a phrase, because an absence assertion passes just as happily when a field was dropped, renamed, or never reached. Each carries a non-vacuity guard that the `contained` entries and their `name` arrays are still present.

The mutation's blast radius is wider than the row describes, so it gets two observers: contained `RelatedPerson` + `Practitioner` inside an Observation, and a **non-Patient root** (`Practitioner`), which the census row does not mention.

Red under the mutation:

```
E  AssertionError: assert {'family': 'V...['Anastasia']} == {'family': 'V...iven': ['A.']}
E    {'given': ['Anastasia']} != {'given': ['A.']}
E    {'family': 'Vasilakopoulos'} != {'family': 'V.'}

2 failed, 2 passed
```

Green on clean code: `4 passed in 0.30s`.

Checked against #615's diff: it rewrites the identifier block and `apply_patient_controlled_redaction`, and leaves the name-truncation block alone. These assertions hold either side of that merge. No file overlap with #615 or #631.

## F6 — `tests/test_no_raw_step_up_reason_reaches_a_caller.py`

`_reason_names` recognised only a two-element tuple assignment, so binding the tuple and reaching for `res[1]` was invisible.

`_reason_names` and `_guarded_uses` are unchanged — `test_the_leak_detector_actually_detects_the_leak` asserts `== {'err'}` and that stands. Added alongside:

- `_tuple_names` / `_guarded_tuple_uses` — `res[1]` is a leak unless it is inside an allowed sink; a **bare** read of `res` is a leak too, which is also what catches `if res:`, the always-true truthiness test CLAUDE.md names as a silent auth bypass; `res[0]` is always allowed.
- `_direct_reason_subscripts` — `validate_step_up_token(...)[1]` with no name at all.
- Synthetic cases for each shape, including the negative ones (`res[0]` in an `if`, `res[1]` inside `logger.info` and inside `public_step_up_reason`).
- `test_a_token_for_another_tenant_is_refused_without_naming_why` — a wire backstop that reads no source at all, driving both #508 sites with a real, unexpired, correctly-signed token minted for a **different** tenant.

The module docstring claimed `MUTATION: interpolate the raw reason into any response anywhere -> red`. "Anywhere" was the false part, and adding two more shapes does not make it true. It now names the three shapes it recognises and the shapes it does not (a reason travelling through another function's return, a dict, `*rest` unpacking), with the wire test as the reason it can afford to be honest about that boundary.

Red under the mutation:

```
E  AssertionError: the raw validator reason reached the caller:
   {"error":"step-up token rejected: Token tenant mismatch"}

2 failed, 8 passed
```

That is #508 verbatim, caught by both the scanner and the wire test.

The same mutation applied to the **second** site, `api_generate_link` (routes.py:618-623), reddens the scanner and the other wire row:

```
FAILED ...::test_no_production_site_uses_the_raw_validator_reason
FAILED ...::test_a_token_for_another_tenant_is_refused_without_naming_why[/command-center/api/generate-link-payload1]
2 failed, 8 passed
```

Both sites were mutated separately rather than one plus an assumption about the other. Green on clean code: `10 passed in 2.05s`.

## Census corrections

**`/command-center/api/generate-link` cannot be probed with the `test-tenant` fixture.** `test-tenant` is in `PUBLIC_TENANTS` under the test config, and that route skips the step-up branch entirely for a public tenant — the first draft of the wire test got `200` and a minted link. That is the documented demo carve-out, not a defect, but a probe pointed at a public tenant would have measured nothing. The test uses a private tenant and asserts `not access.is_public(...)` up front so it cannot silently go vacuous. Same failure shape as the `/AppointmentBrief` correction in #631: a route whose gate is not the one the row assumed.

**"Deleting the branch outright IS caught, seven tests over" undercounts.** Deleting the name-truncation block wholesale and running the full suite gives **17 failures, 15 of them pre-existing** — `test_guardrail_conformance` (4), `test_conformance_endpoint` (3), `test_claimed_properties_are_pinned` (2), `test_r6_routes`, `test_r6_dashboard`, `test_medplum_in_front`, `test_public_fhir_servers`, `test_ingest_bundle_endpoint`, `test_redaction_coverage_inventory`. The shape of the finding is unchanged and gets sharper: the suite is *well* defended against removing the control and was defended by nothing against narrowing it.

**F2's blast radius is bigger than the row.** The row names contained RelatedPerson and Practitioner. Scoping the branch to Patient also de-redacts every **root** non-Patient resource with a `name` — Practitioner, Organization, RelatedPerson read directly. Covered here.

**`test_prod_watch_build.py::test_a_dirty_build_is_never_accepted` passed in all four full-suite runs** (one clean, three mutated). Consistent with correction 4: that item looks like the bytecode trap rather than test ordering.

## Verification

```
uv run python -m pytest tests/ -q
3164 passed, 13 skipped, 1 xfailed, 2 warnings in 134.22s

uv run ruff check .
All checks passed!
```

+7 tests, and no existing assertion was weakened, deleted, or relaxed.

Every `MUTATION:` line added or edited in this PR was executed. The second commit exists because the first one shipped two that were not — "either command_center site" (one had been run) and #630's "seven tests over" (quoted, not measured).

## Not done

**F8 stays open**, as it did after #631. `tests/test_ratchets.py` is contended by #618, #595 and #562 and was declared off-limits for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
