### PR TITLE
test(guards): repair two guards that stay green when their control breaks (#634 F2, F6)

### DIFF
--- a/tests/test_phi_safe_errors.py
+++ b/tests/test_phi_safe_errors.py
@@ -10,6 +10,24 @@ from r6.fhir_proxy import FHIRUpstreamProxy
 
 
 def test_fasten_failure_records_category_without_exception_text(app, caplog):
+    """The failure log names a category, never the exception text, at DEBUG or above.
+
+    MUTATION: r6/fasten/ingester.py:354 ->
+    `logger.warning('Fasten job %d failed: %s', job_id, exc)` — red on the
+    canary. Capturing at ERROR (this test before #634 F2) raised the floor
+    above the root logger's default of WARNING, so the identical leak one
+    level quieter was invisible. Deleting the at_level line outright would
+    have caught it: main.py's basicConfig is a no-op under pytest, which
+    already owns root's handlers, so WARNING records reach caplog by default.
+    MUTATION: keep the sanitized error and add
+    `logger.warning('Fasten job %d detail: %s', job_id, exc)` — red on the
+    canary. A second, chattier record is the shape the non-vacuity assertion
+    alone cannot see.
+    MUTATION: delete the logger.error call — red on the sanitized-line
+    assertion. Without it the canary passes vacuously whenever the record
+    never reaches caplog at all, which is how the sibling below stayed
+    honest and this one did not.
+    """
     canary = "Patient/secret-123?access_token=do-not-log"
     with app.app_context():
         job = FastenJob(
@@ -25,7 +43,7 @@ def test_fasten_failure_records_category_without_exception_text(app, caplog):
         with patch(
             "r6.fasten.ingester.httpx.stream",
             side_effect=RuntimeError(canary),
-        ), caplog.at_level(logging.ERROR):
+        ), caplog.at_level(logging.DEBUG):
             stream_ingest(
                 app,
                 job_id,
@@ -38,6 +56,9 @@ def test_fasten_failure_records_category_without_exception_text(app, caplog):
         assert failed.status == "failed"
         assert failed.failure_reason == "RuntimeError"
         assert canary not in caplog.text
+        # Non-vacuity: the sanitized line was logged AND caplog saw it, so the
+        # canary check above cannot be passing against an empty capture.
+        assert f"Fasten job {job_id} failed: RuntimeError" in caplog.text
 
 
 def test_upstream_proxy_logs_only_sanitized_failure_categories(caplog):

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -2,7 +2,7 @@
 Defense-in-depth security hardening tests.
 
 Covers:
-- security response headers on every response
+- security response headers on every zero-argument GET route the app registers
 - dashboards still render (200) with CSP present
 - opt-in step-up token replay guard
 - global payload cap (413 on oversized body)
@@ -46,6 +46,43 @@ def test_dashboards_200_with_csp(client, path):
     assert resp.status_code == 200
     assert 'Content-Security-Policy' in resp.headers
     assert resp.headers.get('X-Content-Type-Options') == 'nosniff'
+
+
+# The audit SSE stream is an infinite generator (while True + sleep) and the
+# Werkzeug test client buffers the body, so a GET here never returns.
+_UNSWEEPABLE_RULES = {'/r6/fhir/AuditEvent/$stream'}
+
+
+def test_security_headers_on_every_registered_get_route(app, client):
+    """MUTATION: early-return `response` from app.py's _security_headers when
+    request.path starts with '/r6/fhir' or '/fasten' -> red, naming every
+    stripped path. The three page checks above stay green under it: they only
+    reach the web blueprint, so /r6/fhir/mcp-apps/care-gaps — a patient-facing
+    text/html surface — could lose X-Frame-Options: DENY and its CSP
+    frame-ancestors 'none' with the file green (#634 F6).
+
+    Enumerating the url_map rather than a hand-kept path list means a new
+    blueprint is covered the moment it is registered.
+    """
+    rules = {str(r) for r in app.url_map.iter_rules()
+             if not r.arguments and 'GET' in (r.methods or set())}
+    stale = _UNSWEEPABLE_RULES - rules
+    assert not stale, f'exclusion names routes that no longer exist: {stale}'
+    # Non-vacuity: an empty or mis-read url_map would sweep nothing and pass.
+    assert '/r6/fhir/mcp-apps/care-gaps' in rules
+
+    failures = []
+    for path in sorted(rules - _UNSWEEPABLE_RULES):
+        resp = client.get(path)
+        bad = [f'{h}={resp.headers.get(h)!r}'
+               for h, expected in SECURITY_HEADERS.items()
+               if resp.headers.get(h) != expected]
+        if "frame-ancestors 'none'" not in resp.headers.get(
+                'Content-Security-Policy', ''):
+            bad.append("CSP frame-ancestors 'none'")
+        if bad:
+            failures.append(f'{path} -> {", ".join(bad)}')
+    assert not failures, failures
 
 
 def test_command_center_has_csp(client):


### PR DESCRIPTION
Repairs two rows from the #634 census: **F2** (`tests/test_phi_safe_errors.py`) and **F6** (`tests/test_security_hardening.py`). Production code is unchanged — every mutation below was applied transiently and reverted, each revert confirmed with `git diff --quiet`.

Harness: `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged before every run, mutations applied through a helper that asserts the replacement count is exactly 1 and re-reads from disk to confirm the edit landed. One `uv` process at a time.

**Baseline before any change:** `3157 passed, 13 skipped, 1 xfailed, 2 warnings in 138.90s` — byte-identical to the census.

---

## F2 — the PHI canary only watched ERROR

`caplog.at_level(logging.ERROR)` with no assertion that anything was logged at all. The identical leak one level quieter was invisible.

### Every MUTATION line, executed

**1. Census mutation, unrepaired guard — row reproduced.**
`r6/fasten/ingester.py:354` → `logger.warning('Fasten job %d failed: %s', job_id, exc)`

```
tests/test_phi_safe_errors.py    2 passed in 1.36s
```

**2. Same mutation, repaired guard — red on the canary.**

```
>           assert canary not in caplog.text
E           AssertionError: assert 'Patient/sec...n=do-not-log' not in 'INFO     r6...do-not-log\n'
------------------------------ Captured log call -------------------------------
INFO     r6.fasten.ingester:ingester.py:209 Fasten: streaming download for job phi-safe-job
DEBUG    r6.audit:audit.py:94 AuditEvent recorded: fasten_import_failed on None/None by fasten-connect
WARNING  r6.fasten.ingester:ingester.py:354 Fasten job 1 failed: Patient/secret-123?access_token=do-not-log
1 failed, 1 passed in 1.35s
```

**3. Discriminating mutation A — keep the sanitized error, add a chattier record.** Red on the canary, while the sanitized ERROR line is still there, so the non-vacuity assertion passes. Only the level-lowering half sees this.

```
logger.error('Fasten job %d failed: %s', job_id, type(exc).__name__)
logger.warning('Fasten job %d detail: %s', job_id, exc)
```

```
ERROR    r6.fasten.ingester:ingester.py:354 Fasten job 1 failed: RuntimeError
WARNING  r6.fasten.ingester:ingester.py:356 Fasten job 1 detail: Patient/secret-123?access_token=do-not-log
1 failed, 1 passed in 1.35s
```

**4. Discriminating mutation B — delete the sanitized log call.** Red on the non-vacuity assertion; the canary assertion passes vacuously. Only that half sees this.

```
>           assert f"Fasten job {job_id} failed: RuntimeError" in caplog.text
E           AssertionError: assert 'Fasten job 1 failed: RuntimeError' in 'INFO ... \nDEBUG ... \n'
1 failed, 1 passed in 1.48s
```

**5. Clean tree:** `2 passed in 1.28s`

### Why this shape

Both halves are load-bearing and mutations 3 and 4 are the proof. Lowering the capture makes the canary level-agnostic, which is the stated defect. The non-vacuity assertion makes it plumbing-agnostic: it pins that the sanitized record was produced *and* that caplog saw it, so the canary cannot pass against an empty capture. That is the failure mode the census's own S1 trace exhibits — all three of the sibling's leak assertions passed vacuously and only its positive assertion fired.

---

## F6 — headers claimed on "every response", checked on three pages

Mutation at `app.py:119`, early return from `_security_headers`:

```python
if request.path.startswith(('/r6/fhir', '/fasten')):
    return response
```

**1. Existing guards under the mutation — still green.** `21 passed in 2.78s` (see correction 1 below on the census's "34").

**2. With the new sweep — red, naming all 26 stripped paths**, including the surface the census names:

```
"/r6/fhir/mcp-apps/care-gaps -> X-Content-Type-Options=None, X-Frame-Options=None,
 Referrer-Policy=None, Strict-Transport-Security=None, CSP frame-ancestors 'none'"
```

```
1 failed, 21 passed in 2.06s
```

**3. Clean tree:** `24 passed in 2.27s` (both repaired files together).

### Why this shape

The sweep enumerates `app.url_map` rather than a hand-kept path list, so a new blueprint is covered the moment it is registered — the census's mutation is prefix-based and any list of named pages is one route behind it. One documented exclusion: `/r6/fhir/AuditEvent/$stream`, an infinite generator (`while True` + `sleep(1)`) that the buffering Werkzeug test client would hang on. The exclusion set is asserted against the url_map so a typo becomes a failure rather than a hang, and `/r6/fhir/mcp-apps/care-gaps` is asserted present so an empty sweep cannot pass — the F2 lesson applied to the new guard.

Measured cost: 71 requests, all in-process, no network, ~0.2s.

The module docstring's "on every response" is narrowed to what the file proves. A claim exceeding its check is the #630 defect shape, so leaving it would have been half a repair.

---

## Verification

```
uv run python -m pytest tests/ -q
3158 passed, 13 skipped, 1 xfailed, 2 warnings in 121.29s (0:02:01)

uv run ruff check .
All checks passed!
```

3157 → 3158: the one added test. Only `tests/` changed:

```
$ git diff --name-only
tests/test_phi_safe_errors.py
tests/test_security_hardening.py
```

---

## Three corrections to #634

**1. F6's "34 passed" is not that file.** `tests/test_security_hardening.py` collects **21** tests at HEAD; `tests/test_metadata_security.py` collects 13. The row's number is the two files run together, reported against the one file it names. The substantive claim reproduces exactly — the mutation leaves every existing test in the file green. Only the count is wrong, but a reader reproducing the row against the named file gets 21 and may conclude the tree has drifted.

**2. F2 understates itself: `at_level(logging.ERROR)` was worse than no `at_level` at all.** Under pytest the root logger sits at Python's default of **WARNING** — `main.py:65`'s `basicConfig` is a no-op there, because pytest's logging plugin has already attached its handlers to root and `basicConfig` does nothing when root has handlers. Confirmed transiently with `assert logging.getLogger().getEffectiveLevel() == logging.WARNING` inside the test (green), and visible in the probe capture below, which contains the WARNING record but not the INFO one from `ingester.py:209` that every DEBUG-capture run shows. So WARNING records reach caplog by default, and deleting the `at_level` line while leaving the guard otherwise untouched makes the census mutation **red**:

```
E   AssertionError: assert 'Patient/sec...n=do-not-log' not in 'WARNING  r6...do-not-log\n'
WARNING  r6.fasten.ingester:ingester.py:354 Fasten job 1 failed: Patient/secret-123?access_token=do-not-log
1 failed, 1 passed in 1.38s
```

The line written to make the guard precise is the line that blinded it. That is a sharper lesson than "the canary only looks at ERROR", and it generalises: `caplog.at_level` raises a floor as readily as it lowers one.

**3. S1 has a narrower version of the same blind spot — flagged, not fixed, and NOT verified.** `test_upstream_proxy_logs_only_sanitized_failure_categories` captures at `logging.INFO`. Note the direction is opposite to F2's: against a WARNING default, INFO *lowers* the floor, so its `at_level` helps rather than harms. It is still not the floor, so a leak emitted at DEBUG alongside the sanitized record would be invisible to it — the same shape as mutation A above, which a non-vacuity check alone cannot see. It survived the census because that mutation *replaced* the sanitized log rather than adding a quieter second one. **I did not run this mutation** — it is reasoning from the code, offered as a suspicion in the census's own sense of the word, not a finding. S1 is not one of my rows and I left it alone.

## Incidental

`tests/test_public_fhir_servers.py::TestFlaskGuardrailsWithHAPI::test_observation_search_via_route` passed in both full-suite runs here. That does not clear it — it corroborates the census's read that the earlier failure was network flake rather than a regression, and the test does still reach `hapi.fhir.org` from the default suite.

## Harness note for the next census

A mutation helper that refuses when the original text is still present after the write is wrong for *superset* mutations — mutation A above appends a line and keeps the original two, so the helper reported a refusal on a write that had already landed and verified. The write was correct; only the post-check was. Worth guarding as "skip the original-absent check when `old in new`" rather than trusting the exit code.

## Gates

Not merged, not approved, auto-merge not armed. Base `main`.
