### PR TITLE
ci(pr-agent): the job condition named an event the workflow no longer listens for

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,7 +48,7 @@ jobs:
     if: >-
       github.event.sender.type != 'Bot' &&
       (
-        (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+        (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/'))
       )
     runs-on: ubuntu-latest

--- a/docs/agent-task-guide.md
+++ b/docs/agent-task-guide.md
@@ -223,6 +223,15 @@ auditor.
   CodeQL here is GitHub default setup, which runs only against the default
   branch, so even once #588 has landed a stacked pull request gets 15 checks
   where one into `main` gets 19. Count the checks on a stacked pull request; don't read the tick.
+- **A `pull_request_target` fix cannot show on its own pull request.** That
+  event runs the base branch's copy of the workflow, never the PR's. #643
+  moved the second reviewer's trigger to `pull_request_target` and left its
+  job condition on `pull_request`. The job skipped itself on every pull
+  request, and a skipped job reads as green in a check list. #651 fixed the
+  token, and its own run was still decided by main's broken file. Verify such
+  a fix on the first pull-request event after it merges, not before. The
+  property is pinned: `tests/test_ci_hardening.py` refuses a job condition
+  that names an event its workflow never listens for.
 
 ---
 

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -183,3 +183,39 @@ def test_nothing_that_runs_on_a_pull_request_can_write_anything():
     # The loop above is vacuous if it matched nothing, and a workflow file
     # renamed out of the glob would make it so silently.
     assert sorted(checked) == ["ci.yml", "security-baseline.yml"], checked
+
+
+def test_every_event_a_job_condition_names_is_one_the_workflow_listens_for():
+    """A job whose `if:` tests `github.event_name == 'x'` while the workflow
+    never triggers on `x` can never run; it is skipped before its first step,
+    and a skipped job reads as green in a check list. That is how #643 shipped
+    with a reviewer that never reviewed: the trigger moved to
+    pull_request_target and the condition still said pull_request.
+
+    MUTATION: put `github.event_name == 'pull_request'` back into
+    pr-agent.yml's job `if:` -> red naming the workflow, the job and the event.
+    """
+    import re
+    workflow_dir = ROOT / ".github" / "workflows"
+    checked = 0
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        workflow = yaml.safe_load(path.read_text())
+        triggers = workflow.get(True) or workflow.get("on")
+        if isinstance(triggers, str):
+            triggers = [triggers]
+        if isinstance(triggers, list):
+            triggers = dict.fromkeys(triggers)
+        listens_for = set(triggers or {})
+        for job_name, job in workflow["jobs"].items():
+            condition = job.get("if")
+            if not isinstance(condition, str):
+                continue
+            named = set(re.findall(r"github\.event_name\s*==\s*'([a-z_]+)'", condition))
+            for event in sorted(named):
+                checked += 1
+                assert event in listens_for, (
+                    f"{path.name} job {job_name!r} runs only on "
+                    f"github.event_name == {event!r}, but the workflow never "
+                    f"triggers on {event!r} (it listens for "
+                    f"{sorted(listens_for)}); the job can never run")
+    assert checked >= 1, "no job condition names an event; the scan is broken"


### PR DESCRIPTION
## What

#643 moved the trigger to `pull_request_target` and left the job's `if:` on `github.event_name == 'pull_request'`. On every pull request the job was skipped before its first step, so the check list showed `SKIPPED pr-agent` (#650 was the first to show it) and the second reviewer never ran. One token fixes it.

## The guard

`tests/test_ci_hardening.py` gains a rule: every event a job condition names must be one its workflow triggers on. A skipped job reads as green in a check list, which is how this shipped. Mutation: naming `pull_request` again goes red with the workflow, job and event in the message.

## Why this PR's own check still says SKIPPED

A `pull_request_target` workflow runs the **base branch's** copy of the file, never the PR's. So the run on this PR (event `pull_request_target`, run 34016169037) was decided by main's broken condition and skipped again. The fix shows on the first pull-request event after it merges; the test above is the proof available before then. The secret (#608) is still the owner's, so the first post-merge run will show SUCCESS with the "key not set" warning rather than a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)