### PR TITLE
fix(careagents): the records-purge response says what it observed, not a field named deleted set to false (#586)

### DIFF
--- a/careagents/app.py
+++ b/careagents/app.py
@@ -626,16 +626,20 @@ def create_app(config: Config | None = None,
             # this file for claims about what was sent, approved, recorded or
             # retried rather than by another report about one arm.
             #
-            # `deleted: False` stays and is not the same claim: it is what
-            # keeps the connection linked here, which is observed — the
-            # unlink below is not reached — and is the conservative half.
-            return jsonify({"error": "deletion_failed", "deleted": False,
+            # No `deleted` field here at all (#586). `purge_tenant` raises on
+            # any non-200 and on a lost answer, so on this branch the records
+            # may be gone or may not; a field named `deleted` saying False
+            # would be wrong on exactly the outcome where the purge ran. What
+            # IS observed is that the unlink below was not reached, and the
+            # field says that by its name: the connection is still linked.
+            return jsonify({"error": "deletion_failed", "unlinked": False,
                             "message": "We couldn't confirm your records were "
                                        "deleted. Your connection is still "
                                        "linked here — please try again."}), 502
         svc.delete_connection(acct.id, conn_id)
         return jsonify({
             "deleted": True,
+            "unlinked": True,
             "connection_id": conn_id,
             "rows_deleted": purged.get("rows_deleted", 0),
             "audit_retained": True,

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -3629,6 +3629,7 @@ def test_delete_purges_records_then_removes_the_connection(cfg, svc, monkeypatch
     assert r.status_code == 200
     d = r.get_json()
     assert d["deleted"] is True and d["rows_deleted"] == 42
+    assert d["unlinked"] is True               # and the hub no longer lists it
     assert d["audit_retained"] is True          # says so to the patient
     assert len(fake.purged) == 1                # records purged, not just unlinked
     # connection is gone from the hub
@@ -3649,7 +3650,14 @@ def test_delete_does_not_unlink_when_the_purge_fails(cfg, svc, monkeypatch):
 
     r = c.delete(f"/api/connections/{conn}")
     assert r.status_code == 502
-    assert r.get_json()["deleted"] is False
+    body = r.get_json()
+    # #586: the purge raises on any non-200 and on a lost answer, so the
+    # records may or may not be gone. A field named `deleted` cannot say
+    # False here without lying on the outcome where they are gone; what
+    # is observed is that the connection was not unlinked.
+    assert "deleted" not in body
+    assert body["unlinked"] is False
+    assert body["error"] == "deletion_failed"
     # connection survives, so the patient can retry
     assert c.post(f"/api/connections/{conn}/disconnect").status_code == 200
 


### PR DESCRIPTION
Closes #586.

## What was happening

The failed-purge branch of `DELETE /api/connections/<id>` answered `deleted: False` on every failure, including the outcome where the records are demonstrably gone (a purge that ran and then lost its answer, since `purge_tenant` raises on any non-200 and on a read timeout). The comment beside it redefined the field as "the connection is still linked here", which is true and a different proposition from the field's name. Nothing in the repository reads the field, so it reached no screen; the first thing to read it would have read the name.

## What changes

- The failure body carries **no `deleted` field at all** and says the observed fact by its name: `unlinked: False` (the unlink was not reached). The user-facing message is unchanged.
- The success body says `deleted: True` **and** `unlinked: True`.
- The two delete tests moved from the value to the property: the failure body has no `deleted` key and `unlinked` is `False`; the success body has both.

**Mutation**, executed 2026-09-06: put `deleted: False` back on the failure branch, red.

The second item in #586 (a test pinning the phrase "will not resend") no longer exists in the file; that test now asserts the property (`confirmed is None`, and what the message must not say).

Careagents and transport suites green (364 passed). Full suite on the branch: 3661 passed, 13 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
