### PR TITLE
candidate: the approve reply no longer claims an outcome it cannot know (#645)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -678,7 +678,13 @@ def create_app(config: Config | None = None,
     @login_required
     def chat():
         acct = current_account()
-        agent_id = request.args.get("agent", "")
+        # #645: a tester who typed `agent_id` (the name every JSON-body
+        # endpoint in this file uses — /api/agents, /api/chat, /api/form)
+        # got a silent redirect to /home with no error. `agent` is this
+        # route's actual name (the one internal JS call site that builds
+        # this URL uses it); accept the other spelling too rather than
+        # failing silently on it.
+        agent_id = request.args.get("agent") or request.args.get("agent_id", "")
         ctx = svc.get_agent_context(acct.id, agent_id)
         if not ctx:
             return redirect(url_for("home"))

--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -455,16 +455,26 @@ def review_submit(action_id):
         detail='reviewed via review-page; qr=%s' % qr_row.id,
     )
 
+    # #645: this response used to assert the executor's OUTCOME — "the
+    # form-fill executor currently returns an honest needs_review
+    # placeholder" — as if this handler could see it. It can't: this handler
+    # only stages a confirmation row (issue_confirmation, above); execution
+    # happens on a separate call (r6/actions/routes.py's confirm route),
+    # which this function returns before. A caller reading only this
+    # response has no way to know the true outcome yet, and the old string
+    # was itself only ever a guess — one that outlived being true, so a
+    # tester who generated a real PDF was told nothing had been generated.
+    # Say only what this handler actually knows: the review was recorded.
     from flask import jsonify
     return jsonify({
         'id': action.id,
         'status': action.status,
         'reviewed_qr_id': qr_row.id,
         'approved_via': 'review-page',
-        'next_step': ('Review recorded and approval issued. Form generation '
-                      '(PDF/DocumentReference) is Task 8; the form-fill '
-                      'executor currently returns an honest needs_review '
-                      'placeholder.'),
+        'next_step': ('Review recorded and approval issued. The form is '
+                      'generated once the confirmation above is claimed and '
+                      'executed — check the action\'s own status for the '
+                      'outcome.'),
     }), 200
 
 

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -391,6 +391,42 @@ def test_post_with_nka_affirmed_succeeds(client, app, tenant_headers,
         assert _nka_answer(qr) is True
 
 
+def test_post_next_step_does_not_claim_an_outcome_it_cannot_know(
+        client, app, tenant_headers, auth_headers):
+    """#645: this handler stages a confirmation row (ActionConfirmation) and
+    returns BEFORE the separate confirm/execute call that actually renders
+    the form — so it cannot know, at response time, whether that later call
+    will produce a completed PDF or a needs_review/failed outcome. The old
+    text asserted one specific outcome ("the form-fill executor currently
+    returns an honest needs_review placeholder") — true when written, false
+    once form-fill was actually implemented, and nobody read the string
+    again to notice. Pin the PROPERTY, not a phrase: no wording produced
+    here may name a terminal, verifiable outcome ('completed', 'placeholder',
+    'generated', a task number) as if it already happened.
+
+    MUTATION: restore the deleted 'Task 8'/'placeholder' string -> red.
+    """
+    tenant = tenant_headers['X-Tenant-Id']
+    _seed(app, tenant, [PATIENT, MED_A, MED_B])
+    action_id = _staged_form_fill(client, tenant_headers, auth_headers)
+
+    resp = _post(client, auth_headers, action_id,
+                 {'med-0': 'yes', 'med-1': 'no', 'nka': 'true'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    next_step = resp.get_json()['next_step']
+
+    # This handler DID succeed at what it does — say that plainly.
+    assert 'Review recorded' in next_step
+
+    # It must not assert what only the later execute() call can determine.
+    forbidden = ('Task 8', 'placeholder', 'needs_review', 'completed',
+                'generated.', 'was generated')
+    hits = [w for w in forbidden if w in next_step]
+    assert not hits, (
+        f'next_step claims an outcome this handler cannot know: {hits} '
+        f'in {next_step!r}')
+
+
 def test_post_confirming_real_allergy_succeeds(client, app, tenant_headers,
                                                auth_headers):
     tenant = tenant_headers['X-Tenant-Id']

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -666,6 +666,26 @@ def test_a_chat_turn_is_persisted_to_healthclaw_not_careagents(
     assert stored[1]["content"] == "here you go"
 
 
+def test_chat_route_also_accepts_agent_id_as_the_query_param(cfg, svc,
+                                                              monkeypatch):
+    """#645: every other endpoint in this file names the identifier
+    `agent_id` (/api/agents, /api/chat's JSON body, /api/form). This route
+    alone required the bare name `agent` and silently redirected to /home on
+    the equally-plausible `agent_id` — no error, just a dead end a tester
+    hit. Both spellings must resolve the same agent.
+
+    MUTATION: drop the `or request.args.get("agent_id", "")` fallback ->
+    the `agent_id=` request 302s to /home instead of 200.
+    """
+    app, c, fake, agent_id, tenant, _conn_id = _chat_app(cfg, svc, monkeypatch)
+
+    by_agent = c.get(f"/chat?agent={agent_id}")
+    by_agent_id = c.get(f"/chat?agent_id={agent_id}")
+
+    assert by_agent.status_code == 200
+    assert by_agent_id.status_code == 200
+
+
 def test_a_returning_person_sees_the_conversation_they_had(cfg, svc,
                                                            monkeypatch):
     # The core of #222: process memory is a cache, not the record. Wiping it


### PR DESCRIPTION
## What

A first-time tester submitted the intake-form review and read: "Form generation (PDF/DocumentReference) is Task 8; the form-fill executor currently returns an honest needs_review placeholder." Polling the form's status immediately after showed a real, complete, properly secured `intake.pdf`. Generation worked; the message said it did not.

The message was architecturally unable to be right either way: `r6/actions/review.py`'s `review_submit` only stages an `ActionConfirmation` row and returns — execution happens on a separate call (`r6/actions/routes.py`'s confirm route), after this response is already sent. The old string was a guess about a state that hadn't happened yet, written back when form-fill genuinely returned that placeholder. Nobody re-read it once form-fill was implemented for real, so a true sentence quietly turned false with no test to catch the drift.

Fixed to say only what this handler actually knows (the review was recorded), rather than assert an outcome only the confirm route can determine.

Also fixed, from the same walkthrough: `/chat`'s query parameter was named `agent`, while every other endpoint in this file (`/api/agents`, `/api/chat`, `/api/form`) uses `agent_id` — the equally-plausible wrong name silently redirected home with no error. Now accepts both.

**Left open, not fixed here** (no evidence either way from the one walkthrough that reported them — see #645): the review page renders under "HealthClaw Guardrails" branding mid-flow instead of "CareAgents"; the review-card event's server-sent `review_url` field is unused dead data (harmless — the client discards it and rebuilds the link itself).

## Why

Property protected: a message shown at the moment a patient decides whether to trust an approval must not assert a specific outcome the code path producing it cannot see yet.

## Ran

`tests/actions/test_review_flow.py` — 21 passed. `tests/test_careagents.py` — 204 passed. `ruff check` — clean. `scripts/check_table_stakes.py --base main` — clean.

## Mutation evidence

Restored the old `next_step` string verbatim → the new test's forbidden-phrase check fails, naming exactly the three deleted phrases (`Task 8`, `placeholder`, `needs_review`) as present. Restored the fix, re-ran clean.

Removed the `agent_id` fallback in `/chat` → the new test's second assertion fails (`agent_id=` request returns 302 instead of 200). Restored the fix, re-ran clean.

## What was NOT run

The full `tests/` suite hung on this branch after merging main (something unrelated to this change — an individual small test file completed in under a second both before and after this commit, but the full run stalled at 0% CPU for minutes on multiple attempts, with and without `-k "not prod_watch"`). Not diagnosed further here since it reproduces independent of this diff; the two test files this PR actually touches were run directly and pass. Deferring the full-suite gate to CI's isolated environment.

## Generalization check

No real names, tenant ids, or credentials in this diff or PR body.

## For the owner

Per a note from the session walking the merge queue: every PR in that queue is currently merging with the standards review (`claude-standards-review`) skipped, because `ANTHROPIC_API_KEY` is unset (#608) — the check reports success on a skip rather than a real review. #643 turns on a second reviewer using the same secret. Could this secret be set?

🤖 Generated with [Claude Code](https://claude.com/claude-code)