### PR TITLE
fix(sdc): $extract never writes another resource type's answer into the target (#572, part 1)

### DIFF
--- a/r6/sdc/extract.py
+++ b/r6/sdc/extract.py
@@ -92,15 +92,26 @@ def _extract_by_definition(questionnaire, answers, subject_ref):
         # element Patient does not have and no validator catches. Until the
         # engine builds those types too, the answer is dropped and the drop
         # is said out loud, naming the item and the types, never the answer.
-        defined_type = path.split(".", 1)[0]
-        if defined_type != target_type:
+        # A definition names its resource type twice: in the StructureDefinition
+        # URL before "#" and as the first segment of the element path after
+        # it. Both must be the type this questionnaire extracts. The QA pass
+        # on #664 showed why one is not enough: `AllergyIntolerance#Patient.
+        # name.given` passed a path-only check and landed the allergen answer
+        # in Patient.name.given, and a Questionnaire is a stored resource
+        # that can arrive through the ordinary ingest paths, not only the
+        # intake form this engine was written for.
+        defined_url_type = _definition_url_type(definition)
+        defined_path_type = path.split(".", 1)[0]
+        if defined_path_type != target_type or (
+                defined_url_type and defined_url_type != target_type):
             # %r for the linkId, as the handler in expressions.py does: it is
             # caller-supplied questionnaire structure, and %r is what escapes
             # a newline that would forge a log line.
             logger.warning(
                 "extract: item %r not extracted: its definition targets %s "
-                "and this questionnaire extracts %s (#572)",
-                item.get("linkId"), defined_type, target_type)
+                "(url) / %s (path) and this questionnaire extracts %s (#572)",
+                item.get("linkId"), defined_url_type or "none",
+                defined_path_type, target_type)
             continue
         _value_key, value = _answer_value(item_answers[0])
         if value is None:
@@ -110,6 +121,27 @@ def _extract_by_definition(questionnaire, answers, subject_ref):
     if not populated:
         return []
     return [_post_entry(resource)]
+
+
+_HL7_BASE_SD = "http://hl7.org/fhir/StructureDefinition/"
+
+
+def _definition_url_type(definition):
+    """The base resource type the StructureDefinition URL before "#" names,
+    when that can be read off the URL: the last segment under the HL7 base
+    namespace (http://hl7.org/fhir/StructureDefinition/Patient -> Patient),
+    or a bare type name ("Patient"). Any other URL is a profile whose base
+    type is not in its name (http://example.org/SD, us-core-patient), and
+    cannot be checked without resolving the profile: "" means unknown, and
+    the element path's own type is what the check has."""
+    url = definition.split("#", 1)[0].strip()
+    if not url:
+        return ""
+    if url.startswith(_HL7_BASE_SD):
+        return url[len(_HL7_BASE_SD):].strip("/")
+    if "/" not in url and ":" not in url:
+        return url
+    return ""
 
 
 def _set_path(resource, dotted_path, value):

