### PR TITLE
chore(site): the tests-passing figure was 2812; the suite passes 3168 today

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
       <div class="spec__label">FHIR resource types</div>
     </div>
     <div class="spec">
-      <span class="spec__num" data-target="2812">0</span>
+      <span class="spec__num" data-target="3168">0</span>
       <div class="spec__label">Tests passing</div>
     </div>
     <div class="spec">


### PR DESCRIPTION
## What

One number in `templates/index.html`: the "Tests passing" figure goes from 2812 to 3168.

## Why now

The stale-number guard in `tests/test_site_version_sync.py` requires the figure to sit between the count of `def test_` functions under `tests/` and twice that count. On `main` today that floor is 2554, so 2812 passes.

Merging the open queue in the planned order adds test functions. On an integration branch of every open PR (2026-09-05), the floor passes 2812 at the merge of `fix/458-curatr-says-what-it-checked` (#555) and ends at 2877. From that point every later PR fails this guard on "update branch", for a reason that has nothing to do with the PR.

3168 is what the full suite passed on `main` at 89b42fb this week (`3168 passed, 13 skipped, 1 xfailed`). It is inside the band on `main` now and after the whole queue lands.

## Verification

`uv run pytest tests/test_site_version_sync.py` on this branch: 6 passed.

## Merge order

Right after #544 (the lockfile fix), before anything that adds tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)