### PR TITLE
fix(sdc): $extract commit mode refuses to write clinical rows on a step-up token alone (#572)

### DIFF
--- a/r6/sdc/extract.py
+++ b/r6/sdc/extract.py
@@ -18,6 +18,14 @@ DEFINITION_EXTRACT_URL = (
 )
 
 
+#: The types the form-fill rail commits after human confirmation. Nothing on
+#: the human-gated path calls $extract, so commit mode on the raw endpoint
+#: refuses a bundle carrying them (r6/sdc/routes.py): a step-up token alone
+#: must not write clinical rows (#572).
+RAIL_ONLY_TYPES = frozenset({"AllergyIntolerance", "Condition",
+                             "MedicationRequest"})
+
+
 def extract_resources(questionnaire_response, questionnaire):
     """Return a FHIR transaction Bundle of resources extracted from `qr`."""
     subject_ref = questionnaire_response.get("subject")

--- a/r6/sdc/routes.py
+++ b/r6/sdc/routes.py
@@ -31,7 +31,7 @@ from r6.models import R6Resource
 from r6.audit import record_audit_event
 from r6.redaction import apply_redaction
 from r6.sdc.populate import NOT_POPULATED, populate_questionnaire
-from r6.sdc.extract import extract_resources
+from r6.sdc.extract import RAIL_ONLY_TYPES, extract_resources
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +139,23 @@ def register_sdc_routes(blueprint, deps):
                 "Questionnaire for the response could not be resolved"), 404
 
         bundle = extract_resources(qr, questionnaire)
+
+        if not dry_run and any(
+                e["resource"]["resourceType"] in RAIL_ONLY_TYPES
+                for e in bundle["entry"]):
+            # #572. Nothing on the human-gated path calls $extract, so commit
+            # mode here runs on a step-up token alone; a bundle carrying
+            # allergies, conditions or medications is refused rather than
+            # written on that, and rather than dropped silently after dryRun
+            # showed it. The form-fill rail commits those rows after the
+            # person confirms them. Measured on main before this: the legacy
+            # single-target engine wrote an AllergyIntolerance this way.
+            return operation_outcome(
+                "error", "business-rule",
+                "This bundle carries clinical rows (allergies, conditions or "
+                "medications). The form-fill rail commits those after human "
+                "confirmation; $extract does not. Use dryRun=true to preview "
+                "them."), 422
 
         if not dry_run:
             # H4 posture (deliberate): $extract commits clinical resources as a

