### PR TITLE
docs: three drawn views of the system, and where to post the launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ private/
 
 # LinkedIn digest pending drafts (local queue)
 .digest/
+graphify-out/

--- a/docs/2026-09-05-where-to-post-the-launch.md
+++ b/docs/2026-09-05-where-to-post-the-launch.md
@@ -1,0 +1,102 @@
+# Where to post the launch, ranked by fit
+
+Source list: [PlacesToPostYourStartup](https://github.com/mmccaff/PlacesToPostYourStartup)
+(CC0), 19 subreddits and 85 sites. This document is the cut of that list that
+fits what we are: an open-source guardrail layer for health-data agents, and a
+consumer app in a gated beta. Everything not listed here was read and set
+aside, with the reason in the last section.
+
+Status: a plan. Nothing here has been posted. The pacing rule and the two
+gates below come first.
+
+## Two gates and one rule, before any post
+
+1. **Real-record beta stays closed until the FTC Health Breach Notification
+   Rule decision is made** (#168). Every post below invites people to the
+   synthetic track, or to the code. None invites anyone to connect their own
+   records. `docs/2026-08-16-tester-program.md` explains why.
+2. **The consumer directory listings are blocked on two human actions**
+   (Claude connectors need a Team plan; the ChatGPT app needs org
+   verification). A launch post that says "add it to your assistant" before
+   those clear sends people to a dead end. Post the developer story first.
+3. **One external post per day, and none into a channel that has not
+   answered a previous one.** Nine ecosystem touchpoints from July are still
+   waiting on maintainers. Saturation reads as spam.
+
+## What we are posting
+
+Two stories, two audiences.
+
+| Story | Audience | One-line pitch | Call to action |
+|---|---|---|---|
+| **The guardrail layer** | developers, FHIR integrators, agent builders | An open-source layer between an AI agent and a patient's record: redaction on every read, an audit row on every access, step-up auth on writes, and a human gate no agent tool can reach. Conformance is verifiable live. | Clone it, run the conformance probe, open an issue. |
+| **The consumer app** | people who want to ask an agent about their own record | Connect your records, ask, and approve what the agent proposes. Nothing executes without you. | Try the synthetic patient. Ten minutes, zero risk. |
+
+Assets each post needs, none of which exist yet: a demo GIF of the human gate
+refusing an unapproved write; a clean-clone `docker compose up` that a stranger
+has verified; three fresh good-first-issues.
+
+## Tier 1: post here first
+
+High fit. Each one has an audience that reads what we are and can act on it.
+
+| Place | Story | What to post | Notes |
+|---|---|---|---|
+| Show HN | guardrail | "Show HN: open-source guardrails between an AI agent and your health record" | Text post. Lead with the human gate and the live conformance endpoint. Answer every comment the same day. |
+| Product Hunt | consumer | CareAgents, synthetic track | Needs the GIF and five screenshots. A Tuesday or Wednesday. |
+| r/SideProject | consumer | the build-in-public story | Plain language; no acronyms in the title. |
+| r/buildinpublic | both | the merge-queue and evidence-first process | This subreddit rewards honesty about what does not work yet. |
+| r/indiehackers and Indie Hackers | consumer | "solo founder, guardrailed health agent, gated beta" | Indie Hackers wants a product page plus a milestone post. |
+| The Changelog (ping) | guardrail | open-source news tip | Short, factual, link to the repo and the conformance page. |
+| r/AlphaandBetausers | consumer | recruit synthetic-track testers | Exactly what the tester program needs: strangers with a phone. |
+| BetaBound and BetaTesting | consumer | the same recruitment, on a form | Paid listing options exist; start with the free tier. |
+| StackShare | guardrail | tool profile | Developer discovery; needs a logo and a one-paragraph description. |
+| SaaSHub and AlternativeTo | both | product listings | Discovery by search. AlternativeTo needs a category; "health record agent" has few peers, so file under AI assistants. |
+
+## Tier 2: post after the first responses
+
+Good fit, lower reach or more preparation.
+
+| Place | Story | Notes |
+|---|---|---|
+| r/Startups, r/Entrepreneur | consumer | Rules require a story, not a link. Tell the beta-program story. |
+| r/SaaS, r/microsaas | guardrail | Only if a hosted tier exists to describe. Today it does not. |
+| Launched, LaunchIgniter, Launching Next, Tiny Launch, Startup Stash, Startup Base, Startup Inspire, Startup Buffer, Startup Tabs, Killer Startups, SnapMunk, Postmake, Side Projectors, Startups.gallery, Awesome Indie, 10words, Website Hunt, Land-book | consumer | Submission forms. One afternoon fills all of them. Low individual reach; useful for backlinks and search. |
+| AI Collection | both | An AI-tool directory; fits the assistant story. |
+| Slant | guardrail | Only once there is a comparison to be in ("best MCP servers for health data"). |
+| Crunchbase, F6S, Wellfound (was AngelList) | company | Company profiles, not launch posts. Fill them once, keep them current. |
+| G2, Capterra, GetApp, Software Advice, CrozDesk, Discover Cloud | consumer | Review sites. They need customers who will leave reviews. Not yet. |
+| Starter Story | company | A founder interview, after there is a revenue or user number to state. |
+| Startup Ranking, StartupBlink, Startup Tracker, Startup Benchmarks, Tech Map | company | Databases. Register and move on. |
+
+## Not a fit, and why
+
+- **Mobile app review sites** (App Rater, Appoid, appPicker, Apps Listo,
+  Apps Mamma, AppsThunder, Appvita, PreApps, Tapscape, Web App Rater, State of
+  Tech): CareAgents is web and text, not an app-store app.
+- **Regional outlets** (BuiltInChicago, Arctic Startup, Geek Wire, Inc 42,
+  Next Big What): we are not in those regions.
+- **r/Coupons, r/LadyBusiness, r/thesidehustle, r/shamelessplug,
+  r/plugyourproduct, r/IMadeThis, r/IndieBiz**: audience mismatch, or
+  low-signal link dumps.
+- **r/RoastMyStartup, r/Design_Critiques**: worth a post on the landing page
+  design, but they are feedback venues, not launch venues. Later.
+- **Gust, Vator, Collaborizm, Loop, Netted, MakeUseOf, Startup Beat,
+  Startup 88, Tech Pluto, eBool, All My Faves, All Startups, All Top
+  Startups, Alternative.me, Getworm, Micro SaaS Examples, PitchWall,
+  Saijo's Tools List, Simple Lister, SimilarSiteSearch, Beta Bound's paid
+  tiers**: either fundraising channels, pay-to-list, or inactive. Skip.
+
+## Health-specific channels not on that list
+
+The source list is general. The channels that matter most for the guardrail
+story are the ones already opened in July, tracked in the contribution plan
+kept outside the public repository: the FHIR community chat, the HL7
+connectathon track, the MCP registry, the awesome-lists, and the partner
+repositories. The pacing rule applies to them first.
+
+## How to measure
+
+One sheet, one row per post: date, place, story, link, replies in 48 hours,
+sign-ups to the synthetic track, issues opened. If a channel produces
+nothing in a week, it is not a channel for us; do not post there again.

--- a/docs/2026-09-05-where-to-post-the-launch.md
+++ b/docs/2026-09-05-where-to-post-the-launch.md
@@ -20,8 +20,17 @@ gates below come first.
    verification). A launch post that says "add it to your assistant" before
    those clear sends people to a dead end. Post the developer story first.
 3. **One external post per day, and none into a channel that has not
-   answered a previous one.** Nine ecosystem touchpoints from July are still
-   waiting on maintainers. Saturation reads as spam.
+   answered a previous one.** Eight of the nine ecosystem touchpoints from
+   July are still waiting on maintainers; one was closed unmerged. Recount
+   from the live trackers on the day of the first post. Saturation reads as
+   spam.
+4. **The product must enforce gate 1 before the first post.** Today anyone
+   who signs up can upload real records or connect a live source: the
+   `direct` upload tile and the Fasten tile are served to every account, and
+   nothing in the code turns them off. Before posting, either set those
+   tiles to "soon" for the launch window (a configuration change) or gate
+   sign-up behind an allowlist. A gate that lives only in this document is
+   not a gate.
 
 ## What we are posting
 
@@ -29,12 +38,15 @@ Two stories, two audiences.
 
 | Story | Audience | One-line pitch | Call to action |
 |---|---|---|---|
-| **The guardrail layer** | developers, FHIR integrators, agent builders | An open-source layer between an AI agent and a patient's record: redaction on every read, an audit row on every access, step-up auth on writes, and a human gate no agent tool can reach. Conformance is verifiable live. | Clone it, run the conformance probe, open an issue. |
-| **The consumer app** | people who want to ask an agent about their own record | Connect your records, ask, and approve what the agent proposes. Nothing executes without you. | Try the synthetic patient. Ten minutes, zero risk. |
+| **The guardrail layer** | developers, FHIR integrators, agent builders | An open-source layer between an AI agent and a patient's record: redaction on every read, an audit row on every access, step-up auth on writes, and a human approval step on actions that none of the agent's tools call. Direct clinical FHIR writes still rely on a client header (#214, open); say so in the post before a commenter does. Conformance is verifiable live. | Clone it, run the conformance probe, open an issue. |
+| **The consumer app** | people who want to see what a guardrailed health agent is | Ask an agent about a sample patient's records, then approve the intake form it drafts. Nothing is generated until you do. That form is the only action today; the agent can be wrong, and it is not medical advice. | Try the synthetic patient. Ten minutes, zero risk. |
 
-Assets each post needs, none of which exist yet: a demo GIF of the human gate
-refusing an unapproved write; a clean-clone `docker compose up` that a stranger
-has verified; three fresh good-first-issues.
+Assets each post needs, and their state: a GIF of the human gate refusing an
+unapproved write (three demo videos exist under `static/videos/`; none is
+confirmed to show that moment); a stranger's run of the existing
+`docker-compose.yml` (#184 has had no external run yet); three fresh
+good-first-issues (check the label before posting; do not assume any are
+open).
 
 ## Tier 1: post here first
 

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The guardrail boundary</title>
+  <title>The guardrail boundary, as built today</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -23,97 +23,106 @@
 <body>
   <div class="frame">
     <p class="eyebrow">Architecture &#183; HealthClaw</p>
-    <h1>The guardrail boundary</h1>
+    <h1>The guardrail boundary, as built today</h1>
     <div class="scroll">
 <svg viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="arch-title arch-desc">
-<title id="arch-title">The guardrail boundary</title>
-<desc id="arch-desc">The boundary as HealthClaw 2.0 defines it: every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. The kernel is not yet the only path. On 2026-09-05 the ratchets in tests/test_ratchets.py still count 12 step-up call sites, 5 raw tenant reads and 89 audit calls outside it; the migration that closes them is the open 2.0 workstream. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</desc>
+<title id="arch-title">The guardrail boundary, as built today</title>
+<desc id="arch-desc">The boundary as HealthClaw 2.0 defines it, drawn with what exists on 2026-09-05. Every agent surface reaches the record through one kernel, which today resolves the tenant and checks the step-up grant at the sites that have adopted it; its audit call and redacted exit exist but no handler calls them yet. Route handlers still do the audit, redaction and upstream work themselves: the ratchets count 12 step-up call sites and 5 raw tenant reads outside the kernel (one of them the hook meant to read it), and 89 audit calls on the post-commit primitive the kernel is meant to replace. Reads leave through redaction: upstream display text is dropped and labels rebuilt from codes, names cut to initials, dates to the year, identifiers truncated (removed once #615 lands). An agent can propose an action; only a person can approve one, and the endpoint that executes needs a single-use credential only the internal approval mint issues; none of the agent's tools call it. Direct clinical FHIR writes do not pass that gate: they are still gated by a client-supplied header (#214, open), drawn dashed. The Telegram bot reaches the engine through the MCP server and is not drawn separately.</desc>
 <defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#55534B"/></marker><marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#1B2FBF"/></marker><marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3D4E6B"/></marker></defs>
 <rect width="100%" height="100%" fill="#FAF9F5"/>
-<rect x="40" y="80" width="260" height="312" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<rect x="40" y="80" width="260" height="232" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <rect x="56" y="84" width="88" height="12" rx="2" fill="#FAF9F5"/>
 <text x="100.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">AGENT SURFACES</text>
 
 <rect x="340" y="80" width="480" height="416" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
-<rect x="356" y="84" width="164" height="12" rx="2" fill="#FAF9F5"/>
-<text x="438.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HEALTHCLAW ENGINE &#183; r6/</text>
+<rect x="356" y="84" width="136" height="12" rx="2" fill="#FAF9F5"/>
+<text x="424.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HEALTHCLAW ENGINE &#183; r6/</text>
 
-<rect x="860" y="80" width="300" height="320" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
-<rect x="876" y="84" width="52" height="12" rx="2" fill="#FAF9F5"/>
-<text x="902.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RECORDS</text>
+<rect x="860" y="80" width="300" height="416" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<rect x="876" y="84" width="124" height="12" rx="2" fill="#FAF9F5"/>
+<text x="938.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RECORDS AND THE WORLD</text>
 
-<path d="M 276,144 H 316 Q 324,144 324,152 V 210 Q 324,218 332,218 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<line x1="276" y1="240" x2="372" y2="240" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<path d="M 276,336 H 316 Q 324,336 324,328 V 270 Q 324,262 332,262 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<line x1="572" y1="224" x2="884" y2="224" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<path d="M 572,256 H 764 Q 772,256 772,264 V 344 Q 772,352 780,352 H 884" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<path d="M 472,196 V 152 Q 472,144 480,144 H 612" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<path d="M 276,152 H 316 Q 324,152 324,160 V 218 Q 324,226 332,226 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="276" y1="254" x2="372" y2="254" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="548" y1="240" x2="604" y2="240" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="702" y1="196" x2="702" y2="168" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="800" y1="218" x2="884" y2="218" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="800" y1="240" x2="884" y2="240" stroke="#55534B" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+<path d="M 800,262 H 836 Q 844,262 844,270 V 340 Q 844,348 852,348 H 884" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
 <line x1="276" y1="448" x2="612" y2="448" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
-<path d="M 792,448 H 836 Q 844,448 844,440 V 360 a 8,8 0 0,1 0,-16 V 264 Q 844,256 852,256 H 884" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<rect x="676.0" y="204" width="104" height="12" rx="2" fill="#FAF9F5"/>
-<text x="728" y="213" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ &#183; WRITE</text>
+<line x1="792" y1="448" x2="884" y2="448" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<rect x="558.0" y="220" width="36" height="12" rx="2" fill="#FAF9F5"/>
+<text x="576" y="229" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">GRANT</text>
 
-<rect x="780" y="278" width="32" height="12" rx="2" fill="#FAF9F5"/>
-<text x="796.0" y="287" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
+<rect x="710" y="176" width="64" height="12" rx="2" fill="#FAF9F5"/>
+<text x="742.0" y="185" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
 
-<rect x="514.0" y="124" width="64" height="12" rx="2" fill="#FAF9F5"/>
-<text x="546" y="133" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
+<rect x="810.0" y="198" width="64" height="12" rx="2" fill="#FAF9F5"/>
+<text x="842" y="207" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ/WRITE</text>
+
+<rect x="812.0" y="248" width="60" height="12" rx="2" fill="#FAF9F5"/>
+<text x="842" y="257" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">#214 GATE</text>
+
+<rect x="804" y="306" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="820.0" y="315" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
 
 <rect x="420.0" y="428" width="48" height="12" rx="2" fill="#FAF9F5"/>
 <text x="444" y="437" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">APPROVE</text>
 
-<rect x="788" y="390" width="48" height="12" rx="2" fill="#FAF9F5"/>
-<text x="812.0" y="399" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
+<rect x="814.0" y="428" width="48" height="12" rx="2" fill="#FAF9F5"/>
+<text x="838" y="437" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
 
-<rect x="64" y="112" width="212" height="64" rx="6" fill="#FAF9F5"/>
-<rect x="64" y="112" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="64" y="112" width="212" height="80" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="112" width="212" height="80" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
 <rect x="72" y="118" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="90.0" y="127" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
-<text x="170.0" y="146.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">MCP server</text>
-<text x="170.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">agent-orchestrator &#183; token-locked</text>
+<text x="170.0" y="148.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">MCP server</text>
+<text x="170.0" y="164.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">agent-orchestrator &#183; token-locked</text>
+<text x="170.0" y="178.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">also the Telegram bot's path</text>
 
-<rect x="64" y="208" width="212" height="64" rx="6" fill="#FAF9F5"/>
-<rect x="64" y="208" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
-<rect x="72" y="214" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
-<text x="90.0" y="223" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
-<text x="170.0" y="242.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">CareAgents</text>
-<text x="170.0" y="258.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">web &#183; text &#183; stores no PHI</text>
-
-<rect x="64" y="304" width="212" height="64" rx="6" fill="#FAF9F5"/>
-<rect x="64" y="304" width="212" height="64" rx="6" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="1" stroke-dasharray="4,3"/>
-<rect x="72" y="310" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
-<text x="90.0" y="319" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
-<text x="170.0" y="338.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Telegram bot</text>
-<text x="170.0" y="354.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">openclaw &#183; sunset candidate</text>
+<rect x="64" y="222" width="212" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="222" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="72" y="228" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="90.0" y="237" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
+<text x="170.0" y="256.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">CareAgents</text>
+<text x="170.0" y="272.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">web &#183; text &#183; stores no PHI</text>
 
 <rect x="64" y="416" width="212" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="416" width="212" height="64" rx="6" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
 <rect x="72" y="422" width="36" height="12" rx="2" fill="transparent" stroke="rgba(118,116,106,0.40)" stroke-width="0.8"/>
 <text x="90.0" y="431" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">HUMAN</text>
 <text x="170.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">The patient</text>
-<text x="170.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">a separate page, out of band</text>
+<text x="170.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">a page none of the agent's tools call</text>
 
-<rect x="372" y="196" width="200" height="88" rx="6" fill="#FAF9F5"/>
-<rect x="372" y="196" width="200" height="88" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="372" y="196" width="176" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="372" y="196" width="176" height="88" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
 <rect x="380" y="202" width="40" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
 <text x="400.0" y="211" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">KERNEL</text>
-<text x="472.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
-<text x="472.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py &#183; require_grant</text>
-<text x="472.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant &#183; step-up &#183; audit</text>
+<text x="460.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
+<text x="460.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py &#183; require_grant</text>
+<text x="460.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant &#183; step-up today &#183; audit+exit: 2.0</text>
 
-<rect x="612" y="112" width="180" height="64" rx="6" fill="#FAF9F5"/>
-<rect x="612" y="112" width="180" height="64" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
-<rect x="620" y="118" width="32" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
-<text x="636.0" y="127" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">EXIT</text>
-<text x="702.0" y="146.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Redaction</text>
-<text x="702.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">labels by code, never by display</text>
+<rect x="604" y="196" width="196" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="604" y="196" width="196" height="88" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="612" y="202" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="630.0" y="211" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">TODAY</text>
+<text x="702.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Route handlers</text>
+<text x="702.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/routes.py + blueprints</text>
+<text x="702.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">audit &#183; redaction &#183; upstream calls</text>
+
+<rect x="612" y="104" width="180" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="612" y="104" width="180" height="64" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="620" y="110" width="32" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="636.0" y="119" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">EXIT</text>
+<text x="702.0" y="138.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Redaction</text>
+<text x="702.0" y="154.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">labels by code, never by display</text>
 
 <rect x="612" y="416" width="180" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="612" y="416" width="180" height="64" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
 <rect x="620" y="422" width="32" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
 <text x="636.0" y="431" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">GATE</text>
 <text x="702.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Human gate</text>
-<text x="702.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail &#183; approve endpoint</text>
+<text x="702.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">/confirm &#183; single-use credential</text>
 
 <rect x="884" y="196" width="252" height="88" rx="6" fill="#FAF9F5"/>
 <rect x="884" y="196" width="252" height="88" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
@@ -123,12 +132,19 @@
 <text x="1010.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">SQLite / Postgres</text>
 <text x="1010.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">R6Resource &#183; AuditEvent &#183; ProposedAction</text>
 
-<rect x="884" y="320" width="252" height="64" rx="6" fill="#FAF9F5"/>
-<rect x="884" y="320" width="252" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
-<rect x="892" y="326" width="52" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
-<text x="918.0" y="335" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">UPSTREAM</text>
-<text x="1010.0" y="354.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Upstream FHIR</text>
-<text x="1010.0" y="370.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Aidbox &#183; Medplum &#183; HAPI &#183; generic</text>
+<rect x="884" y="316" width="252" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="884" y="316" width="252" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="892" y="322" width="52" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="918.0" y="331" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">UPSTREAM</text>
+<text x="1010.0" y="350.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Upstream FHIR</text>
+<text x="1010.0" y="366.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Aidbox &#183; Medplum &#183; HAPI &#183; generic</text>
+
+<rect x="884" y="416" width="252" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="884" y="416" width="252" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="892" y="422" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="910.0" y="431" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">WORLD</text>
+<text x="1010.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Provider</text>
+<text x="1010.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Bland &#183; Twilio &#183; the call that leaves</text>
 
 <line x1="40" y1="528" x2="1160" y2="528" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="40" y="544" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
@@ -139,21 +155,21 @@
 <rect x="276" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
 <text x="296" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Store</text>
 <rect x="352" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
-<text x="372" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Agent / upstream</text>
-<rect x="480" y="558" width="14" height="10" rx="2" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
-<text x="500" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Person</text>
-<rect x="560" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="1" stroke-dasharray="4,3"/>
-<text x="580" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Being retired</text>
-<line x1="672" y1="563" x2="700" y2="563" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<text x="708" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">API call</text>
-<line x1="776" y1="563" x2="804" y2="563" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
-<text x="812" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Human approval</text>
-<line x1="912" y1="563" x2="940" y2="563" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<text x="948" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Engine call</text>
+<text x="372" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Agent / upstream / provider</text>
+<rect x="536" y="558" width="14" height="10" rx="2" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
+<text x="556" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Person</text>
+<line x1="616" y1="563" x2="644" y2="563" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<text x="652" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">API call</text>
+<line x1="720" y1="563" x2="748" y2="563" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+<text x="756" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Human approval</text>
+<line x1="856" y1="563" x2="884" y2="563" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<text x="892" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Engine call</text>
+<line x1="976" y1="563" x2="1004" y2="563" stroke="#55534B" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+<text x="1012" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Known gap (#214)</text>
 
 </svg>
     </div>
-    <p class="note">The boundary as HealthClaw 2.0 defines it: every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. The kernel is not yet the only path. On 2026-09-05 the ratchets in tests/test_ratchets.py still count 12 step-up call sites, 5 raw tenant reads and 89 audit calls outside it; the migration that closes them is the open 2.0 workstream. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</p>
+    <p class="note">The boundary as HealthClaw 2.0 defines it, drawn with what exists on 2026-09-05. Every agent surface reaches the record through one kernel, which today resolves the tenant and checks the step-up grant at the sites that have adopted it; its audit call and redacted exit exist but no handler calls them yet. Route handlers still do the audit, redaction and upstream work themselves: the ratchets count 12 step-up call sites and 5 raw tenant reads outside the kernel (one of them the hook meant to read it), and 89 audit calls on the post-commit primitive the kernel is meant to replace. Reads leave through redaction: upstream display text is dropped and labels rebuilt from codes, names cut to initials, dates to the year, identifiers truncated (removed once #615 lands). An agent can propose an action; only a person can approve one, and the endpoint that executes needs a single-use credential only the internal approval mint issues; none of the agent's tools call it. Direct clinical FHIR writes do not pass that gate: they are still gated by a client-supplied header (#214, open), drawn dashed. The Telegram bot reaches the engine through the MCP server and is not drawn separately.</p>
   </div>
 </body>
 </html>

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The guardrail boundary</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }
+    body { font-family: var(--sans); background: var(--paper); color: var(--ink); min-height: 100vh;
+           display: flex; align-items: center; justify-content: center; padding: 3rem 2rem; }
+    .frame { max-width: 1240px; width: 100%; }
+    .eyebrow { font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.18em; text-transform: uppercase;
+                color: var(--muted); margin-bottom: 0.5rem; }
+    h1 { font-size: clamp(1.5rem, 2.4vw + 0.75rem, 2rem); font-weight: 500; letter-spacing: -0.02em;
+          line-height: 1.15; margin-bottom: 1.5rem; }
+    p.note { font-size: 0.875rem; color: var(--muted); max-width: 64ch; margin-top: 1rem; line-height: 1.5; }
+    svg { width: 100%; min-width: 960px; display: block; }
+    .scroll { overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Architecture · HealthClaw</p>
+    <h1>The guardrail boundary</h1>
+    <div class="scroll">
+<svg viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="arch-title arch-desc">
+<title id="arch-title">The guardrail boundary</title>
+<desc id="arch-desc">Every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</desc>
+<defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#55534B"/></marker><marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#1B2FBF"/></marker><marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3D4E6B"/></marker></defs>
+<rect width="100%" height="100%" fill="#FAF9F5"/>
+<rect x="40" y="80" width="260" height="312" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<rect x="56" y="84" width="88" height="12" rx="2" fill="#FAF9F5"/>
+<text x="100.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">AGENT SURFACES</text>
+
+<rect x="340" y="80" width="480" height="416" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<rect x="356" y="84" width="136" height="12" rx="2" fill="#FAF9F5"/>
+<text x="424.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HEALTHCLAW ENGINE · r6/</text>
+
+<rect x="860" y="80" width="300" height="320" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<rect x="876" y="84" width="52" height="12" rx="2" fill="#FAF9F5"/>
+<text x="902.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RECORDS</text>
+
+<path d="M 276,144 H 316 Q 324,144 324,152 V 210 Q 324,218 332,218 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="276" y1="240" x2="372" y2="240" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<path d="M 276,336 H 316 Q 324,336 324,328 V 270 Q 324,262 332,262 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="572" y1="224" x2="884" y2="224" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<path d="M 572,256 H 764 Q 772,256 772,264 V 344 Q 772,352 780,352 H 884" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<path d="M 472,196 V 152 Q 472,144 480,144 H 612" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="276" y1="448" x2="612" y2="448" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+<path d="M 792,448 H 836 Q 844,448 844,440 V 360 a 8,8 0 0,1 0,-16 V 264 Q 844,256 852,256 H 884" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<rect x="690.0" y="204" width="76" height="12" rx="2" fill="#FAF9F5"/>
+<text x="728" y="213" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ · WRITE</text>
+
+<rect x="780" y="294" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="796.0" y="303" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
+
+<rect x="514.0" y="124" width="64" height="12" rx="2" fill="#FAF9F5"/>
+<text x="546" y="133" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
+
+<rect x="420.0" y="428" width="48" height="12" rx="2" fill="#FAF9F5"/>
+<text x="444" y="437" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">APPROVE</text>
+
+<rect x="788" y="300" width="48" height="12" rx="2" fill="#FAF9F5"/>
+<text x="812.0" y="309" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
+
+<rect x="64" y="112" width="212" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="112" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="72" y="118" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="90.0" y="127" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
+<text x="170.0" y="146.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">MCP server</text>
+<text x="170.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">agent-orchestrator · token-locked</text>
+
+<rect x="64" y="208" width="212" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="208" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="72" y="214" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="90.0" y="223" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
+<text x="170.0" y="242.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">CareAgents</text>
+<text x="170.0" y="258.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">web · text · stores no PHI</text>
+
+<rect x="64" y="304" width="212" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="304" width="212" height="64" rx="6" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="1" stroke-dasharray="4,3"/>
+<rect x="72" y="310" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="90.0" y="319" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
+<text x="170.0" y="338.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Telegram bot</text>
+<text x="170.0" y="354.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">openclaw · sunset candidate</text>
+
+<rect x="64" y="416" width="212" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="416" width="212" height="64" rx="6" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
+<rect x="72" y="422" width="36" height="12" rx="2" fill="transparent" stroke="rgba(118,116,106,0.40)" stroke-width="0.8"/>
+<text x="90.0" y="431" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">HUMAN</text>
+<text x="170.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">The patient</text>
+<text x="170.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">a separate page, out of band</text>
+
+<rect x="372" y="196" width="200" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="372" y="196" width="200" height="88" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="380" y="202" width="40" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
+<text x="400.0" y="211" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">KERNEL</text>
+<text x="472.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
+<text x="472.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py · require_grant</text>
+<text x="472.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant · step-up · audit</text>
+
+<rect x="612" y="112" width="180" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="612" y="112" width="180" height="64" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="620" y="118" width="32" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="636.0" y="127" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">EXIT</text>
+<text x="702.0" y="146.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Redaction</text>
+<text x="702.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">labels by code, never by display</text>
+
+<rect x="612" y="416" width="180" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="612" y="416" width="180" height="64" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="620" y="422" width="32" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
+<text x="636.0" y="431" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">GATE</text>
+<text x="702.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Human gate</text>
+<text x="702.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail · approve endpoint</text>
+
+<rect x="884" y="196" width="252" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="884" y="196" width="252" height="88" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<rect x="892" y="202" width="36" height="12" rx="2" fill="transparent" stroke="rgba(85,83,75,0.50)" stroke-width="0.8"/>
+<text x="910.0" y="211" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">STORE</text>
+<text x="1010.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Record store</text>
+<text x="1010.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">SQLite / Postgres</text>
+<text x="1010.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">R6Resource · AuditEvent · ProposedAction</text>
+
+<rect x="884" y="320" width="252" height="64" rx="6" fill="#FAF9F5"/>
+<rect x="884" y="320" width="252" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="892" y="326" width="52" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="918.0" y="335" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">UPSTREAM</text>
+<text x="1010.0" y="354.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Upstream FHIR</text>
+<text x="1010.0" y="370.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Aidbox · Medplum · HAPI · generic</text>
+
+<line x1="40" y1="528" x2="1160" y2="528" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="40" y="544" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
+<rect x="40" y="558" width="14" height="10" rx="2" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<text x="60" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Guardrail (focal)</text>
+<rect x="172" y="558" width="14" height="10" rx="2" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<text x="192" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Engine step</text>
+<rect x="276" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<text x="296" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Store</text>
+<rect x="352" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<text x="372" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Agent / upstream</text>
+<rect x="480" y="558" width="14" height="10" rx="2" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
+<text x="500" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Person</text>
+<rect x="560" y="558" width="14" height="10" rx="2" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="580" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Being retired</text>
+<line x1="672" y1="563" x2="700" y2="563" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<text x="708" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">API call</text>
+<line x1="776" y1="563" x2="804" y2="563" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+<text x="812" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Human approval</text>
+<line x1="912" y1="563" x2="940" y2="563" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<text x="948" y="566" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Engine call</text>
+
+</svg>
+    </div>
+    <p class="note">Every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</p>
+  </div>
+</body>
+</html>

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -27,7 +27,7 @@
     <div class="scroll">
 <svg viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="arch-title arch-desc">
 <title id="arch-title">The guardrail boundary</title>
-<desc id="arch-desc">Every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</desc>
+<desc id="arch-desc">The boundary as HealthClaw 2.0 defines it: every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. The kernel is not yet the only path. On 2026-09-05 the ratchets in tests/test_ratchets.py still count 12 step-up call sites, 5 raw tenant reads and 89 audit calls outside it; the migration that closes them is the open 2.0 workstream. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</desc>
 <defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#55534B"/></marker><marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#1B2FBF"/></marker><marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3D4E6B"/></marker></defs>
 <rect width="100%" height="100%" fill="#FAF9F5"/>
 <rect x="40" y="80" width="260" height="312" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
@@ -153,7 +153,7 @@
 
 </svg>
     </div>
-    <p class="note">Every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</p>
+    <p class="note">The boundary as HealthClaw 2.0 defines it: every agent surface reaches the record through one kernel, which resolves the tenant, checks the step-up grant and writes the audit row before any FHIR read or write. The kernel is not yet the only path. On 2026-09-05 the ratchets in tests/test_ratchets.py still count 12 step-up call sites, 5 raw tenant reads and 89 audit calls outside it; the migration that closes them is the open 2.0 workstream. Reads leave through redaction, where identifiers are stripped and labels are rebuilt from codes. An agent can propose an action; only a person can approve one, on an endpoint the agent's tools cannot reach.</p>
   </div>
 </body>
 </html>

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -22,7 +22,7 @@
 </head>
 <body>
   <div class="frame">
-    <p class="eyebrow">Architecture · HealthClaw</p>
+    <p class="eyebrow">Architecture &#183; HealthClaw</p>
     <h1>The guardrail boundary</h1>
     <div class="scroll">
 <svg viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="arch-title arch-desc">
@@ -35,8 +35,8 @@
 <text x="100.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">AGENT SURFACES</text>
 
 <rect x="340" y="80" width="480" height="416" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
-<rect x="356" y="84" width="136" height="12" rx="2" fill="#FAF9F5"/>
-<text x="424.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HEALTHCLAW ENGINE · r6/</text>
+<rect x="356" y="84" width="164" height="12" rx="2" fill="#FAF9F5"/>
+<text x="438.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HEALTHCLAW ENGINE &#183; r6/</text>
 
 <rect x="860" y="80" width="300" height="320" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <rect x="876" y="84" width="52" height="12" rx="2" fill="#FAF9F5"/>
@@ -50,11 +50,11 @@
 <path d="M 472,196 V 152 Q 472,144 480,144 H 612" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
 <line x1="276" y1="448" x2="612" y2="448" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
 <path d="M 792,448 H 836 Q 844,448 844,440 V 360 a 8,8 0 0,1 0,-16 V 264 Q 844,256 852,256 H 884" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<rect x="690.0" y="204" width="76" height="12" rx="2" fill="#FAF9F5"/>
-<text x="728" y="213" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ · WRITE</text>
+<rect x="676.0" y="204" width="104" height="12" rx="2" fill="#FAF9F5"/>
+<text x="728" y="213" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ &#183; WRITE</text>
 
-<rect x="780" y="294" width="32" height="12" rx="2" fill="#FAF9F5"/>
-<text x="796.0" y="303" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
+<rect x="780" y="278" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="796.0" y="287" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
 
 <rect x="514.0" y="124" width="64" height="12" rx="2" fill="#FAF9F5"/>
 <text x="546" y="133" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
@@ -62,29 +62,29 @@
 <rect x="420.0" y="428" width="48" height="12" rx="2" fill="#FAF9F5"/>
 <text x="444" y="437" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">APPROVE</text>
 
-<rect x="788" y="300" width="48" height="12" rx="2" fill="#FAF9F5"/>
-<text x="812.0" y="309" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
+<rect x="788" y="390" width="48" height="12" rx="2" fill="#FAF9F5"/>
+<text x="812.0" y="399" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
 
 <rect x="64" y="112" width="212" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="112" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
 <rect x="72" y="118" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="90.0" y="127" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
 <text x="170.0" y="146.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">MCP server</text>
-<text x="170.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">agent-orchestrator · token-locked</text>
+<text x="170.0" y="162.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">agent-orchestrator &#183; token-locked</text>
 
 <rect x="64" y="208" width="212" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="208" width="212" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
 <rect x="72" y="214" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="90.0" y="223" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
 <text x="170.0" y="242.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">CareAgents</text>
-<text x="170.0" y="258.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">web · text · stores no PHI</text>
+<text x="170.0" y="258.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">web &#183; text &#183; stores no PHI</text>
 
 <rect x="64" y="304" width="212" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="304" width="212" height="64" rx="6" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="1" stroke-dasharray="4,3"/>
 <rect x="72" y="310" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="90.0" y="319" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">AGENT</text>
 <text x="170.0" y="338.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Telegram bot</text>
-<text x="170.0" y="354.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">openclaw · sunset candidate</text>
+<text x="170.0" y="354.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">openclaw &#183; sunset candidate</text>
 
 <rect x="64" y="416" width="212" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="416" width="212" height="64" rx="6" fill="rgba(85,83,75,0.10)" stroke="#76746A" stroke-width="1"/>
@@ -98,8 +98,8 @@
 <rect x="380" y="202" width="40" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
 <text x="400.0" y="211" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">KERNEL</text>
 <text x="472.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
-<text x="472.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py · require_grant</text>
-<text x="472.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant · step-up · audit</text>
+<text x="472.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py &#183; require_grant</text>
+<text x="472.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant &#183; step-up &#183; audit</text>
 
 <rect x="612" y="112" width="180" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="612" y="112" width="180" height="64" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
@@ -113,7 +113,7 @@
 <rect x="620" y="422" width="32" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
 <text x="636.0" y="431" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">GATE</text>
 <text x="702.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Human gate</text>
-<text x="702.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail · approve endpoint</text>
+<text x="702.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail &#183; approve endpoint</text>
 
 <rect x="884" y="196" width="252" height="88" rx="6" fill="#FAF9F5"/>
 <rect x="884" y="196" width="252" height="88" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
@@ -121,14 +121,14 @@
 <text x="910.0" y="211" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">STORE</text>
 <text x="1010.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Record store</text>
 <text x="1010.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">SQLite / Postgres</text>
-<text x="1010.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">R6Resource · AuditEvent · ProposedAction</text>
+<text x="1010.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">R6Resource &#183; AuditEvent &#183; ProposedAction</text>
 
 <rect x="884" y="320" width="252" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="884" y="320" width="252" height="64" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
 <rect x="892" y="326" width="52" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="918.0" y="335" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">UPSTREAM</text>
 <text x="1010.0" y="354.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Upstream FHIR</text>
-<text x="1010.0" y="370.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Aidbox · Medplum · HAPI · generic</text>
+<text x="1010.0" y="370.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">Aidbox &#183; Medplum &#183; HAPI &#183; generic</text>
 
 <line x1="40" y1="528" x2="1160" y2="528" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="40" y="544" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The guardrail boundary, as built today</title>
-  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    @font-face { font-family: 'Archivo'; font-weight: 400 600; font-display: swap;
+                 src: url('../../../static/fonts/archivo-latin.woff2') format('woff2'); }
+    @font-face { font-family: 'Fragment Mono'; font-weight: 400; font-display: swap;
+                 src: url('../../../static/fonts/fragment-mono-latin.woff2') format('woff2'); }
+  </style>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }

--- a/docs/design/diagrams/architecture.html
+++ b/docs/design/diagrams/architecture.html
@@ -42,26 +42,26 @@
 <rect x="876" y="84" width="124" height="12" rx="2" fill="#FAF9F5"/>
 <text x="938.0" y="93" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RECORDS AND THE WORLD</text>
 
-<path d="M 276,152 H 316 Q 324,152 324,160 V 218 Q 324,226 332,226 H 372" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<line x1="276" y1="254" x2="372" y2="254" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<line x1="548" y1="240" x2="604" y2="240" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<line x1="702" y1="196" x2="702" y2="168" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<line x1="800" y1="218" x2="884" y2="218" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<line x1="800" y1="240" x2="884" y2="240" stroke="#55534B" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
-<path d="M 800,262 H 836 Q 844,262 844,270 V 340 Q 844,348 852,348 H 884" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<path d="M 276,152 H 312 Q 320,152 320,160 V 218 Q 320,226 328,226 H 364" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="276" y1="254" x2="364" y2="254" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
+<line x1="560" y1="240" x2="608" y2="240" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="706" y1="196" x2="706" y2="168" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="804" y1="218" x2="884" y2="218" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="804" y1="240" x2="884" y2="240" stroke="#55534B" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+<path d="M 804,262 H 836 Q 844,262 844,270 V 340 Q 844,348 852,348 H 884" fill="none" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
 <line x1="276" y1="448" x2="612" y2="448" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
 <line x1="792" y1="448" x2="884" y2="448" stroke="#3D4E6B" stroke-width="1.2" marker-end="url(#arrow-link)"/>
-<rect x="558.0" y="220" width="36" height="12" rx="2" fill="#FAF9F5"/>
-<text x="576" y="229" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">GRANT</text>
+<rect x="566.0" y="220" width="36" height="12" rx="2" fill="#FAF9F5"/>
+<text x="584" y="229" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">GRANT</text>
 
-<rect x="710" y="176" width="64" height="12" rx="2" fill="#FAF9F5"/>
-<text x="742.0" y="185" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
+<rect x="714" y="176" width="64" height="12" rx="2" fill="#FAF9F5"/>
+<text x="746.0" y="185" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">EVERY READ</text>
 
-<rect x="810.0" y="198" width="64" height="12" rx="2" fill="#FAF9F5"/>
-<text x="842" y="207" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ/WRITE</text>
+<rect x="812.0" y="198" width="64" height="12" rx="2" fill="#FAF9F5"/>
+<text x="844" y="207" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">READ/WRITE</text>
 
-<rect x="812.0" y="248" width="60" height="12" rx="2" fill="#FAF9F5"/>
-<text x="842" y="257" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">#214 GATE</text>
+<rect x="814.0" y="248" width="60" height="12" rx="2" fill="#FAF9F5"/>
+<text x="844" y="257" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">#214 GATE</text>
 
 <rect x="804" y="306" width="32" height="12" rx="2" fill="#FAF9F5"/>
 <text x="820.0" y="315" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">FHIR</text>
@@ -94,21 +94,21 @@
 <text x="170.0" y="450.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">The patient</text>
 <text x="170.0" y="466.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">a page none of the agent's tools call</text>
 
-<rect x="372" y="196" width="176" height="88" rx="6" fill="#FAF9F5"/>
-<rect x="372" y="196" width="176" height="88" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
-<rect x="380" y="202" width="40" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
-<text x="400.0" y="211" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">KERNEL</text>
-<text x="460.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
-<text x="460.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py &#183; require_grant</text>
-<text x="460.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant &#183; step-up today &#183; audit+exit: 2.0</text>
+<rect x="364" y="196" width="196" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="364" y="196" width="196" height="88" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="372" y="202" width="40" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
+<text x="392.0" y="211" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">KERNEL</text>
+<text x="462.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Access kernel</text>
+<text x="462.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/access.py &#183; require_grant</text>
+<text x="462.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">tenant &#183; step-up &#183; exit: 2.0</text>
 
-<rect x="604" y="196" width="196" height="88" rx="6" fill="#FAF9F5"/>
-<rect x="604" y="196" width="196" height="88" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
-<rect x="612" y="202" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
-<text x="630.0" y="211" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">TODAY</text>
-<text x="702.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Route handlers</text>
-<text x="702.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/routes.py + blueprints</text>
-<text x="702.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">audit &#183; redaction &#183; upstream calls</text>
+<rect x="608" y="196" width="196" height="88" rx="6" fill="#FAF9F5"/>
+<rect x="608" y="196" width="196" height="88" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="616" y="202" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="634.0" y="211" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">TODAY</text>
+<text x="706.0" y="236.0" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Route handlers</text>
+<text x="706.0" y="252.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">r6/routes.py + blueprints</text>
+<text x="706.0" y="266.0" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">audit &#183; redaction &#183; upstream</text>
 
 <rect x="612" y="104" width="180" height="64" rx="6" fill="#FAF9F5"/>
 <rect x="612" y="104" width="180" height="64" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Where HealthClaw runs</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }
+    body { font-family: var(--sans); background: var(--paper); color: var(--ink); min-height: 100vh;
+           display: flex; align-items: center; justify-content: center; padding: 3rem 2rem; }
+    .frame { max-width: 1240px; width: 100%; }
+    .eyebrow { font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.18em; text-transform: uppercase;
+                color: var(--muted); margin-bottom: 0.5rem; }
+    h1 { font-size: clamp(1.5rem, 2.4vw + 0.75rem, 2rem); font-weight: 500; letter-spacing: -0.02em;
+          line-height: 1.15; margin-bottom: 1.5rem; }
+    p.note { font-size: 0.875rem; color: var(--muted); max-width: 64ch; margin-top: 1rem; line-height: 1.5; }
+    svg { width: 100%; min-width: 960px; display: block; }
+    .scroll { overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Deployment · HealthClaw</p>
+    <h1>Where HealthClaw runs</h1>
+    <div class="scroll">
+<svg viewBox="0 0 1040 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="deploy-title deploy-desc">
+<title id="deploy-title">Where HealthClaw runs</title>
+<desc id="deploy-desc">Production is three Railway services and one Postgres. The MCP server is the focal piece: token-locked, reached with a bearer token from the home gateway, and the one thing that is not up for negotiation. CareAgents deploys by hand and has drifted from main before. Two self-hosted hosts run agent gateways; the VPS has no verified path into production, so none is drawn. A Vercel copy of the site exists for demos and is omitted here.</desc>
+<defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#55534B"/></marker><marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#1B2FBF"/></marker><marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3D4E6B"/></marker></defs>
+<rect width="100%" height="100%" fill="#FAF9F5"/>
+<rect x="40" y="40" width="232" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
+<rect x="56" y="44" width="56" height="12" rx="2" fill="#FAF9F5"/>
+<text x="84.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HOME LAN</text>
+
+<rect x="304" y="40" width="472" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
+<rect x="320" y="44" width="120" height="12" rx="2" fill="#FAF9F5"/>
+<text x="380.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RAILWAY · PRODUCTION</text>
+
+<rect x="792" y="40" width="208" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
+<rect x="808" y="44" width="28" height="12" rx="2" fill="#FAF9F5"/>
+<text x="822.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">VPS</text>
+
+<path d="M 156,92 V 72 Q 156,64 164,64 H 660 Q 668,64 668,72 V 80" fill="none" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+<path d="M 156,208 V 246 Q 156,254 164,254 H 328" fill="none" stroke="#3D4E6B" stroke-width="1" stroke-dasharray="5,4" marker-end="url(#arrow-link)"/>
+<line x1="428" y1="196" x2="428" y2="164" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="576" y1="122" x2="520" y2="122" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<path d="M 520,148 H 560 Q 568,148 568,156 V 248 Q 568,256 576,256" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<line x1="520" y1="284" x2="576" y2="284" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<rect x="406.0" y="44" width="76" height="12" rx="2" fill="#FAF9F5"/>
+<text x="444" y="53" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS BEARER</text>
+
+<rect x="208.0" y="234" width="76" height="12" rx="2" fill="#FAF9F5"/>
+<text x="246" y="243" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">RELAY STAGED</text>
+
+<rect x="436" y="174" width="36" height="12" rx="2" fill="#FAF9F5"/>
+<text x="454.0" y="183" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS</text>
+
+<rect x="530.0" y="102" width="36" height="12" rx="2" fill="#FAF9F5"/>
+<text x="548" y="111" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS</text>
+
+<rect x="532.0" y="264" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="548" y="273" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">5432</text>
+
+<rect x="64" y="92" width="184" height="116" rx="6" fill="#FAF9F5"/>
+<rect x="64" y="92" width="184" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="72" y="100" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="86.0" y="109" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MAC</text>
+<text x="156.0" y="132" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Mac mini · home</text>
+<rect x="72" y="144" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="80" y="160" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">openclaw gateway</text>
+<text x="232" y="160" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:18789</text>
+<rect x="72" y="176" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="80" y="192" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">ollama</text>
+<text x="232" y="192" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:11434</text>
+
+<rect x="328" y="80" width="192" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="328" y="80" width="192" height="84" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="336" y="88" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="350.0" y="97" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">WEB</text>
+<text x="424.0" y="120" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">app.healthclaw.io</text>
+<rect x="336" y="132" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="344" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">flask + site</text>
+<text x="504" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">v1.10.0</text>
+
+<rect x="576" y="80" width="184" height="116" rx="6" fill="#FAF9F5"/>
+<rect x="576" y="80" width="184" height="116" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="584" y="88" width="28" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
+<text x="598.0" y="97" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MCP</text>
+<text x="668.0" y="120" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">mcp-server</text>
+<rect x="584" y="132" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="592" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">agent-orchestrator</text>
+<text x="744" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">LOCKED</text>
+<rect x="584" y="164" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="592" y="180" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">mcp-demo</text>
+<text x="744" y="180" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN · SYNTH</text>
+
+<rect x="328" y="196" width="192" height="116" rx="6" fill="#FAF9F5"/>
+<rect x="328" y="196" width="192" height="116" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="336" y="204" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="350.0" y="213" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">APP</text>
+<text x="424.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents</text>
+<rect x="336" y="248" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="344" y="264" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">web</text>
+<text x="504" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">≠ main · #427</text>
+<rect x="336" y="280" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="344" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">worker</text>
+<text x="504" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">railway up</text>
+
+<rect x="576" y="228" width="184" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="576" y="228" width="184" height="84" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<rect x="584" y="236" width="48" height="12" rx="2" fill="transparent" stroke="rgba(85,83,75,0.50)" stroke-width="0.8"/>
+<text x="608.0" y="245" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MANAGED</text>
+<text x="668.0" y="268" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">postgres</text>
+<rect x="584" y="280" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="592" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway pg</text>
+<text x="744" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">16</text>
+
+<rect x="816" y="92" width="160" height="116" rx="6" fill="#FAF9F5"/>
+<rect x="816" y="92" width="160" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<rect x="824" y="100" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
+<text x="838.0" y="109" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">VPS</text>
+<text x="896.0" y="132" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents.cloud</text>
+<rect x="824" y="144" width="144" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="832" y="160" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">nginx</text>
+<text x="960" y="160" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:443</text>
+<rect x="824" y="176" width="144" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="832" y="192" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">openclaw gateway</text>
+<text x="960" y="192" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:18789</text>
+
+<line x1="40" y1="360" x2="1000" y2="360" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="40" y="376" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
+<rect x="40" y="390" width="14" height="10" rx="2" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<text x="60" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Locked MCP (focal)</text>
+<rect x="180" y="390" width="14" height="10" rx="2" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<text x="200" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Service</text>
+<rect x="264" y="390" width="14" height="10" rx="2" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<text x="284" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Managed store</text>
+<rect x="376" y="390" width="14" height="10" rx="2" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<text x="396" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Self-hosted host</text>
+<line x1="504" y1="395" x2="532" y2="395" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+<text x="540" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Bearer call</text>
+<line x1="624" y1="395" x2="652" y2="395" stroke="#55534B" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+<text x="660" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Staged, not live</text>
+<line x1="768" y1="395" x2="796" y2="395" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<text x="804" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">In-zone call</text>
+
+</svg>
+    </div>
+    <p class="note">Production is three Railway services and one Postgres. The MCP server is the focal piece: token-locked, reached with a bearer token from the home gateway, and the one thing that is not up for negotiation. CareAgents deploys by hand and has drifted from main before. Two self-hosted hosts run agent gateways; the VPS has no verified path into production, so none is drawn. A Vercel copy of the site exists for demos and is omitted here.</p>
+  </div>
+</body>
+</html>

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Where HealthClaw runs</title>
-  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    @font-face { font-family: 'Archivo'; font-weight: 400 600; font-display: swap;
+                 src: url('../../../static/fonts/archivo-latin.woff2') format('woff2'); }
+    @font-face { font-family: 'Fragment Mono'; font-weight: 400; font-display: swap;
+                 src: url('../../../static/fonts/fragment-mono-latin.woff2') format('woff2'); }
+  </style>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -25,43 +25,42 @@
     <p class="eyebrow">Deployment &#183; HealthClaw</p>
     <h1>Where HealthClaw runs</h1>
     <div class="scroll">
-<svg viewBox="0 0 1040 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="deploy-title deploy-desc">
+<svg viewBox="0 0 1040 460" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="deploy-title deploy-desc">
 <title id="deploy-title">Where HealthClaw runs</title>
-<desc id="deploy-desc">Production is three Railway services and one Postgres. The MCP server is the focal piece: token-locked, reached with a bearer token from the home gateway, and the one thing that is not up for negotiation. CareAgents deploys by hand and has drifted from main before. Two self-hosted hosts run agent gateways; the VPS has no verified path into production, so none is drawn. A Vercel copy of the site exists for demos and is omitted here.</desc>
+<desc id="deploy-desc">Production is one Railway project: the engine at app.healthclaw.io, the token-locked MCP server and its open demo twin on a separate host, the CareAgents web and worker at careagents.cloud (build stamped in /healthz and equal to main on 2026-09-05), and two Postgres databases, one per app, so the no-PHI app never shares the engine's store. Smart Health Links also runs there and is omitted. The home gateway reaches the MCP server with a bearer token (verified 2026-07-30). CareAgents calls the engine through Railway's internal hostname, not the public one. The iMessage relay is staged, not live (2026-07-16). A legacy VPS at 187.77.4.50 still answers nginx but serves nothing in production, and a Vercel copy of the site exists for demos; neither is drawn. Seven nodes is one over the type's budget, kept so both databases show.</desc>
 <defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#55534B"/></marker><marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#1B2FBF"/></marker><marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3D4E6B"/></marker></defs>
 <rect width="100%" height="100%" fill="#FAF9F5"/>
-<rect x="40" y="40" width="232" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
+<rect x="40" y="40" width="232" height="320" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
 <rect x="56" y="44" width="56" height="12" rx="2" fill="#FAF9F5"/>
 <text x="84.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HOME LAN</text>
 
-<rect x="304" y="40" width="472" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
-<rect x="320" y="44" width="148" height="12" rx="2" fill="#FAF9F5"/>
-<text x="394.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RAILWAY &#183; PRODUCTION</text>
-
-<rect x="792" y="40" width="208" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
-<rect x="808" y="44" width="28" height="12" rx="2" fill="#FAF9F5"/>
-<text x="822.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">VPS</text>
+<rect x="304" y="40" width="696" height="320" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
+<rect x="320" y="44" width="120" height="12" rx="2" fill="#FAF9F5"/>
+<text x="380.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RAILWAY &#183; PRODUCTION</text>
 
 <path d="M 156,92 V 72 Q 156,64 164,64 H 660 Q 668,64 668,72 V 80" fill="none" stroke="#1B2FBF" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
 <path d="M 156,208 V 246 Q 156,254 164,254 H 328" fill="none" stroke="#3D4E6B" stroke-width="1" stroke-dasharray="5,4" marker-end="url(#arrow-link)"/>
 <line x1="428" y1="196" x2="428" y2="164" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
 <line x1="576" y1="122" x2="520" y2="122" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<path d="M 520,148 H 560 Q 568,148 568,156 V 248 Q 568,256 576,256" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<line x1="520" y1="284" x2="576" y2="284" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<path d="M 520,148 H 560 Q 568,148 568,156 V 232 Q 568,240 576,240" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<path d="M 424,312 V 332 Q 424,340 432,340 H 876 Q 884,340 884,332 V 280" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
 <rect x="522.0" y="44" width="76" height="12" rx="2" fill="#FAF9F5"/>
 <text x="560" y="53" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS BEARER</text>
 
 <rect x="208.0" y="234" width="76" height="12" rx="2" fill="#FAF9F5"/>
 <text x="246" y="243" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">RELAY STAGED</text>
 
-<rect x="436" y="174" width="36" height="12" rx="2" fill="#FAF9F5"/>
-<text x="454.0" y="183" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS</text>
+<rect x="436" y="174" width="80" height="12" rx="2" fill="#FAF9F5"/>
+<text x="476.0" y="183" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">INTERNAL HOST</text>
 
 <rect x="530.0" y="102" width="36" height="12" rx="2" fill="#FAF9F5"/>
 <text x="548" y="111" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS</text>
 
-<rect x="532.0" y="264" width="32" height="12" rx="2" fill="#FAF9F5"/>
-<text x="548" y="273" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">5432</text>
+<rect x="528" y="190" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="544.0" y="199" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">5432</text>
+
+<rect x="634.0" y="320" width="32" height="12" rx="2" fill="#FAF9F5"/>
+<text x="650" y="329" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">5432</text>
 
 <rect x="64" y="92" width="184" height="116" rx="6" fill="#FAF9F5"/>
 <rect x="64" y="92" width="184" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
@@ -84,71 +83,74 @@
 <text x="344" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">flask + site</text>
 <text x="504" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">v1.10.0</text>
 
-<rect x="576" y="80" width="184" height="116" rx="6" fill="#FAF9F5"/>
-<rect x="576" y="80" width="184" height="116" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<rect x="576" y="80" width="184" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="576" y="80" width="184" height="84" rx="6" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
 <rect x="584" y="88" width="28" height="12" rx="2" fill="transparent" stroke="#1B2FBF" stroke-width="0.8"/>
 <text x="598.0" y="97" fill="#1B2FBF" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MCP</text>
 <text x="668.0" y="120" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">mcp-server</text>
 <rect x="584" y="132" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="592" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">agent-orchestrator</text>
 <text x="744" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">LOCKED</text>
-<rect x="584" y="164" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="592" y="180" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">mcp-demo</text>
-<text x="744" y="180" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN &#183; SYNTH</text>
+
+<rect x="792" y="80" width="184" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="792" y="80" width="184" height="84" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<rect x="800" y="88" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
+<text x="814.0" y="97" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MCP</text>
+<text x="884.0" y="120" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">mcp-demo</text>
+<rect x="800" y="132" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="808" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">agent-orchestrator</text>
+<text x="960" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN &#183; SYNTH</text>
 
 <rect x="328" y="196" width="192" height="116" rx="6" fill="#FAF9F5"/>
 <rect x="328" y="196" width="192" height="116" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
 <rect x="336" y="204" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.4)" stroke-width="0.8"/>
 <text x="350.0" y="213" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">APP</text>
-<text x="424.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents</text>
+<text x="424.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents.cloud</text>
 <rect x="336" y="248" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="344" y="264" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">web</text>
-<text x="504" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">&#8800; main &#183; #427</text>
+<text x="504" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">build = main</text>
 <rect x="336" y="280" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="344" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">worker</text>
 <text x="504" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">railway up</text>
 
-<rect x="576" y="228" width="184" height="84" rx="6" fill="#FAF9F5"/>
-<rect x="576" y="228" width="184" height="84" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
-<rect x="584" y="236" width="48" height="12" rx="2" fill="transparent" stroke="rgba(85,83,75,0.50)" stroke-width="0.8"/>
-<text x="608.0" y="245" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MANAGED</text>
-<text x="668.0" y="268" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">postgres</text>
-<rect x="584" y="280" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="592" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway postgres</text>
-<text x="744" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">managed</text>
+<rect x="576" y="196" width="184" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="576" y="196" width="184" height="84" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<rect x="584" y="204" width="48" height="12" rx="2" fill="transparent" stroke="rgba(85,83,75,0.50)" stroke-width="0.8"/>
+<text x="608.0" y="213" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MANAGED</text>
+<text x="668.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">postgres &#183; engine</text>
+<rect x="584" y="248" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="592" y="264" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway postgres</text>
+<text x="744" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">managed</text>
 
-<rect x="816" y="92" width="160" height="116" rx="6" fill="#FAF9F5"/>
-<rect x="816" y="92" width="160" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
-<rect x="824" y="100" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
-<text x="838.0" y="109" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">VPS</text>
-<text x="896.0" y="132" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents.cloud</text>
-<rect x="824" y="144" width="144" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="832" y="160" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">nginx</text>
-<text x="960" y="160" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:443</text>
-<rect x="824" y="176" width="144" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="832" y="192" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">openclaw gateway</text>
-<text x="960" y="192" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:18789</text>
+<rect x="792" y="196" width="184" height="84" rx="6" fill="#FAF9F5"/>
+<rect x="792" y="196" width="184" height="84" rx="6" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<rect x="800" y="204" width="48" height="12" rx="2" fill="transparent" stroke="rgba(85,83,75,0.50)" stroke-width="0.8"/>
+<text x="824.0" y="213" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MANAGED</text>
+<text x="884.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">postgres &#183; careagents</text>
+<rect x="800" y="248" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
+<text x="808" y="264" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway postgres</text>
+<text x="960" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">managed</text>
 
-<line x1="40" y1="360" x2="1000" y2="360" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
-<text x="40" y="376" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
-<rect x="40" y="390" width="14" height="10" rx="2" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
-<text x="60" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Locked MCP (focal)</text>
-<rect x="180" y="390" width="14" height="10" rx="2" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
-<text x="200" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Service</text>
-<rect x="264" y="390" width="14" height="10" rx="2" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
-<text x="284" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Managed store</text>
-<rect x="376" y="390" width="14" height="10" rx="2" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
-<text x="396" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Self-hosted host</text>
-<line x1="504" y1="395" x2="532" y2="395" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
-<text x="540" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Bearer call</text>
-<line x1="624" y1="395" x2="652" y2="395" stroke="#55534B" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
-<text x="660" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Staged, not live</text>
-<line x1="768" y1="395" x2="796" y2="395" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<text x="804" y="398" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">In-zone call</text>
+<line x1="40" y1="380" x2="1000" y2="380" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="40" y="396" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
+<rect x="40" y="410" width="14" height="10" rx="2" fill="rgba(27,47,191,0.08)" stroke="#1B2FBF" stroke-width="1"/>
+<text x="60" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Locked MCP (focal)</text>
+<rect x="180" y="410" width="14" height="10" rx="2" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
+<text x="200" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Service</text>
+<rect x="264" y="410" width="14" height="10" rx="2" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="1"/>
+<text x="284" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Managed store</text>
+<rect x="376" y="410" width="14" height="10" rx="2" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
+<text x="396" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Self-hosted host</text>
+<line x1="504" y1="415" x2="532" y2="415" stroke="#1B2FBF" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+<text x="540" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Bearer call</text>
+<line x1="624" y1="415" x2="652" y2="415" stroke="#3D4E6B" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow-link)"/>
+<text x="660" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Staged, not live</text>
+<line x1="768" y1="415" x2="796" y2="415" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
+<text x="804" y="418" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">In-zone call</text>
 
 </svg>
     </div>
-    <p class="note">Production is three Railway services and one Postgres. The MCP server is the focal piece: token-locked, reached with a bearer token from the home gateway, and the one thing that is not up for negotiation. CareAgents deploys by hand and has drifted from main before. Two self-hosted hosts run agent gateways; the VPS has no verified path into production, so none is drawn. A Vercel copy of the site exists for demos and is omitted here.</p>
+    <p class="note">Production is one Railway project: the engine at app.healthclaw.io, the token-locked MCP server and its open demo twin on a separate host, the CareAgents web and worker at careagents.cloud (build stamped in /healthz and equal to main on 2026-09-05), and two Postgres databases, one per app, so the no-PHI app never shares the engine's store. Smart Health Links also runs there and is omitted. The home gateway reaches the MCP server with a bearer token (verified 2026-07-30). CareAgents calls the engine through Railway's internal hostname, not the public one. The iMessage relay is staged, not live (2026-07-16). A legacy VPS at 187.77.4.50 still answers nginx but serves nothing in production, and a Vercel copy of the site exists for demos; neither is drawn. Seven nodes is one over the type's budget, kept so both databases show.</p>
   </div>
 </body>
 </html>

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -98,7 +98,7 @@
 <text x="814.0" y="97" fill="#14140F" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MCP</text>
 <text x="884.0" y="120" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">mcp-demo</text>
 <rect x="800" y="132" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="808" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">agent-orchestrator</text>
+<text x="808" y="148" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">orchestrator</text>
 <text x="960" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN &#183; SYNTH</text>
 
 <rect x="328" y="196" width="192" height="116" rx="6" fill="#FAF9F5"/>

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -22,7 +22,7 @@
 </head>
 <body>
   <div class="frame">
-    <p class="eyebrow">Deployment · HealthClaw</p>
+    <p class="eyebrow">Deployment &#183; HealthClaw</p>
     <h1>Where HealthClaw runs</h1>
     <div class="scroll">
 <svg viewBox="0 0 1040 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="deploy-title deploy-desc">
@@ -35,8 +35,8 @@
 <text x="84.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">HOME LAN</text>
 
 <rect x="304" y="40" width="472" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
-<rect x="320" y="44" width="120" height="12" rx="2" fill="#FAF9F5"/>
-<text x="380.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RAILWAY · PRODUCTION</text>
+<rect x="320" y="44" width="148" height="12" rx="2" fill="#FAF9F5"/>
+<text x="394.0" y="53" fill="rgba(20,20,15,0.4)" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">RAILWAY &#183; PRODUCTION</text>
 
 <rect x="792" y="40" width="208" height="300" rx="8" fill="rgba(20,20,15,0.02)" stroke="rgba(20,20,15,0.2)" stroke-width="0.8" stroke-dasharray="4,4"/>
 <rect x="808" y="44" width="28" height="12" rx="2" fill="#FAF9F5"/>
@@ -48,8 +48,8 @@
 <line x1="576" y1="122" x2="520" y2="122" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
 <path d="M 520,148 H 560 Q 568,148 568,156 V 248 Q 568,256 576,256" fill="none" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
 <line x1="520" y1="284" x2="576" y2="284" stroke="#55534B" stroke-width="1.2" marker-end="url(#arrow)"/>
-<rect x="406.0" y="44" width="76" height="12" rx="2" fill="#FAF9F5"/>
-<text x="444" y="53" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS BEARER</text>
+<rect x="522.0" y="44" width="76" height="12" rx="2" fill="#FAF9F5"/>
+<text x="560" y="53" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">HTTPS BEARER</text>
 
 <rect x="208.0" y="234" width="76" height="12" rx="2" fill="#FAF9F5"/>
 <text x="246" y="243" fill="#3D4E6B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.06em">RELAY STAGED</text>
@@ -67,7 +67,7 @@
 <rect x="64" y="92" width="184" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>
 <rect x="72" y="100" width="28" height="12" rx="2" fill="transparent" stroke="rgba(20,20,15,0.22)" stroke-width="0.8"/>
 <text x="86.0" y="109" fill="#76746A" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MAC</text>
-<text x="156.0" y="132" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Mac mini · home</text>
+<text x="156.0" y="132" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Mac mini &#183; home</text>
 <rect x="72" y="144" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="80" y="160" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">openclaw gateway</text>
 <text x="232" y="160" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">:18789</text>
@@ -94,7 +94,7 @@
 <text x="744" y="148" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">LOCKED</text>
 <rect x="584" y="164" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="592" y="180" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">mcp-demo</text>
-<text x="744" y="180" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN · SYNTH</text>
+<text x="744" y="180" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">OPEN &#183; SYNTH</text>
 
 <rect x="328" y="196" width="192" height="116" rx="6" fill="#FAF9F5"/>
 <rect x="328" y="196" width="192" height="116" rx="6" fill="#FFFFFF" stroke="#14140F" stroke-width="1"/>
@@ -103,7 +103,7 @@
 <text x="424.0" y="236" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">careagents</text>
 <rect x="336" y="248" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="344" y="264" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">web</text>
-<text x="504" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">≠ main · #427</text>
+<text x="504" y="264" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">&#8800; main &#183; #427</text>
 <rect x="336" y="280" width="176" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
 <text x="344" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">worker</text>
 <text x="504" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">railway up</text>

--- a/docs/design/diagrams/deployment.html
+++ b/docs/design/diagrams/deployment.html
@@ -114,8 +114,8 @@
 <text x="608.0" y="245" fill="#55534B" font-size="7" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.08em">MANAGED</text>
 <text x="668.0" y="268" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">postgres</text>
 <rect x="584" y="280" width="168" height="24" rx="4" fill="rgba(20,20,15,0.05)" stroke="#55534B" stroke-width="0.8"/>
-<text x="592" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway pg</text>
-<text x="744" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">16</text>
+<text x="592" y="296" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">railway postgres</text>
+<text x="744" y="296" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end">managed</text>
 
 <rect x="816" y="92" width="160" height="116" rx="6" fill="#FAF9F5"/>
 <rect x="816" y="92" width="160" height="116" rx="6" fill="rgba(20,20,15,0.03)" stroke="rgba(20,20,15,0.3)" stroke-width="1"/>

--- a/docs/design/diagrams/journey.html
+++ b/docs/design/diagrams/journey.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The synthetic track, first session</title>
-  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    @font-face { font-family: 'Archivo'; font-weight: 400 600; font-display: swap;
+                 src: url('../../../static/fonts/archivo-latin.woff2') format('woff2'); }
+    @font-face { font-family: 'Fragment Mono'; font-weight: 400; font-display: swap;
+                 src: url('../../../static/fonts/fragment-mono-latin.woff2') format('woff2'); }
+  </style>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }

--- a/docs/design/diagrams/journey.html
+++ b/docs/design/diagrams/journey.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Connect your records, ask, approve</title>
+  <title>The synthetic track, first session</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -23,70 +23,77 @@
 <body>
   <div class="frame">
     <p class="eyebrow">User journey &#183; CareAgents</p>
-    <h1>Connect your records, ask, approve</h1>
+    <h1>The synthetic track, first session</h1>
     <div class="scroll">
 <svg viewBox="0 0 1200 580" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="journey-title journey-desc">
-<title id="journey-title">Connect your records, ask, approve</title>
-<desc id="journey-desc">One person's first session on CareAgents across five stages, as the team expects it before the first outside tester. No tester has walked this yet; the end-user slot in the tester program is unassigned. The expected trough is connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision (#168). Approval is expected to recover it: the agent proposes, the person confirms on a page the agent cannot reach. Replace this curve with the first tester's.</desc>
+<title id="journey-title">The synthetic track, first session</title>
+<desc id="journey-desc">One person's first session on the synthetic track, the track the first outside tester will walk; the real-record path is not walkable until #168 is decided. Walked once on 2026-09-05 by an agent over HTTP against the deployed app, not by a person in a browser: no dead ends, sign-up to first answer in under twenty seconds. The trough is approval: the reply says form generation is not built while the PDF is already generated and secured (#645). Sentiment is the team's reading of that walk. Replace this curve with the first human tester's.</desc>
 <rect width="100%" height="100%" fill="#FAF9F5"/>
-<text x="164" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 1</text>
-<text x="164" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Sign up</text>
-<text x="388" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 2</text>
-<text x="388" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Connect records</text>
-<text x="612" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 3</text>
-<text x="612" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask</text>
-<text x="836" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 4</text>
-<text x="836" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Agent proposes</text>
-<text x="1060" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 5</text>
-<text x="1060" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Approve</text>
+<text x="148" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 1</text>
+<text x="148" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Sign up</text>
+<text x="332" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 2</text>
+<text x="332" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Sample records</text>
+<text x="516" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 3</text>
+<text x="516" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Create an agent</text>
+<text x="700" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 4</text>
+<text x="700" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask</text>
+<text x="884" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 5</text>
+<text x="884" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Read the proposal</text>
+<text x="1068" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 6</text>
+<text x="1068" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Approve</text>
 <line x1="64" y1="100" x2="1160" y2="100" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="56" y="104" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">HIGH</text>
 <line x1="64" y1="180" x2="1160" y2="180" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="56" y="184" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">NEUTRAL</text>
 <line x1="64" y1="260" x2="1160" y2="260" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="56" y="264" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">LOW</text>
-<polyline points="164,140 388,260" fill="none" stroke="#1B2FBF" stroke-width="1.5" stroke-linejoin="round"/>
-<polyline points="388,260 612,100" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
-<polyline points="612,100 836,180" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
-<polyline points="836,180 1060,140" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
-<circle cx="164" cy="140" r="5" fill="#55534B"/>
-<circle cx="388" cy="260" r="5" fill="#1B2FBF"/>
-<circle cx="612" cy="100" r="5" fill="#55534B"/>
-<circle cx="836" cy="180" r="5" fill="#55534B"/>
-<circle cx="1060" cy="140" r="5" fill="#55534B"/>
+<polyline points="148,140 332,100" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="332,100 516,180" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="516,180 700,100" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="700,100 884,180" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="884,180 1068,220" fill="none" stroke="#1B2FBF" stroke-width="1.5" stroke-linejoin="round"/>
+<circle cx="148" cy="140" r="5" fill="#55534B"/>
+<circle cx="332" cy="100" r="5" fill="#55534B"/>
+<circle cx="516" cy="180" r="5" fill="#55534B"/>
+<circle cx="700" cy="100" r="5" fill="#55534B"/>
+<circle cx="884" cy="180" r="5" fill="#55534B"/>
+<circle cx="1068" cy="220" r="5" fill="#1B2FBF"/>
 <line x1="64" y1="280" x2="1160" y2="280" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <line x1="64" y1="384" x2="1160" y2="384" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <line x1="64" y1="440" x2="1160" y2="440" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="56" y="328" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">ACTIONS</text>
 <text x="72" y="416" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">TOUCHPOINTS</text>
 <text x="64" y="472" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">GUARDRAIL</text>
-<text x="164" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Passkey or a one-time code</text>
-<text x="164" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">careagents web &#183; text</text>
-<text x="164" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">no PHI stored here</text>
-<text x="388" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Consent, then provider sign-in</text>
-<text x="388" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">connector marketplace</text>
-<text x="388" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">consent recorded first</text>
-<text x="612" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask about your own record</text>
-<text x="612" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">chat &#183; text</text>
-<text x="612" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">redacted read &#183; audit row</text>
-<text x="836" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Read what the agent proposes</text>
-<text x="836" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail card</text>
-<text x="836" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">proposal only, no execution</text>
-<text x="1060" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Confirm on a separate page</text>
-<text x="1060" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">approve page &#183; audit log</text>
-<text x="1060" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">step-up token &#183; human gate</text>
-<rect x="304.0" y="312" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
-<text x="388" y="324" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">CONSENT + OAUTH + EXPORT WAIT</text>
-<rect x="304.0" y="332" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
-<text x="388" y="344" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">REAL-RECORD BETA GATED (#168)</text>
+<text x="148" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Email code, then passkey</text>
+<text x="148" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">careagents web</text>
+<text x="148" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">no PHI stored here</text>
+<text x="332" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Tap the sample patient</text>
+<text x="332" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">connect tiles</text>
+<text x="332" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">synthetic only, no consent</text>
+<text x="516" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Name, voice, specialty</text>
+<text x="516" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">new-agent modal</text>
+<text x="516" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">no PHI stored here</text>
+<text x="700" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask three plain questions</text>
+<text x="700" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">chat &#183; text</text>
+<text x="700" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">redacted read &#183; audit row</text>
+<text x="884" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Read the drafted form</text>
+<text x="884" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail card</text>
+<text x="884" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">proposal only, no execution</text>
+<text x="1068" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Confirm the intake form</text>
+<text x="1068" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">approve page</text>
+<text x="1068" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">step-up &#183; human gate &#183; audit</text>
+<rect x="990.0" y="312" width="156" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
+<text x="1068" y="324" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">SAYS NOT BUILT, PDF EXISTS</text>
+<rect x="1000.0" y="332" width="136" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
+<text x="1068" y="344" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">PAGE REBRANDS MID-FLOW</text>
 <line x1="40" y1="512" x2="1160" y2="512" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="40" y="528" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
-<line x1="40" y1="546" x2="56" y2="546" stroke="#55534B" stroke-width="1.5"/><circle cx="48" cy="546" r="3" fill="#55534B"/><text x="64" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Sentiment</text>
-<line x1="220" y1="546" x2="236" y2="546" stroke="#1B2FBF" stroke-width="1.5"/><circle cx="228" cy="546" r="3" fill="#1B2FBF"/><text x="244" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Trough stage</text>
-<rect x="384" y="542" width="16" height="8" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/><text x="408" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Friction</text>
+<line x1="40" y1="546" x2="56" y2="546" stroke="#55534B" stroke-width="1.5"/><circle cx="48" cy="546" r="3" fill="#55534B"/><text x="64" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Sentiment, one HTTP walk</text>
+<line x1="260" y1="546" x2="276" y2="546" stroke="#1B2FBF" stroke-width="1.5"/><circle cx="268" cy="546" r="3" fill="#1B2FBF"/><text x="284" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Trough stage</text>
+<rect x="424" y="542" width="16" height="8" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/><text x="448" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Friction (#645)</text>
 </svg>
     </div>
-    <p class="note">One person's first session on CareAgents across five stages, as the team expects it before the first outside tester. No tester has walked this yet; the end-user slot in the tester program is unassigned. The expected trough is connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision (#168). Approval is expected to recover it: the agent proposes, the person confirms on a page the agent cannot reach. Replace this curve with the first tester's.</p>
+    <p class="note">One person's first session on the synthetic track, the track the first outside tester will walk; the real-record path is not walkable until #168 is decided. Walked once on 2026-09-05 by an agent over HTTP against the deployed app, not by a person in a browser: no dead ends, sign-up to first answer in under twenty seconds. The trough is approval: the reply says form generation is not built while the PDF is already generated and secured (#645). Sentiment is the team's reading of that walk. Replace this curve with the first human tester's.</p>
   </div>
 </body>
 </html>

--- a/docs/design/diagrams/journey.html
+++ b/docs/design/diagrams/journey.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connect your records, ask, approve</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&amp;family=Fragment+Mono&amp;display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --paper: #FAF9F5; --ink: #14140F; --muted: #55534B; --sans: 'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif; --mono: 'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace; }
+    body { font-family: var(--sans); background: var(--paper); color: var(--ink); min-height: 100vh;
+           display: flex; align-items: center; justify-content: center; padding: 3rem 2rem; }
+    .frame { max-width: 1240px; width: 100%; }
+    .eyebrow { font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.18em; text-transform: uppercase;
+                color: var(--muted); margin-bottom: 0.5rem; }
+    h1 { font-size: clamp(1.5rem, 2.4vw + 0.75rem, 2rem); font-weight: 500; letter-spacing: -0.02em;
+          line-height: 1.15; margin-bottom: 1.5rem; }
+    p.note { font-size: 0.875rem; color: var(--muted); max-width: 64ch; margin-top: 1rem; line-height: 1.5; }
+    svg { width: 100%; min-width: 960px; display: block; }
+    .scroll { overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">User journey · CareAgents</p>
+    <h1>Connect your records, ask, approve</h1>
+    <div class="scroll">
+<svg viewBox="0 0 1200 580" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="journey-title journey-desc">
+<title id="journey-title">Connect your records, ask, approve</title>
+<desc id="journey-desc">One person's first session on CareAgents across five stages. Sentiment dips hardest at connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision. Approval recovers it: the agent proposes, the person confirms on a page the agent cannot reach.</desc>
+<rect width="100%" height="100%" fill="#FAF9F5"/>
+<text x="164" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 1</text>
+<text x="164" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Sign up</text>
+<text x="388" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 2</text>
+<text x="388" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Connect records</text>
+<text x="612" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 3</text>
+<text x="612" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask</text>
+<text x="836" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 4</text>
+<text x="836" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Agent proposes</text>
+<text x="1060" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 5</text>
+<text x="1060" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Approve</text>
+<line x1="64" y1="100" x2="1160" y2="100" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="56" y="104" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">HIGH</text>
+<line x1="64" y1="180" x2="1160" y2="180" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="56" y="184" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">NEUTRAL</text>
+<line x1="64" y1="260" x2="1160" y2="260" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="56" y="264" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.10em">LOW</text>
+<polyline points="164,140 388,260" fill="none" stroke="#1B2FBF" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="388,260 612,100" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="612,100 836,180" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<polyline points="836,180 1060,140" fill="none" stroke="#55534B" stroke-width="1.5" stroke-linejoin="round"/>
+<circle cx="164" cy="140" r="5" fill="#55534B"/>
+<circle cx="388" cy="260" r="5" fill="#1B2FBF"/>
+<circle cx="612" cy="100" r="5" fill="#55534B"/>
+<circle cx="836" cy="180" r="5" fill="#55534B"/>
+<circle cx="1060" cy="140" r="5" fill="#55534B"/>
+<line x1="64" y1="280" x2="1160" y2="280" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<line x1="64" y1="384" x2="1160" y2="384" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<line x1="64" y1="440" x2="1160" y2="440" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="56" y="328" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">ACTIONS</text>
+<text x="56" y="416" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">TOUCHPOINTS</text>
+<text x="56" y="472" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">GUARDRAIL</text>
+<text x="164" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Passkey or a one-time code</text>
+<text x="164" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">careagents web · text</text>
+<text x="164" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">no PHI stored here</text>
+<text x="388" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Consent, then provider sign-in</text>
+<text x="388" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">connector marketplace</text>
+<text x="388" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">consent recorded first</text>
+<text x="612" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask about your own record</text>
+<text x="612" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">chat · text</text>
+<text x="612" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">redacted read · audit row</text>
+<text x="836" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Read what the agent proposes</text>
+<text x="836" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail card</text>
+<text x="836" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">proposal only, no execution</text>
+<text x="1060" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Confirm on a separate page</text>
+<text x="1060" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">approve page · audit log</text>
+<text x="1060" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">step-up token · human gate</text>
+<rect x="304.0" y="312" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
+<text x="388" y="324" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">CONSENT + OAUTH + EXPORT WAIT</text>
+<rect x="304.0" y="332" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
+<text x="388" y="344" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">REAL-RECORD BETA GATED (#168)</text>
+<line x1="40" y1="512" x2="1160" y2="512" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
+<text x="40" y="528" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" letter-spacing="0.18em">LEGEND</text>
+<line x1="40" y1="546" x2="56" y2="546" stroke="#55534B" stroke-width="1.5"/><circle cx="48" cy="546" r="3" fill="#55534B"/><text x="64" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Sentiment</text>
+<line x1="220" y1="546" x2="236" y2="546" stroke="#1B2FBF" stroke-width="1.5"/><circle cx="228" cy="546" r="3" fill="#1B2FBF"/><text x="244" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Trough stage</text>
+<rect x="384" y="542" width="16" height="8" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/><text x="408" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Friction</text>
+</svg>
+    </div>
+    <p class="note">One person's first session on CareAgents across five stages. Sentiment dips hardest at connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision. Approval recovers it: the agent proposes, the person confirms on a page the agent cannot reach.</p>
+  </div>
+</body>
+</html>

--- a/docs/design/diagrams/journey.html
+++ b/docs/design/diagrams/journey.html
@@ -22,7 +22,7 @@
 </head>
 <body>
   <div class="frame">
-    <p class="eyebrow">User journey · CareAgents</p>
+    <p class="eyebrow">User journey &#183; CareAgents</p>
     <h1>Connect your records, ask, approve</h1>
     <div class="scroll">
 <svg viewBox="0 0 1200 580" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="journey-title journey-desc">
@@ -58,23 +58,23 @@
 <line x1="64" y1="384" x2="1160" y2="384" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <line x1="64" y1="440" x2="1160" y2="440" stroke="rgba(20,20,15,0.1)" stroke-width="0.8"/>
 <text x="56" y="328" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">ACTIONS</text>
-<text x="56" y="416" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">TOUCHPOINTS</text>
-<text x="56" y="472" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">GUARDRAIL</text>
+<text x="72" y="416" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">TOUCHPOINTS</text>
+<text x="64" y="472" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="end" letter-spacing="0.14em">GUARDRAIL</text>
 <text x="164" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Passkey or a one-time code</text>
-<text x="164" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">careagents web · text</text>
+<text x="164" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">careagents web &#183; text</text>
 <text x="164" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">no PHI stored here</text>
 <text x="388" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Consent, then provider sign-in</text>
 <text x="388" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">connector marketplace</text>
 <text x="388" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">consent recorded first</text>
 <text x="612" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Ask about your own record</text>
-<text x="612" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">chat · text</text>
-<text x="612" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">redacted read · audit row</text>
+<text x="612" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">chat &#183; text</text>
+<text x="612" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">redacted read &#183; audit row</text>
 <text x="836" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Read what the agent proposes</text>
 <text x="836" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">action rail card</text>
 <text x="836" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">proposal only, no execution</text>
 <text x="1060" y="300" fill="#14140F" font-size="12" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Confirm on a separate page</text>
-<text x="1060" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">approve page · audit log</text>
-<text x="1060" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">step-up token · human gate</text>
+<text x="1060" y="412" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">approve page &#183; audit log</text>
+<text x="1060" y="468" fill="#55534B" font-size="9" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle">step-up token &#183; human gate</text>
 <rect x="304.0" y="312" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>
 <text x="388" y="324" fill="#1B2FBF" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.04em">CONSENT + OAUTH + EXPORT WAIT</text>
 <rect x="304.0" y="332" width="168" height="16" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/>

--- a/docs/design/diagrams/journey.html
+++ b/docs/design/diagrams/journey.html
@@ -27,7 +27,7 @@
     <div class="scroll">
 <svg viewBox="0 0 1200 580" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="journey-title journey-desc">
 <title id="journey-title">Connect your records, ask, approve</title>
-<desc id="journey-desc">One person's first session on CareAgents across five stages. Sentiment dips hardest at connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision. Approval recovers it: the agent proposes, the person confirms on a page the agent cannot reach.</desc>
+<desc id="journey-desc">One person's first session on CareAgents across five stages, as the team expects it before the first outside tester. No tester has walked this yet; the end-user slot in the tester program is unassigned. The expected trough is connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision (#168). Approval is expected to recover it: the agent proposes, the person confirms on a page the agent cannot reach. Replace this curve with the first tester's.</desc>
 <rect width="100%" height="100%" fill="#FAF9F5"/>
 <text x="164" y="40" fill="#55534B" font-size="8" font-family="'Fragment Mono', ui-monospace, 'SF Mono', Menlo, monospace" text-anchor="middle" letter-spacing="0.14em">STAGE 1</text>
 <text x="164" y="60" fill="#14140F" font-size="12" font-weight="600" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">Sign up</text>
@@ -86,7 +86,7 @@
 <rect x="384" y="542" width="16" height="8" rx="2" fill="rgba(27,47,191,0.08)" stroke="rgba(27,47,191,0.50)" stroke-width="0.8" stroke-dasharray="3,3"/><text x="408" y="550" fill="#55534B" font-size="8.5" font-family="'Archivo', 'Helvetica Neue', Helvetica, Arial, sans-serif">Friction</text>
 </svg>
     </div>
-    <p class="note">One person's first session on CareAgents across five stages. Sentiment dips hardest at connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision. Approval recovers it: the agent proposes, the person confirms on a page the agent cannot reach.</p>
+    <p class="note">One person's first session on CareAgents across five stages, as the team expects it before the first outside tester. No tester has walked this yet; the end-user slot in the tester program is unassigned. The expected trough is connecting real records, where consent, the provider's own sign-in and an export wait stack up, and where a real-record beta is still gated on a legal decision (#168). Approval is expected to recover it: the agent proposes, the person confirms on a page the agent cannot reach. Replace this curve with the first tester's.</p>
   </div>
 </body>
 </html>

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -1,0 +1,152 @@
+# Merging the queue, one change at a time
+
+Written 2026-09-05 against the sixty-three open pull requests of that day.
+The order and the known stops are specific to that queue; the method is not.
+
+## Why one at a time
+
+Branch protection on `main` is strict: a branch must be up to date with
+`main` before it can merge. Every merge therefore puts every other open
+branch behind, and each one must be brought forward and re-checked before
+its turn. Arming auto-merge across the queue does not help. GitHub does not
+update branches on its own, and a stacked change runs no tests at all (#585),
+so it cannot go red and would merge unverified.
+
+## What "with care" means here
+
+For each change, in order:
+
+1. Confirm it still carries the standards-review verdict label.
+2. Bring the branch up to date with `main` (`gh pr update-branch`).
+3. Wait for every check to finish; stop on any red.
+4. Squash-merge with branch deletion, so any change stacked on it retargets
+   to `main` by itself.
+
+The standards review has not run on any open change: the API-key secret is
+unset, so the job skips and reports green (#608). With the secret set, the
+update-branch push in step 2 runs it, and step 3 waits for it. Merging
+without it is a decision, not a default; the script below makes it one.
+
+## Measured before merging anything
+
+All sixty were merged in the order below into a throwaway branch off
+`89b42fb`. Fifty-five merged clean; five collided with an earlier change in
+the same order. On the result, `ruff` was clean and the suite reported 3561
+passed, 2 failed. Both failures are sums of changes that pass alone:
+
+| What goes red | Where | Why | Fix |
+|---|---|---|---|
+| `test_the_god_module_only_shrinks` | at #583, once #541 is in | #541 adds three lines to `r6/routes.py`, #583 one; 3928 against a pin of 3927 | raise the pin in #583 with that reason, or move the line |
+| landing-page test count | at #555 and after | the page said 2812; the guard's floor passes 2812 at that merge and ends at 2877 | #641, merged right after #544 |
+
+The five collisions, each resolved by merging `main` into the branch after
+the partner lands, running the suite, and pushing:
+
+| Change | Collides with | File |
+|---|---|---|
+| #598 | #579 | `careagents/static/home.js` |
+| #580 | #549 | `tests/test_build_marker_stamp.py` |
+| #595 | #545, #562 | `tests/test_access_kernel.py` |
+| #603 | #601, #609 | `docs/evidence/2026-08-16-set2-connectors.md` |
+| #622 | #549 | `scripts/prod_watch.py` |
+
+## The order
+
+1. #544, the lockfile fix that turns `dependency-audit` green everywhere.
+   Then close #551 and #552, which are byte-identical subsets of it.
+2. #641, so the landing-page count does not go red mid-queue.
+3. #607 (stops the auto-merge comment on every push) and #588 (CI on
+   stacked changes).
+4. The changes that touch no product code: #543 #560 #593 #605 #609 #610
+   #613 #627 #628 #629.
+5. Tests only: #631 #632 #636 #637 #639 #545 #546.
+6. The chains, base first: #550 #566 #579; #553 #571 #598 #569 #621; #562
+   #576 #578 #584 #594; #563 #619.
+7. The rest: #540 #541 #547 #549 #555 #556 #561 #573 #580 #583 #595 #597
+   #599 #601 #603 #611 #612 #614 #615 #618 #622 #623.
+8. #582, the remaining dependabot change (its packages are not in #544;
+   comment `@dependabot rebase` if it is dirty).
+9. #642, then #643 last so the new reviewer does not fire on every
+   update-branch of the queue.
+
+## The script
+
+Run from the repository root as a maintainer. It walks the order above,
+performs the four steps for each change, and stops at the first one that
+conflicts or goes red. Re-run to resume; merged changes are skipped.
+
+```zsh
+set -u
+REQUIRE_REVIEW_LABEL=${REQUIRE_REVIEW_LABEL:-1}
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+ORDER=(
+  544 641
+  607 588
+  543 560 593 605 609 610 613 627 628 629
+  631 632 636 637 639 545 546
+  550 566 579
+  553 571 598 569 621
+  562 576 578 584 594
+  563 619
+  540 541 547 549 555 556 561 573 580 583 595 597 599 601 603 611 612 614 615 618 622 623
+  582
+  642 643
+)
+if [ $# -gt 0 ]; then ORDER=("$@"); fi
+
+wait_checks() {
+  # Poll until every check on the PR has a conclusion; print the failures.
+  local n=$1
+  while true; do
+    local pending
+    pending=$(gh pr checks "$n" --repo "$REPO" --json state --jq '[.[] | select(.state=="PENDING" or .state=="QUEUED" or .state=="IN_PROGRESS")] | length')
+    [ "$pending" = "0" ] && break
+    sleep 45
+  done
+  gh pr checks "$n" --repo "$REPO" --json name,state --jq '.[] | select(.state=="FAILURE" or .state=="ERROR" or .state=="CANCELLED") | .name'
+}
+
+for n in $ORDER; do
+  state=$(gh pr view "$n" --repo "$REPO" --json state --jq .state)
+  if [ "$state" != "OPEN" ]; then echo "#$n is $state, skipping"; continue; fi
+  labels=$(gh pr view "$n" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+  case "$labels" in
+    *claude:approve*) ;;
+    *) if [ "$REQUIRE_REVIEW_LABEL" = "1" ]; then
+         echo "STOP #$n: no claude:approve label (labels: '$labels'). The standards review has not run;"
+         echo "  set ANTHROPIC_API_KEY (#608) so it runs on the update-branch push, or REQUIRE_REVIEW_LABEL=0."; exit 1
+       else
+         echo "   (merging without a standards-review verdict, REQUIRE_REVIEW_LABEL=0)"
+       fi ;;
+  esac
+  if [ -n "$(gh pr view "$n" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest // empty')" ]; then
+    echo "STOP #$n: auto-merge is already armed; disarm or let it fire, then re-run"; exit 1
+  fi
+  # 551 and 552 are byte-identical subsets of 544; close them once 544 is in.
+  if [ "$n" = "544" ]; then :; fi
+  echo "== #$n: update branch"
+  if ! gh pr update-branch "$n" --repo "$REPO" >/dev/null 2>&1; then
+    m=$(gh pr view "$n" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)
+    if [ "$m" = "DIRTY" ]; then echo "STOP #$n: merge conflict with main; resolve locally, push, re-run from #$n"; exit 1; fi
+    echo "   (already up to date or nothing to do: $m)"
+  fi
+  sleep 60
+  echo "== #$n: waiting for checks"
+  failed=$(wait_checks "$n")
+  if [ -n "$failed" ]; then echo "STOP #$n: red checks: $failed"; exit 1; fi
+  if [ "$REQUIRE_REVIEW_LABEL" = "1" ]; then
+    labels=$(gh pr view "$n" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+    case "$labels" in *claude:approve*) ;; *) echo "STOP #$n: review verdict after update is '$labels'"; exit 1 ;; esac
+  fi
+  echo "== #$n: merge"
+  if ! gh pr merge "$n" --repo "$REPO" --squash --delete-branch; then
+    echo "STOP #$n: merge refused: $(gh pr view "$n" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)"; exit 1
+  fi
+  if [ "$n" = "544" ]; then
+    gh pr close 551 --repo "$REPO" --comment "Subsumed by #544, which carries the identical fast-uri bump." || true
+    gh pr close 552 --repo "$REPO" --comment "Subsumed by #544, which carries the identical qs bump." || true
+  fi
+  if [ "$n" = "582" ]; then echo "(if #582 was DIRTY: comment '@dependabot rebase' and re-run 582)"; fi
+done
+echo "queue done: $(gh pr list --repo "$REPO" --state open --json number --jq 'length') still open"
+```

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -69,6 +69,15 @@ the partner lands, running the suite, and pushing:
 9. #642, then #643 last so the new reviewer does not fire on every
    update-branch of the queue.
 
+## If auto-merge is already armed
+
+Arming auto-merge on every change does not move the queue by itself: GitHub
+does not bring a branch up to date, and a branch that is behind cannot
+merge. The steps above still apply; the script only notices that the merge
+has already happened when the checks pass and moves on. On 2026-09-05 the
+owner armed forty-four changes and merged six by hand; from there the queue
+was walked exactly this way, one update-branch at a time.
+
 ## The script
 
 Run from the repository root as a maintainer. It walks the order above,
@@ -132,7 +141,7 @@ for n in $ORDER; do
        fi ;;
   esac
   if [ -n "$(gh pr view "$n" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest // empty')" ]; then
-    echo "STOP #$n: auto-merge is already armed; disarm or let it fire, then re-run"; exit 1
+    echo "   (auto-merge is armed; it will fire when the checks pass, and this script will not merge twice)"
   fi
   # 551 and 552 are byte-identical subsets of 544; close them once 544 is in.
   if [ "$n" = "544" ]; then :; fi
@@ -150,6 +159,8 @@ for n in $ORDER; do
     labels=$(gh pr view "$n" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
     case "$labels" in *claude:approve*) ;; *) echo "STOP #$n: review verdict after update is '$labels'"; exit 1 ;; esac
   fi
+  # An armed auto-merge fires the moment the checks above pass; treat that as done.
+  if [ "$(gh pr view "$n" --repo "$REPO" --json state --jq .state)" = "MERGED" ]; then echo "== #$n: merged by auto-merge"; continue; fi
   m=$(gh pr view "$n" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)
   if [ "$m" = "BEHIND" ]; then echo "STOP #$n: main moved under this PR (BEHIND); re-run from #$n"; exit 1; fi
   echo "== #$n: merge ($m)"

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -69,6 +69,25 @@ the partner lands, running the suite, and pushing:
 9. #642, then #643 last so the new reviewer does not fire on every
    update-branch of the queue.
 
+## Stacked changes after their base squash-merges
+
+When a base merges by squash and its branch is deleted, GitHub retargets
+the change stacked on it to `main`, and that change is then dirty: its
+branch still carries the base's original commits, which `main` holds only
+as one squashed commit, so a merge conflicts on every region the base
+touched. Do not resolve that merge by hand. Replay only the stacked
+change's own commits:
+
+```zsh
+FORK=$(git merge-base <last commit of the base branch> origin/<stacked branch>)
+git rebase --onto origin/main "$FORK"
+git push --force-with-lease origin HEAD:<stacked branch>
+```
+
+Measured on #579 (2026-09-05): the merge showed eleven conflict hunks in
+three files; the rebase replayed six commits with none. A stacked change
+carries no auto-merge, so merge it yourself once its checks pass.
+
 ## If auto-merge is already armed
 
 Arming auto-merge on every change does not move the queue by itself: GitHub

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -94,16 +94,28 @@ ORDER=(
 )
 if [ $# -gt 0 ]; then ORDER=("$@"); fi
 
+# The eight contexts branch protection requires. A fresh head has none of
+# them for a moment after update-branch, so "no pending checks" is not
+# "all checks passed"; wait until every required context is present.
+REQUIRED=(claude-standards-review python-tests node-tests postgres-tests lint secret-scan dependency-audit compliance-gates)
+
 wait_checks() {
-  # Poll until every check on the PR has a conclusion; print the failures.
-  local n=$1
+  # Wait until every required context exists and has a conclusion, then print
+  # the names of any that did not succeed. Gives up after 40 minutes.
+  local n=$1 i=0
   while true; do
-    local pending
-    pending=$(gh pr checks "$n" --repo "$REPO" --json state --jq '[.[] | select(.state=="PENDING" or .state=="QUEUED" or .state=="IN_PROGRESS")] | length')
-    [ "$pending" = "0" ] && break
+    local json missing pending
+    json=$(gh pr checks "$n" --repo "$REPO" --json name,state 2>/dev/null || echo '[]')
+    missing=0
+    for c in $REQUIRED; do
+      printf '%s' "$json" | jq -e --arg c "$c" 'map(select(.name==$c)) | length > 0' >/dev/null || missing=$((missing+1))
+    done
+    pending=$(printf '%s' "$json" | jq '[.[] | select(.state=="PENDING" or .state=="QUEUED" or .state=="IN_PROGRESS")] | length')
+    if [ "$missing" = "0" ] && [ "$pending" = "0" ]; then break; fi
+    i=$((i+1)); if [ $i -gt 53 ]; then echo "timeout waiting for checks ($missing missing, $pending pending)"; return; fi
     sleep 45
   done
-  gh pr checks "$n" --repo "$REPO" --json name,state --jq '.[] | select(.state=="FAILURE" or .state=="ERROR" or .state=="CANCELLED") | .name'
+  printf '%s' "$json" | jq -r --argjson req "$(printf '%s\n' $REQUIRED | jq -R . | jq -s .)" '.[] | select((.name as $x | $req | index($x)) and .state != "SUCCESS") | .name'
 }
 
 for n in $ORDER; do
@@ -138,7 +150,9 @@ for n in $ORDER; do
     labels=$(gh pr view "$n" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
     case "$labels" in *claude:approve*) ;; *) echo "STOP #$n: review verdict after update is '$labels'"; exit 1 ;; esac
   fi
-  echo "== #$n: merge"
+  m=$(gh pr view "$n" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)
+  if [ "$m" = "BEHIND" ]; then echo "STOP #$n: main moved under this PR (BEHIND); re-run from #$n"; exit 1; fi
+  echo "== #$n: merge ($m)"
   if ! gh pr merge "$n" --repo "$REPO" --squash --delete-branch; then
     echo "STOP #$n: merge refused: $(gh pr view "$n" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)"; exit 1
   fi

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -92,7 +92,18 @@ on a conflict, `HEAD` is the base you rebased onto, and a force-push at
 that moment replaces the branch with `main`'s tip. GitHub then closes
 the pull request as already merged, and it has to be reopened once the
 real commits are pushed back. This happened on #598 (2026-09-05).
-Rebase, look at `git status`, resolve, run the tests, and only then push. A stacked change
+Rebase, look at `git status`, resolve, run the tests, and only then push.
+
+Two more, both paid for on 2026-09-05:
+
+- Never write `pytest ... | tail -1 && git push`. The `&&` sees `tail`'s
+  exit code, which is always zero, so a red suite pushes. Redirect the
+  output to a file and test `$?` (#584 went out with two failures this
+  way; nothing merged, because CI was red, but it cost a run).
+- When a change adds the test for a shape that the *next* change in its
+  chain fixes, the two cannot land separately: the first is red alone.
+  Fold the fix's commits onto the first change's branch and let the
+  second close itself with an empty diff (#584 and #594). A stacked change
 carries no auto-merge, so merge it yourself once its checks pass.
 
 ## If auto-merge is already armed

--- a/docs/runbooks/merge-the-queue.md
+++ b/docs/runbooks/merge-the-queue.md
@@ -85,7 +85,14 @@ git push --force-with-lease origin HEAD:<stacked branch>
 ```
 
 Measured on #579 (2026-09-05): the merge showed eleven conflict hunks in
-three files; the rebase replayed six commits with none. A stacked change
+three files; the rebase replayed six commits with none.
+
+Never chain the rebase and the push in one command. If the rebase stops
+on a conflict, `HEAD` is the base you rebased onto, and a force-push at
+that moment replaces the branch with `main`'s tip. GitHub then closes
+the pull request as already merged, and it has to be reopened once the
+real commits are pushed back. This happened on #598 (2026-09-05).
+Rebase, look at `git status`, resolve, run the tests, and only then push. A stacked change
 carries no auto-merge, so merge it yourself once its checks pass.
 
 ## If auto-merge is already armed


### PR DESCRIPTION
## What

**Three diagrams** in `docs/design/diagrams/`, self-contained HTML with inline SVG, drawn to the [diagram-design](https://github.com/cathrynlavery/diagram-design) conventions in the site's own skin (`static/css/healthclaw.css` tokens, Archivo and Fragment Mono):

| File | Shows |
|---|---|
| `architecture.html` | The guardrail boundary. Every surface reaches the record through one kernel; reads leave through redaction; only a person reaches the human gate. |
| `journey.html` | One person's first session on CareAgents, five stages, sentiment trough at connecting real records, two frictions named. |
| `deployment.html` | Where each piece runs: three Railway services and a Postgres, the token-locked MCP server as the focal piece, two self-hosted gateways, the CareAgents build that deploys by hand. |

Each passed `scripts/verify-geometry.py` from the diagram-design checkout with zero findings.

**One document**, `docs/2026-09-05-where-to-post-the-launch.md`: the cut of the [PlacesToPostYourStartup](https://github.com/mmccaff/PlacesToPostYourStartup) list that fits what we are. Two gates (real-record beta closed until #168; directory listings blocked on two human actions) and the one-post-per-day rule come first, then three tiers, then everything set aside with the reason.

`.gitignore` gains `graphify-out/` so a local code graph never lands in a commit.

## What this is not

No production code. No test changes. The deployment diagram omits the Vercel demo copy and draws no path from the VPS because none is verified; the note under the diagram says so.

## Verification

Diagrams: `python3 scripts/verify-geometry.py <file>` from a diagram-design checkout, three files, zero findings. Rendered and inspected in a browser at 1280px.

Document: every cited repository path exists (`docs/2026-08-16-tester-program.md`); the contribution plan it mentions is kept outside the public repository and is not cited by path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)