### PR TITLE
ci(pr-agent): a comment run cancelled the review it shared a concurrency group with

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -39,7 +39,10 @@ permissions:
   issues: write
 
 concurrency:
-  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Keyed on the event as well as the number: a comment posted seconds after
+  # a pull request opens fires an issue_comment run in this workflow, and a
+  # group keyed on the number alone let that run cancel the review (#653).
+  group: pr-agent-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/test_ci_hardening.py
+++ b/tests/test_ci_hardening.py
@@ -219,3 +219,40 @@ def test_every_event_a_job_condition_names_is_one_the_workflow_listens_for():
                     f"triggers on {event!r} (it listens for "
                     f"{sorted(listens_for)}); the job can never run")
     assert checked >= 1, "no job condition names an event; the scan is broken"
+
+
+def test_a_cancelling_concurrency_group_is_keyed_on_the_event_when_a_workflow_has_several():
+    """cancel-in-progress cancels whatever else is running in the same group,
+    and a workflow with several triggers puts several kinds of run in it. The
+    second reviewer keyed its group on the pull-request number alone, so the
+    issue_comment run that any comment fires (a bot comment lands seconds
+    after a pull request opens) cancelled the review that had just started;
+    the comment run then skipped itself, and the check list showed a cancelled
+    reviewer on every pull request (#653). A group that names the event keeps
+    the runs of one kind from cancelling another.
+
+    MUTATION: drop `${{ github.event_name }}` from pr-agent.yml's group -> red
+    naming the workflow and its triggers.
+    """
+    workflow_dir = ROOT / ".github" / "workflows"
+    checked = 0
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        workflow = yaml.safe_load(path.read_text())
+        triggers = workflow.get(True) or workflow.get("on")
+        if isinstance(triggers, str):
+            triggers = [triggers]
+        if isinstance(triggers, list):
+            triggers = dict.fromkeys(triggers)
+        events = sorted(triggers or {})
+        concurrency = workflow.get("concurrency")
+        if not isinstance(concurrency, dict) or not concurrency.get("cancel-in-progress"):
+            continue
+        if len(events) < 2:
+            continue
+        checked += 1
+        group = str(concurrency.get("group", ""))
+        assert "github.event_name" in group, (
+            f"{path.name} cancels in-progress runs and triggers on {events}, "
+            f"but its concurrency group {group!r} does not name the event, so "
+            f"a run of one kind cancels a run of another")
+    assert checked >= 1, "no workflow cancels in-progress across several triggers; the scan is broken"


### PR DESCRIPTION
## What #653 showed

With #651 in, the second reviewer's job ran on the first pull request opened afterwards (#653, event `pull_request_target`) instead of skipping. It was cancelled four seconds in, while the action image was still building. The Vercel bot's deployment comment landed two seconds after the pull request opened; any comment fires this workflow's `issue_comment` trigger, and the concurrency group was keyed on the pull-request number alone, so with `cancel-in-progress: true` the comment run cancelled the review and then skipped itself. Every pull request would have shown a cancelled reviewer.

## Fix

The group now names the event as well as the number: `pr-agent-<event>-<number>`. A comment run can only cancel an earlier comment run, and a review only an earlier review of the same pull request, which is what cancel-in-progress was for.

## Guard

`tests/test_ci_hardening.py`: every workflow that cancels in-progress runs and listens for more than one event must key its group on `github.event_name`. Mutation: dropping the event from pr-agent.yml's group goes red naming the workflow and its triggers.

## Why this PR's own check will not show it

Same as #651: a `pull_request_target` workflow runs the base branch's copy of the file, so this pull request's own review run is still governed by main's group and is cancelled the same way. The fix shows on the first pull request opened after it merges. The secret (#608) is still unset, so that run will show SUCCESS with the "key not set" warning rather than a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)