### PR TITLE
refactor(kernel): slice 7, $curatr-apply-fix gates through require_grant

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -3087,27 +3087,22 @@ def curatr_apply_fix(resource_type, resource_id):
             f'Resource type {resource_type} is not supported'
         ), 400
 
-    tenant_id = tenant_from_request(sources=(TenantSource.HEADER,)).id
-    step_up_token = request.headers.get('X-Step-Up-Token')
-    if not step_up_token:
-        return _operation_outcome(
-            'error', 'security',
-            'Write operations require X-Step-Up-Token header'
-        ), 403
+    tenant = tenant_from_request(sources=(TenantSource.HEADER,))
+    tenant_id = tenant.id
 
     production_approval = resolve_app_env() == 'production'
     operation = f'curatr-apply-fix:{resource_type}/{resource_id}'
-    valid, err = validate_step_up_token(
-        step_up_token,
-        tenant_id,
-        require_audience='curatr' if production_approval else None,
-        require_operation=operation if production_approval else None,
+    # Kernel slice 7 (spec §2.5): the same two-phase gate, through the
+    # kernel. Phase one checks without spending, so a malformed body below
+    # cannot burn a one-time approval. The 403 dialect this site answers
+    # today is passed through, not normalized. The refusal text changes: the
+    # kernel names the public causes and withholds the rest (#478).
+    require_grant(
+        scope=Scope.WRITE, tenant=tenant,
+        audience='curatr' if production_approval else None,
+        operation=operation if production_approval else None,
+        absent_status=403, rejected_status=403,
     )
-    if not valid:
-        return _operation_outcome(
-            'error', 'security',
-            f'Step-up token rejected: {public_step_up_reason(err)}'
-        ), 403
 
     body = request.get_json(silent=True)
     if not body:
@@ -3124,19 +3119,13 @@ def curatr_apply_fix(resource_type, resource_id):
         ), 400
 
     if production_approval:
-        # Consume only after the request shape is valid so malformed attempts
-        # cannot burn a legitimate one-time approval credential.
-        valid, err = validate_step_up_token(
-            step_up_token,
-            tenant_id,
-            consume_nonce=True,
-            require_audience='curatr',
-            require_operation=operation,
+        # Phase two: consume only after the request shape is valid so
+        # malformed attempts cannot burn a legitimate one-time approval.
+        require_grant(
+            scope=Scope.WRITE, tenant=tenant,
+            audience='curatr', operation=operation, consume_nonce=True,
+            absent_status=403, rejected_status=403,
         )
-        if not valid:
-            return _operation_outcome(
-                'error', 'security',
-                f'Step-up token rejected: {public_step_up_reason(err)}'), 403
 
     try:
         result = _curatr_apply_fix(

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -137,7 +137,10 @@ def _report(sites, pin, what):
 #: behind. It was blocked on whether a refusal may state its reason; the
 #: owner ruled yes (#475), so the three reasons its contract pins survive
 #: the kernel.
-_STEP_UP_CALLSITES = 12
+#: 12 -> 10 (kernel slice 7): $curatr-apply-fix's two-phase gate now goes
+#: through require_grant, both phases. r6/routes.py keeps two direct sites
+#: ($ingest-context at its flag-conditional gate, bind-telegram).
+_STEP_UP_CALLSITES = 10
 
 
 def test_direct_step_up_validation_only_decreases():
@@ -396,7 +399,8 @@ def test_soft_delete_blind_query_files_only_decrease():
 #: 3927 -> 3928 (#583): one entry in the tenant-exemption table for the
 #: published privacy policy (#574). The table is the guard, so the line
 #: has to sit here; nothing else in that change touches this file.
-_GOD_MODULE_LINES = 3928
+#: 3928 -> 3917 (kernel slice 7): eleven lines of hand-rolled gate removed.
+_GOD_MODULE_LINES = 3917
 
 
 def test_the_god_module_only_shrinks():

--- a/tests/test_step_up_refuses_a_non_ascii_token.py
+++ b/tests/test_step_up_refuses_a_non_ascii_token.py
@@ -143,6 +143,13 @@ ROWS = [
     # assert sameness rather than 401.
     Row('wearables-sync-now', 'r6/wearables/routes.py:sync_now',
         'POST', '/wearables/sync-now', 403, body={}),
+    # Kernel slice 7. The 403 dialect again; phase one of the two-phase gate
+    # answers before the body is read, so the id need not exist.
+    Row('curatr-apply-fix', 'r6/routes.py:curatr_apply_fix',
+        'POST', '/r6/fhir/Condition/no-such-condition/$curatr-apply-fix', 403,
+        body={'fixes': [{'field_path': 'Condition.code.coding[0].code',
+                         'new_value': 'E11.9'}]},
+        headers=_HUMAN_CONFIRMED),
 ]
 
 


### PR DESCRIPTION
## What

One guard, one blueprint, one PR (`docs/2026-08-03-refactor-working-protocol.md`). The hand-rolled step-up gate in `curatr_apply_fix` (absent-token check, first `validate_step_up_token`, second consuming `validate_step_up_token`) becomes two `require_grant` calls with the same shape:

- **Phase one** checks the audience and operation binding (production only) without spending the nonce.
- **Phase two** consumes it only after the body has parsed and the fixes list is non-empty, so a malformed request cannot burn a one-time approval.

The 403 dialect this site answers is passed through as `absent_status`/`rejected_status`, not normalized. This is kernel spec §2.5, slice 7, the curatr half; `$ingest-context` stays for its own PR because its refusal writes an audit row the kernel does not yet write, and that is a decision, not a move.

## What changes on the wire

Only the refusal diagnostics. The old site echoed `public_step_up_reason(err)` behind "Step-up token rejected:". The kernel renders the same public reasons ("Token audience mismatch", "Token already used (replay)") in its uniform OperationOutcome. The production tests pin exactly those words; no test pinned the old sentence.

## Evidence

| Check | Result |
|---|---|
| `tests/test_curatr.py`, write-guard matrix, conformance, ratchets, access kernel | 359 passed |
| Mutation A: delete phase two | `test_production_requires_operation_bound_single_use_approval` fails (replay accepted) |
| Mutation B: delete phase one | `test_apply_fix_requires_step_up` fails (no token accepted) |
| Full suite on the migration commit | 3655 passed, 1 failed: the non-ASCII census (#597) refusing a new `require_grant` site without a row |
| After adding curatr's census row (403, same body ASCII or not) | census + curatr files: 56 passed |

Ratchets moved by exactly what this removes: direct step-up validation sites 12 → 10, `r6/routes.py` 3928 → 3917 lines. Grade A unchanged.

## Not in this PR

- `$ingest-context` (`r6/routes.py:1248`): its refusal records an AuditEvent, pinned by `tests/test_ingest_auth.py`; the kernel's refusal path does not audit. Migrating it means deciding where that audit lives.
- `bind-telegram` (`r6/routes.py:2186`): no matrix row; needs a characterization test first (protocol rule 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)