### PR TITLE
ci(audit): a registry outage is retried, then fails as an outage, never as a finding (#589)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,11 @@ jobs:
         # repository access, so it gates too. If that ever becomes noisy,
         # narrow it on purpose and write the reason here — do not let it
         # narrow by accident.
-        run: uv run --with pip-audit==2.9.0 pip-audit --strict --format json --output audit.json
+        # Through scripts/audit_with_retry.py (#589): a registry outage is
+        # retried with backoff and, if it persists, fails with its own exit
+        # code and a message naming the outage; a finding is never retried
+        # and keeps pip-audit's exit code. Nothing is suppressed.
+        run: uv run python scripts/audit_with_retry.py -- uv run --with pip-audit==2.9.0 pip-audit --strict --format json --output audit.json
 
       - name: The audit examined the project, not an empty interpreter
         # The positive half, and the reason this gate is trustworthy now:
@@ -362,7 +366,7 @@ jobs:
         working-directory: services/agent-orchestrator
         run: |
           npm ci
-          npm audit --audit-level=high
+          python3 ../../scripts/audit_with_retry.py -- npm audit --audit-level=high
 
   # ─────────────────────────────────────────────
   # Compliance Gate 3: Guardrail enforcement checks

--- a/scripts/audit_with_retry.py
+++ b/scripts/audit_with_retry.py
@@ -43,10 +43,26 @@ _OUTAGE = re.compile(
     re.IGNORECASE)
 
 
+# The tools' own verdict lines. Checked BEFORE the outage patterns: an
+# advisory title can contain "timeout" or "connection reset", and a real
+# finding must never be retried and then reported as an outage.
+_FINDING = re.compile(
+    r'found \d+ .*vulnerabilit|Found \d+ known vulnerabilit',
+    re.IGNORECASE)
+
+
 def classify(returncode: int, output: str) -> str:
-    """'ok', 'outage' or 'finding' (anything non-zero that is not an outage)."""
+    """'ok', 'finding' or 'outage'.
+
+    A finding is the tool saying so in its summary line; an outage is a
+    non-zero exit whose output names the registry not answering; anything
+    else non-zero is treated as a finding (never retried, code passed
+    through), because a tool error is not an outage either.
+    """
     if returncode == 0:
         return 'ok'
+    if _FINDING.search(output):
+        return 'finding'
     if _OUTAGE.search(output):
         return 'outage'
     return 'finding'

--- a/scripts/audit_with_retry.py
+++ b/scripts/audit_with_retry.py
@@ -1,0 +1,99 @@
+"""Run a dependency audit and say which of two things happened (#589).
+
+The registry not answering is not the same finding as the registry
+answering with an advisory, and the dependency-audit job could not tell
+them apart: a 503 from the package index failed the job with the same
+red, in the same place, as a real vulnerability. This wrapper runs the
+audit command, retries a registry outage a few times with backoff, and
+if it still cannot reach the registry fails with its own exit code and a
+message that names the outage. A finding is never retried and keeps the
+tool's own exit code. Nothing here suppresses a failure.
+
+Exit codes:
+  0  the audit ran and found nothing
+  2  the registry could not be reached after every attempt (an outage)
+  otherwise  the tool's own code (a finding, or a tool error), unchanged
+
+Usage:
+  python scripts/audit_with_retry.py [--attempts N] [--backoff S] -- <command...>
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+
+OUTAGE_EXIT = 2
+
+# What a registry outage looks like on stderr/stdout for pip-audit (requests
+# under the hood) and npm audit (node's DNS/TCP error names). A real finding
+# looks like neither: pip-audit prints the advisory table or JSON; npm prints
+# "found N vulnerabilities".
+_OUTAGE = re.compile(
+    r'503|service unavailable|502 bad gateway|504 gateway|'
+    r'connection ?error|connection reset|connection refused|timed? ?out|'
+    r'temporary failure in name resolution|name or service not known|'
+    r'ENOTFOUND|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|'
+    r'failed to (fetch|connect)|could not (fetch|connect)|unable to (fetch|connect)|'
+    r'network error|HTTPSConnectionPool|max retries exceeded|'
+    r'request to https?://\S+ failed',
+    re.IGNORECASE)
+
+
+def classify(returncode: int, output: str) -> str:
+    """'ok', 'outage' or 'finding' (anything non-zero that is not an outage)."""
+    if returncode == 0:
+        return 'ok'
+    if _OUTAGE.search(output):
+        return 'outage'
+    return 'finding'
+
+
+def run_once(command: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(command, capture_output=True, text=True)
+    output = proc.stdout + proc.stderr
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    return proc.returncode, output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--attempts', type=int, default=3)
+    parser.add_argument('--backoff', type=float, default=10.0,
+                        help='seconds before the second attempt; doubles each time')
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = [c for c in args.command if c != '--'] if args.command and args.command[0] == '--' else args.command
+    if not command:
+        parser.error('no audit command given after --')
+
+    delay = args.backoff
+    for attempt in range(1, args.attempts + 1):
+        code, output = run_once(command)
+        verdict = classify(code, output)
+        if verdict == 'ok':
+            return 0
+        if verdict == 'finding':
+            # A finding is the tool's answer; it is never retried and its
+            # exit code passes through untouched.
+            return code
+        if attempt < args.attempts:
+            print(f'::warning::dependency audit could not reach the registry '
+                  f'(attempt {attempt} of {args.attempts}); retrying in {delay:g}s',
+                  file=sys.stderr)
+            time.sleep(delay)
+            delay *= 2
+    print('::error::dependency audit could not reach the package registry after '
+          f'{args.attempts} attempts. This is a registry outage, NOT a '
+          'vulnerability finding; re-run when the registry answers.',
+          file=sys.stderr)
+    return OUTAGE_EXIT
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_audit_with_retry.py
+++ b/tests/test_audit_with_retry.py
@@ -21,6 +21,13 @@ from audit_with_retry import OUTAGE_EXIT, classify  # noqa: E402
     (2, 'ConnectionError: HTTPSConnectionPool(host=\'pypi.org\', port=443): Max retries exceeded', 'outage'),
     (1, 'getaddrinfo EAI_AGAIN registry.npmjs.org', 'outage'),
     (3, 'some other tool error', 'finding'),
+    # A finding whose advisory title happens to name an outage word is
+    # still a finding: the summary line wins.
+    (1, 'Regular Expression Denial of Service via timeout in some-lib\n'
+        'found 1 high severity vulnerability', 'finding'),
+    (1, 'Found 1 known vulnerability in 1 package\n'
+        'Name Version ID Fix Versions\n'
+        'requests 2.0 GHSA-xxxx connection reset handling', 'finding'),
 ])
 def test_classify(code, output, verdict):
     assert classify(code, output) == verdict

--- a/tests/test_audit_with_retry.py
+++ b/tests/test_audit_with_retry.py
@@ -1,0 +1,83 @@
+"""The dependency audit tells a registry outage from a finding (#589)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / 'scripts' / 'audit_with_retry.py'
+sys.path.insert(0, str(ROOT / 'scripts'))
+from audit_with_retry import OUTAGE_EXIT, classify  # noqa: E402
+
+
+@pytest.mark.parametrize('code, output, verdict', [
+    (0, 'No known vulnerabilities found', 'ok'),
+    (1, 'Found 2 known vulnerabilities in 1 package', 'finding'),
+    (1, 'found 3 vulnerabilities (1 moderate, 2 high)', 'finding'),
+    (1, 'HTTPError: 503 Server Error: Service Unavailable for url: https://pypi.org/pypi/x/json', 'outage'),
+    (1, 'npm ERR! code ECONNRESET\nnpm ERR! network request to https://registry.npmjs.org/-/npm/v1/security/advisories/bulk failed', 'outage'),
+    (2, 'ConnectionError: HTTPSConnectionPool(host=\'pypi.org\', port=443): Max retries exceeded', 'outage'),
+    (1, 'getaddrinfo EAI_AGAIN registry.npmjs.org', 'outage'),
+    (3, 'some other tool error', 'finding'),
+])
+def test_classify(code, output, verdict):
+    assert classify(code, output) == verdict
+
+
+def _fake_audit(tmp_path, script_body):
+    fake = tmp_path / 'fake_audit.sh'
+    fake.write_text('#!/bin/sh\n' + script_body)
+    fake.chmod(0o755)
+    return str(fake)
+
+
+def _run(*args):
+    return subprocess.run([sys.executable, str(SCRIPT), *args],
+                          capture_output=True, text=True)
+
+
+def test_a_transient_outage_is_retried_and_then_passes(tmp_path):
+    counter = tmp_path / 'n'
+    counter.write_text('0')
+    fake = _fake_audit(tmp_path, f'''
+n=$(cat {counter}); n=$((n+1)); echo $n > {counter}
+if [ $n -lt 3 ]; then echo "HTTPError: 503 Service Unavailable" >&2; exit 1; fi
+echo "No known vulnerabilities found"; exit 0
+''')
+    r = _run('--attempts', '3', '--backoff', '0', '--', fake)
+    assert r.returncode == 0, r.stderr
+    assert counter.read_text().strip() == '3'
+    assert r.stderr.count('::warning::') == 2
+
+
+def test_a_sustained_outage_fails_with_its_own_code_and_message(tmp_path):
+    fake = _fake_audit(tmp_path, 'echo "npm ERR! code ENOTFOUND" >&2; exit 1\n')
+    r = _run('--attempts', '3', '--backoff', '0', '--', fake)
+    assert r.returncode == OUTAGE_EXIT
+    assert '::error::' in r.stderr
+    assert 'registry outage, NOT a vulnerability finding' in r.stderr
+
+
+def test_a_finding_is_never_retried_and_keeps_the_tools_exit_code(tmp_path):
+    counter = tmp_path / 'n'
+    counter.write_text('0')
+    fake = _fake_audit(tmp_path, f'''
+n=$(cat {counter}); n=$((n+1)); echo $n > {counter}
+echo "Found 1 known vulnerability in 1 package"; exit 1
+''')
+    r = _run('--attempts', '3', '--backoff', '0', '--', fake)
+    assert r.returncode == 1
+    assert counter.read_text().strip() == '1'
+    assert '::error::' not in r.stderr and '::warning::' not in r.stderr
+
+
+def test_ci_routes_both_audits_through_the_wrapper():
+    """MUTATION: call pip-audit or npm audit directly in ci.yml -> red."""
+    text = (ROOT / '.github' / 'workflows' / 'ci.yml').read_text()
+    job = text.split('  dependency-audit:', 1)[1].split('  compliance-gates:', 1)[0]
+    lines = [ln for ln in job.splitlines() if 'pip-audit --strict' in ln or 'npm audit --audit-level=high' in ln]
+    assert len(lines) == 2, lines
+    assert all('scripts/audit_with_retry.py' in ln for ln in lines), lines
+    assert '|| true' not in job


### PR DESCRIPTION
Closes #589.

## What was happening

The dependency-audit job failed the same way on a `503` from the package index as on a real advisory: same red, same job name, same place. A reader had to open the log to tell them apart, in a check everyone had learned to expect red from, which is exactly where a real advisory during an outage gets read as more of the same.

## What changes

`scripts/audit_with_retry.py` wraps both audits:

- **Classifies** the tool's output: a registry outage looks like a 503, a connection error, a DNS failure (`ENOTFOUND`, `EAI_AGAIN`), a `Max retries exceeded`; a finding looks like the advisory table or `found N vulnerabilities`.
- **Retries an outage** up to three times with backoff (10s, 20s), each attempt announced as a `::warning::`.
- **Fails a sustained outage with its own exit code (2)** and a `::error::` line that says "registry outage, NOT a vulnerability finding".
- **Never retries a finding**, and passes the tool's own exit code through untouched.

Nothing is suppressed: the CI-hardening test that bans `|| true` in this job still passes, and `ci.yml` still contains the literal `pip-audit --strict` and `npm audit --audit-level=high` invocations it pins. A new test pins that both go through the wrapper (mutation: call pip-audit directly, red).

## Evidence

- Unit tests for the classifier (eight samples across pip-audit and npm) and three end-to-end runs against a fake audit: a transient outage retried twice then passing; a sustained outage failing with code 2 and the message; a finding failing once with code 1 and no retry.
- **Live run**, locally, the real pip-audit through the wrapper: exit 0, `No known vulnerabilities found`, `audit.json` written (5.7 KB) for the coverage check that follows it. This PR's own `dependency-audit` lane is the same path on GitHub (a `pull_request` workflow runs the PR's copy of `ci.yml`, unlike the reviewer's).
- **On GitHub:** this PR's `dependency-audit` lane passed through the wrapper (both audits). Full suite on the branch: 3673 passed, 13 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