--- a/tests/test_extract_refuses_clinical_rows_on_step_up_alone.py
+++ b/tests/test_extract_refuses_clinical_rows_on_step_up_alone.py
@@ -1,0 +1,89 @@
+"""$extract commit mode refuses to write allergies, conditions or
+medications on a step-up token alone (#572, the class the CTO design pass
+named worse than #214's header).
+
+Nothing on the human-gated path calls $extract: the form-fill executor
+never extracts, and $extract's callers are the raw endpoint (step-up only)
+and the MCP write tool. Measured on main before this change: a
+Questionnaire whose root definitionExtract names AllergyIntolerance, with
+definitions for clinicalStatus, verificationStatus, patient and code.text,
+answered with plain strings, POSTed to commit mode with a step-up token
+and answered 200 with one AllergyIntolerance row stored, its statuses and
+patient reference written as bare strings the validator waved through by
+truthiness. A clinical write with no human confirmation, on the credential
+an agent holds.
+
+Commit mode now refuses a bundle carrying any of the three types with a
+422 naming the form-fill rail and dryRun; dryRun still previews them. The
+refusal writes no audit row (consistent with the kernel's own refusals):
+the audit trail does not cover refused attempts here.
+
+MUTATION: r6/sdc/routes.py, drop the refusal -> red (the row is stored and
+the response is 200).
+"""
+
+from r6.sdc.extract import RAIL_ONLY_TYPES
+
+SD = "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+DEF_EXTRACT = ("http://hl7.org/fhir/uv/sdc/StructureDefinition/"
+               "sdc-questionnaire-definitionExtract")
+
+
+def _legacy_allergy_questionnaire():
+    return {"resourceType": "Questionnaire", "status": "active",
+            "extension": [{"url": DEF_EXTRACT, "valueCode": "AllergyIntolerance"}],
+            "item": [
+                {"linkId": "cs", "type": "string", "definition": f"{SD}#AllergyIntolerance.clinicalStatus"},
+                {"linkId": "vs", "type": "string", "definition": f"{SD}#AllergyIntolerance.verificationStatus"},
+                {"linkId": "pt", "type": "string", "definition": f"{SD}#AllergyIntolerance.patient"},
+                {"linkId": "al", "type": "string", "definition": f"{SD}#AllergyIntolerance.code.text"},
+            ]}
+
+
+def _response():
+    return {"resourceType": "QuestionnaireResponse", "status": "completed",
+            "item": [{"linkId": "cs", "answer": [{"valueString": "active"}]},
+                     {"linkId": "vs", "answer": [{"valueString": "unconfirmed"}]},
+                     {"linkId": "pt", "answer": [{"valueString": "Patient/p-hole"}]},
+                     {"linkId": "al", "answer": [{"valueString": "peanut-hole"}]}]}
+
+
+def _params():
+    return {"resourceType": "Parameters", "parameter": [
+        {"name": "questionnaire-response", "resource": _response()},
+        {"name": "questionnaire", "resource": _legacy_allergy_questionnaire()}]}
+
+
+def _rows(app, tenant_id):
+    from r6.models import R6Resource
+    with app.app_context():
+        return R6Resource.query.filter_by(
+            tenant_id=tenant_id, resource_type="AllergyIntolerance").count()
+
+
+def test_commit_mode_refuses_a_clinical_row_on_a_step_up_token_alone(
+        client, app, auth_headers, tenant_id):
+    before = _rows(app, tenant_id)
+    resp = client.post("/r6/fhir/QuestionnaireResponse/$extract",
+                       headers=auth_headers, json=_params())
+    assert resp.status_code == 422, resp.get_data(as_text=True)[:200]
+    outcome = resp.get_json()
+    assert outcome["resourceType"] == "OperationOutcome"
+    diag = outcome["issue"][0]["diagnostics"]
+    assert "form-fill" in diag and "dryRun" in diag
+    assert "peanut-hole" not in diag
+    assert _rows(app, tenant_id) == before
+
+
+def test_dry_run_still_previews_the_row(client, app, auth_headers, tenant_id):
+    before = _rows(app, tenant_id)
+    resp = client.post("/r6/fhir/QuestionnaireResponse/$extract?dryRun=true",
+                       headers=auth_headers, json=_params())
+    assert resp.status_code == 200
+    assert "peanut-hole" in resp.get_data(as_text=True)
+    assert _rows(app, tenant_id) == before
+
+
+def test_the_refused_types_are_the_three_rail_only_types():
+    assert RAIL_ONLY_TYPES == frozenset({"AllergyIntolerance", "Condition",
+                                         "MedicationRequest"})


### PR DESCRIPTION
Part of #572, lifted out of the held part-2 stack because it closes a live guardrail gap on `main`. **This one jumps the queue**, the way #615 did.

## Measured on main, not inferred

Nothing on the human-gated path calls `$extract`: the form-fill executor never extracts, and `$extract`'s callers are the raw endpoint (step-up only) and the MCP write tool. In a scratch worktree on `main`: a Questionnaire whose root `definitionExtract` names `AllergyIntolerance`, with definitions for `clinicalStatus`, `verificationStatus`, `patient` and `code.text` answered as plain strings, POSTed to commit mode with a step-up token:

```
status=200 rows_before=0 rows_after=1
```

One AllergyIntolerance stored, its statuses and patient reference written as bare strings that the validator waved through by truthiness. A clinical write with no human confirmation, on the credential an agent holds: the class the CTO design pass for #572 named worse than the #214 header.

## What changes

- `RAIL_ONLY_TYPES` (`AllergyIntolerance`, `Condition`, `MedicationRequest`) in `r6/sdc/extract.py`.
- Commit mode on `$extract` refuses a bundle carrying any of them with a 422 OperationOutcome naming the form-fill rail and `dryRun`, before validation and before any write. `dryRun` still previews them. The refusal writes no audit row, consistent with the kernel's own refusals, so the audit trail does not cover refused attempts here.

## Evidence

- **Pin** (`tests/test_extract_refuses_clinical_rows_on_step_up_alone.py`): the measured request now answers 422 and stores nothing; dryRun previews it; the three types are named.
- **Mutation**, executed 2026-09-06: drop the refusal, red (200 and a stored row).
- SDC guardrails/routes/roundtrip/extract, the write-guard matrix, conformance and the ratchets green (247 passed). Full suite on the branch: 3664 passed, 13 skipped, 1 xfailed.

## What this leaves

The rest of part 2 of #572 (no Patient on a subject-bound response, populated rows carrying their source, the engine building the clinical rows for the executor to commit after confirmation) is built and held as branches behind #664; that stack drops this commit when it retargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
