### PR TITLE
feat(oauth): the authorization server behaves like one (#568 phase 2, P2-a to P2-d)

### DIFF
--- a/docs/specs/2026-08-16-mcp-authorization.md
+++ b/docs/specs/2026-08-16-mcp-authorization.md
@@ -1132,8 +1132,18 @@ end-user run.
   port.
 - A manual client id and secret can be pasted under "Advanced settings"; that
   path is not designed for and not needed.
-- Whether Claude uses the refresh grant is not stated. The server offers it
-  (§13.5); the end-user run reports whether it was taken.
+- **Claude registers as a confidential client**: its registration body carries
+  `token_endpoint_auth_method: client_secret_post`, and at the token endpoint
+  it sends `client_id` and `client_secret` in the form body, as
+  `application/x-www-form-urlencoded`, for the code exchange and for refresh
+  (Anthropic's connector authentication notes, read 2026-09-06). The MCP
+  Python SDK's client, which Claude's user agent identifies, sends the
+  credential the way the registration answered, refuses a registration that
+  names a secret-bearing method without a secret, uses the refresh grant, and
+  sends RFC 8707 `resource` when the protocol version calls for it. So the
+  token endpoint's client authentication (P2-d, #669) is what Claude expects,
+  and the refresh chain (§13.5) will be exercised. Still measured only by the
+  §8.4 run.
 
 ### 13.2 The shape: Flask stays the issuer, CareAgents is the front door
 

--- a/docs/specs/2026-08-16-mcp-authorization.md
+++ b/docs/specs/2026-08-16-mcp-authorization.md
@@ -1102,3 +1102,183 @@ refresh, and the missing `aud` check in `_oauth_authorizes`.
   `services/agent-orchestrator/src/index.ts`). On the
   OAuth path `_tenantId`, `_stepUpToken` and `_authorization` are discarded,
   exactly as `isPublicDemo()` pins them. Asserted as R8.
+
+---
+
+## 13. Amendment 2026-09-06: the consent surface, and a hosted connector reaching a real tenant (#568)
+
+**Status: proposed by the founder on 2026-09-06; design only in this section.**
+The founder asked for the locked server to work as an ordinary claude.ai
+connector on real records, with CareAgents as the account and consent surface.
+That request overrides the "phase 2 waits" clause of ruling D4. Everything in
+§1 to §12 stands; this section fills the one hole §6.1 and #568 left open.
+
+### 13.1 What claude.ai actually does, from Anthropic's own connector notes
+
+Read, not run, on 2026-09-06. Measured against our deployment only in the §8.4
+end-user run.
+
+- Claude registers itself with Dynamic Client Registration. The client name is
+  `Claude`. The callback is `https://claude.ai/api/mcp/auth_callback`, and
+  Anthropic says it may become `https://claude.com/api/mcp/auth_callback`, so
+  both are accepted as registered redirect URIs.
+- The authorize request carries `resource=` (the PRM `resource`, RFC 8707),
+  `scope=` (from the PRM), `code_challenge` with `S256`, and `state`. Claude
+  supports the 2025-03-26 and 2025-06-18 authorization specs, which is the
+  discovery chain §3 designs to.
+- Claude Code, as a native client, registers loopback redirect URIs
+  (`http://localhost/callback`, `http://127.0.0.1/callback`) on ephemeral
+  ports; redirect-URI matching for `localhost` and `127.0.0.1` must ignore the
+  port.
+- A manual client id and secret can be pasted under "Advanced settings"; that
+  path is not designed for and not needed.
+- Whether Claude uses the refresh grant is not stated. The server offers it
+  (§13.5); the end-user run reports whether it was taken.
+
+### 13.2 The shape: Flask stays the issuer, CareAgents is the front door
+
+The issuer is unchanged (`https://app.healthclaw.io`, D4). The MCP server
+still introspects at Flask (§3.5). What changes is what happens between a
+browser arriving at `/oauth/authorize` and a code being issued:
+
+```
+claude.ai ── GET /r6/fhir/oauth/authorize?...&resource=<RESOURCE> ──▶ Flask
+                Flask validates client, PKCE, resource; parks the request
+                302 ─▶ https://careagents.cloud/authorize?req=<signed handle>
+                                                                     │
+      CareAgents: passkey sign-in; consent page lists the account's   │
+      connections (each one a tenant) plus "the demo records";        │
+      approval requires a fresh passkey assertion; Grant row written  │
+                302 ◀─ /r6/fhir/oauth/consent/return?grant=<signed>  ─┘
+                Flask verifies the grant, binds the code to its tenant,
+                audits the consent under that tenant
+                302 ─▶ https://claude.ai/api/mcp/auth_callback?code&state&iss
+```
+
+Two extra top-level redirects. From the client's side it is ordinary OAuth
+2.1 with PKCE. CareAgents runs no authorization server: no registration, no
+token endpoint, no PKCE. It authenticates a person and records a decision.
+
+**The alternative, stated so it can be chosen instead:** CareAgents as the
+issuer. It would port registration, PKCE, the stores and revocation from
+`r6/oauth.py`, re-rule D4, and move the PRM's `authorization_servers`. Nothing
+the founder asked for needs that.
+
+### 13.3 The handoff protocol
+
+Both sides already share `INTERNAL_TOKEN_MINT_SECRET` (CareAgents mints
+step-up tokens with it). The handoff key is derived from it with domain
+separation, the way `payload_digest` derives from `STEP_UP_SECRET`:
+`sha256(b'healthclaw-consent-handoff:' + INTERNAL_TOKEN_MINT_SECRET)`. One
+fewer secret to provision, and a forged grant needs the mint secret, which
+already grants everything.
+
+**Outbound (Flask to CareAgents).** Flask stores the parked request under a
+random `request_id` (10 minutes, single use) with `client_id`, `client_name`,
+`redirect_uri`, `scopes`, `code_challenge`, `state`, `resource`. The URL
+carries `req=<request_id>.<exp>.<tag>`, where `tag` is HMAC-SHA256 over
+`request_id.exp` under the handoff key. The page shows the client name and
+scopes from the parked request, fetched by CareAgents from Flask
+(`GET /r6/fhir/oauth/consent/<request_id>`, service-authenticated with the
+mint secret), so nothing about the client rides in the URL.
+
+**Inbound (CareAgents to Flask).** `grant=<base64url(JSON)>.<tag>` where the
+JSON is `{request_id, tenant_id, consent_id, nonce, exp, decision}` and
+`decision` is `approved` or `denied`. Flask: `compare_digest` on the tag;
+`exp` in the future; `nonce` unused (the nonce cache in `r6/stepup.py`);
+the parked request popped exactly once; `tenant_id` matches
+`^[a-zA-Z0-9_-]{1,64}$`. Then the code is issued bound to `tenant_id`, or
+the client is sent `error=access_denied`.
+
+**Trust, written down as an assumption.** Flask cannot verify that the
+CareAgents account owns `tenant_id`; it trusts the signed assertion. That
+trust exists today: CareAgents holds the mint secret and can act on any
+tenant. This section adds no authority, it moves an existing one onto a
+signed, single-use, expiring message.
+
+**The tenant policy of the `invalid_target` map (§3.5.1) gains a third value.**
+`demo` binds `MCP_OAUTH_DEMO_TENANT`; `careagents` sends the request through
+§13.3 and binds whatever the grant names; the FHIR resource keeps binding the
+header tenant behind the existing public-tenant guard. With
+`CAREAGENTS_CONSENT_URL` unset, the MCP resource falls back to `demo`, which
+is the §3.5.1 behaviour unchanged.
+
+### 13.4 Consent is a tenant event, and it can be taken back
+
+- Flask writes an AuditEvent under the tenant on approval: `event_type=create`,
+  `resource_type=Consent`, `resource_id=<consent_id>`, detail
+  `client_id=… scopes=… via=careagents`. No account id, no email, no label.
+- Flask stores the consent (`consent_id` to `{tenant_id, client_id, scopes,
+  granted_at, revoked_at}`) beside the OAuth stores. Every access token and
+  refresh token carries its `consent_id`.
+- `POST /r6/fhir/oauth/consent/<consent_id>/revoke`, service-authenticated
+  with the mint secret, sets `revoked_at`. Introspection answers
+  `active: false` for every token of a revoked consent, and the refresh chain
+  dies with it.
+- CareAgents keeps a `Grant` row per approval (account, connection, client
+  name, scopes, granted and revoked times; no PHI) and shows it on the home
+  page with "Revoke", which calls the endpoint above.
+
+### 13.5 Refresh tokens, because hourly re-consent on real records is not acceptable (§6.8)
+
+The token endpoint gains `grant_type=refresh_token` for the clients registered
+here. Refresh tokens are opaque, live 30 days, carry `consent_id`, `aud`,
+`tenant_id`, `scopes` and `client_id`, and rotate on every use: the response
+carries a new refresh token and the old one is dead. Presenting a rotated
+token again revokes the whole chain (OAuth 2.1 §4.3.1). Public clients must
+send their `client_id`; a refresh token is bound to the client it was issued
+to. Discovery advertises `refresh_token` in `grant_types_supported`.
+
+### 13.6 The downstream credential on the OAuth path
+
+§3.6 leaves the MCP server without a credential for a protected tenant. The
+MCP server already holds `INTERNAL_TOKEN_MINT_SECRET` and already has
+`ensureReadToken`, which mints a step-up token per tenant. The gap is that
+`/internal/step-up-token` accepts no scope, so that mint is write-capable.
+Change: the mint endpoint accepts an optional `scope`, only `"read"` or
+absent, and the OAuth path always sends `"read"`. `generate_step_up_token`
+already produces read-scoped tokens and `authorize_tenant_read` already
+accepts them; a read-scoped token can never authorize a write (H4). The
+consent scopes are `fhir.read` and `context.read`, both reads, so the
+downstream authority equals the consented one. The minted token is cached
+under the SHA-256 of the OAuth token, never per tenant, for at most 5 minutes
+and never past the OAuth token's own expiry, so a revoked consent stops
+being served within the cache window.
+
+Token exchange (RFC 8693) was the alternative and is the more standard shape;
+it was not chosen because it adds a grant type and a second audience to the
+same outcome.
+
+### 13.7 What the person sees, and what is true about their identity
+
+The consent page says who is asking (`Claude`), what they get (read access,
+redacted, audited; never writes, which still need the human gate), and to
+which records. Approval requires a fresh passkey assertion with
+`user_verification=required`, not a remembered session. That is what makes
+"biometric" a true word here. The tenants offered are the account's
+connections, each created through a provider-portal sign-in via Fasten or
+through the person's own upload. No identity-assurance level is claimed
+anywhere; the page says what happened, not what it proves.
+
+Consent to expose a real tenant to a third-party agent is gated by
+`CARE_REAL_RECORDS` exactly as a new real-record connection is: `off` offers
+only the demo records, `allowlist` offers real tenants to listed accounts,
+`on` offers them to everyone. The founder can widen it later.
+
+### 13.8 Delivery, and the gates that are not ours
+
+Seven pull requests, each independently green and each behind the existing
+flags: Flask conformance (§3.5 P2-a to P2-d, root discovery, `aud` in
+`_oauth_authorizes`); introspection plus the mint scope; the handoff, revoke
+and consent audit; refresh; CareAgents consent page and Grant; MCP server
+phase 3 (`MCP_OAUTH_ENABLED`, drop passthrough and the tool-argument
+overrides, read-scoped mint, CORS on the 401 and its preflight); the
+walkthrough and this document's test plan.
+
+Nothing in the list deploys. The owner's checklist before the §8.4 run:
+repoint `mcp.healthclaw.io` and verify over DoH (#522); check the Vercel
+domain verification; set `MCP_CANONICAL_RESOURCE`, `OAUTH_ISSUER`,
+`MCP_INTROSPECTION_CLIENT_ID` and `_SECRET`, `CAREAGENTS_CONSENT_URL`; confirm
+`READ_AUTH_ENABLED=true` by observation (§10.2); deploy Flask, the MCP server
+and CareAgents web and worker from the same stage; then `MCP_OAUTH_ENABLED=true`
+in staging first.

--- a/main.py
+++ b/main.py
@@ -205,6 +205,12 @@ def _register_blueprints(flask_app: Flask) -> None:
     from r6.routes import r6_blueprint
 
     flask_app.register_blueprint(r6_blueprint)
+    # RFC 8414: the issuer is the host root (no path), so a client looks for
+    # the metadata at the root well-known path first. The prefixed copy under
+    # /r6/fhir stays for anything that already reads it (spec §3.3).
+    from r6.oauth import discovery_root_view
+    flask_app.add_url_rule('/.well-known/oauth-authorization-server',
+                           'oauth_discovery_root', discovery_root_view)
 
     from r6.fasten.routes import fasten_blueprint
 

--- a/r6/oauth.py
+++ b/r6/oauth.py
@@ -21,16 +21,138 @@ import secrets
 import time
 import uuid
 from functools import wraps
-from flask import request, jsonify
+from urllib.parse import urlencode, urlsplit
+from flask import request, jsonify, redirect
 from r6.runtime_config import resolve_app_env
 from r6.runtime_config import read_auth_enabled
+from r6.constant_time import equal as constant_time_equal
 
 logger = logging.getLogger(__name__)
 
 # Configuration
-OAUTH_ISSUER = os.environ.get('OAUTH_ISSUER', '')
 OAUTH_SECRET = os.environ.get('OAUTH_SECRET', os.environ.get('STEP_UP_SECRET', ''))
 TOKEN_TTL_SECONDS = int(os.environ.get('OAUTH_TOKEN_TTL', '3600'))
+#: A registered client lives this long; `client_secret_expires_at` says so.
+CLIENT_TTL_SECONDS = 30 * 24 * 3600
+#: RFC 7591 methods a client may register with. `none` is a public client:
+#: no secret is issued and `client_id` is required at the token endpoint.
+CLIENT_AUTH_METHODS = ('none', 'client_secret_post', 'client_secret_basic')
+#: Loopback hosts whose redirect URIs match on any port (RFC 8252 §7.3).
+#: Native clients such as Claude Code listen on an ephemeral port.
+_LOOPBACK_HOSTS = frozenset({'localhost', '127.0.0.1', '::1'})
+
+
+def issuer():
+    """The issuer identifier (RFC 8414). `OAUTH_ISSUER` when set, else the
+    request's own root. Read per call: the tests set the variable after import,
+    and a deployment sets it without a code change."""
+    configured = os.environ.get('OAUTH_ISSUER', '').strip().rstrip('/')
+    return configured or request.host_url.rstrip('/')
+
+
+def fhir_resource():
+    """RFC 8707 identifier of the FHIR surface this issuer fronts. A token
+    minted for it carries it as `aud`; `r6.read_auth` accepts nothing else."""
+    return f'{issuer()}/r6/fhir'
+
+
+def resource_policies():
+    """Every audience this server will mint for, and how a browser-initiated
+    authorize binds its tenant for that audience (spec §3.5.1, P2-b).
+
+    `header`: today's behaviour, the `X-Tenant-Id` header behind the
+    public-tenant guard. `demo`: `MCP_OAUTH_DEMO_TENANT`, and the header is
+    ignored, because a browser flow has no trusted place to put a tenant.
+    The map is explicit; an audience not in it is `invalid_target`, never
+    recorded as sent.
+    """
+    policies = {fhir_resource(): 'header'}
+    mcp = os.environ.get('MCP_CANONICAL_RESOURCE', '').strip()
+    if mcp:
+        policies[mcp] = 'demo'
+    return policies
+
+
+def _loopback_form(uri):
+    """The port-stripped form of a plain-http loopback URI, else None."""
+    parts = urlsplit(uri)
+    if parts.scheme == 'http' and (parts.hostname or '') in _LOOPBACK_HOSTS:
+        return parts._replace(netloc=parts.hostname)
+    return None
+
+
+def redirect_uri_allowed(uri):
+    """RFC 7591 registration: `https://`, or a plain-http loopback URI.
+    Anything else is a redirect we would send a code to over the open
+    network, and the registration is refused rather than stored."""
+    if not isinstance(uri, str):
+        return False
+    parts = urlsplit(uri)
+    if not parts.netloc or parts.fragment:
+        return False
+    if parts.scheme == 'https':
+        return True
+    return _loopback_form(uri) is not None
+
+
+def redirect_uri_matches(candidate, registered):
+    """Exact match, except that loopback URIs match on any port."""
+    if candidate == registered:
+        return True
+    a, b = _loopback_form(candidate), _loopback_form(registered)
+    return a is not None and b is not None and a == b
+
+
+def _redirect_to_client(redirect_uri, state, **params):
+    """302 to the client's registered redirect URI (OAuth 2.1 §4.1.2), with
+    each parameter URL-encoded and RFC 9207 `iss` appended so the client can
+    tell which issuer answered. `state` is echoed only when it was sent."""
+    if state:
+        params['state'] = state
+    params['iss'] = issuer()
+    separator = '&' if '?' in redirect_uri else '?'
+    response = redirect(f'{redirect_uri}{separator}{urlencode(params)}',
+                        code=302)
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
+def discovery_document():
+    """RFC 8414 metadata. Served under the issuer's root and under the FHIR
+    prefix; both copies are this one document."""
+    base = issuer()
+    return {
+        'issuer': base,
+        'authorization_endpoint': f'{base}/r6/fhir/oauth/authorize',
+        'token_endpoint': f'{base}/r6/fhir/oauth/token',
+        'registration_endpoint': f'{base}/r6/fhir/oauth/register',
+        'revocation_endpoint': f'{base}/r6/fhir/oauth/revoke',
+        'scopes_supported': list(SMART_SCOPES.keys()),
+        'response_types_supported': ['code'],
+        'grant_types_supported': ['authorization_code'],
+        'token_endpoint_auth_methods_supported': list(CLIENT_AUTH_METHODS),
+        'code_challenge_methods_supported': ['S256'],
+        'authorization_response_iss_parameter_supported': True,
+        'service_documentation': f'{base}/r6/fhir/docs/privacy-policy',
+    }
+
+
+def discovery_root_view():
+    """The issuer-root copy of the metadata, registered by `main` at
+    `/.well-known/oauth-authorization-server` — the first location a client
+    tries for a path-less issuer (RFC 8414 §3)."""
+    return jsonify(discovery_document())
+
+
+def _presented_client_credentials(body):
+    """(client_id, client_secret) from the POST body, else HTTP Basic."""
+    client_id = body.get('client_id')
+    client_secret = body.get('client_secret')
+    basic = request.authorization
+    if basic is not None and basic.type == 'basic':
+        client_id = client_id or basic.username
+        client_secret = client_secret or basic.password
+    return client_id, client_secret
 
 # SMART-on-FHIR v2 scope definitions
 SMART_SCOPES = {
@@ -172,28 +294,16 @@ def register_oauth_routes(blueprint):
 
     @blueprint.route('/.well-known/oauth-authorization-server', methods=['GET'])
     def oauth_discovery():
-        """RFC 8414 OAuth Authorization Server Metadata."""
-        base = request.host_url.rstrip('/')
-        return jsonify({
-            'issuer': OAUTH_ISSUER or base,
-            'authorization_endpoint': f'{base}/r6/fhir/oauth/authorize',
-            'token_endpoint': f'{base}/r6/fhir/oauth/token',
-            'registration_endpoint': f'{base}/r6/fhir/oauth/register',
-            'revocation_endpoint': f'{base}/r6/fhir/oauth/revoke',
-            'scopes_supported': list(SMART_SCOPES.keys()),
-            'response_types_supported': ['code'],
-            'grant_types_supported': ['authorization_code'],
-            'token_endpoint_auth_methods_supported': ['client_secret_post', 'none'],
-            'code_challenge_methods_supported': ['S256'],
-            'service_documentation': f'{base}/r6/fhir/docs/privacy-policy',
-        })
+        """RFC 8414 OAuth Authorization Server Metadata (the prefixed copy;
+        the issuer-root copy is registered in `main`)."""
+        return jsonify(discovery_document())
 
     # --- SMART-on-FHIR Well-Known ---
 
     @blueprint.route('/.well-known/smart-configuration', methods=['GET'])
     def smart_configuration():
         """SMART App Launch v2 configuration."""
-        base = request.host_url.rstrip('/')
+        base = issuer()
         return jsonify({
             'authorization_endpoint': f'{base}/r6/fhir/oauth/authorize',
             'token_endpoint': f'{base}/r6/fhir/oauth/token',
@@ -220,28 +330,49 @@ def register_oauth_routes(blueprint):
         if not body:
             return jsonify({'error': 'invalid_request'}), 400
 
+        redirect_uris = body.get('redirect_uris')
+        if (not isinstance(redirect_uris, list) or not redirect_uris
+                or not all(redirect_uri_allowed(u) for u in redirect_uris)):
+            return jsonify({
+                'error': 'invalid_redirect_uri',
+                'error_description': 'redirect_uris must be https URLs or '
+                'plain-http loopback URLs (localhost, 127.0.0.1, [::1])',
+            }), 400
+        auth_method = body.get('token_endpoint_auth_method') or 'client_secret_post'
+        if auth_method not in CLIENT_AUTH_METHODS:
+            return jsonify({
+                'error': 'invalid_client_metadata',
+                'error_description': 'token_endpoint_auth_method must be one of '
+                + ', '.join(CLIENT_AUTH_METHODS),
+            }), 400
+
         client_id = str(uuid.uuid4())
-        client_secret = secrets.token_urlsafe(32)
-        redirect_uris = body.get('redirect_uris', [])
+        client_secret = None if auth_method == 'none' else secrets.token_urlsafe(32)
         client_name = body.get('client_name', 'Unknown Client')
         scope = body.get('scope', 'fhir.read context.read')
+        issued_at = int(time.time())
 
         _oauth_store_set('client', client_id, {
             'client_secret': client_secret,
             'redirect_uris': redirect_uris,
             'client_name': client_name,
             'scope': scope,
-            'created_at': time.time(),
-        }, ttl=30 * 24 * 3600)
+            'token_endpoint_auth_method': auth_method,
+            'created_at': issued_at,
+        }, ttl=CLIENT_TTL_SECONDS)
 
-        return jsonify({
+        response = {
             'client_id': client_id,
-            'client_secret': client_secret,
+            'client_id_issued_at': issued_at,
             'client_name': client_name,
             'redirect_uris': redirect_uris,
             'scope': scope,
-            'token_endpoint_auth_method': 'client_secret_post',
-        }), 201
+            'token_endpoint_auth_method': auth_method,
+        }
+        if client_secret is not None:
+            response['client_secret'] = client_secret
+            response['client_secret_expires_at'] = issued_at + CLIENT_TTL_SECONDS
+        return jsonify(response), 201
 
     # --- Authorization Endpoint ---
 
@@ -264,7 +395,8 @@ def register_oauth_routes(blueprint):
         if not registered_client:
             return jsonify({'error': 'invalid_client',
                           'error_description': 'Client not registered'}), 401
-        if redirect_uri not in registered_client.get('redirect_uris', []):
+        if not any(redirect_uri_matches(redirect_uri, registered)
+                   for registered in registered_client.get('redirect_uris', [])):
             return jsonify({'error': 'invalid_request',
                           'error_description': 'redirect_uri not registered for this client'}), 400
 
@@ -276,19 +408,45 @@ def register_oauth_routes(blueprint):
             return jsonify({'error': 'invalid_request',
                           'error_description': 'Only S256 code_challenge_method supported'}), 400
 
-        # H3: this endpoint AUTO-APPROVES with no consent screen and binds the
-        # token's tenant from the request header. When read-auth is on, that
-        # would let anyone mint a read bearer for any tenant, bypassing the gate.
-        # Restrict auto-approve to public/demo tenants; a protected tenant needs
-        # real per-user consent (out of scope for this reference OAuth server).
-        requested_tenant = request.headers.get('X-Tenant-Id', 'default')
+        # From here the redirect URI is the client's own registered one, so
+        # protocol errors go back to it (OAuth 2.1 §4.1.2.1) instead of to a
+        # JSON body a browser popup cannot act on.
+        resource = (request.args.get('resource') or '').strip()
+        policies = resource_policies()
+        if resource and resource not in policies:
+            # RFC 8707 §2: an audience we do not know is refused, and is never
+            # recorded as sent — that would make `aud` a caller-chosen string.
+            return _redirect_to_client(redirect_uri, state, error='invalid_target',
+                                       error_description='unknown resource')
+        audience = resource or fhir_resource()
+        policy = policies[audience]
+
         from r6.command_center.access import is_public
-        if read_auth_enabled() and not is_public(requested_tenant):
-            return jsonify({
-                'error': 'access_denied',
-                'error_description': 'Auto-approve authorization is limited to '
-                'public/demo tenants; protected tenants require per-user consent.',
-            }), 403
+        if policy == 'demo':
+            # P2-b: for the MCP audience the tenant is config, not a header.
+            # The demo tenant must be public; anything else fails closed here
+            # rather than minting the strongest token a browser flow can ask for.
+            requested_tenant = os.environ.get('MCP_OAUTH_DEMO_TENANT', '').strip()
+            if not requested_tenant or (
+                    read_auth_enabled() and not is_public(requested_tenant)):
+                return jsonify({
+                    'error': 'access_denied',
+                    'error_description': 'The MCP resource binds a configured '
+                    'demo tenant, and none is configured or it is not public.',
+                }), 403
+        else:
+            # H3: this endpoint AUTO-APPROVES with no consent screen and binds
+            # the token's tenant from the request header. When read-auth is on,
+            # that would let anyone mint a read bearer for any tenant, bypassing
+            # the gate. Restrict auto-approve to public/demo tenants; a protected
+            # tenant needs real per-user consent (spec §13, not built here).
+            requested_tenant = request.headers.get('X-Tenant-Id', 'default')
+            if read_auth_enabled() and not is_public(requested_tenant):
+                return jsonify({
+                    'error': 'access_denied',
+                    'error_description': 'Auto-approve authorization is limited to '
+                    'public/demo tenants; protected tenants require per-user consent.',
+                }), 403
 
         # Generate authorization code
         code = secrets.token_urlsafe(32)
@@ -299,18 +457,14 @@ def register_oauth_routes(blueprint):
             'code_challenge_method': code_challenge_method,
             'scopes': scope.split(),
             'tenant_id': requested_tenant,
+            'aud': audience,
             'exp': time.time() + 600,  # 10 minutes
         }, ttl=600)
 
-        # In production, this would render a consent screen.
-        # For the MCP server, we auto-approve and redirect.
-        separator = '&' if '?' in redirect_uri else '?'
-        location = f'{redirect_uri}{separator}code={code}&state={state}'
-        return jsonify({
-            'redirect': location,
-            'code': code,
-            'state': state,
-        })
+        # OAuth 2.1 §4.1.2: the code travels in a 302 to the registered
+        # redirect URI, with RFC 9207 `iss`. A JSON body here is a flow no
+        # browser can finish (#568).
+        return _redirect_to_client(redirect_uri, state, code=code)
 
     # --- Token Endpoint ---
 
@@ -324,13 +478,14 @@ def register_oauth_routes(blueprint):
         body = request.form.to_dict() if request.form else (request.get_json(silent=True) or {})
         code = body.get('code')
         code_verifier = body.get('code_verifier')
-        client_id = body.get('client_id')
+        client_id, client_secret = _presented_client_credentials(body)
 
         if not code or not code_verifier:
             return jsonify({'error': 'invalid_request',
                           'error_description': 'code and code_verifier required'}), 400
 
-        # Validate authorization code
+        # Validate authorization code. Popped before the client is checked so
+        # a failed exchange burns the code: a code is single-use either way.
         auth_code = _oauth_store_pop('auth-code', code)
         if not auth_code:
             return jsonify({'error': 'invalid_grant',
@@ -339,6 +494,24 @@ def register_oauth_routes(blueprint):
         if auth_code['exp'] < time.time():
             return jsonify({'error': 'invalid_grant',
                           'error_description': 'Authorization code expired'}), 400
+
+        # Client authentication (RFC 6749 §3.2.1). A public client has no
+        # secret, so its `client_id` is the only thing binding the code to the
+        # client it was issued to (§4.1.3) and is required. A confidential
+        # client authenticates with the secret it was issued, POST body or
+        # HTTP Basic; a secret that is absent or wrong is `invalid_client`.
+        registered_client = _oauth_store_get('client', auth_code['client_id']) or {}
+        auth_method = registered_client.get('token_endpoint_auth_method',
+                                            'client_secret_post')
+        if auth_method == 'none':
+            if not client_id:
+                return jsonify({'error': 'invalid_request',
+                              'error_description': 'client_id required for a public client'}), 400
+        else:
+            expected_secret = registered_client.get('client_secret') or ''
+            if not client_secret or not expected_secret or not constant_time_equal(
+                    client_secret, expected_secret):
+                return jsonify({'error': 'invalid_client'}), 401
 
         if client_id and auth_code['client_id'] != client_id:
             return jsonify({'error': 'invalid_grant',
@@ -359,12 +532,21 @@ def register_oauth_routes(blueprint):
             return jsonify({'error': 'invalid_grant',
                           'error_description': 'PKCE verification failed'}), 400
 
+        # RFC 8707 (P2-c): a `resource` here must be the one the code was
+        # issued for; absent, it inherits. A code for one audience is never
+        # redeemed for another.
+        resource = (body.get('resource') or '').strip()
+        if resource and resource != auth_code.get('aud'):
+            return jsonify({'error': 'invalid_target',
+                          'error_description': 'resource does not match the authorization'}), 400
+
         # Issue access token
         access_token = secrets.token_urlsafe(48)
         _oauth_store_set('access-token', access_token, {
             'client_id': auth_code['client_id'],
             'scopes': auth_code['scopes'],
             'tenant_id': auth_code['tenant_id'],
+            'aud': auth_code.get('aud'),
             'exp': time.time() + TOKEN_TTL_SECONDS,
         }, ttl=TOKEN_TTL_SECONDS)
 

--- a/r6/read_auth.py
+++ b/r6/read_auth.py
@@ -12,7 +12,7 @@ from flask import request, session
 # environment variable. Re-exported so this module's own importers are
 # unchanged.
 from r6.runtime_config import is_public_tenant, read_auth_enabled
-from r6.oauth import validate_bearer_token
+from r6.oauth import fhir_resource, validate_bearer_token
 from r6.stepup import validate_step_up_token
 
 
@@ -37,6 +37,12 @@ def _oauth_authorizes(token: str, tenant_id: str) -> bool:
     if not ok or not isinstance(info, dict):
         return False
     if info.get("tenant_id") != tenant_id:
+        return False
+    # RFC 8707: only a token minted for this FHIR surface is a credential
+    # here. One minted at the same issuer for another audience (the MCP
+    # server's) is refused, whatever tenant and scopes it carries — spec
+    # §9.2, the replay nobody would otherwise notice.
+    if info.get("aud") != fhir_resource():
         return False
     return bool(set(info.get("scopes") or ()) & _OAUTH_READ_SCOPES)
 

--- a/tests/test_oauth_as_conformance.py
+++ b/tests/test_oauth_as_conformance.py
@@ -1,0 +1,378 @@
+"""The authorization server behaves like one (#568, spec §3.3, §3.5, §13).
+
+Phase 2 of the MCP authorization design: a browser can finish the flow, the
+token carries the audience it was asked for, a client authenticates the way
+it registered, and the FHIR read surface refuses a token minted for any other
+audience. Each test names the mutation that turns it red.
+"""
+import base64
+import hashlib
+import json
+import secrets
+import time
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from r6 import oauth
+
+FHIR_RESOURCE = 'http://localhost/r6/fhir'
+MCP_RESOURCE = 'https://mcp.healthclaw.io/mcp'
+
+
+def _pkce():
+    verifier = secrets.token_urlsafe(32)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).rstrip(b'=').decode()
+    return verifier, challenge
+
+
+def _register(client, redirect_uris=('https://client.example/cb',),
+              method=None, **extra):
+    body = {'client_name': 'Conformance', 'redirect_uris': list(redirect_uris),
+            **extra}
+    if method:
+        body['token_endpoint_auth_method'] = method
+    resp = client.post('/r6/fhir/oauth/register', data=json.dumps(body),
+                       content_type='application/json')
+    return resp
+
+
+def _authorize(client, reg, challenge, redirect_uri=None, tenant='desktop-demo',
+               **query):
+    params = {'client_id': reg['client_id'],
+              'redirect_uri': redirect_uri or reg['redirect_uris'][0],
+              'code_challenge': challenge, 'code_challenge_method': 'S256',
+              'scope': 'fhir.read', **query}
+    return client.get('/r6/fhir/oauth/authorize', query_string=params,
+                      headers={'X-Tenant-Id': tenant})
+
+
+def _redirect_params(resp):
+    assert resp.status_code == 302, resp.get_data(as_text=True)
+    location = resp.headers['Location']
+    return location, {k: v[0] for k, v in parse_qs(urlsplit(location).query).items()}
+
+
+def _token(client, reg, code, verifier, **extra):
+    body = {'grant_type': 'authorization_code', 'code': code,
+            'code_verifier': verifier, 'client_id': reg['client_id'], **extra}
+    if 'client_secret' in reg and 'client_secret' not in extra:
+        body['client_secret'] = reg['client_secret']
+    return client.post('/r6/fhir/oauth/token', data=body)
+
+
+# --- the browser can finish the flow (P2-a) ---------------------------------
+
+
+def test_authorize_answers_302_to_the_registered_redirect_with_code_state_and_iss(client):
+    """MUTATION: return the JSON body again -> red. A popup cannot act on JSON."""
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    resp = _authorize(client, reg, challenge, state='st ate&1')
+    location, params = _redirect_params(resp)
+    assert location.startswith('https://client.example/cb?')
+    assert params['state'] == 'st ate&1', 'state is echoed URL-encoded, verbatim'
+    assert params['iss'] == 'http://localhost', 'RFC 9207 names the issuer'
+    assert params['code']
+    assert resp.headers['Cache-Control'] == 'no-store'
+    assert not resp.data.startswith(b'{"'), 'no JSON body carrying the code'
+
+
+def test_state_is_omitted_when_the_client_sent_none(client):
+    reg = _register(client).get_json()
+    _, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    assert 'state' not in params and 'iss' in params
+
+
+def test_the_code_from_the_redirect_buys_a_token(client):
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    resp = _token(client, reg, params['code'], verifier)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.get_json()['token_type'] == 'Bearer'
+
+
+# --- the audience (RFC 8707, P2-b, P2-c) ------------------------------------
+
+
+def test_a_token_carries_the_fhir_audience_when_no_resource_was_asked_for(client):
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    token = _token(client, reg, params['code'], verifier).get_json()['access_token']
+    ok, info = oauth.validate_bearer_token(token)
+    assert ok, info
+    assert info['aud'] == FHIR_RESOURCE
+
+
+def test_an_unknown_resource_is_invalid_target_back_at_the_client(client):
+    """MUTATION: record `resource` as sent instead of refusing -> red."""
+    reg = _register(client).get_json()
+    _, challenge = _pkce()
+    resp = _authorize(client, reg, challenge, state='s1',
+                      resource='https://somebody-else.example/api')
+    location, params = _redirect_params(resp)
+    assert params['error'] == 'invalid_target'
+    assert params['state'] == 's1' and params['iss'] == 'http://localhost'
+
+
+def test_the_token_endpoint_refuses_a_resource_other_than_the_code_was_issued_for(client):
+    """MUTATION: drop the aud comparison at /oauth/token -> red."""
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge,
+                                            resource=FHIR_RESOURCE))
+    resp = _token(client, reg, params['code'], verifier, resource=MCP_RESOURCE)
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'invalid_target'
+
+
+def test_the_token_endpoint_accepts_the_same_resource_and_inherits_when_absent(client):
+    reg = _register(client).get_json()
+    for sent in (FHIR_RESOURCE, None):
+        verifier, challenge = _pkce()
+        _, params = _redirect_params(_authorize(client, reg, challenge,
+                                                resource=FHIR_RESOURCE))
+        extra = {'resource': sent} if sent else {}
+        resp = _token(client, reg, params['code'], verifier, **extra)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        ok, info = oauth.validate_bearer_token(resp.get_json()['access_token'])
+        assert ok and info['aud'] == FHIR_RESOURCE
+
+
+def test_the_mcp_resource_binds_the_configured_demo_tenant_and_ignores_the_header(
+        client, monkeypatch):
+    """P2-b: a browser flow has no trusted place to put a tenant.
+
+    MUTATION: bind `request.headers.get('X-Tenant-Id')` on the demo policy
+    -> red (the token lands on victim-tenant).
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    monkeypatch.setenv('MCP_CANONICAL_RESOURCE', MCP_RESOURCE)
+    monkeypatch.setenv('MCP_OAUTH_DEMO_TENANT', 'desktop-demo')
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge,
+                                            tenant='victim-tenant',
+                                            resource=MCP_RESOURCE))
+    token = _token(client, reg, params['code'], verifier).get_json()['access_token']
+    ok, info = oauth.validate_bearer_token(token)
+    assert ok, info
+    assert info['tenant_id'] == 'desktop-demo'
+    assert info['aud'] == MCP_RESOURCE
+
+
+def test_the_mcp_resource_fails_closed_when_the_demo_tenant_is_not_public(
+        client, monkeypatch):
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    monkeypatch.setenv('MCP_CANONICAL_RESOURCE', MCP_RESOURCE)
+    monkeypatch.setenv('MCP_OAUTH_DEMO_TENANT', 'private-tenant')
+    reg = _register(client).get_json()
+    _, challenge = _pkce()
+    resp = _authorize(client, reg, challenge, resource=MCP_RESOURCE)
+    assert resp.status_code == 403
+    assert resp.get_json()['error'] == 'access_denied'
+
+
+def test_without_the_mcp_resource_configured_that_audience_is_unknown(client):
+    reg = _register(client).get_json()
+    _, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge,
+                                            resource=MCP_RESOURCE))
+    assert params['error'] == 'invalid_target'
+
+
+# --- R3 in reverse: the FHIR surface refuses a token for another audience ---
+
+
+def _store_token(tenant_id, aud, scopes=('fhir.read',)):
+    token = secrets.token_urlsafe(48)
+    oauth._oauth_store_set('access-token', token, {
+        'client_id': 'test', 'scopes': list(scopes), 'tenant_id': tenant_id,
+        'aud': aud, 'exp': time.time() + 300}, ttl=300)
+    return token
+
+
+@pytest.mark.parametrize('aud', [MCP_RESOURCE, None, FHIR_RESOURCE + '/',
+                                 'https://localhost/r6/fhir'])
+def test_a_read_bearer_minted_for_another_audience_is_refused(
+        client, monkeypatch, aud):
+    """Spec §9.2 / §8.2 R3, at the surface that would otherwise accept it.
+
+    MUTATION: delete the `aud` comparison in r6/read_auth._oauth_authorizes
+    -> red for every row.
+    """
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    token = _store_token('private-tenant', aud)
+    resp = client.get('/r6/fhir/Patient?_summary=count', headers={
+        'X-Tenant-Id': 'private-tenant', 'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 401, resp.get_data(as_text=True)
+
+
+def test_a_read_bearer_minted_for_this_surface_is_accepted(client, monkeypatch):
+    """Non-vacuity for the row above: same record, right audience, 200."""
+    monkeypatch.setenv('READ_AUTH_ENABLED', 'true')
+    monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
+    token = _store_token('private-tenant', FHIR_RESOURCE)
+    resp = client.get('/r6/fhir/Patient?_summary=count', headers={
+        'X-Tenant-Id': 'private-tenant', 'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+
+# --- registration (RFC 7591, P2-d) ------------------------------------------
+
+
+def test_a_public_client_gets_no_secret_and_its_method_is_honoured(client):
+    """MUTATION: always answer client_secret_post -> red."""
+    reg = _register(client, method='none').get_json()
+    assert reg['token_endpoint_auth_method'] == 'none'
+    assert 'client_secret' not in reg
+    assert 'client_secret_expires_at' not in reg
+
+
+def test_a_confidential_client_is_told_when_its_secret_expires(client):
+    reg = _register(client).get_json()
+    assert reg['token_endpoint_auth_method'] == 'client_secret_post'
+    assert reg['client_secret_expires_at'] == (
+        reg['client_id_issued_at'] + oauth.CLIENT_TTL_SECONDS)
+
+
+@pytest.mark.parametrize('uri', [
+    'http://client.example/cb',            # plain http off the loopback
+    'https://client.example/cb#frag',      # fragment
+    'javascript:alert(1)',
+    'client.example/cb',
+    '',
+])
+def test_a_redirect_uri_that_is_neither_https_nor_loopback_is_refused(client, uri):
+    """MUTATION: store redirect_uris unvalidated -> red."""
+    resp = _register(client, redirect_uris=(uri,))
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+    assert resp.get_json()['error'] == 'invalid_redirect_uri'
+
+
+@pytest.mark.parametrize('uri', [
+    'https://claude.ai/api/mcp/auth_callback',
+    'http://localhost/callback',
+    'http://127.0.0.1:53211/callback',
+    'http://[::1]:8080/cb',
+])
+def test_https_and_loopback_redirect_uris_register(client, uri):
+    resp = _register(client, redirect_uris=(uri,))
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+
+
+def test_an_unknown_auth_method_is_refused(client):
+    resp = _register(client, method='private_key_jwt')
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'invalid_client_metadata'
+
+
+def test_a_loopback_redirect_matches_on_any_port_and_nothing_else_does(client):
+    """RFC 8252 §7.3: Claude Code listens on an ephemeral port.
+
+    MUTATION: exact-match every redirect -> the first assertion goes red;
+    ignore the port everywhere -> the second does.
+    """
+    reg = _register(client, redirect_uris=('http://127.0.0.1/callback',
+                                           'https://client.example/cb')).get_json()
+    _, challenge = _pkce()
+    resp = _authorize(client, reg, challenge,
+                      redirect_uri='http://127.0.0.1:53211/callback')
+    location, _ = _redirect_params(resp)
+    assert location.startswith('http://127.0.0.1:53211/callback?')
+
+    resp = _authorize(client, reg, challenge,
+                      redirect_uri='https://client.example:8443/cb')
+    assert resp.status_code == 400
+
+
+# --- client authentication at the token endpoint ----------------------------
+
+
+def test_a_public_client_must_send_its_client_id(client):
+    """RFC 6749 §4.1.3. MUTATION: drop the requirement -> red."""
+    reg = _register(client, method='none').get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    resp = client.post('/r6/fhir/oauth/token', data={
+        'grant_type': 'authorization_code', 'code': params['code'],
+        'code_verifier': verifier})
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'invalid_request'
+
+
+def test_a_confidential_client_must_present_the_secret_it_was_issued(client):
+    """MUTATION: skip the compare_digest -> the wrong-secret row goes green."""
+    reg = _register(client).get_json()
+    for secret, status in ((None, 401), ('not-the-secret', 401)):
+        verifier, challenge = _pkce()
+        _, params = _redirect_params(_authorize(client, reg, challenge))
+        body = {'grant_type': 'authorization_code', 'code': params['code'],
+                'code_verifier': verifier, 'client_id': reg['client_id']}
+        if secret:
+            body['client_secret'] = secret
+        resp = client.post('/r6/fhir/oauth/token', data=body)
+        assert resp.status_code == status, resp.get_data(as_text=True)
+        assert resp.get_json()['error'] == 'invalid_client'
+
+
+def test_a_confidential_client_may_authenticate_with_http_basic(client):
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    basic = base64.b64encode(
+        f"{reg['client_id']}:{reg['client_secret']}".encode()).decode()
+    resp = client.post('/r6/fhir/oauth/token', data={
+        'grant_type': 'authorization_code', 'code': params['code'],
+        'code_verifier': verifier}, headers={'Authorization': f'Basic {basic}'})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+
+def test_a_failed_exchange_burns_the_code(client):
+    reg = _register(client).get_json()
+    verifier, challenge = _pkce()
+    _, params = _redirect_params(_authorize(client, reg, challenge))
+    assert _token(client, reg, params['code'], verifier,
+                  client_secret='wrong').status_code == 401
+    assert _token(client, reg, params['code'], verifier).status_code == 400
+
+
+# --- discovery at the issuer root (spec §3.3) -------------------------------
+
+
+def test_the_metadata_is_served_at_the_issuer_root_and_matches_the_prefixed_copy(client):
+    """RFC 8414 §3: a path-less issuer's clients look at the root first.
+
+    MUTATION: remove the root rule from main._register_blueprints -> red.
+    """
+    root = client.get('/.well-known/oauth-authorization-server')
+    prefixed = client.get('/r6/fhir/.well-known/oauth-authorization-server')
+    assert root.status_code == 200 and prefixed.status_code == 200
+    assert root.get_json() == prefixed.get_json()
+    doc = root.get_json()
+    assert doc['issuer'] == 'http://localhost'
+    assert doc['authorization_response_iss_parameter_supported'] is True
+    assert set(doc['token_endpoint_auth_methods_supported']) == {
+        'none', 'client_secret_post', 'client_secret_basic'}
+
+
+def test_oauth_issuer_pins_every_published_endpoint(client, monkeypatch):
+    """Behind a proxy that loses the scheme, the configured issuer wins over
+    the request (spec §3.3 change 1). The audience follows it too."""
+    monkeypatch.setenv('OAUTH_ISSUER', 'https://app.healthclaw.io/')
+    doc = client.get('/.well-known/oauth-authorization-server').get_json()
+    assert doc['issuer'] == 'https://app.healthclaw.io'
+    for key in ('authorization_endpoint', 'token_endpoint',
+                'registration_endpoint', 'revocation_endpoint'):
+        assert doc[key].startswith('https://app.healthclaw.io/r6/fhir/oauth/')
+    smart = client.get('/r6/fhir/.well-known/smart-configuration').get_json()
+    assert smart['token_endpoint'] == 'https://app.healthclaw.io/r6/fhir/oauth/token'
+    with client.application.test_request_context('/'):
+        assert oauth.fhir_resource() == 'https://app.healthclaw.io/r6/fhir'

--- a/tests/test_oauth_redis.py
+++ b/tests/test_oauth_redis.py
@@ -1,6 +1,7 @@
 """OAuth state must survive worker changes when Redis is configured."""
 
 import base64
+from urllib.parse import parse_qs, urlsplit
 import hashlib
 
 from r6 import oauth
@@ -49,6 +50,7 @@ def test_oauth_flow_survives_process_local_state_loss(client, monkeypatch):
         "client_name": "Redis OAuth Client",
         "redirect_uris": ["https://client.example/callback"],
         "scope": "fhir.read",
+        "token_endpoint_auth_method": "none",
     }).get_json()
     _clear_process_local_oauth_state()
 
@@ -67,8 +69,8 @@ def test_oauth_flow_survives_process_local_state_loss(client, monkeypatch):
         },
         headers={"X-Tenant-Id": "desktop-demo"},
     )
-    assert authorized.status_code == 200
-    code = authorized.get_json()["code"]
+    assert authorized.status_code == 302
+    code = parse_qs(urlsplit(authorized.headers["Location"]).query)["code"][0]
     _clear_process_local_oauth_state()
 
     token_response = client.post("/r6/fhir/oauth/token", json={

--- a/tests/test_oauth_tenant_binding.py
+++ b/tests/test_oauth_tenant_binding.py
@@ -4,6 +4,13 @@ import base64
 import hashlib
 import json
 import secrets
+from urllib.parse import parse_qs, urlsplit
+
+
+def _code_of(resp):
+    """The code rides in the 302 to the registered redirect URI (#568)."""
+    assert resp.status_code == 302, resp.get_data(as_text=True)
+    return parse_qs(urlsplit(resp.headers['Location']).query)['code'][0]
 
 
 def _register(client, tenant_headers):
@@ -11,6 +18,7 @@ def _register(client, tenant_headers):
                        data=json.dumps({
                            'client_name': 'Binding Test',
                            'redirect_uris': ['http://localhost/cb'],
+                           'token_endpoint_auth_method': 'none',
                        }),
                        content_type='application/json',
                        headers=tenant_headers)
@@ -44,8 +52,7 @@ def test_authorize_allows_public_tenant_when_read_auth_on(client, monkeypatch):
     monkeypatch.setenv('PUBLIC_TENANTS', 'desktop-demo')
     client_id = _register(client, {'X-Tenant-Id': 'desktop-demo'})
     resp = _authorize(client, client_id, 'desktop-demo')
-    assert resp.status_code == 200
-    assert 'code' in resp.get_json()
+    assert _code_of(resp)
 
 
 # --- What the code is BOUND to, not merely that one was issued ---------------
@@ -109,8 +116,7 @@ def test_the_granted_code_is_bound_to_the_header_tenant_not_a_query_param(
 
     resp = _authorize_claiming(client, client_id, 'desktop-demo', challenge,
                                tenant_id='victim-tenant')
-    assert resp.status_code == 200
-    token = _exchange(client, client_id, resp.get_json()['code'], verifier)
+    token = _exchange(client, client_id, _code_of(resp), verifier)
 
     # Destructured, never truthiness-tested — validate_bearer_token returns
     # a tuple whose first element is the answer.
@@ -139,7 +145,7 @@ def test_a_code_granted_to_a_public_tenant_cannot_read_a_private_one(
 
     resp = _authorize_claiming(client, client_id, 'desktop-demo', challenge,
                                tenant_id='victim-tenant')
-    token = _exchange(client, client_id, resp.get_json()['code'], verifier)
+    token = _exchange(client, client_id, _code_of(resp), verifier)
 
     read = client.get('/r6/fhir/Patient?_summary=count', headers={
         'X-Tenant-Id': 'victim-tenant',

--- a/tests/test_r6_dashboard.py
+++ b/tests/test_r6_dashboard.py
@@ -19,6 +19,7 @@ Tests cover:
 import hashlib
 import base64
 import json
+from urllib.parse import parse_qs, urlsplit
 import secrets
 
 
@@ -318,6 +319,12 @@ class TestETagLifecycle:
 
 # ===== OAuth Complete Flow =====
 
+def _code_of(resp):
+    """The code rides in the 302 to the registered redirect URI (#568)."""
+    assert resp.status_code == 302, resp.get_data(as_text=True)
+    return parse_qs(urlsplit(resp.headers['Location']).query)['code'][0]
+
+
 class TestOAuthCompleteFlow:
     """Full OAuth 2.1 flow with error cases."""
 
@@ -349,7 +356,7 @@ class TestOAuthCompleteFlow:
             f'&redirect_uri=http://localhost/cb&scope=fhir.read'
             f'&code_challenge={challenge}&code_challenge_method=S256',
             headers=tenant_headers)
-        code = auth_resp.get_json()['code']
+        code = _code_of(auth_resp)
 
         # Use a DIFFERENT verifier
         token_resp = client.post('/r6/fhir/oauth/token',
@@ -357,6 +364,8 @@ class TestOAuthCompleteFlow:
                                     'grant_type': 'authorization_code',
                                     'code': code,
                                     'code_verifier': 'completely-wrong-verifier',
+                                    'client_id': reg['client_id'],
+                                    'client_secret': reg['client_secret'],
                                 }),
                                 content_type='application/json',
                                 headers=tenant_headers)
@@ -373,7 +382,7 @@ class TestOAuthCompleteFlow:
             f'&redirect_uri=http://localhost/cb&scope=fhir.read'
             f'&code_challenge={challenge}&code_challenge_method=S256',
             headers=tenant_headers)
-        code = auth_resp.get_json()['code']
+        code = _code_of(auth_resp)
 
         # First exchange succeeds
         client.post('/r6/fhir/oauth/token',
@@ -381,6 +390,8 @@ class TestOAuthCompleteFlow:
                         'grant_type': 'authorization_code',
                         'code': code,
                         'code_verifier': verifier,
+                        'client_id': reg['client_id'],
+                        'client_secret': reg['client_secret'],
                     }),
                     content_type='application/json',
                     headers=tenant_headers)

