### PR TITLE
refactor(kernel): slice 7c, bind-telegram gates through require_grant (stacked on #647)

### DIFF
--- a/r6/routes.py
+++ b/r6/routes.py
@@ -37,8 +37,8 @@ from r6.validator import R6Validator
 from r6.audit import add_audit_event, record_audit_event
 from r6.redaction import apply_patient_controlled_redaction
 from r6.redaction import apply_redaction
-from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
-                       public_step_up_reason, tenant_from_request)
+from r6.access import (Scope, Tenant, TenantRejected, TenantSource,
+                       require_grant, tenant_from_request)
 from r6.stepup import validate_step_up_token, generate_step_up_token
 from r6.oauth import register_oauth_routes
 from r6.read_auth import (
@@ -2168,8 +2168,6 @@ def bind_telegram_chat():
     tenant_id = (body.get('tenant_id') or '').strip()
     chat_id_raw = body.get('chat_id')
     username = (body.get('username') or '').strip() or None
-    token = (body.get('step_up_token')
-             or request.headers.get('X-Step-Up-Token', '')).strip()
 
     if not tenant_id or chat_id_raw is None:
         return jsonify({'error': 'tenant_id and chat_id are required'}), 400
@@ -2180,12 +2178,13 @@ def bind_telegram_chat():
     if not _TENANT_ID_PATTERN.fullmatch(tenant_id):
         return jsonify({'error': 'invalid tenant_id format'}), 400
 
-    from r6.stepup import validate_step_up_token
-    if not token:
-        return jsonify({'error': 'valid step-up token required'}), 401
-    valid, err = validate_step_up_token(token, tenant_id)
-    if not valid:
-        return jsonify({'error': public_step_up_reason(err)}), 401
+    # Kernel slice 7c: the body tenant (validated above, as the matrix row
+    # says) is bound to the grant; the token may come from body or header.
+    # The refusal is now an OperationOutcome; no caller reads that body.
+    require_grant(scope=Scope.WRITE,
+                  tenant=Tenant(id=tenant_id, source=TenantSource.BODY),
+                  also_body_field='step_up_token',
+                  absent_status=401, rejected_status=401)
 
     from r6.telegram_push import bind as bind_chat
     try:

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -140,7 +140,10 @@ def _report(sites, pin, what):
 #: 12 -> 10 (kernel slice 7): $curatr-apply-fix's two-phase gate now goes
 #: through require_grant, both phases. r6/routes.py keeps two direct sites
 #: ($ingest-context at its flag-conditional gate, bind-telegram).
-_STEP_UP_CALLSITES = 10
+#: 10 -> 9 (kernel slice 7c): bind-telegram, the body-tenant site, through
+#: require_grant with also_body_field. One direct site left in r6/routes.py:
+#: $ingest-context, waiting on #648.
+_STEP_UP_CALLSITES = 9
 
 
 def test_direct_step_up_validation_only_decreases():
@@ -400,7 +403,8 @@ def test_soft_delete_blind_query_files_only_decrease():
 #: published privacy policy (#574). The table is the guard, so the line
 #: has to sit here; nothing else in that change touches this file.
 #: 3928 -> 3917 (kernel slice 7): eleven lines of hand-rolled gate removed.
-_GOD_MODULE_LINES = 3917
+#: 3917 -> 3916 (kernel slice 7c).
+_GOD_MODULE_LINES = 3916
 
 
 def test_the_god_module_only_shrinks():

--- a/tests/test_step_up_refuses_a_non_ascii_token.py
+++ b/tests/test_step_up_refuses_a_non_ascii_token.py
@@ -150,6 +150,11 @@ ROWS = [
         body={'fixes': [{'field_path': 'Condition.code.coding[0].code',
                          'new_value': 'E11.9'}]},
         headers=_HUMAN_CONFIRMED),
+    # Kernel slice 7c. The tenant travels in the body; the token may too, but
+    # the census sends it in the header, which the kernel reads first.
+    Row('internal-bind-telegram', 'r6/routes.py:bind_telegram_chat',
+        'POST', '/r6/fhir/internal/bind-telegram', 401,
+        body={'tenant_id': 'test-tenant', 'chat_id': 4242}),
 ]
 
 


### PR DESCRIPTION
## What

Stacked on #647 because both move the step-up ratchet pin; merge #647 first, then this retargets to `main` (rebase from the fork point, per `docs/runbooks/merge-the-queue.md`).

One guard, one blueprint, one PR. `bind_telegram_chat` keeps its own input validation and every 400 it answers today; only the token check moves. The tenant is read from the body by design (matrix row `internal-bind-telegram`, `tenant_from_body=True`), validated by the handler, and handed to the kernel as `Tenant(id, TenantSource.BODY)` so the grant is bound to it. The token may still arrive in the body (`also_body_field='step_up_token'`) or the header.

## What changes on the wire

The two refusals (no token; a token for another tenant) answer the kernel's OperationOutcome at the same 401 instead of `{"error": ...}`. Neither caller reads that body: `openclaw/bot.py` checks the status and `careagents/healthclaw.py` returns a boolean. `tests/test_telegram_connect_flow.py` pins the statuses, not the body. One edge no test pins: when both a body token and a header token are present, the kernel reads the header first; the old code read the body first.

The dead local token read and the now-unused `public_step_up_reason` import go with it (protocol rule 8).

## Evidence

| Check | Result |
|---|---|
| Telegram flow, write-guard matrix, ratchets, non-ASCII census, conformance, access kernel | 359 passed |
| Mutation: delete the `require_grant` call | `test_rejects_missing_step_up` and `test_rejects_cross_tenant_step_up` both fail |
| Full suite on the commit | 3658 passed, 13 skipped, 1 xfailed |

Ratchets: direct step-up sites 10 → 9, `r6/routes.py` 3917 → 3916 lines. After this, the god module holds one direct gate, `$ingest-context`, which waits on the decision in #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)