### PR TITLE
refactor(kernel): slice 16, agent_runs' session-or-token predicate asks has_grant (stacked on #649)

### DIFF
--- a/r6/agent_runs/routes.py
+++ b/r6/agent_runs/routes.py
@@ -32,7 +32,7 @@ from r6.agent_runs.service import (
 from r6.agent_runs.state import InvalidTransition
 from r6.command_center.models import ConversationMessage
 from r6.read_auth import TENANT_SESSION_KEY
-from r6.stepup import validate_step_up_token
+from r6.access import Scope, Tenant, TenantSource, has_grant
 
 
 agent_runs_blueprint = Blueprint(
@@ -52,19 +52,16 @@ _MAX_EVENT_PAYLOAD_BYTES = 256 * 1024
 def _tenant_authorized(tenant_id: str) -> bool:
     if session.get(TENANT_SESSION_KEY) == tenant_id:
         return True
-    token = request.headers.get("X-Step-Up-Token", "")
-    if not token:
-        return False
-    # Destructure both halves (#307). `[0]` returned the correct boolean, but
-    # it sits one keystroke from `if validate_step_up_token(...)`, which is a
-    # silent auth bypass because a 2-tuple is always truthy — including
-    # `(False, 'expired')`. The reason is the other half of the fix: a refusal
-    # nobody can name is a refusal nobody can diagnose.
-    valid, error = validate_step_up_token(token, tenant_id)
-    if not valid:
-        logger.info("agent-runs step-up refused: tenant=%s reason=%s",
-                    tenant_id, error)
-    return valid
+    # Kernel slice 16 (spec §2.5b): the token branch of this predicate asks
+    # the kernel. has_grant returns the Grant or None and never raises, so the
+    # session-or-token shape and every JSON 401 below are unchanged. The
+    # kernel logs each refusal with its public reason ("step-up refused for
+    # tenant ..."), which is the line #307 asked for, so this site no longer
+    # logs one of its own. The id was chosen by the caller (body or header on
+    # create, the run row elsewhere); the grant is bound to it either way.
+    return has_grant(scope=Scope.WRITE,
+                     tenant=Tenant(id=tenant_id, source=TenantSource.DEFAULT),
+                     ) is not None
 
 
 def _internal_authorized() -> bool:

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -731,7 +731,9 @@ def test_a_grant_is_constructed_in_exactly_one_place():
 #: adopted by nothing, exactly as the kernel itself landed. A migration slice
 #: adds its site here in the same PR that writes it — adoption is a reviewable
 #: list, not a thing that happens quietly.
-_HAS_GRANT_CALLSITES: frozenset[str] = frozenset()
+#: Kernel slice 16: r6/agent_runs/routes.py:_tenant_authorized, the
+#: session-or-token predicate. Its answer is returned, never discarded.
+_HAS_GRANT_CALLSITES: frozenset[str] = frozenset({'r6/agent_runs/routes.py:62'})
 
 
 def _has_grant_calls():
@@ -751,7 +753,7 @@ def _has_grant_calls():
                        node.lineno in discarded)
 
 
-def test_has_grant_is_adopted_by_nothing_yet():
+def test_has_grant_is_adopted_only_where_listed():
     """MUTATION: call has_grant from any production module -> red."""
     sites = sorted(site for site, _ in _has_grant_calls())
     unexpected = [s for s in sites if s not in _HAS_GRANT_CALLSITES]
@@ -1435,7 +1437,10 @@ _ADOPTION_ALLOWED = {'main.py', 'r6/smbp/routes.py', 'r6/shc/routes.py',
                      # these functions owns its own transaction, and the
                      # kernel's audit() only keeps its promise when it flushes
                      # inside the transaction it is evidence for.
-                     'r6/agent_runs/service.py'}
+                     'r6/agent_runs/service.py',
+                     # Kernel slice 16: the session-or-token predicate
+                     # asks has_grant; its four JSON 401s are unchanged.
+                     'r6/agent_runs/routes.py'}
 
 
 def test_no_request_handler_has_adopted_the_kernel():

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -143,7 +143,9 @@ def _report(sites, pin, what):
 #: 10 -> 9 (kernel slice 7c): bind-telegram, the body-tenant site, through
 #: require_grant with also_body_field. One direct site left in r6/routes.py:
 #: $ingest-context, waiting on #648.
-_STEP_UP_CALLSITES = 9
+#: 9 -> 8 (kernel slice 16): agent_runs' session-or-token predicate asks
+#: has_grant; no direct validator call is left in r6/agent_runs/.
+_STEP_UP_CALLSITES = 8
 
 
 def test_direct_step_up_validation_only_decreases():


### PR DESCRIPTION
## What

Stacked on #649 (which is stacked on #647); merge in that order and each retargets by rebase from its fork point.

The first adoption of the kernel's non-raising half. The token branch of `_tenant_authorized` in `r6/agent_runs/routes.py` called `validate_step_up_token` and logged the refusal itself. It now asks `has_grant(scope=Scope.WRITE, tenant=Tenant(id, TenantSource.DEFAULT))`, which returns the Grant or `None` and never raises, so the predicate's shape, the session branch and the four JSON 401s it guards are unchanged. Kernel spec §2.5b, slice 16.

The site's own log line goes: the kernel's `_evaluate` logs every refusal as `step-up refused for tenant ...: <public reason>`, which is the line #307 asked for, and the spec says one log, not two. `tests/test_agent_runs.py::test_a_refused_step_up_names_its_reason` still holds, on the kernel's line.

The tenant source is `DEFAULT` because the id is chosen by the caller (body or header on create, the run row elsewhere) and the predicate takes a string; the grant is bound to that id either way. A source that names "the record" does not exist in the kernel today; adding one is a kernel change and belongs in its own PR if wanted.

## Evidence

| Check | Result |
|---|---|
| agent runs, access kernel, ratchets, agent-run audit, write-guard matrix | 345 passed |
| Mutation: the predicate returns `True` without asking | the cross-tenant 401 test fails |
| Full suite on the commit | 3658 passed, 13 skipped, 1 xfailed |

The call site is listed in `_HAS_GRANT_CALLSITES` and the module in the kernel-adopter set, as the two adoption tests require. Ratchet: direct step-up sites 9 → 8; `r6/agent_runs/` now has no direct validator call. After this stack: 8 remain (`$ingest-context` on #648, `command_center` ×3, `sdc`, `rate_limit`, `read_auth`, `actions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)