### PR TITLE
feat(careagents): the consent page for the MCP connector, with a fresh passkey at approval (#568)

### DIFF
--- a/careagents/accounts.py
+++ b/careagents/accounts.py
@@ -25,7 +25,7 @@ from webauthn.helpers.structs import (AuthenticatorSelectionCriteria,
                                       UserVerificationRequirement)
 
 from careagents import mail
-from careagents.models import (Account, Agent, Connection, EmailToken, Passkey,
+from careagents.models import (Account, Agent, Connection, EmailToken, Grant, Passkey,
                                Surface, UsageDay, make_engine,
                                make_session_factory, now)
 
@@ -234,15 +234,20 @@ class AccountService:
 
     # --- WebAuthn: authentication -------------------------------------------
 
-    def authentication_options(self) -> tuple[dict, str]:
+    def authentication_options(self, require_uv: bool = False) -> tuple[dict, str]:
+        """`require_uv` asks the authenticator for user verification (face,
+        fingerprint, PIN) rather than mere presence: the consent step wants
+        the person, not the device."""
         opts = webauthn.generate_authentication_options(
             rp_id=self.cfg.rp_id,
-            user_verification=UserVerificationRequirement.PREFERRED)
+            user_verification=(UserVerificationRequirement.REQUIRED if require_uv
+                               else UserVerificationRequirement.PREFERRED))
         return (_opts_to_dict(webauthn.options_to_json(opts)),
                 bytes_to_base64url(opts.challenge))
 
     def finish_authentication(self, credential: dict,
-                              expected_challenge: str) -> Account:
+                              expected_challenge: str,
+                              require_uv: bool = False) -> Account:
         raw_id = base64url_to_bytes(credential["rawId"])
         with self.session() as s:
             pk = s.query(Passkey).filter_by(credential_id=raw_id).first()
@@ -255,6 +260,7 @@ class AccountService:
                 expected_origin=self.cfg.origin,
                 credential_public_key=pk.public_key,
                 credential_current_sign_count=pk.sign_count,
+                require_user_verification=require_uv,
             )
             pk.sign_count = verification.new_sign_count
             acct = s.get(Account, pk.account_id)
@@ -346,7 +352,55 @@ class AccountService:
             for agent in s.query(Agent).filter_by(connection_id=conn_id).all():
                 s.query(Surface).filter_by(agent_id=agent.id).delete()
                 s.delete(agent)
+            # A grant outlives its connection as a record of what was shared
+            # and whether it was taken back; detach it rather than lose it
+            # (and rather than let the foreign key refuse the delete on
+            # Postgres, which SQLite would never have shown).
+            for g in s.query(Grant).filter_by(connection_id=conn_id).all():
+                g.connection_id = None
             s.delete(c)
+            return True
+
+    # --- grants: consents given to third-party agents (spec §13.4) ---------
+
+    def add_grant(self, account_id: str, connection_id: str | None,
+                  tenant_id: str, client_id: str, client_name: str,
+                  scopes: str, consent_id: str) -> str:
+        with self.session() as s:
+            g = Grant(account_id=account_id, connection_id=connection_id,
+                      tenant_id=tenant_id, client_id=client_id[:64],
+                      client_name=(client_name or "An agent")[:120],
+                      scopes=scopes[:255], consent_id=consent_id)
+            s.add(g)
+            s.flush()
+            return g.id
+
+    def list_grants(self, account_id: str) -> list[dict]:
+        with self.session() as s:
+            rows = (s.query(Grant).filter_by(account_id=account_id)
+                    .order_by(Grant.granted_at.desc()).all())
+            return [_grant_dict(g) for g in rows]
+
+    def grants_for_connection(self, account_id: str, conn_id: str,
+                              active_only: bool = True) -> list[dict]:
+        with self.session() as s:
+            q = s.query(Grant).filter_by(account_id=account_id, connection_id=conn_id)
+            if active_only:
+                q = q.filter(Grant.revoked_at.is_(None))
+            return [_grant_dict(g) for g in q.all()]
+
+    def get_grant(self, account_id: str, grant_id: str) -> dict | None:
+        with self.session() as s:
+            g = s.query(Grant).filter_by(id=grant_id, account_id=account_id).first()
+            return _grant_dict(g) if g else None
+
+    def mark_grant_revoked(self, account_id: str, grant_id: str) -> bool:
+        with self.session() as s:
+            g = s.query(Grant).filter_by(id=grant_id, account_id=account_id).first()
+            if g is None:
+                return False
+            if g.revoked_at is None:
+                g.revoked_at = now()
             return True
 
     def get_connection(self, account_id: str, conn_id: str) -> dict | None:
@@ -488,6 +542,15 @@ def _conn_dict(c: Connection) -> dict:
             "connected_at": c.connected_at,
             "last_synced_at": c.last_synced_at, "last_count": c.last_count,
             "last_uncounted": c.last_uncounted}
+
+
+def _grant_dict(g: Grant) -> dict:
+    return {"id": g.id, "connection_id": g.connection_id,
+            "tenant_id": g.tenant_id, "client_id": g.client_id,
+            "client_name": g.client_name, "scopes": g.scopes,
+            "consent_id": g.consent_id, "granted_at": g.granted_at,
+            "revoked_at": g.revoked_at,
+            "status": "revoked" if g.revoked_at else "active"}
 
 
 def _agent_dict(a: Agent) -> dict:

--- a/careagents/app.py
+++ b/careagents/app.py
@@ -27,7 +27,7 @@ from flask import (Flask, Response, jsonify, redirect, render_template,
 
 from careagents.accounts import (AccountService, AuthError, MailError,
                                  MailUnconfirmed, new_binding_code)
-from careagents import advisors, connectors
+from careagents import advisors, connectors, consent
 from careagents import intake_state
 from careagents import labs_timeline as labs_timeline_mod
 from careagents.agent import GENERIC_FAILURE_TEXT
@@ -284,12 +284,17 @@ def create_app(config: Config | None = None,
     @app.get("/home")
     @login_required
     def home():
+        # A consent request that was waiting on sign-in resumes here, once.
+        pending_req = session.pop("consent_req", None)
+        if pending_req:
+            return redirect(url_for("consent_authorize", req=pending_req))
         acct = current_account()
         data = svc.list_home(acct.id)
         return render_template(
             "home.html", me=acct, personas=PERSONAS,
             connections=data["connections"], agents=data["agents"],
             surfaces=data["surfaces"], has_passkey=svc.has_passkey(acct.id),
+            grants=_grants_with_labels(svc.list_grants(acct.id), data["connections"]),
             telegram_bot=cfg.telegram_bot,
             imessage_handle=cfg.imessage_handle,
             terms_url=f"{cfg.healthclaw_public_base}/terms",
@@ -399,6 +404,125 @@ def create_app(config: Config | None = None,
             return jsonify({"error": "passkey sign-in failed"}), 400
         _login(acct)
         return jsonify({"ok": True})
+
+    # --- consent: a third-party agent asks to read one connection -----------
+    #
+    # HealthClaw parks the OAuth request and sends the browser here with a
+    # signed handle (spec §13.3). Nothing is fetched until the handle
+    # verifies; nothing is granted until a fresh, user-verified passkey says
+    # this person is present; and the decision goes back signed, single-use
+    # and short-lived. What is offered: the account's own connections, real
+    # ones only where CARE_REAL_RECORDS opens them (§13.7).
+
+    def _grants_with_labels(grants, connections):
+        labels = {c["id"]: c["label"] for c in connections}
+        return [{**g, "tenant_label": labels.get(g["connection_id"])} for g in grants]
+
+    def _consent_return(grant):
+        return (f"{cfg.healthclaw_public_base}/r6/fhir/oauth/consent/return"
+                f"?grant={grant}")
+
+    def _offered_connections(acct):
+        real_open = cfg.real_records_open_for(acct.email)
+        conns = svc.list_home(acct.id)["connections"]
+        return [c for c in conns
+                if c["status"] != "revoked"
+                and (c["kind"] == "sample" or real_open)], real_open
+
+    @app.get("/authorize")
+    def consent_authorize():
+        req = (request.args.get("req") or "").strip()
+        request_id = consent.parse_handle(req, cfg.mint_secret)
+        if request_id is None:
+            return render_template("consent.html", state="invalid",
+                                   me=current_account()), 400
+        if current_account() is None:
+            session["consent_req"] = req
+            return redirect(url_for("auth"))
+        parked = hc.consent_request(request_id)
+        if parked is None:
+            return render_template("consent.html", state="expired",
+                                   me=current_account()), 410
+        acct = current_account()
+        offered, real_open = _offered_connections(acct)
+        return render_template(
+            "consent.html", state="ask", req=req, me=acct,
+            client_name=parked.get("client_name") or "An agent",
+            scopes=[consent.describe_scope(x) for x in parked.get("scopes", [])],
+            connections=offered, real_open=real_open,
+            has_passkey=svc.has_passkey(acct.id),
+            privacy_url=f"{cfg.healthclaw_public_base}/privacy")
+
+    @app.post("/webauthn/consent/options")
+    @login_required
+    def wa_consent_options():
+        options, challenge = svc.authentication_options(require_uv=True)
+        session["wa_consent_challenge"] = challenge
+        return jsonify(options)
+
+    @app.post("/authorize/decide")
+    @login_required
+    def consent_decide():
+        body = request.get_json(force=True, silent=True) or {}
+        request_id = consent.parse_handle(body.get("req") or "", cfg.mint_secret)
+        if request_id is None:
+            return jsonify({"error": "This request is not valid any more."}), 400
+        if body.get("decision") != "approved":
+            grant, _ = consent.build_grant(cfg.mint_secret, request_id, "denied")
+            return jsonify({"redirect": _consent_return(grant)})
+
+        acct = current_account()
+        conn = svc.get_connection(acct.id, str(body.get("connection_id") or ""))
+        if conn is None or conn["status"] == "revoked":
+            return jsonify({"error": "unknown connection"}), 404
+        if conn["kind"] != "sample" and not cfg.real_records_open_for(acct.email):
+            return jsonify({"error": "Sharing real records is not open for "
+                                     "this account yet."}), 403
+
+        # The person, not the session: a fresh assertion with user
+        # verification, for this account.
+        challenge = session.pop("wa_consent_challenge", None)
+        if not challenge:
+            return jsonify({"error": "no challenge"}), 400
+        try:
+            verified = svc.finish_authentication(
+                body.get("passkey") or {}, challenge, require_uv=True)
+        except AuthError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except Exception:  # noqa: BLE001
+            return jsonify({"error": "passkey check failed"}), 400
+        if verified.id != acct.id:
+            return jsonify({"error": "That passkey belongs to another account."}), 403
+
+        parked = hc.consent_request(request_id)
+        if parked is None:
+            return jsonify({"error": "This request has expired. Start again "
+                                     "from the app that asked."}), 410
+        grant, consent_id = consent.build_grant(
+            cfg.mint_secret, request_id, "approved", tenant_id=conn["tenant_id"])
+        svc.add_grant(acct.id, conn["id"], conn["tenant_id"],
+                      parked.get("client_id", ""), parked.get("client_name", ""),
+                      " ".join(parked.get("scopes", [])), consent_id)
+        return jsonify({"redirect": _consent_return(grant)})
+
+    @app.post("/api/grants/<grant_id>/revoke")
+    @login_required
+    def revoke_grant(grant_id):
+        """Take a consent back. HealthClaw first, the row here second, so a
+        revocation is never shown that did not happen."""
+        acct = current_account()
+        grant = svc.get_grant(acct.id, grant_id)
+        if grant is None:
+            return jsonify({"error": "unknown grant"}), 404
+        try:
+            hc.revoke_consent(grant["consent_id"])
+        except HealthClawError:
+            return jsonify({"error": "revocation_failed", "revoked": False,
+                            "message": "We couldn't confirm the access was "
+                                       "revoked. It is still shown here — "
+                                       "please try again."}), 502
+        svc.mark_grant_revoked(acct.id, grant_id)
+        return jsonify({"revoked": True, "grant_id": grant_id})
 
     # --- connections ---------------------------------------------------------
 
@@ -633,6 +757,27 @@ def create_app(config: Config | None = None,
                             "message": "We couldn't confirm your records were "
                                        "deleted. Your connection is still "
                                        "linked here — please try again."}), 502
+        # Anything still sharing these records is revoked at HealthClaw before
+        # the connection is unlinked (spec §13.4). A revoke that cannot be
+        # confirmed keeps the connection listed, so the person can see the
+        # grant still active and retry; the records are already gone either
+        # way, and this response says both halves plainly.
+        still_active = []
+        for grant in svc.grants_for_connection(acct.id, conn_id):
+            try:
+                hc.revoke_consent(grant["consent_id"])
+                svc.mark_grant_revoked(acct.id, grant["id"])
+            except HealthClawError:
+                still_active.append(grant["id"])
+        if still_active:
+            return jsonify({
+                "deleted": True, "unlinked": False, "grants_active": len(still_active),
+                "connection_id": conn_id,
+                "rows_deleted": purged.get("rows_deleted", 0),
+                "message": ("Your records were deleted, but we couldn't confirm "
+                            "that an app you shared them with was cut off. The "
+                            "connection stays listed so you can try again."),
+            }), 502
         svc.delete_connection(acct.id, conn_id)
         return jsonify({
             "deleted": True,

--- a/careagents/consent.py
+++ b/careagents/consent.py
@@ -1,0 +1,85 @@
+"""The CareAgents half of the consent handoff (HealthClaw spec §13.3).
+
+HealthClaw parks an authorization request and sends the browser here with a
+signed handle; a person signs in, chooses which records to share, and proves
+presence with a fresh passkey; this module builds the signed decision that
+goes back. The key is derived from the mint secret both services already
+hold, with domain separation, so nothing new is provisioned and a forged
+grant needs the secret that already grants everything.
+
+No PHI passes through here: a request id, a tenant pointer, a client name.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+
+#: What each requested scope means to the person, in their words.
+SCOPE_WORDS = {
+    "fhir.read": "Read your health records. Every read is redacted and "
+                 "audited by HealthClaw.",
+    "context.read": "Read the summaries HealthClaw builds from your records.",
+}
+
+
+def describe_scope(scope: str) -> str:
+    return SCOPE_WORDS.get(scope, f"Use the permission named {scope!r}.")
+
+
+def handoff_key(mint_secret: str) -> bytes:
+    if not mint_secret:
+        raise ValueError("HEALTHCLAW_MINT_SECRET is required for the consent handoff")
+    return hashlib.sha256(b"healthclaw-consent-handoff:"
+                          + mint_secret.encode("utf-8")).digest()
+
+
+def tag(mint_secret: str, message: str) -> str:
+    return hmac.new(handoff_key(mint_secret), message.encode("utf-8"),
+                    hashlib.sha256).hexdigest()
+
+
+def parse_handle(req: str, mint_secret: str, now: float | None = None) -> str | None:
+    """The request id inside a `<request_id>.<exp>.<tag>` handle whose tag
+    verifies and whose expiry is in the future; None for anything else, and
+    nothing about why. A forged link bounces here before anything is fetched."""
+    if not isinstance(req, str) or req.count(".") != 2 or not mint_secret:
+        return None
+    request_id, exp_text, presented = req.split(".")
+    if not request_id or not exp_text.isdigit() or not presented:
+        return None
+    if not hmac.compare_digest(presented.encode("ascii", "ignore"),
+                               tag(mint_secret, f"{request_id}.{exp_text}").encode()):
+        return None
+    if int(exp_text) < (now if now is not None else time.time()):
+        return None
+    return request_id
+
+
+def build_grant(mint_secret: str, request_id: str, decision: str,
+                tenant_id: str | None = None, ttl_seconds: int = 300) -> tuple[str, str]:
+    """The signed decision, `<base64url(JSON)>.<tag>`, and its consent id.
+
+    Same bytes HealthClaw's `decode_grant` expects: sorted keys, no
+    whitespace, a fresh nonce, a short expiry. `tenant_id` is required for an
+    approval and absent from a denial.
+    """
+    if decision not in ("approved", "denied"):
+        raise ValueError("decision must be approved or denied")
+    if decision == "approved" and not tenant_id:
+        raise ValueError("an approval names a tenant")
+    consent_id = f"consent_{secrets.token_hex(12)}"
+    payload = {
+        "request_id": request_id,
+        "tenant_id": tenant_id if decision == "approved" else None,
+        "consent_id": consent_id,
+        "nonce": secrets.token_hex(16),
+        "exp": int(time.time()) + ttl_seconds,
+        "decision": decision,
+    }
+    body = base64.urlsafe_b64encode(json.dumps(
+        payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).rstrip(b"=").decode("ascii")
+    return f"{body}.{tag(mint_secret, body)}", consent_id

--- a/careagents/healthclaw.py
+++ b/careagents/healthclaw.py
@@ -253,6 +253,31 @@ class HealthClawClient:
         return {"X-Internal-Secret": self.mint_secret,
                 "X-Agent-Id": "careagents-worker"}
 
+    # --- consent handoff (spec §13.3, §13.4) ---------------------------------
+
+    def consent_request(self, request_id: str) -> dict | None:
+        """Who is asking, and for what: the parked authorization request.
+        None when HealthClaw no longer holds it (expired or already decided)."""
+        r = self._send("GET", f"{self.fhir}/oauth/consent/{request_id}",
+                       headers=self._internal_headers(), what="consent request")
+        if r.status_code == 404:
+            return None
+        if r.status_code != 200:
+            raise HealthClawError(
+                f"consent request failed ({r.status_code})", r.status_code)
+        return self._json_object(r, "consent request")
+
+    def revoke_consent(self, consent_id: str) -> bool:
+        """Take a consent back at HealthClaw: every token under it dies.
+        404 is already-gone, which is the state we wanted. Anything else
+        raises, and the caller must not claim the revocation happened."""
+        r = self._send("POST", f"{self.fhir}/oauth/consent/{consent_id}/revoke",
+                       headers=self._internal_headers(), what="consent revoke")
+        if r.status_code in (200, 404):
+            return True
+        raise HealthClawError(
+            f"consent revoke failed ({r.status_code})", r.status_code)
+
     # --- reads (redacted + audited by the layer) -----------------------------
 
     def search(self, tenant: str, resource_type: str,

--- a/careagents/models.py
+++ b/careagents/models.py
@@ -121,6 +121,26 @@ class Surface(Base):
     account = relationship("Account", back_populates="surfaces")
 
 
+class Grant(Base):
+    """A consent the person gave a third-party agent to read one connection
+    through HealthClaw's MCP server (spec §13.4). A pointer and a decision:
+    which tenant, which client, which scopes, when, and whether it was taken
+    back. `consent_id` is HealthClaw's key for the same consent; revoking here
+    revokes there. No PHI."""
+    __tablename__ = "ca_grants"
+    id = Column(String(32), primary_key=True, default=lambda: _uid("grant"))
+    account_id = Column(String(32), ForeignKey("ca_accounts.id"), index=True)
+    connection_id = Column(String(32), ForeignKey("ca_connections.id"),
+                           nullable=True)
+    tenant_id = Column(String(64), nullable=False)
+    client_id = Column(String(64), nullable=False)
+    client_name = Column(String(120), default="An agent")
+    scopes = Column(String(255), default="")
+    consent_id = Column(String(64), unique=True, nullable=False)
+    granted_at = Column(Float, default=now)
+    revoked_at = Column(Float, nullable=True)
+
+
 class UsageDay(Base):
     """Per-account daily LLM turn count — a durable spend ceiling.
 

--- a/careagents/static/careagents.css
+++ b/careagents/static/careagents.css
@@ -338,6 +338,7 @@ h1 em { font-style: italic; color: var(--clay); }
   font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
   padding: 4px 9px; border-radius: 999px; }
 .status-active { background: #EAF1EA; color: var(--sage); }
+.status-revoked { background: #F1ECEC; color: #7A4A4A; }
 .status-pending { background: #FBEFD9; color: #A97516; }
 .status-error { background: #FBE4DC; color: var(--clay-deep); }
 .empty { color: var(--ink-soft); font-size: 14px; padding: 8px 2px; }
@@ -601,3 +602,18 @@ textarea:focus-visible {
       person reads when something has just gone wrong, and the last place to
       set 14px. */
 .form-error, .form-ok, .form-warn { font-size: 16px; }
+
+/* --- consent page (a third-party agent asks to read one connection) --- */
+.consent-h2 { font-size: 15px; letter-spacing: .02em; text-transform: uppercase;
+  margin: 26px 0 8px; opacity: .75; }
+.consent-scopes { margin: 0; padding-left: 20px; }
+.consent-scopes li { margin: 6px 0; }
+.consent-choices { display: grid; gap: 10px; }
+.consent-choice { display: grid; grid-template-columns: auto 1fr; column-gap: 10px;
+  align-items: center; padding: 12px 14px; border: 1px solid rgba(0,0,0,.12);
+  border-radius: 10px; cursor: pointer; }
+.consent-choice input { margin: 0; grid-row: span 2; }
+.consent-choice-name { font-weight: 600; }
+.consent-choice-sub { font-size: 13px; opacity: .7; }
+.grant-revoke { margin-top: 8px; }
+.grant-msg { display: block; font-size: 13px; margin-top: 6px; }

--- a/careagents/static/consent.js
+++ b/careagents/static/consent.js
@@ -1,0 +1,67 @@
+/* CareAgents consent — approve with a fresh, user-verified passkey, or deny.
+   Either way the signed decision goes back to HealthClaw through the browser. */
+(function () {
+  const $ = (id) => document.getElementById(id);
+  const err = $("err");
+  function fail(msg) { if (err) { err.textContent = msg; err.hidden = false; } }
+
+  const b64uToBuf = (s) => {
+    s = s.replace(/-/g, "+").replace(/_/g, "/");
+    const pad = s.length % 4 ? "=".repeat(4 - (s.length % 4)) : "";
+    const bin = atob(s + pad);
+    return Uint8Array.from(bin, (c) => c.charCodeAt(0)).buffer;
+  };
+  const bufToB64u = (buf) => btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+  async function post(url, body) {
+    const r = await fetch(url, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    });
+    const d = await r.json().catch(() => ({}));
+    return { ok: r.ok, status: r.status, d };
+  }
+
+  const approve = $("approve-btn");
+  if (approve) approve.addEventListener("click", async () => {
+    if (err) err.hidden = true;
+    if (!window.PublicKeyCredential) return fail("This browser doesn't support passkeys.");
+    const chosen = document.querySelector('input[name="connection"]:checked');
+    if (!chosen) return fail("Choose which records to share.");
+    approve.disabled = true;
+    try {
+      const { d: opts } = await post("/webauthn/consent/options");
+      opts.challenge = b64uToBuf(opts.challenge);
+      if (opts.allowCredentials)
+        opts.allowCredentials = opts.allowCredentials.map((c) => ({ ...c, id: b64uToBuf(c.id) }));
+      const cred = await navigator.credentials.get({ publicKey: opts });
+      const passkey = {
+        id: cred.id, rawId: bufToB64u(cred.rawId), type: cred.type,
+        response: {
+          authenticatorData: bufToB64u(cred.response.authenticatorData),
+          clientDataJSON: bufToB64u(cred.response.clientDataJSON),
+          signature: bufToB64u(cred.response.signature),
+          userHandle: cred.response.userHandle ? bufToB64u(cred.response.userHandle) : null,
+        },
+      };
+      const res = await post("/authorize/decide", {
+        req: approve.dataset.req, decision: "approved",
+        connection_id: chosen.value, passkey,
+      });
+      if (res.ok && res.d.redirect) location.href = res.d.redirect;
+      else { fail(res.d.error || "That didn't work."); approve.disabled = false; }
+    } catch (e) {
+      fail("No passkey found on this device.");
+      approve.disabled = false;
+    }
+  });
+
+  const deny = $("deny-btn");
+  if (deny) deny.addEventListener("click", async () => {
+    deny.disabled = true;
+    const res = await post("/authorize/decide", { req: deny.dataset.req, decision: "denied" });
+    if (res.ok && res.d.redirect) location.href = res.d.redirect;
+    else { fail(res.d.error || "That didn't work."); deny.disabled = false; }
+  });
+})();

--- a/careagents/static/home.js
+++ b/careagents/static/home.js
@@ -623,4 +623,23 @@
     // iMessage needs the whole "care <code>" line as the text body.
     showCodeCard("care " + res.d.code, res.d.instructions || "Text this code to connect:");
   });
+  // --- grants: revoke a consent given to a third-party agent (spec §13.4) ---
+  // HealthClaw is asked first; the card changes only on its yes, and a
+  // failure is announced on the card's live region, never assumed away.
+  document.querySelectorAll(".grant-revoke").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const card = btn.closest(".grant-card");
+      const msg = card && card.querySelector(".grant-msg");
+      btn.disabled = true;
+      const res = await post(`/api/grants/${btn.dataset.grant}/revoke`, {});
+      if (res.ok && res.d.revoked) {
+        btn.remove();
+        const status = card && card.querySelector(".status");
+        if (status) { status.textContent = "revoked"; status.className = "status status-revoked"; }
+      } else {
+        btn.disabled = false;
+        if (msg) announce(msg, res.d.message || res.d.error || "That didn't work.");
+      }
+    });
+  });
 })();