--- a/r6/sdc/extract.py
+++ b/r6/sdc/extract.py
@@ -8,6 +8,10 @@ Pure function. Supports two SDC extraction mechanisms:
 Out of scope (v1): template-based and StructureMap-based extraction.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 OBSERVATION_EXTRACT_URL = (
     "http://hl7.org/fhir/uv/sdc/StructureDefinition/"
     "sdc-questionnaire-observationExtract"
@@ -79,6 +83,21 @@ def _extract_by_definition(questionnaire, answers, subject_ref):
         path = definition.split("#", 1)[1]  # e.g. Patient.name.family
         item_answers = answers.get(item.get("linkId"), [])
         if not item_answers:
+            continue
+        # #572: a definition names its own resource type. This engine builds
+        # ONE target type, so an answer declared for another type (the intake
+        # form's allergen, AllergyIntolerance#AllergyIntolerance.code.text)
+        # must not be written into the target as if it were an element of
+        # it: that produced Patient.code.text holding an allergen name, an
+        # element Patient does not have and no validator catches. Until the
+        # engine builds those types too, the answer is dropped and the drop
+        # is said out loud, naming the item and the types, never the answer.
+        defined_type = path.split(".", 1)[0]
+        if defined_type != target_type:
+            logger.warning(
+                "extract: item %s not extracted: its definition targets %s "
+                "and this questionnaire extracts %s (#572)",
+                item.get("linkId"), defined_type, target_type)
             continue
         _value_key, value = _answer_value(item_answers[0])
         if value is None:

--- a/r6/sdc/extract.py
+++ b/r6/sdc/extract.py
@@ -94,8 +94,11 @@ def _extract_by_definition(questionnaire, answers, subject_ref):
         # is said out loud, naming the item and the types, never the answer.
         defined_type = path.split(".", 1)[0]
         if defined_type != target_type:
+            # %r for the linkId, as the handler in expressions.py does: it is
+            # caller-supplied questionnaire structure, and %r is what escapes
+            # a newline that would forge a log line.
             logger.warning(
-                "extract: item %s not extracted: its definition targets %s "
+                "extract: item %r not extracted: its definition targets %s "
                 "and this questionnaire extracts %s (#572)",
                 item.get("linkId"), defined_type, target_type)
             continue

--- a/tests/test_sdc_extract.py
+++ b/tests/test_sdc_extract.py
@@ -69,3 +69,74 @@ def test_extract_empty_when_no_directives():
 
     bundle = extract_resources(qr, q)
     assert bundle["entry"] == []
+
+
+# ---------------------------------------------------------------------------
+# #572, part 1: an answer whose definition names ANOTHER resource type is never
+# written into the extraction target.
+# ---------------------------------------------------------------------------
+
+def _intake_like_questionnaire():
+    return {
+        "resourceType": "Questionnaire",
+        "extension": [{"url": DEF_EXTRACT_URL, "valueCode": "Patient"}],
+        "item": [
+            {"linkId": "family", "type": "string",
+             "definition": "http://hl7.org/fhir/StructureDefinition/Patient#Patient.name.family"},
+            {"linkId": "allergies", "type": "group", "item": [
+                {"linkId": "allergies.item.allergen", "type": "string",
+                 "definition": "http://hl7.org/fhir/StructureDefinition/"
+                               "AllergyIntolerance#AllergyIntolerance.code.text"},
+            ]},
+        ],
+    }
+
+
+def _intake_like_response():
+    return {
+        "resourceType": "QuestionnaireResponse", "status": "completed",
+        "subject": {"reference": "Patient/p-572"},
+        "item": [
+            {"linkId": "family", "answer": [{"valueString": "Synthetic"}]},
+            {"linkId": "allergies", "item": [
+                {"linkId": "allergies.item.allergen",
+                 "answer": [{"valueString": "peanut-572"}]},
+            ]},
+        ],
+    }
+
+
+def test_an_answer_for_another_resource_type_never_lands_on_the_target(caplog):
+    """The engine walked every `definition` into the one target type, so the
+    allergen answer (AllergyIntolerance#AllergyIntolerance.code.text) was
+    written as Patient.code.text: an element Patient does not have, holding
+    clinical text no clinician can find and no validator catches (#572).
+
+    MUTATION: r6/sdc/extract.py, drop the resource-type comparison in
+    _extract_by_definition -> red (the Patient carries `code`).
+    """
+    import json
+    import logging
+    with caplog.at_level(logging.WARNING, logger="r6.sdc.extract"):
+        bundle = extract_resources(_intake_like_response(), _intake_like_questionnaire())
+    patients = [e["resource"] for e in bundle["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1
+    assert patients[0]["name"][0]["family"] == "Synthetic"   # demographics still extract
+    assert "code" not in patients[0]
+    assert "peanut-572" not in json.dumps(bundle)              # not written anywhere
+    # The drop is said out loud, naming the item and the two types, never
+    # the answer.
+    dropped = [r for r in caplog.records if "not extracted" in r.getMessage()]
+    assert len(dropped) == 1
+    msg = dropped[0].getMessage()
+    assert "allergies.item.allergen" in msg
+    assert "AllergyIntolerance" in msg and "Patient" in msg
+    assert "peanut-572" not in msg
+
+
+def test_a_definition_for_the_target_type_still_extracts():
+    q = _intake_like_questionnaire()
+    qr = _intake_like_response()
+    bundle = extract_resources(qr, q)
+    assert [e["resource"]["resourceType"] for e in bundle["entry"]] == ["Patient"]

--- a/tests/test_sdc_extract.py
+++ b/tests/test_sdc_extract.py
@@ -94,8 +94,10 @@ def _intake_like_questionnaire():
 
 def _intake_like_response():
     return {
+        # No subject on purpose: part 2 of #572 stops a subject-bound response
+        # from yielding a Patient at all, and these pins are about the
+        # allergen answer, not the subject.
         "resourceType": "QuestionnaireResponse", "status": "completed",
-        "subject": {"reference": "Patient/p-572"},
         "item": [
             {"linkId": "family", "answer": [{"valueString": "Synthetic"}]},
             {"linkId": "allergies", "item": [

--- a/tests/test_sdc_extract.py
+++ b/tests/test_sdc_extract.py
@@ -140,3 +140,54 @@ def test_a_definition_for_the_target_type_still_extracts():
     qr = _intake_like_response()
     bundle = extract_resources(qr, q)
     assert [e["resource"]["resourceType"] for e in bundle["entry"]] == ["Patient"]
+
+
+def test_a_definition_whose_url_and_path_disagree_is_refused(caplog):
+    """The QA pass on #664: `AllergyIntolerance#Patient.name.given` names one
+    type in the URL and another in the path. A path-only check let the
+    allergen answer land in Patient.name.given. Both halves must be the
+    target type now.
+
+    MUTATION: r6/sdc/extract.py, drop the URL half of the comparison -> red
+    (the Patient carries name.given).
+    """
+    import json
+    import logging
+    q = _intake_like_questionnaire()
+    q["item"][1]["item"][0]["definition"] = (
+        "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance#Patient.name.given")
+    with caplog.at_level(logging.WARNING, logger="r6.sdc.extract"):
+        bundle = extract_resources(_intake_like_response(), q)
+    patients = [e["resource"] for e in bundle["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1
+    assert patients[0]["name"][0].get("given") is None
+    assert "peanut-572" not in json.dumps(bundle)
+    dropped = [r.getMessage() for r in caplog.records if "not extracted" in r.getMessage()]
+    assert len(dropped) == 1
+    assert "AllergyIntolerance" in dropped[0] and "Patient" in dropped[0]
+
+
+def test_bare_absent_and_profile_url_forms_of_the_target_type_still_extract():
+    """A custom profile URL does not carry its base type in its name
+    (us-core-patient, http://example.org/SD), so it cannot be checked
+    without resolving the profile; the element path's type is what governs
+    there, as it always did. Only the HL7 base namespace and a bare type
+    name are read off the URL."""
+    for definition in ("Patient#Patient.name.family", "#Patient.name.family",
+                       "http://example.org/fhir/StructureDefinition/my-patient#Patient.name.family",
+                       "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient#Patient.name.family"):
+        q = _intake_like_questionnaire()
+        q["item"][0]["definition"] = definition
+        bundle = extract_resources(_intake_like_response(), q)
+        patient = bundle["entry"][0]["resource"]
+        assert patient["resourceType"] == "Patient"
+        assert patient["name"][0]["family"] == "Synthetic", definition
+
+
+def test_a_definition_with_no_element_path_does_not_crash():
+    q = _intake_like_questionnaire()
+    q["item"][0]["definition"] = "http://hl7.org/fhir/StructureDefinition/Patient#"
+    bundle = extract_resources(_intake_like_response(), q)
+    assert all(e["resource"]["resourceType"] == "Patient" for e in bundle["entry"])
+


### PR DESCRIPTION
Part 1 of #572 (the fabricated element). Part 2 (the forked Patient) stays open on the issue; see below.

## What was happening

`_extract_by_definition` walks every item carrying a `definition` into the one target resource type the root `definitionExtract` names. The intake form's allergen item is defined as `AllergyIntolerance#AllergyIntolerance.code.text`, so a committed form wrote its answer into the Patient being built as `Patient.code.text`: an element Patient does not have, holding an allergen name (or the blank-allergen placeholder) that no clinician can find and no validator catches. Measured against a running app by the review that filed #572.

## What changes

A definition names its own resource type, twice: in the StructureDefinition URL before `#` and as the first segment of the element path after it. Both must be the type this questionnaire extracts where the URL says what type it is (the HL7 base namespace, or a bare type name); an answer declared for a type this engine is not building is **dropped rather than misfiled**, and the drop is logged naming the item and the types, never the answer. Demographics extract exactly as before.

The adversarial QA pass on this PR found the first version read only the path: `http://hl7.org/fhir/StructureDefinition/AllergyIntolerance#Patient.name.given` walked through. Fixed and pinned. **Stated limit:** a profile URL (`us-core-patient`, `http://example.org/SD`) does not carry its base type in its name and cannot be checked without resolving the profile, so there the element path's type governs, as it always did; the existing guardrail test that sends `http://example.org/SD#Foobar.name.family` to `$validate` is what draws that line.

## Evidence

- **Pins first** (`tests/test_sdc_extract.py`, red on main): an intake-shaped questionnaire with a Patient target and an allergen item; the extracted Patient carries no `code`, the answer appears nowhere in the bundle, the family name still extracts, and the warning names `allergies.item.allergen`, `AllergyIntolerance` and `Patient` and not the answer.
- **Mutation**, executed 2026-09-06: drop the type comparison, red (the Patient carries `code`).
- SDC extract, guardrails, roundtrip, routes, populate, intake and conformance suites green (86 passed). Full suite on the branch: 3666 passed, 13 skipped, 1 xfailed (with the both-halves rule; 3663 before the QA fix).

## Not in this PR (part 2 of #572)

Each committed form still creates a **new** Patient rather than updating the one the response's `subject` names. Reconciling is a design question (what to merge, keyed on what; a PUT with the form's demographics alone would replace identifiers the form never asked about), and belongs with the engine growing the other target types, so the allergen has somewhere to go instead of being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


