### PR TITLE
test: the live public-FHIR-server tests are opt-in, and no test module reaches the network at import (#635)

### DIFF
--- a/tests/test_no_network_at_import.py
+++ b/tests/test_no_network_at_import.py
@@ -1,0 +1,96 @@
+"""No test module performs network I/O at import time (#635).
+
+tests/test_public_fhir_servers.py used to probe two public FHIR servers at
+module load, so every `pytest` invocation in this repository made two live
+HTTP calls, whether or not those tests were selected: measured, a run with
+every test in that file deselected still spent two seconds on the network,
+and twenty with both hosts unreachable. A probe at import is also a
+point-in-time answer that the test then trusts minutes later, which is how
+a reachable-at-collection server produced a red suite at 412 seconds.
+
+This scans every test module's top-level statements (module scope only:
+functions, classes and fixtures are where calls belong) for a call to one
+of the HTTP/socket entry points, directly or through a helper defined in
+the same module that calls one.
+
+MUTATION: in tests/test_public_fhir_servers.py, put back
+`_hapi_available = _server_reachable(HAPI_FHIR_R4)` at module scope -> red,
+naming the file, the line and the helper that reaches the network.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / 'tests'
+
+_NETWORK_CALLS = {
+    'httpx.get', 'httpx.post', 'httpx.request', 'httpx.Client',
+    'requests.get', 'requests.post', 'requests.request', 'requests.Session',
+    'urllib.request.urlopen', 'socket.create_connection', 'socket.socket',
+}
+
+
+def _dotted(node: ast.AST) -> str | None:
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return '.'.join(reversed(parts))
+    return None
+
+
+def _calls_in(node: ast.AST) -> set[str]:
+    return {name for sub in ast.walk(node)
+            if isinstance(sub, ast.Call) and (name := _dotted(sub.func))}
+
+
+def _network_reaching_helpers(tree: ast.Module) -> set[str]:
+    """Module-level functions whose body calls a network entry point."""
+    return {fn.name for fn in tree.body
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and _calls_in(fn) & _NETWORK_CALLS}
+
+
+def _module_scope_network_calls(path: Path, root: Path = ROOT) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    helpers = _network_reaching_helpers(tree)
+    reaching = _NETWORK_CALLS | helpers
+    findings = []
+    for stmt in tree.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for name in sorted(_calls_in(stmt) & reaching):
+            findings.append(f'{path.relative_to(root)}:{stmt.lineno} calls {name}')
+    return findings
+
+
+def test_no_test_module_reaches_the_network_at_import():
+    findings = []
+    scanned = 0
+    for path in sorted(TESTS.glob('test_*.py')):
+        scanned += 1
+        findings.extend(_module_scope_network_calls(path))
+    assert scanned >= 50, f'scan broken: only {scanned} test modules found'
+    assert not findings, (
+        'network I/O at module scope; every pytest run pays for it whether or '
+        'not these tests are selected (#635):\n  ' + '\n  '.join(findings))
+
+
+def test_the_scan_sees_a_helper_that_reaches_the_network(tmp_path):
+    """Self-check: a module-level call to a helper that calls httpx is found,
+    and a call inside a test function is not (that is where calls belong)."""
+    sample = tmp_path / 'test_sample.py'
+    sample.write_text(
+        'import httpx\n'
+        'def _probe(url):\n'
+        '    return httpx.get(url).status_code == 200\n'
+        'AVAILABLE = _probe("https://example.invalid")\n'
+        'def test_x():\n'
+        '    assert httpx.get("https://example.invalid")\n')
+    assert _module_scope_network_calls(sample, root=tmp_path) == [
+        'test_sample.py:4 calls _probe']

--- a/tests/test_public_fhir_servers.py
+++ b/tests/test_public_fhir_servers.py
@@ -1,17 +1,23 @@
 """
-Integration tests against public FHIR servers.
+Integration tests against public FHIR servers. Opt-in, never default.
 
 Tests the FHIRUpstreamProxy and Flask route guardrails against real public
-FHIR servers. These tests require network access and may be slow.
+FHIR servers. They need network access, they are slow, and they assert
+against shared sandboxes nobody here controls, so they are not part of the
+default suite (#635): a default `pytest` run makes no network call, here or
+anywhere (tests/test_no_network_at_import.py pins the import-time half).
+The guardrail properties these exercise are pinned against a local server
+by tests/test_guardrail_conformance.py; this file checks the proxy against
+real upstreams and is evidence, not a gate.
 
 Tested servers:
   - HAPI FHIR R4: https://hapi.fhir.org/baseR4
   - SMART Health IT R4: https://r4.smarthealthit.org
 
 Run with:
-  python -m pytest tests/test_public_fhir_servers.py -v
-  python -m pytest tests/test_public_fhir_servers.py -v -k hapi
-  python -m pytest tests/test_public_fhir_servers.py -v -k smart
+  HEALTHCLAW_LIVE_FHIR_TESTS=1 python -m pytest tests/test_public_fhir_servers.py -v
+  HEALTHCLAW_LIVE_FHIR_TESTS=1 python -m pytest tests/test_public_fhir_servers.py -v -k hapi
+  HEALTHCLAW_LIVE_FHIR_TESTS=1 python -m pytest tests/test_public_fhir_servers.py -v -k smart
 """
 
 import json
@@ -19,6 +25,14 @@ import os
 import pytest
 
 from r6.fhir_proxy import FHIRUpstreamProxy, reset_proxy
+
+LIVE_FLAG = 'HEALTHCLAW_LIVE_FHIR_TESTS'
+
+# Every test in this module is skipped at collection unless the flag is set,
+# so the default suite never reaches the probes below.
+pytestmark = pytest.mark.skipif(
+    os.environ.get(LIVE_FLAG, '').strip().lower() not in ('1', 'true', 'yes'),
+    reason=f'live public FHIR servers; set {LIVE_FLAG}=1 to run')
 
 # --- Public FHIR servers ---
 HAPI_FHIR_R4 = 'https://hapi.fhir.org/baseR4'
@@ -37,12 +51,26 @@ def _server_reachable(url: str) -> bool:
         return False
 
 
-# Check reachability once at module load
-_hapi_available = _server_reachable(HAPI_FHIR_R4)
-_smart_available = _server_reachable(SMART_HEALTH_IT)
+# Reachability is probed lazily, once per session, by the first opted-in test
+# that asks; nothing runs at import. A probe that fails skips every test that
+# depends on that server, with the reason naming it. (The probe is still a
+# point-in-time answer: a server that goes away mid-run fails the tests that
+# reach it after that, which an opt-in run is allowed to report.)
 
-skip_hapi = pytest.mark.skipif(not _hapi_available, reason='HAPI FHIR R4 server unreachable')
-skip_smart = pytest.mark.skipif(not _smart_available, reason='SMART Health IT server unreachable')
+@pytest.fixture(scope='session')
+def hapi_reachable():
+    if not _server_reachable(HAPI_FHIR_R4):
+        pytest.skip('HAPI FHIR R4 server unreachable')
+
+
+@pytest.fixture(scope='session')
+def smart_reachable():
+    if not _server_reachable(SMART_HEALTH_IT):
+        pytest.skip('SMART Health IT server unreachable')
+
+
+skip_hapi = pytest.mark.usefixtures('hapi_reachable')
+skip_smart = pytest.mark.usefixtures('smart_reachable')
 
 
 # ============================================================================
@@ -220,8 +248,8 @@ class TestCrossServerComparison:
         self.hapi.close()
         self.smart.close()
 
-    @pytest.mark.skipif(not (_hapi_available and _smart_available),
-                        reason='Both FHIR servers must be reachable')
+    @skip_hapi
+    @skip_smart
     def test_both_servers_return_valid_bundles(self):
         """Both servers return structurally valid search Bundles."""
         hapi_result, _ = self.hapi.search('Patient', {'_count': '2'})
@@ -234,8 +262,8 @@ class TestCrossServerComparison:
             # offset paging can return a first page carrying only link.
             assert 'entry' in result or 'total' in result or 'link' in result
 
-    @pytest.mark.skipif(not (_hapi_available and _smart_available),
-                        reason='Both FHIR servers must be reachable')
+    @skip_hapi
+    @skip_smart
     def test_both_servers_metadata_connected(self):
         """Both servers report healthy via /metadata."""
         hapi_health = self.hapi.healthy()
@@ -244,8 +272,8 @@ class TestCrossServerComparison:
         assert hapi_health['status'] == 'connected'
         assert smart_health['status'] == 'connected'
 
-    @pytest.mark.skipif(not (_hapi_available and _smart_available),
-                        reason='Both FHIR servers must be reachable')
+    @skip_hapi
+    @skip_smart
     def test_url_rewriting_prevents_upstream_leakage(self):
         """Neither server's URLs leak through the proxy."""
         hapi_result, _ = self.hapi.search('Patient', {'_count': '1'})


### PR DESCRIPTION
Closes #635.

## What was happening

`tests/test_public_fhir_servers.py` probed two public sandboxes at module load, so every `pytest` run in this repository made two live HTTP calls whether or not those tests were selected, and the probe was a point-in-time answer the tests trusted minutes later. A server reachable at collection produced a red suite at 412 seconds, on two different hosts, and again on 2026-09-06 during the kernel-slice runs (`TestSMARTHealthITProxy::test_patient_search`, an OperationOutcome where a Bundle was expected; green alone and on main).

## The decision the issue left open

The tests are evidence against real upstreams, not a gate: the guardrail properties they exercise are pinned against a local server by the conformance suite. So they leave the default suite rather than being recorded and replayed. Recording would keep them running by default at the cost of a fixture to maintain against sandboxes anyone can write to; that trade can still be made later, on top of this.

## What changes

- **Opt-in.** `HEALTHCLAW_LIVE_FHIR_TESTS=1` runs the file; without it all 31 tests skip at collection (measured: 31 skipped in 0.12s, no network). The module docstring carries the command.
- **Lazy probes.** Reachability is a session-scoped fixture, probed once by the first opted-in test that asks; an unreachable server skips its tests with the reason naming it (measured with an invalid host: `SKIPPED ... HAPI FHIR R4 server unreachable`). `skip_hapi` / `skip_smart` keep their names as `usefixtures` markers, and the three tests that needed both servers now carry both.
- **Guard.** `tests/test_no_network_at_import.py`: no test module calls an HTTP or socket entry point at module scope, directly or through a helper defined in the same module. A self-check proves the scan sees a helper. **Mutation:** main's version of the live file goes red naming lines 41 and 42.

Still a point-in-time probe inside an opted-in run, which the file now says; that is the honest limit of an integration test against servers nobody here controls.

Opted-in smoke on this branch: the two `health_check` tests pass live.

Full suite on this branch: 3632 passed, 44 skipped (the 31 live tests plus the 13 that already skipped), 1 xfailed, in 2:12 against 2:47 for the run that flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