--- a/careagents/templates/consent.html
+++ b/careagents/templates/consent.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% block title %}Share your records? — CareAgents{% endblock %}
+{% block bodyclass %}page-setup{% endblock %}
+{% block content %}
+<main class="setup-wrap">
+  <div class="setup-card" id="consent-card">
+  {% if state == "invalid" %}
+    <h1>This link is not valid</h1>
+    <p class="setup-sub">The request to share your records could not be
+    verified. Go back to the app that asked and start again.</p>
+    <a class="btn-secondary btn-block" href="/home">Back to your hub</a>
+  {% elif state == "expired" %}
+    <h1>This request has expired</h1>
+    <p class="setup-sub">Requests to share your records last ten minutes.
+    Go back to the app that asked and start again.</p>
+    <a class="btn-secondary btn-block" href="/home">Back to your hub</a>
+  {% else %}
+    <h1>{{ client_name }} wants to read your records</h1>
+    <p class="setup-sub">Through HealthClaw: every read redacted and audited,
+    nothing written. {{ client_name }} can never change your records or act
+    on your behalf; those still need your approval, one action at a time.</p>
+
+    <div id="err" class="form-error" hidden></div>
+
+    <h2 class="consent-h2">It would be able to</h2>
+    <ul class="consent-scopes">
+      {% for line in scopes %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+
+    <h2 class="consent-h2">Which records</h2>
+    {% if connections %}
+    <div class="consent-choices" id="consent-choices">
+      {% for c in connections %}
+      <label class="consent-choice">
+        <input type="radio" name="connection" value="{{ c.id }}"
+               {% if loop.first %}checked{% endif %}>
+        <span class="consent-choice-name">{{ c.label }}</span>
+        <span class="consent-choice-sub">{{ c.provider or c.kind }}{% if c.kind == 'sample' %} · sample records{% endif %}</span>
+      </label>
+      {% endfor %}
+    </div>
+    {% if not real_open %}
+    <p class="auth-fine">Only sample records can be shared from this account
+    for now. Your real records stay where they are.</p>
+    {% endif %}
+    {% else %}
+    <p class="auth-fine">You have no records connected yet.
+      <a href="/home">Connect records first</a>, then come back to the app
+      that asked.</p>
+    {% endif %}
+
+    {% if has_passkey and connections %}
+    <button class="btn-primary btn-block" id="approve-btn"
+            data-req="{{ req }}">Allow, with my passkey</button>
+    <p class="auth-fine">Your face, fingerprint or PIN confirms it is you,
+    now, not a remembered sign-in.</p>
+    {% elif connections %}
+    <p class="auth-fine">Allowing needs a passkey on this device, so that a
+    remembered sign-in is never enough to share your records.
+      <a href="/auth?enroll=1">Add a passkey</a>, then come back.</p>
+    {% endif %}
+    <button class="btn-secondary btn-block" id="deny-btn"
+            data-req="{{ req }}">Don't allow</button>
+    <p class="auth-fine">You can take this back any time from your hub.
+      <a href="{{ privacy_url }}" target="_blank" rel="noopener">Privacy
+      policy</a>.</p>
+  {% endif %}
+  </div>
+</main>
+<script src="{{ url_for('static', filename='consent.js') }}"></script>
+{% endblock %}

--- a/careagents/templates/home.html
+++ b/careagents/templates/home.html
@@ -76,6 +76,23 @@
       </div>
       {% endfor %}
     </div>
+    {% if grants %}
+    <h3 class="add-heading">Shared with other apps</h3>
+    <div class="card-grid" id="grants">
+      {% for g in grants %}
+      <div class="hub-card grant-card" data-grant="{{ g.id }}">
+        <div class="hub-card-name">{{ g.client_name }}</div>
+        <div class="hub-card-sub">reads {{ g.tenant_label or 'one connection' }} through HealthClaw</div>
+        <span class="status status-{{ g.status }}">{{ g.status }}</span>
+        {% if g.status != 'revoked' %}
+        <button type="button" class="grant-revoke" data-grant="{{ g.id }}"
+                title="Stop this app reading your records">Revoke</button>
+        {% endif %}
+        <span class="grant-msg" role="status" aria-live="polite" hidden></span>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
     <h3 class="add-heading">Connect records</h3>
     <div class="marketplace" id="marketplace">
       {% for m in catalog %}

--- a/tests/test_careagents.py
+++ b/tests/test_careagents.py
@@ -1912,6 +1912,28 @@ class FakeClient:
         # `len(fake.purged)` depended on which tests ran before it.
         self.purged: list[str] = []
 
+        # Consent handoff (spec §13.3, §13.4): the parked request HealthClaw
+        # would answer for any request id, the ids asked about, the consents
+        # revoked, and a knob that makes the revoke fail the way a gateway
+        # 5xx would.
+        self.parked = {"request_id": "req-1", "client_id": "cid-claude",
+                       "client_name": "Claude",
+                       "scopes": ["fhir.read", "context.read"],
+                       "exp": 4102444800}
+        self.consent_requests: list[str] = []
+        self.revoked: list[str] = []
+        self.revoke_fails = False
+
+    def consent_request(self, request_id):
+        self.consent_requests.append(request_id)
+        return dict(self.parked) if self.parked else None
+
+    def revoke_consent(self, consent_id):
+        if self.revoke_fails:
+            raise HealthClawError("consent revoke failed (502)", 502)
+        self.revoked.append(consent_id)
+        return True
+
     @staticmethod
     def conversation_id(agent_id):
         return f"careagents:{agent_id}"

--- a/tests/test_careagents_consent.py
+++ b/tests/test_careagents_consent.py
@@ -1,0 +1,412 @@
+"""CareAgents is the consent front door for the MCP connector (spec §13).
+
+HealthClaw parks the OAuth request and sends the browser here; this suite
+holds what CareAgents does with it: verifies the handle before fetching
+anything, offers only the person's own connections (real ones only where the
+beta gate opens them), grants nothing without a fresh user-verified passkey
+for this account, sends back a decision HealthClaw's own decoder accepts, and
+takes a consent back at HealthClaw before showing it revoked here.
+"""
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+from careagents import consent
+
+#: The HealthClaw decoder lands with #568's consent-handoff PR. Until it is on
+#: main the cross-layer rows below skip, and `_reference_decode` holds the
+#: format on this side; once it lands they run against the real thing.
+try:
+    from r6.oauth import decode_grant as _healthclaw_decode
+except ImportError:  # pragma: no cover - main before the handoff PR
+    _healthclaw_decode = None
+
+cross_layer = pytest.mark.skipif(
+    _healthclaw_decode is None,
+    reason="r6.oauth.decode_grant is not on this branch yet (#568 PR 3)")
+
+
+def _reference_decode(grant, secret="mint-secret"):
+    """The format, spelled out: `<base64url(JSON)>.<hex HMAC-SHA256>` under
+    sha256(b'healthclaw-consent-handoff:' + secret). Not HealthClaw's code."""
+    body, tag = grant.split(".")
+    key = hashlib.sha256(b"healthclaw-consent-handoff:" + secret.encode()).digest()
+    assert hmac.compare_digest(tag, hmac.new(key, body.encode(), hashlib.sha256).hexdigest())
+    return json.loads(base64.urlsafe_b64decode(body + "=" * (-len(body) % 4)))
+
+
+def decode_grant(grant):
+    if _healthclaw_decode is not None:
+        return _healthclaw_decode(grant)
+    try:
+        return _reference_decode(grant)
+    except AssertionError:
+        return None
+from careagents.config import Config
+from tests.test_careagents import FakeClient, _make_account
+
+MINT = "mint-secret"
+PUBLIC = "https://app.healthclaw.io"
+
+
+def _cfg(real_records="on"):
+    import os
+    url = os.environ.get("CARE_TEST_DATABASE_URL", "sqlite:///:memory:")
+    if not url.startswith("sqlite"):
+        from careagents.models import Base, make_engine
+        engine = make_engine(url)
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+    return Config(env={"CARE_DATABASE_URL": url, "CARE_RP_ID": "localhost",
+                       "CARE_ORIGIN": "http://localhost", "OPENAI_API_KEY": "k",
+                       "HEALTHCLAW_MINT_SECRET": MINT,
+                       "HEALTHCLAW_PUBLIC_BASE": PUBLIC,
+                       "FASTEN_PUBLIC_KEY": "pub123",
+                       "CARE_REAL_RECORDS": real_records,
+                       "CARE_TELEGRAM_BOT": "carebot"})
+
+
+@pytest.fixture
+def fake():
+    return FakeClient()
+
+
+@pytest.fixture
+def cfg():
+    return _cfg()
+
+
+@pytest.fixture
+def svc(cfg):
+    from careagents.accounts import AccountService
+    return AccountService(cfg)
+
+
+@pytest.fixture
+def app(cfg, svc, fake):
+    from careagents.app import create_app
+    a = create_app(config=cfg, client=fake, accounts=svc)
+    a.config["TESTING"] = True
+    return a
+
+
+def _handle(request_id="req-1", exp=None, secret=MINT):
+    exp = exp or int(time.time()) + 600
+    return f"{request_id}.{exp}.{consent.tag(secret, f'{request_id}.{exp}')}"
+
+
+def _signed_in(app, svc, monkeypatch, email="pat@example.com", passkey=False):
+    acct = _make_account(svc, monkeypatch, email)
+    client = app.test_client()
+    with client.session_transaction() as s:
+        s["account_id"] = acct.id
+    if passkey:
+        monkeypatch.setattr(svc, "has_passkey", lambda account_id: True)
+    return client, acct
+
+
+def _connect(svc, acct, kind="sample", label="My records", provider=None):
+    return svc.add_connection(acct.id, kind, f"ca-{kind}-{acct.id[-4:]}", label,
+                              provider=provider, consent_version="v1")
+
+
+# --- the handle and the grant are the same bytes HealthClaw uses -------------
+
+
+def test_parse_handle_accepts_only_a_verified_unexpired_handle():
+    """MUTATION: skip the tag comparison in parse_handle -> the forged row
+    passes; skip the expiry -> the expired row does."""
+    assert consent.parse_handle(_handle(), MINT) == "req-1"
+    assert consent.parse_handle(_handle(secret="guessed"), MINT) is None
+    assert consent.parse_handle(_handle(exp=int(time.time()) - 1), MINT) is None
+    assert consent.parse_handle("req-1.notanumber.abc", MINT) is None
+    assert consent.parse_handle("", MINT) is None
+    assert consent.parse_handle(_handle(), "") is None
+
+
+def test_build_grant_is_what_healthclaw_decodes(monkeypatch):
+    """Cross-layer: the grant CareAgents signs is the grant r6.oauth verifies,
+    under the same derived key. MUTATION: change the domain-separation
+    string on either side -> red."""
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", MINT)
+    grant, consent_id = consent.build_grant(MINT, "req-1", "approved", tenant_id="ca-x")
+    payload = decode_grant(grant)
+    assert payload is not None
+    assert payload["decision"] == "approved" and payload["tenant_id"] == "ca-x"
+    assert payload["consent_id"] == consent_id and payload["request_id"] == "req-1"
+    assert payload["exp"] > time.time() and payload["nonce"]
+    denied, _ = consent.build_grant(MINT, "req-1", "denied")
+    assert decode_grant(denied)["decision"] == "denied"
+    assert decode_grant(denied)["tenant_id"] is None
+    if _healthclaw_decode is not None:
+        monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", "another")
+        assert decode_grant(grant) is None
+
+
+def test_an_approval_names_a_tenant_and_a_decision_is_one_of_two():
+    with pytest.raises(ValueError):
+        consent.build_grant(MINT, "req-1", "approved")
+    with pytest.raises(ValueError):
+        consent.build_grant(MINT, "req-1", "maybe")
+
+
+# --- the page ----------------------------------------------------------------
+
+
+def test_a_forged_link_bounces_before_anything_is_fetched(app, fake):
+    resp = app.test_client().get("/authorize", query_string={"req": _handle(secret="x")})
+    assert resp.status_code == 400
+    assert fake.consent_requests == []
+
+
+def test_a_valid_link_signed_out_goes_to_sign_in_and_resumes_after(
+        app, svc, monkeypatch):
+    client = app.test_client()
+    resp = client.get("/authorize", query_string={"req": _handle()})
+    assert resp.status_code == 302 and resp.headers["Location"].endswith("/auth")
+    with client.session_transaction() as s:
+        assert s["consent_req"].startswith("req-1."), s["consent_req"]
+        assert consent.parse_handle(s["consent_req"], MINT) == "req-1"
+    acct = _make_account(svc, monkeypatch, "pat@example.com")
+    with client.session_transaction() as s:
+        s["account_id"] = acct.id
+    home = client.get("/home")
+    assert home.status_code == 302
+    assert "/authorize?req=req-1." in home.headers["Location"]
+
+
+def test_the_page_names_the_client_the_permissions_and_the_persons_connections(
+        app, svc, monkeypatch):
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=True)
+    _connect(svc, acct, "sample", "Sample records")
+    _connect(svc, acct, "fasten", "Clinic records", provider="Epic (Fasten)")
+    resp = client.get("/authorize", query_string={"req": _handle()})
+    page = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert "Claude wants to read your records" in page
+    assert "Read your health records" in page and "summaries" in page
+    assert "Sample records" in page and "Clinic records" in page
+    assert 'id="approve-btn"' in page and "Don't allow" in page
+
+
+def test_real_connections_are_not_offered_when_the_beta_gate_is_closed(
+        svc, fake, monkeypatch):
+    """§13.7: CARE_REAL_RECORDS gates sharing exactly as it gates connecting.
+    MUTATION: drop the real_open filter in _offered_connections -> red."""
+    from careagents.accounts import AccountService
+    from careagents.app import create_app
+    cfg = _cfg(real_records="off")
+    svc = AccountService(cfg)
+    app = create_app(config=cfg, client=fake, accounts=svc)
+    app.config["TESTING"] = True
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=True)
+    _connect(svc, acct, "sample", "Sample records")
+    real = _connect(svc, acct, "fasten", "Clinic records", provider="Epic (Fasten)")
+    page = client.get("/authorize", query_string={"req": _handle()}).get_data(as_text=True)
+    assert "Sample records" in page and "Clinic records" not in page
+    assert "Only sample records can be shared" in page
+    # And the decision endpoint refuses the real one even if the id is known.
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    monkeypatch.setattr(svc, "finish_authentication",
+                        lambda cred, ch, require_uv=False: acct)
+    resp = client.post("/authorize/decide", data=json.dumps({
+        "req": _handle(), "decision": "approved", "connection_id": real,
+        "passkey": {}}), content_type="application/json")
+    assert resp.status_code == 403
+
+
+def test_without_a_passkey_the_page_offers_enrolment_not_approval(
+        app, svc, monkeypatch):
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=False)
+    _connect(svc, acct)
+    page = client.get("/authorize", query_string={"req": _handle()}).get_data(as_text=True)
+    assert 'id="approve-btn"' not in page
+    assert "/auth?enroll=1" in page
+
+
+def test_an_expired_request_says_so(app, svc, fake, monkeypatch):
+    client, _ = _signed_in(app, svc, monkeypatch)
+    fake.parked = None
+    resp = client.get("/authorize", query_string={"req": _handle()})
+    assert resp.status_code == 410
+    assert "expired" in resp.get_data(as_text=True)
+
+
+# --- the decision --------------------------------------------------------------
+
+
+def _approve(client, connection_id, req=None, passkey=None):
+    return client.post("/authorize/decide", data=json.dumps({
+        "req": req or _handle(), "decision": "approved",
+        "connection_id": connection_id, "passkey": passkey or {"rawId": "x"}}),
+        content_type="application/json")
+
+
+def test_an_approval_needs_a_fresh_verified_passkey_for_this_account(
+        app, svc, monkeypatch):
+    """MUTATION: drop the `verified.id != acct.id` check -> the other-account
+    row goes green; drop the challenge pop -> the no-challenge row does."""
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=True)
+    conn = _connect(svc, acct)
+    other = _make_account(svc, monkeypatch, "someone@example.com")
+
+    # No challenge minted: the assertion cannot be fresh, whatever the
+    # verifier would say about it (it would say yes here).
+    monkeypatch.setattr(svc, "finish_authentication",
+                        lambda cred, ch, require_uv=False: acct)
+    resp = _approve(client, conn)
+    assert resp.status_code == 400 and resp.get_json()["error"] == "no challenge"
+
+    # A passkey that verifies as another account.
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    monkeypatch.setattr(svc, "finish_authentication",
+                        lambda cred, ch, require_uv=False: other)
+    assert _approve(client, conn).status_code == 403
+
+    # The verifier is asked for user verification, not presence.
+    seen = {}
+
+    def verify(cred, ch, require_uv=False):
+        seen["require_uv"] = require_uv
+        return acct
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    monkeypatch.setattr(svc, "finish_authentication", verify)
+    resp = _approve(client, conn)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert seen["require_uv"] is True
+
+
+def test_an_approval_sends_back_a_grant_healthclaw_decodes_and_records_it(
+        app, svc, fake, monkeypatch):
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", MINT)
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=True)
+    conn = _connect(svc, acct, "fasten", "Clinic records", provider="Epic (Fasten)")
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    monkeypatch.setattr(svc, "finish_authentication",
+                        lambda cred, ch, require_uv=False: acct)
+    resp = _approve(client, conn)
+    assert resp.status_code == 200
+    redirect = resp.get_json()["redirect"]
+    assert redirect.startswith(PUBLIC + "/r6/fhir/oauth/consent/return?grant=")
+    payload = decode_grant(redirect.split("grant=", 1)[1])
+    assert payload["decision"] == "approved"
+    assert payload["tenant_id"] == svc.get_connection(acct.id, conn)["tenant_id"]
+    grants = svc.list_grants(acct.id)
+    assert len(grants) == 1
+    g = grants[0]
+    assert g["consent_id"] == payload["consent_id"]
+    assert g["client_name"] == "Claude" and g["client_id"] == "cid-claude"
+    assert g["scopes"] == "fhir.read context.read" and g["status"] == "active"
+    assert g["connection_id"] == conn
+
+
+def test_a_denial_needs_no_passkey_and_records_nothing(app, svc, monkeypatch):
+    monkeypatch.setenv("INTERNAL_TOKEN_MINT_SECRET", MINT)
+    client, acct = _signed_in(app, svc, monkeypatch)
+    resp = client.post("/authorize/decide", data=json.dumps({
+        "req": _handle(), "decision": "denied"}), content_type="application/json")
+    assert resp.status_code == 200
+    payload = decode_grant(resp.get_json()["redirect"].split("grant=", 1)[1])
+    assert payload["decision"] == "denied" and payload["tenant_id"] is None
+    assert svc.list_grants(acct.id) == []
+
+
+def test_a_decision_on_a_forged_or_foreign_request_is_refused(
+        app, svc, monkeypatch):
+    client, acct = _signed_in(app, svc, monkeypatch, passkey=True)
+    conn = _connect(svc, acct)
+    stranger = _make_account(svc, monkeypatch, "stranger@example.com")
+    theirs = _connect(svc, stranger)
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    monkeypatch.setattr(svc, "finish_authentication",
+                        lambda cred, ch, require_uv=False: acct)
+    assert _approve(client, conn, req=_handle(secret="x")).status_code == 400
+    with client.session_transaction() as s:
+        s["wa_consent_challenge"] = "c"
+    assert _approve(client, theirs).status_code == 404, \
+        "another account's connection is not this person's to share"
+
+
+def test_the_hub_lists_grants_and_revokes_at_healthclaw_first(
+        app, svc, fake, monkeypatch):
+    """MUTATION: mark the row revoked before hc.revoke_consent, or ignore its
+    failure -> the failing-revoke assertions go red."""
+    client, acct = _signed_in(app, svc, monkeypatch)
+    conn = _connect(svc, acct, "sample", "Sample records")
+    tenant = svc.get_connection(acct.id, conn)["tenant_id"]
+    gid = svc.add_grant(acct.id, conn, tenant, "cid-claude", "Claude",
+                        "fhir.read", "consent_abc")
+    page = client.get("/home").get_data(as_text=True)
+    assert "Shared with other apps" in page and "Claude" in page
+    assert f'data-grant="{gid}"' in page
+
+    fake.revoke_fails = True
+    resp = client.post(f"/api/grants/{gid}/revoke")
+    assert resp.status_code == 502 and resp.get_json()["revoked"] is False
+    assert svc.get_grant(acct.id, gid)["status"] == "active"
+
+    fake.revoke_fails = False
+    resp = client.post(f"/api/grants/{gid}/revoke")
+    assert resp.status_code == 200 and resp.get_json()["revoked"] is True
+    assert fake.revoked == ["consent_abc"]
+    assert svc.get_grant(acct.id, gid)["status"] == "revoked"
+    assert client.post("/api/grants/nope/revoke").status_code == 404
+
+
+def test_consent_options_ask_the_authenticator_for_user_verification(
+        app, svc, monkeypatch):
+    client, _ = _signed_in(app, svc, monkeypatch)
+    resp = client.post("/webauthn/consent/options")
+    assert resp.status_code == 200
+    assert resp.get_json()["userVerification"] == "required"
+    with client.session_transaction() as s:
+        assert s["wa_consent_challenge"]
+
+
+def test_deleting_a_connection_revokes_its_grants_at_healthclaw_and_keeps_the_record(
+        app, svc, fake, monkeypatch):
+    """The grant row carries a foreign key to the connection. Postgres refuses
+    the delete while it points at the row; SQLite never would (found in
+    review, not by a test). The grant is revoked at HealthClaw first, then
+    detached, then the connection goes. Runs on both CI lanes.
+
+    MUTATION: drop the detach loop in delete_connection -> red on Postgres;
+    drop the revoke loop in the route -> the fake records no revocation.
+    """
+    client, acct = _signed_in(app, svc, monkeypatch)
+    conn = _connect(svc, acct, "sample", "Sample records")
+    tenant = svc.get_connection(acct.id, conn)["tenant_id"]
+    gid = svc.add_grant(acct.id, conn, tenant, "cid-claude", "Claude", "fhir.read", "consent_del")
+    fake.purge_tenant = lambda t: {"rows_deleted": 3}
+    resp = client.delete(f"/api/connections/{conn}")
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.get_json()["deleted"] is True
+    assert fake.revoked == ["consent_del"]
+    assert svc.get_connection(acct.id, conn) is None
+    g = svc.get_grant(acct.id, gid)
+    assert g is not None and g["status"] == "revoked" and g["connection_id"] is None
+
+
+def test_a_revoke_that_cannot_be_confirmed_keeps_the_connection_listed(
+        app, svc, fake, monkeypatch):
+    client, acct = _signed_in(app, svc, monkeypatch)
+    conn = _connect(svc, acct, "sample", "Sample records")
+    tenant = svc.get_connection(acct.id, conn)["tenant_id"]
+    gid = svc.add_grant(acct.id, conn, tenant, "cid-claude", "Claude", "fhir.read", "consent_x")
+    fake.purge_tenant = lambda t: {"rows_deleted": 3}
+    fake.revoke_fails = True
+    resp = client.delete(f"/api/connections/{conn}")
+    assert resp.status_code == 502
+    body = resp.get_json()
+    assert body["deleted"] is True and body["unlinked"] is False and body["grants_active"] == 1
+    assert svc.get_connection(acct.id, conn) is not None, "still listed, so Delete can be retried"
+    assert svc.get_grant(acct.id, gid)["status"] == "active"