--- a/tests/test_r6_routes.py
+++ b/tests/test_r6_routes.py
@@ -3,6 +3,7 @@ Tests for R6 FHIR REST endpoints.
 """
 
 import json
+from urllib.parse import parse_qs, urlsplit
 
 
 class TestR6Metadata:
@@ -1038,10 +1039,10 @@ class TestOAuthFlow:
             f'&code_challenge_method=S256'
             f'&state=test-state',
             headers=tenant_headers)
-        assert auth_resp.status_code == 200
-        auth_data = auth_resp.get_json()
-        code = auth_data['code']
-        assert auth_data['state'] == 'test-state'
+        assert auth_resp.status_code == 302
+        auth_data = parse_qs(urlsplit(auth_resp.headers['Location']).query)
+        code = auth_data['code'][0]
+        assert auth_data['state'] == ['test-state']
 
         token_resp = client.post('/r6/fhir/oauth/token',
                                 data=json.dumps({
@@ -1049,6 +1050,7 @@ class TestOAuthFlow:
                                     'code': code,
                                     'code_verifier': code_verifier,
                                     'client_id': client_id,
+                                    'client_secret': reg_resp.get_json()['client_secret'],
                                 }),
                                 content_type='application/json',
                                 headers=tenant_headers)
@@ -1082,13 +1084,15 @@ class TestOAuthFlow:
             f'&redirect_uri=http://localhost/cb&scope=fhir.read'
             f'&code_challenge={code_challenge}&code_challenge_method=S256',
             headers=tenant_headers)
-        code = auth_resp.get_json()['code']
+        code = parse_qs(urlsplit(auth_resp.headers['Location']).query)['code'][0]
 
         token_resp = client.post('/r6/fhir/oauth/token',
                                 data=json.dumps({
                                     'grant_type': 'authorization_code',
                                     'code': code,
                                     'code_verifier': code_verifier,
+                                    'client_id': client_id,
+                                    'client_secret': reg_resp.get_json()['client_secret'],
                                 }),
                                 content_type='application/json',
                                 headers=tenant_headers)

--- a/tests/test_read_auth.py
+++ b/tests/test_read_auth.py
@@ -294,6 +294,10 @@ def _mint_oauth_token(tenant_id, scopes):
         'client_id': 'test-client',
         'scopes': scopes,
         'tenant_id': tenant_id,
+        # RFC 8707: a read bearer is a credential here only when it was
+        # minted for this FHIR surface (tests/test_oauth_as_conformance.py
+        # holds the refusals for every other audience).
+        'aud': 'http://localhost/r6/fhir',
         'exp': time.time() + 3600,
     }
     return tok

--- a/tests/test_tenant_read_boundaries.py
+++ b/tests/test_tenant_read_boundaries.py
@@ -38,6 +38,9 @@ def _oauth_token(tenant=PRIVATE_TENANT):
         "client_id": "boundary-test",
         "scopes": ["patient/*.read"],
         "tenant_id": tenant,
+        # RFC 8707: a read bearer is a credential only for the surface it was
+        # minted for (tests/test_oauth_as_conformance.py holds the refusals).
+        "aud": "http://localhost/r6/fhir",
         "exp": time.time() + 3600,
     }
     return token


### PR DESCRIPTION
## What

Phase 2 of the MCP authorization design, the authorization-server half. After this a browser can finish our OAuth flow and a token knows what it is for. Everything is inert for existing callers except where a caller was relying on a defect (a JSON authorize body, an unverified client secret).

- `/oauth/authorize` answers **302** to the registered redirect URI with `code`, `state` (URL-encoded, only when sent) and RFC 9207 `iss`. Today it returns the code in a JSON body, which no connector popup can act on (#568).
- RFC 8707 `resource` is read at both endpoints. A known audience is recorded on the code and the token as `aud`; an unknown one is `invalid_target` back at the client, never recorded as sent. The token endpoint refuses a `resource` the code was not issued for and inherits it when absent (P2-c).
- The audience map (spec §3.5.1, P2-b): the FHIR resource keeps today's header-bound tenant behind the public-tenant guard; `MCP_CANONICAL_RESOURCE`, when set, binds `MCP_OAUTH_DEMO_TENANT` and **ignores the header**, failing closed when that tenant is not public.
- `r6.read_auth` accepts a bearer only when its `aud` is this FHIR surface. A token minted at the same issuer for the MCP audience is refused on every tenant (spec §9.2, R3 in reverse). This lands with the `aud` recording, not after it.
- `/oauth/register` (RFC 7591, P2-d): honours `token_endpoint_auth_method` (`none`, `client_secret_post`, `client_secret_basic`), issues no secret to a public client, reports `client_secret_expires_at` and `client_id_issued_at`, refuses a redirect URI that is neither `https://` nor a plain-http loopback, and loopback URIs match on any port (RFC 8252 §7.3, Claude Code's ephemeral port).
- `/oauth/token` authenticates the client: a public client must send `client_id`; a confidential client must present its secret, POST body or HTTP Basic, compared through `r6.constant_time.equal`. Today no secret is ever checked.
- The metadata is served at the issuer root, `/.well-known/oauth-authorization-server`, the first place a client looks for a path-less issuer, and every published URL derives from `OAUTH_ISSUER` when it is set. `authorization_response_iss_parameter_supported` is advertised.
- First commit: spec §13, the consent surface (the founder's 2026-09-06 direction: HealthClaw stays the issuer, CareAgents is the sign-in and consent front door, revocable consent, rotating refresh, a read-only downstream mint). Design only; the PRs that build it follow this one.

## Evidence

Full suite 3664 passed, 13 skipped, 1 xfailed. `tests/test_oauth_as_conformance.py` (26 tests) plus four existing test files moved from the JSON body to the redirect. Nine mutations executed on a separate worktree, every one caught:

| mutation | failing |
|---|---|
| `aud` comparison dropped in `_oauth_authorizes` | 4 |
| unknown `resource` recorded as sent | 2 |
| token endpoint ignores a `resource` mismatch | 1 |
| demo policy binds the header tenant | 2 |
| redirect matched on host only (port ignored everywhere) | 1 |
| client secret never compared | 2 |
| `iss` omitted from the redirect | 3 |
| public client's `client_id` not required | 1 |
| root discovery rule removed | 2 |

## Not in this PR

Introspection and the read-only mint (next), the CareAgents handoff, refresh tokens, the MCP server's OAuth path. No deploy step and no DNS. `MCP_CANONICAL_RESOURCE` unset on Flask keeps the audience map at today's single entry.

Closes nothing yet; #568 closes on the spec's §8.4 end-user run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)