### PR TITLE
refactor(kernel): slice 18, the command-center session-or-token predicate asks has_grant

### DIFF
--- a/r6/command_center/routes.py
+++ b/r6/command_center/routes.py
@@ -44,7 +44,8 @@ from r6.command_center.models import (
     default_conversation_id,
 )
 from r6.command_center.agents import load_agents, load_agent_templates, get_agent
-from r6.access import public_step_up_reason
+from r6.access import (Scope, TenantRejected, TenantSource, has_grant,
+                       public_step_up_reason, tenant_from_request)
 from r6.read_auth import TENANT_SESSION_KEY, authorize_tenant_read
 from r6.stepup import validate_step_up_token
 
@@ -258,22 +259,24 @@ def _require_session_or_stepup():
     """System status / sessions-list leak infra URLs — require session or step-up."""
     if session.get(SESSION_KEY):
         return None
-    step_up = request.headers.get("X-Step-Up-Token")
-    if step_up:
-        tenant = (
-            request.args.get("tenant")
-            or request.headers.get("X-Tenant-Id")
-            or DEFAULT_TENANT
-        )
-        # Both halves used, not just destructured (#307). Throwing the reason
-        # away made every refusal here indistinguishable — a misconfigured
-        # STEP_UP_SECRET, an expired token and a token for someone else's
-        # tenant all produced the same silent 401.
-        valid, error = validate_step_up_token(step_up, tenant)
-        if valid:
+    if request.headers.get("X-Step-Up-Token"):
+        # Kernel slice 18: a predicate, not a gate, so it asks has_grant,
+        # which answers None in exactly the cases require_grant would refuse
+        # and never raises; the kernel logs each refusal with its public
+        # reason (the line #307 asked for), so this site no longer logs one
+        # of its own. The tenant is read in the order this predicate always
+        # used (?tenant=, then X-Tenant-Id, then the blueprint default). A
+        # malformed id is not a 400 here: it never was, it was a token that
+        # failed its tenant binding, and it stays the same 401.
+        try:
+            tenant = tenant_from_request(
+                sources=(TenantSource.QUERY, TenantSource.HEADER),
+                default=DEFAULT_TENANT, query_keys=("tenant",))
+        except TenantRejected:
+            tenant = None
+        if tenant is not None and has_grant(
+                scope=Scope.TENANT_BOUND, tenant=tenant) is not None:
             return None
-        logger.info("command-center step-up refused: tenant=%s reason=%s",
-                    tenant, error)
     return jsonify({"error": "authentication required"}), 401
 
 

--- a/tests/test_access_kernel.py
+++ b/tests/test_access_kernel.py
@@ -736,8 +736,12 @@ def test_a_grant_is_constructed_in_exactly_one_place():
 #: Kernel slice 17: r6/actions/routes.py:action_status, the privileged-view
 #: predicate (full record with a tenant-bound grant, PHI-safe summary
 #: without one). A predicate, never a gate, so it asks rather than refuses.
+#: Kernel slice 18: r6/command_center/routes.py:_require_session_or_stepup,
+#: the session-or-token predicate guarding system status and the sessions
+#: list. The tenant is read by the kernel in the order the site always used.
 _HAS_GRANT_CALLSITES: frozenset[str] = frozenset({'r6/agent_runs/routes.py:62',
-                                                  'r6/actions/routes.py:714'})
+                                                  'r6/actions/routes.py:714',
+                                                  'r6/command_center/routes.py:277'})
 
 
 def _has_grant_calls():

--- a/tests/test_command_center.py
+++ b/tests/test_command_center.py
@@ -336,7 +336,8 @@ class TestRestEndpoints:
     # MUTATION (pre-kernel shape): `if valid: return None` -> `return None`
     # (presence check) -> the malformed, other-tenant and default-binding
     # tests go red while the valid-token test stays green. Executed
-    # 2026-09-06.
+    # 2026-09-06. Kernel shape: `has_grant(...) is not None` -> `True`
+    # -> the same three red. Executed 2026-09-06.
 
     def test_api_system_with_a_step_up_token_for_the_named_tenant(self, client):
         from r6.stepup import generate_step_up_token

--- a/tests/test_command_center.py
+++ b/tests/test_command_center.py
@@ -325,6 +325,57 @@ class TestRestEndpoints:
         body = resp.get_json()
         assert body["flask"]["up"] is True
 
