### PR TITLE
fix(review): the content list handed to the populate engine no longer holds the Patient, and the expression handler is reached (#581)

### DIFF
--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -205,7 +205,12 @@ def _gather_content(tenant_id, patient, subject_ref=None):
 
     patient_id = patient['id']
     ref = 'Patient/%s' % patient_id
-    content = [patient]
+    # The Patient is NOT in this list (#581). populate_questionnaire takes
+    # the subject as its own argument; a copy in here was dead weight held
+    # beside a redaction boundary, the same door $populate closed in #578
+    # after proving nothing read it. Nothing reads it here either: the
+    # list reaches the engine and nowhere else.
+    content = []
     unanchored = False
     for resource_type, subject_field in _CONTENT_TYPES:
         for row in R6Resource.query.filter_by(

--- a/tests/actions/test_review_flow.py
+++ b/tests/actions/test_review_flow.py
@@ -668,3 +668,56 @@ def test_review_refuses_a_read_scoped_token(client, app, tenant_headers,
             tenant_headers['X-Tenant-Id'], scope='read'),
     }, action_id)
     assert resp.status_code == 401, resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# #581 item 1: the content list handed to the populate engine never holds the
+# Patient. The Patient arrives as `subject`; a copy inside the list was dead
+# weight sitting beside a redaction boundary, the same door $populate closed
+# in #578 after proving nothing read it.
+# ---------------------------------------------------------------------------
+
+def test_the_content_list_never_holds_the_patient(app, tenant_id, monkeypatch):
+    """MUTATION: r6/actions/review.py, seed the list with the patient again
+    (`content = [patient]`) -> red."""
+    from r6.actions import review
+    from r6.models import R6Resource
+    from models import db
+
+    with app.app_context():
+        db.session.add(R6Resource(
+            resource_type='Patient', resource_id='p-581', tenant_id=tenant_id,
+            resource_json='{"resourceType":"Patient","id":"p-581","name":[{"family":"Quux581"}]}'))
+        db.session.add(R6Resource(
+            resource_type='AllergyIntolerance', resource_id='a-581', tenant_id=tenant_id,
+            resource_json='{"resourceType":"AllergyIntolerance","id":"a-581",'
+                          '"patient":{"reference":"Patient/p-581"},'
+                          '"code":{"text":"peanut-581"}}'))
+        db.session.commit()
+        patient = review._load_patient(tenant_id, 'Patient/p-581')
+        assert patient and patient['id'] == 'p-581'
+        content = review._gather_content(tenant_id, patient, 'Patient/p-581')
+        assert content.resolved
+        types = [r['resourceType'] for r in content.resources]
+        assert 'Patient' not in types
+        assert types == ['AllergyIntolerance']       # the record still reaches the engine
+
+        # And what the engine is handed on the page's own path: the subject
+        # separately, the list without it.
+        seen = {}
+        real = review.populate_questionnaire
+
+        def _capture(questionnaire, subject, content_resources):
+            seen['subject'] = subject
+            seen['content'] = list(content_resources)
+            return real(questionnaire, subject, content_resources)
+
+        monkeypatch.setattr(review, 'populate_questionnaire', _capture)
+        from r6.actions.models import ProposedAction
+        action = ProposedAction(tenant_id=tenant_id, kind='form-fill',
+                                payload={'subject': {'reference': 'Patient/p-581'}})
+        db.session.add(action)
+        db.session.commit()
+        review._draft_qr(action, tenant_id)
+        assert seen['subject']['id'] == 'p-581'
+        assert all(r['resourceType'] != 'Patient' for r in seen['content'])

--- a/tests/test_sdc_expressions.py
+++ b/tests/test_sdc_expressions.py
@@ -22,8 +22,28 @@ def test_evaluate_returns_none_on_no_match():
     assert evaluate("Patient.name.given.first()", patient) is None
 
 
-def test_evaluate_returns_none_on_bad_expression():
+def test_evaluate_returns_none_on_an_empty_result():
+    """The library answers an empty result for this input rather than
+    raising, so this exercises the empty path, not the handler (#581 item
+    2 renamed it to say so)."""
     assert evaluate("this is not fhirpath (((", {}) is None
+
+
+def test_evaluate_returns_none_when_the_library_raises(caplog):
+    """The handler: fhirpathpy raises on an unknown function ("Not
+    implemented: foo"), and evaluate swallows it, answers None, and logs the
+    failure naming the item, never the expression (#581 item 2).
+
+    MUTATION: r6/sdc/expressions.py, remove the except clause -> this test
+    errors with the library's exception.
+    """
+    import logging
+    with caplog.at_level(logging.WARNING, logger="r6.sdc.expressions"):
+        assert evaluate("foo()", {"resourceType": "Patient"},
+                        link_id="item-581") is None
+    logged = [r.getMessage() for r in caplog.records]
+    assert any("item-581" in m for m in logged), logged
+    assert not any("foo()" in m for m in logged), logged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #581.

## Item 1: an unredacted Patient beside a redaction boundary

`_gather_content` in `r6/actions/review.py` seeded its list with the Patient. `populate_questionnaire` takes the subject as its own argument, and its docstring already says the list must not hold it (the #562 review); the copy was dead weight sitting beside a redaction boundary, the same door `$populate` closed in #578 after proving nothing read it. Checked here with its own proof rather than the assumption the issue asked us not to make: the list reaches the engine and nowhere else (the page reads only `content.resolved` and `content.reason`), and the engine matches the list groups (medications, allergies, conditions) against it, never the subject. The list now starts empty; the clinical rows reach the engine unchanged.

**Pin** (red on main): a resolved patient with one allergy yields a content list of exactly `['AllergyIntolerance']`, and on the page's own path the engine receives the subject separately and a list with no Patient. **Mutation**, executed 2026-09-06: seed the list with the patient again, red.

## Item 2: a test that did not reach the branch it named

`test_evaluate_returns_none_on_bad_expression` passed `"this is not fhirpath ((("`, which the library answers `[]` for rather than raising, so it exercised the empty-result path. It is renamed to say so. A new test reaches the handler with an unknown function (`foo()`, which the library raises `Not implemented: foo` on), and pins that `evaluate` answers `None` and logs the failure naming the item and never the expression (the #581 reflection point, already documented beside the handler).

Actions, SDC expressions/populate/roundtrip, intake, careagents and conformance suites green (487 passed). Full suite on the branch: 3663 passed, 13 skipped, 1 xfailed, 2 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