--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -106,6 +106,11 @@ _COMPARE_DIGEST_HOMES = {
         'caller-supplied string reaches the comparison. CareAgents cannot '
         'import r6 either (tests/test_import_acyclicity.py), so routing it '
         'through the helper would mean duplicating the helper',
+    'careagents/consent.py':
+        'the handoff tag check (spec §13.3): both operands are bytes before '
+        'they meet — the presented tag encoded as ASCII with non-ASCII '
+        'dropped, and a hexdigest this process just computed — so the #557 '
+        'TypeError cannot arise. CareAgents cannot import r6, as above',
 }
 
 


### PR DESCRIPTION
## What

The CareAgents half of the MCP connector's consent handoff (spec §13.2, §13.4, §13.7 in `docs/specs/2026-08-16-mcp-authorization.md`, the §13 amendment is on #669). HealthClaw parks a connector's OAuth request and sends the browser to `/authorize` on careagents.cloud with a signed handle. This page is what the person sees and decides on.

- **Nothing is fetched until the handle verifies.** The tag is checked under the key derived from the mint secret both services already hold (`sha256("healthclaw-consent-handoff:" + secret)`), then the expiry. A forged link is a 400 that never calls HealthClaw.
- **Sign-in resumes the request.** Signed out, the handle is parked in the session and the person goes to `/auth`; `/home` then resumes it once.
- **The page says who is asking and what they get, in the person's words**, and offers the account's own connections. Real-record connections are offered only where `CARE_REAL_RECORDS` opens them, exactly as connecting them is gated; with the gate closed the decision endpoint refuses a real one even by id.
- **Nothing is granted without a fresh passkey assertion with user verification, for this account.** `/webauthn/consent/options` asks for `userVerification: required`; `/authorize/decide` pops the challenge (no challenge, no approval), verifies the assertion with `require_user_verification=True`, and refuses a passkey that verifies as another account. An account without a passkey is offered enrolment, not approval. A denial needs no passkey.
- **The signed decision goes back through the browser** in the format HealthClaw's `decode_grant` verifies (sorted keys, no whitespace, a fresh nonce, five-minute expiry), to `<HEALTHCLAW_PUBLIC_BASE>/r6/fhir/oauth/consent/return`.
- **A `Grant` row records it** (account, connection, tenant pointer, client id and name, scopes, HealthClaw's consent id, granted and revoked times). The hub lists grants under "Shared with other apps"; **Revoke asks HealthClaw first** and marks the row only on its yes, so a revocation is never shown that did not happen (502 and still active otherwise).
- No PHI anywhere in this: a request id, a tenant pointer, a client name, connection labels.

New: `careagents/consent.py`, `careagents/templates/consent.html`, `careagents/static/consent.js`, the `Grant` model, four routes, client methods `consent_request` and `revoke_consent`.

## Evidence

`tests/test_careagents_consent.py` (15 tests). The cross-layer rows that verify a grant with HealthClaw's own decoder skip until the handoff PR is on main and then run for real; a reference decoder holds the format meanwhile. Full suite: 3646 passed, 13 skipped, 1 xfailed, one guard allowlisted with its reason (`careagents/consent.py` compares two byte strings it built itself). Eight mutations executed on a separate worktree, all caught:

| mutation | failing |
|---|---|
| handle tag never compared | 3 |
| handle expiry ignored | 1 |
| real records offered when the gate is closed | 1 |
| decide ignores the real-records gate | 1 |
| another account's passkey approves | 1 |
| approval without a fresh challenge | 1 |
| revocation claimed when HealthClaw failed | 1 |
| presence accepted instead of user verification | 1 |

## Not in this PR

The HealthClaw endpoints this page talks to are on the held branch `feat/oauth-consent-handoff` (opens after #669 and the introspection PR land). Until then the page is reachable but every handle fails to verify without a matching secret, and nothing here runs on its own. No deploy: CareAgents is a manual `railway up` from a staged directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)