+    # The token branch of _require_session_or_stepup, pinned before kernel
+    # slice 18 moves it. The pair above covers header-absent and session; a
+    # predicate that stopped validating and merely checked for the header's
+    # presence stayed green against them. Four facts: a token for the named
+    # tenant is enough, a garbage token is not, another tenant's well-formed
+    # token is not, and with no tenant named the token binds to the
+    # blueprint's default tenant, not to whatever the token says.
+    #
+    # MUTATION (pre-kernel shape): `if valid: return None` -> `return None`
+    # (presence check) -> the malformed, other-tenant and default-binding
+    # tests go red while the valid-token test stays green. Executed
+    # 2026-09-06.
+
+    def test_api_system_with_a_step_up_token_for_the_named_tenant(self, client):
+        from r6.stepup import generate_step_up_token
+        resp = client.get("/command-center/api/system", headers={
+            "X-Step-Up-Token": generate_step_up_token(TENANT),
+            "X-Tenant-Id": TENANT,
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["flask"]["up"] is True
+
+    def test_api_system_refuses_a_malformed_step_up_token(self, client):
+        resp = client.get("/command-center/api/system", headers={
+            "X-Step-Up-Token": "not-a-real-token",
+            "X-Tenant-Id": TENANT,
+        })
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "authentication required"}
+
+    def test_api_system_refuses_another_tenants_step_up_token(self, client):
+        from r6.stepup import generate_step_up_token
+        resp = client.get("/command-center/api/system", headers={
+            "X-Step-Up-Token": generate_step_up_token("someone-else"),
+            "X-Tenant-Id": TENANT,
+        })
+        assert resp.status_code == 401
+
+    def test_api_system_step_up_binds_to_the_default_tenant_when_none_is_named(
+            self, client):
+        from r6.command_center.routes import DEFAULT_TENANT
+        from r6.stepup import generate_step_up_token
+        # No ?tenant= and no X-Tenant-Id: the token must be the default
+        # tenant's. One for TENANT is refused, one for the default is enough.
+        refused = client.get("/command-center/api/system", headers={
+            "X-Step-Up-Token": generate_step_up_token(TENANT)})
+        assert refused.status_code == 401
+        accepted = client.get("/command-center/api/system", headers={
+            "X-Step-Up-Token": generate_step_up_token(DEFAULT_TENANT)})
+        assert accepted.status_code == 200
+
     def test_api_conversations_post_and_get(self, client, step_up_token):
         payload = {
             "tenant_id": TENANT,

--- a/tests/test_ratchets.py
+++ b/tests/test_ratchets.py
@@ -145,7 +145,7 @@ def _report(sites, pin, what):
 #: $ingest-context, waiting on #648.
 #: 9 -> 8 (kernel slice 16): agent_runs' session-or-token predicate asks
 #: has_grant; no direct validator call is left in r6/agent_runs/.
-_STEP_UP_CALLSITES = 7
+_STEP_UP_CALLSITES = 6
 
 
 def test_direct_step_up_validation_only_decreases():


### PR DESCRIPTION
## One guard, one blueprint, one PR

`r6/command_center/routes.py:_require_session_or_stepup` guards system status and the OpenClaw sessions list. Its token branch read `X-Step-Up-Token`, picked the tenant (`?tenant=`, then `X-Tenant-Id`, then the blueprint default) and called `validate_step_up_token` itself. It is a predicate, not a gate, so it now asks `has_grant`, which answers `None` in exactly the cases `require_grant` would refuse and never raises. The kernel reads the tenant in the same order through `tenant_from_request`; a malformed id is caught and stays the 401 it always was (it never reached a 400 here, it was a token failing its tenant binding). The kernel logs each refusal with its public reason, which is the line #307 asked for, so the site's own log line goes. One path loses its log line: a malformed tenant id presented alongside a token is caught before `has_grant` runs, so it answers the same 401 as before but the kernel never logs it (the old line logged that case as a binding failure). The 401 body is unchanged. Third adoption of the kernel's non-raising half, after #650 and #652.

## Pins first, then the move (two commits)

1. **Pins** (`tests/test_command_center.py`): the token branch had no test. The existing pair covered header-absent and session, so a predicate that merely checked for the header's presence stayed green. Four new facts: a token for the named tenant is enough; a garbage token is not; another tenant's well-formed token is not; with no tenant named the token binds to the blueprint's default tenant. **Mutation on the pre-kernel shape** (presence check), executed 2026-09-06: three red, the valid-token test green.
2. **Move**: the site asks `has_grant`. **Mutation on the kernel shape** (predicate to `True`): the same three red. Replacement count asserted at 1 both times.

## Evidence

- **Ratchet:** step-up sites 7 to 6. The god module is untouched.
- **Allowlist:** `_HAS_GRANT_CALLSITES` gains `r6/command_center/routes.py:277`; the adopter set already held this module.
- **Full suite** on the pre-rebase head: 3664 passed, 13 skipped, 1 xfailed. Pinned set green again after the rebase onto main.
- **Grade A** unchanged.

## What this leaves in command-center

Two sites stay direct on purpose: `_authz_write` (:322) and the dashboard-link mint (:618) both answer a JSON body naming the public refusal reason (`step-up token rejected: ...`, per the 2026-08-10 ruling). `has_grant` returns the grant or `None`, not the reason, and `require_grant` renders an OperationOutcome, so either would change the wire. They need the same ruling `sdc` is waiting on: keep the body and add a reason-carrying kernel surface, or accept the uniform outcome.

Refactor protocol: `docs/2026-08-03-refactor-working-protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
