### PR TITLE
fix(ingest-context): validate a caller-supplied resource id the way the Fasten ingester does (#548)

### DIFF
--- a/r6/context_builder.py
+++ b/r6/context_builder.py
@@ -63,11 +63,11 @@ class ContextBuilder:
         # medications in it (#377). Imported here rather than at module level
         # because `r6.fasten` pulls in its blueprint, which imports this
         # module back.
-        from r6.fasten.ingester import safe_skipped_type
+        from r6.fasten.ingester import _RESOURCE_ID_PATTERN, safe_skipped_type
         skipped_types: collections.Counter = collections.Counter()
 
         try:
-            for entry in entries:
+            for index, entry in enumerate(entries):
                 resource = entry.get('resource')
                 if not resource:
                     continue
@@ -81,8 +81,27 @@ class ContextBuilder:
                 # Store canonical JSON (redaction applied at read-time, not write-time)
                 resource_json = json.dumps(resource, separators=(',', ':'), sort_keys=True)
 
+                # A caller-supplied id is validated before use, the way the
+                # Fasten ingester validates it (#548, the #286 shape on this
+                # second path): `resource.get('id', uuid)` kept "" as an id,
+                # stored the row under (tenant, type, ""), and let the next
+                # blank-id resource of the same type upsert over it. Blank,
+                # bool, float, list or object refuses the whole bundle, the
+                # message names the entry and never echoes the value; an int
+                # is stored as its string; an absent id gets a UUID.
+                if 'id' in resource:
+                    raw_id = resource['id']
+                    if (isinstance(raw_id, bool)
+                            or not isinstance(raw_id, (str, int))
+                            or not _RESOURCE_ID_PATTERN.fullmatch(str(raw_id))):
+                        db.session.rollback()
+                        raise ValueError(
+                            f'entry {index}: {resource_type}.id is not a '
+                            f'valid FHIR id and was refused')
+                    resource_id = str(raw_id)
+                else:
+                    resource_id = str(uuid.uuid4())
                 # Create or update the resource (tenant-scoped)
-                resource_id = resource.get('id', str(uuid.uuid4()))
                 existing = R6Resource.query.filter_by(
                     id=resource_id, resource_type=resource_type,
                     tenant_id=tenant_id

--- a/tests/test_ingest_context_refuses_a_blank_id.py
+++ b/tests/test_ingest_context_refuses_a_blank_id.py
@@ -1,0 +1,103 @@
+"""$ingest-context validates a caller-supplied resource id the way the
+Fasten ingester does (#548, the #286 shape on a second path).
+
+r6/context_builder.py read the id as `resource.get('id', uuid)`, so a
+resource carrying `"id": ""` was stored under (tenant, type, ""), and the
+next blank-id resource of the same type upserted over it: a write that
+succeeded and quietly did the wrong thing. The Fasten path refuses the same
+input as `invalid_id` (#546). The two ingest paths now agree: a present id
+must be a string or an int matching the FHIR id shape; blank, bool, float,
+list or object is refused for the whole bundle, naming the entry index and
+never echoing the value; an absent id gets a UUID; an int is stored as str.
+
+MUTATION: r6/context_builder.py, put `resource.get('id', str(uuid.uuid4()))`
+back -> the blank-id, bool-id and list-id tests go red (a 201 and a row
+with id "").
+"""
+
+import json
+import re
+import uuid
+
+import pytest
+
+from r6.models import R6Resource
+
+PATH = '/r6/fhir/Bundle/$ingest-context'
+_UUID = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+
+
+def _bundle(*resources):
+    return {'resourceType': 'Bundle', 'type': 'collection',
+            'entry': [{'resource': r} for r in resources]}
+
+
+def _post(client, headers, bundle):
+    return client.post(PATH, data=json.dumps(bundle),
+                       content_type='application/json', headers=headers)
+
+
+def _stored(app, tenant_id, resource_type, resource_id):
+    with app.app_context():
+        return R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type=resource_type,
+            id=resource_id).first()
+
+
+@pytest.mark.parametrize('bad_id', ['', True, 1.5, ['x'], {'v': 'x'},
+                                    'has space', 'a' * 256])
+def test_a_present_id_outside_the_fhir_shape_refuses_the_bundle(
+        client, app, tenant_headers, tenant_id, bad_id):
+    resp = _post(client, tenant_headers, _bundle(
+        {'resourceType': 'Patient', 'id': bad_id, 'gender': 'female'}))
+    assert resp.status_code == 400
+    outcome = resp.get_json()
+    assert outcome['resourceType'] == 'OperationOutcome'
+    diag = outcome['issue'][0]['diagnostics']
+    assert 'entry 0' in diag and 'id' in diag
+    # The value is never echoed: it is caller-supplied and may be anything.
+    if isinstance(bad_id, str) and bad_id:
+        assert bad_id not in diag
+    assert _stored(app, tenant_id, 'Patient', '') is None
+
+
+def test_a_blank_id_in_a_later_entry_refuses_the_whole_bundle(
+        client, app, tenant_headers, tenant_id):
+    """Atomic, as the builder already was for its other validation errors:
+    the good entry before the bad one is not stored either."""
+    resp = _post(client, tenant_headers, _bundle(
+        {'resourceType': 'Patient', 'id': 'ok-patient-548', 'gender': 'male'},
+        {'resourceType': 'Observation', 'id': '', 'status': 'final',
+         'code': {'coding': [{'system': 'http://loinc.org', 'code': '2339-0'}]}}))
+    assert resp.status_code == 400
+    assert 'entry 1' in resp.get_json()['issue'][0]['diagnostics']
+    assert _stored(app, tenant_id, 'Patient', 'ok-patient-548') is None
+    assert _stored(app, tenant_id, 'Observation', '') is None
+
+
+def test_an_int_id_is_stored_as_its_string(client, app, tenant_headers, tenant_id):
+    resp = _post(client, tenant_headers, _bundle(
+        {'resourceType': 'Patient', 'id': 7548, 'gender': 'other'}))
+    assert resp.status_code == 201
+    assert resp.get_json()['items'][0]['resource_ref'] == 'Patient/7548'
+    assert _stored(app, tenant_id, 'Patient', '7548') is not None
+
+
+def test_an_absent_id_gets_a_uuid(client, tenant_headers):
+    resp = _post(client, tenant_headers, _bundle(
+        {'resourceType': 'Patient', 'gender': 'unknown'}))
+    assert resp.status_code == 201
+    ref = resp.get_json()['items'][0]['resource_ref']
+    assert ref.startswith('Patient/') and _UUID.match(ref.split('/', 1)[1])
+    assert uuid.UUID(ref.split('/', 1)[1])
+
+
+def test_two_blank_ids_no_longer_collapse_into_one_row(
+        client, app, tenant_headers, tenant_id):
+    """The defect as observed: the second blank-id resource upserted over the
+    first. Neither is stored now."""
+    for gender in ('female', 'male'):
+        resp = _post(client, tenant_headers, _bundle(
+            {'resourceType': 'Patient', 'id': '', 'gender': gender}))
+        assert resp.status_code == 400
+    assert _stored(app, tenant_id, 'Patient', '') is None


### PR DESCRIPTION
Closes #548.

## What was happening

`r6/context_builder.py` read the id as `resource.get('id', uuid)`, so a resource carrying `"id": ""` was stored under `(tenant, type, "")`, and the next blank-id resource of the same type upserted over it: a write that succeeded and quietly did the wrong thing, the #286 shape on a second path. The Fasten path refuses the same input as `invalid_id` after #546, so the two ingest paths disagreed.

## What changes

The context builder applies the ingester's rule with the ingester's pattern: a present id must be a string or an int matching the FHIR id shape. Blank, bool, float, list or object refuses the **whole bundle** (the builder was already atomic for its other validation errors) with an OperationOutcome naming the entry index and never echoing the value. An int is stored as its string. An absent id still gets a UUID. The interim until the playbook's `to_canonical()` owns ids.

## Evidence

- **Pins first** (`tests/test_ingest_context_refuses_a_blank_id.py`, red on main: 9 of 11): seven bad shapes refuse with `entry 0` named and nothing stored; a blank id in entry 1 refuses the bundle and the good entry 0 is not stored either; int id stored as its string; absent id gets a UUID; two blank-id posts no longer collapse into one row.
- **Mutation**, executed 2026-09-06: put the old read back, the nine go red again.
- Context builder, ingest resilience, routes, write-guard matrix, healthex import and conformance suites green (390 passed). Full suite on the branch: 3672 passed, 13 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
