### PR TITLE
refactor(kernel): slice 17, the actions status route's privileged-view predicate asks has_grant

### DIFF
--- a/r6/actions/routes.py
+++ b/r6/actions/routes.py
@@ -25,8 +25,8 @@ from flask import Blueprint, jsonify, request
 
 from models import db
 from r6 import constant_time
-from r6.access import (Scope, TenantRejected, TenantSource, require_grant,
-                       tenant_from_request)
+from r6.access import (Scope, TenantRejected, TenantSource, has_grant,
+                       require_grant, tenant_from_request)
 from r6.actions import errors
 from r6.actions.confirmations import (ACTION_APPROVAL_AUDIENCE,
                                       APPROVED_VIA_VALUES,
@@ -40,7 +40,7 @@ from r6.actions.state import transition_action
 from r6.audit import record_audit_event
 from r6.rate_limit import rate_limit_middleware
 from r6.read_auth import authorize_tenant_read
-from r6.stepup import generate_step_up_token, validate_step_up_token
+from r6.stepup import generate_step_up_token
 from r6.telegram_push import notify_tenant
 from r6.body_guard import json_body_within_depth
 
@@ -706,12 +706,12 @@ def action_status(action_id):
 
     # Only a caller holding a valid tenant-bound step-up token gets the full
     # record (phone number + message body). Everyone else gets the PHI-safe
-    # summary (id/kind/recipient-label/status).
-    step_up = request.headers.get('X-Step-Up-Token')
-    privileged = False
-    if step_up:
-        valid, _err = validate_step_up_token(step_up, tenant_id)
-        privileged = valid
+    # summary (id/kind/recipient-label/status). Kernel slice 17: this is a
+    # predicate, not a gate, so it asks has_grant, which answers None in
+    # exactly the cases require_grant would refuse (absent, malformed,
+    # expired, another tenant's token) and never raises. The grant is bound
+    # to the header tenant the kernel already validated above.
+    privileged = has_grant(scope=Scope.TENANT_BOUND, tenant=tenant) is not None
     return jsonify(action.to_dict() if privileged else action.summary()), 200
 
 

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -733,7 +733,11 @@ def test_a_grant_is_constructed_in_exactly_one_place():
 #: list, not a thing that happens quietly.
 #: Kernel slice 16: r6/agent_runs/routes.py:_tenant_authorized, the
 #: session-or-token predicate. Its answer is returned, never discarded.
-_HAS_GRANT_CALLSITES: frozenset[str] = frozenset({'r6/agent_runs/routes.py:62'})
+#: Kernel slice 17: r6/actions/routes.py:action_status, the privileged-view
+#: predicate (full record with a tenant-bound grant, PHI-safe summary
+#: without one). A predicate, never a gate, so it asks rather than refuses.
+_HAS_GRANT_CALLSITES: frozenset[str] = frozenset({'r6/agent_runs/routes.py:62',
+                                                  'r6/actions/routes.py:714'})
 
 
 def _has_grant_calls():

--- a/tests/test_actions_routes.py
+++ b/tests/test_actions_routes.py
@@ -147,9 +147,10 @@ def test_status_hides_payload_with_a_malformed_step_up_token(client,
     presence stayed green. Presenting a garbage token is the only way to
     tell "a valid token" from "a token".
 
-    MUTATION: r6/actions/routes.py, `privileged = valid` ->
-    `privileged = bool(step_up)` (equivalently, collapse the three-line
-    check to `privileged = bool(step_up)`) -> red. Executed 2026-09-04.
+    MUTATION: r6/actions/routes.py, the has_grant predicate ->
+    `privileged = bool(request.headers.get('X-Step-Up-Token'))` -> red.
+    Executed 2026-09-04 against the pre-kernel shape (`privileged = valid` ->
+    `privileged = bool(step_up)`) and again 2026-09-06 for kernel slice 17.
     """
     action_id = _propose(client, tenant_headers)
     headers = dict(tenant_headers)

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -145,7 +145,7 @@ def _report(sites, pin, what):
 #: $ingest-context, waiting on #648.
 #: 9 -> 8 (kernel slice 16): agent_runs' session-or-token predicate asks
 #: has_grant; no direct validator call is left in r6/agent_runs/.
-_STEP_UP_CALLSITES = 8
+_STEP_UP_CALLSITES = 7
 
 
 def test_direct_step_up_validation_only_decreases():


### PR DESCRIPTION
## One guard, one blueprint, one PR

`r6/actions/routes.py:action_status` decided between the full record and the PHI-safe summary by reading `X-Step-Up-Token` and calling `validate_step_up_token` itself. It is a predicate, not a gate: nothing is refused, so it now asks `has_grant`, which answers `None` in exactly the cases `require_grant` would refuse (absent, malformed, expired, another tenant's token) and never raises. The tenant is the kernel `Tenant` the route already validated from the header, so the binding the existing tests pin is unchanged. `validate_step_up_token` leaves the module's imports. This is the second adoption of the kernel's non-raising half, after #650.

## Evidence

- **Pins were already in place** (`tests/test_actions_routes.py`): with a valid token the payload shows; without one, with a malformed token, or with another tenant's well-formed token, the summary shows. No test moved; only the mutation note was updated to the new shape.
- **Mutation, executed 2026-09-06:** replace the predicate with a header-presence check. Two tests red (malformed token, other tenant's token), the rest green. Replacement count asserted at 1.
- **Ratchet:** step-up sites 8 to 7. The god module is untouched (this is the actions blueprint).
- **Allowlist:** `_HAS_GRANT_CALLSITES` gains `r6/actions/routes.py:714`; `test_has_grant_is_adopted_only_where_listed` passes.
- **Full suite** on the pre-rebase head: 3660 passed, 13 skipped, 1 xfailed. Pinned set green again after the rebase onto main.
- **Grade A** (`tests/test_guardrail_conformance.py`) unchanged.

## What this leaves

Direct sites remaining after this lands: `command_center/routes.py` (three: one predicate at :272, two gates), `rate_limit.py` (last, by design), `read_auth.py` (widest), `sdc/routes.py` (CTO ruling on the dry-run message), `routes.py` (`$ingest-context`, blocked on #648, and :2186). Each is its own PR, branched from main once this is in.

Refactor protocol: `docs/2026-08-03-refactor-working-protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)