### PR TITLE
feat(mcp): the server accepts authorization-server tokens for a consented tenant, behind MCP_OAUTH_ENABLED (#568 phase 3)

### DIFF
--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -314,6 +314,44 @@ function challengeHeader(req: express.Request): string {
   return `Bearer ${params.join(", ")}`;
 }
 
+// --- Rate Limiting (in-memory, per IP) ---
+
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX || "120", 10);
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  entry.count++;
+  return entry.count <= RATE_LIMIT_MAX;
+}
+
+app.use((req, res, next) => {
+  // Preflight answers below without reaching a handler, and it did not consume
+  // budget when the limiter sat further down the chain. Keep it that way: a
+  // browser client spends its allowance on requests, not on asking permission.
+  if (req.method === "OPTIONS") return next();
+  const clientIp = req.ip || req.socket.remoteAddress || "unknown";
+  if (!checkRateLimit(clientIp)) {
+    return res.status(429).json({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Rate limit exceeded" },
+    });
+  }
+  next();
+});
+
+// Rate limiting comes before the credential check on purpose. The check now
+// makes a network call of its own (introspection), so a limiter placed after
+// it lets an unauthenticated flood drive unbounded requests at the
+// authorization server. A caller over the limit is refused here, having cost
+// this server one map lookup and Flask nothing.
 // Health probes and CORS preflight remain public. When configured, every MCP
 // network transport requires the deployment-scoped bearer credential.
 app.use(async (req, res, next) => {
@@ -387,35 +425,6 @@ app.use((req, res, next) => {
       res.setHeader("Access-Control-Allow-Origin", "*");
     }
     return res.sendStatus(204);
-  }
-  next();
-});
-
-// --- Rate Limiting (in-memory, per IP) ---
-
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX || "120", 10);
-const SESSION_TTL_MS = 30 * 60 * 1000;
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-  entry.count++;
-  return entry.count <= RATE_LIMIT_MAX;
-}
-
-app.use((req, res, next) => {
-  const clientIp = req.ip || req.socket.remoteAddress || "unknown";
-  if (!checkRateLimit(clientIp)) {
-    return res.status(429).json({
-      jsonrpc: "2.0",
-      error: { code: -32000, message: "Rate limit exceeded" },
-    });
   }
   next();
 });
@@ -1120,6 +1129,10 @@ if (require.main === module) {
   });
 }
 
+function resetRateLimitForTests(): void {
+  rateLimitMap.clear();
+}
+
 function closeMCPServerForTests(): void {
   clearInterval(sessionCleanupInterval);
   rateLimitMap.clear();
@@ -1143,6 +1156,7 @@ function getRuntimeStateForTests(): {
 
 export {
   app,
+  resetRateLimitForTests,
   assertMCPAuthConfigured,
   assertMCPCanonicalResourceConfigured,
   assertMCPOAuthConfigured,

--- a/services/agent-orchestrator/src/index.ts
+++ b/services/agent-orchestrator/src/index.ts
@@ -28,6 +28,7 @@ import {
 import crypto from "crypto";
 import { FHIRTools } from "./tools";
 import { executeMCPTool } from "./mcp-tool-result";
+import { fetchWithTimeout } from "./fetch-timeout";
 
 const { version: SERVER_VERSION } = require("../package.json") as {
   version: string;
@@ -90,6 +91,106 @@ function isMCPBearerCredential(authorization: string | undefined): boolean {
   return Boolean(
     expectedToken && match && tokenMatches(match[1], expectedToken)
   );
+}
+
+// --- Phase 3: authorization-server tokens, behind MCP_OAUTH_ENABLED ---
+//
+// docs/specs/2026-08-16-mcp-authorization.md §3.5, §3.6 and §13.6. A bearer
+// that is not MCP_AUTH_TOKEN is a candidate OAuth access token. It is accepted
+// only when Flask's introspection says it is live, its audience is exactly
+// MCP_CANONICAL_RESOURCE, it carries a read scope and it has not expired.
+// Anything else is the same 401 as today. Off (the default), no introspection
+// happens and every non-static bearer is refused, which is R7's rollback.
+//
+// On this path the caller's own credentials never reach Flask: the tenant
+// comes from introspection and nowhere else, the Authorization header is
+// dropped, the tool-argument overrides are discarded, and the downstream
+// credential is a read-scoped step-up token this server mints for the
+// consented tenant (tools.ts). Introspection is a hard dependency and fails
+// closed: Flask unreachable means 401, never a guess.
+export interface OAuthGrant {
+  tenantId: string;
+  clientId: string;
+  scopes: string[];
+  tokenHash: string;
+  expiresAtMs: number;
+}
+
+const INTROSPECTION_CACHE = new Map<string, { grant: OAuthGrant; expiresAtMs: number }>();
+const INTROSPECTION_CACHE_TTL_MS = 5 * 60 * 1000;
+const TENANT_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+//: The internal marker extractHeaders sets on the OAuth path. Never copied
+//: from a request, so a client cannot supply it.
+export const OAUTH_GRANT_HEADER = "x-oauth-grant";
+
+function oauthEnabled(): boolean {
+  const raw = process.env.MCP_OAUTH_ENABLED;
+  return raw === "true" || raw === "1";
+}
+
+function sha256Hex(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function introspectionURL(): string {
+  return `${FHIR_BASE_URL.replace(/\/$/, "")}/oauth/introspect`;
+}
+
+// Ask Flask. The answer is trusted only when every one of the conditions
+// holds; a missing or odd field is a refusal, not a default. 401 for every
+// failure, never 403: a wrong audience is a token that was never for us, and
+// 403 would tell the caller their token is recognised here (§3.5).
+async function introspect(token: string): Promise<OAuthGrant | null> {
+  const clientId = (process.env.MCP_INTROSPECTION_CLIENT_ID || "").trim();
+  const clientSecret = (process.env.MCP_INTROSPECTION_CLIENT_SECRET || "").trim();
+  const resource = (process.env.MCP_CANONICAL_RESOURCE || "").trim();
+  if (!clientId || !clientSecret || !resource) return null;
+  let body: Record<string, unknown>;
+  try {
+    const form = new URLSearchParams({ token, client_id: clientId, client_secret: clientSecret });
+    const resp = await fetchWithTimeout(introspectionURL(), {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString(),
+    });
+    if (!resp.ok) return null;
+    body = (await resp.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (!body || body.active !== true) return null;
+  if (typeof body.aud !== "string" || body.aud !== resource) return null;
+  const scopes = typeof body.scope === "string" ? body.scope.split(/\s+/).filter(Boolean) : [];
+  if (!scopes.some((s) => RESOURCE_SCOPES.includes(s))) return null;
+  if (typeof body.exp !== "number" || body.exp * 1000 <= Date.now()) return null;
+  if (typeof body.tenant_id !== "string" || !TENANT_ID_PATTERN.test(body.tenant_id)) return null;
+  return {
+    tenantId: body.tenant_id,
+    clientId: typeof body.client_id === "string" ? body.client_id : "unknown",
+    scopes,
+    tokenHash: sha256Hex(token),
+    expiresAtMs: body.exp * 1000,
+  };
+}
+
+// Cached under the token's SHA-256 only, for at most five minutes and never
+// past the token's own expiry, so a revoked consent stops being served within
+// the window and the token value itself is never held (§9.7).
+async function resolveOAuthGrant(token: string): Promise<OAuthGrant | null> {
+  const key = sha256Hex(token);
+  const now = Date.now();
+  const cached = INTROSPECTION_CACHE.get(key);
+  if (cached && cached.expiresAtMs > now) return cached.grant;
+  INTROSPECTION_CACHE.delete(key);
+  const grant = await introspect(token);
+  if (!grant) return null;
+  const expiresAtMs = Math.min(now + INTROSPECTION_CACHE_TTL_MS, grant.expiresAtMs);
+  INTROSPECTION_CACHE.set(key, { grant, expiresAtMs });
+  return grant;
+}
+
+function resetOAuthStateForTests(): void {
+  INTROSPECTION_CACHE.clear();
 }
 
 // --- RFC 9728 protected-resource metadata (phase 1, behind the constant) ---
@@ -215,7 +316,7 @@ function challengeHeader(req: express.Request): string {
 
 // Health probes and CORS preflight remain public. When configured, every MCP
 // network transport requires the deployment-scoped bearer credential.
-app.use((req, res, next) => {
+app.use(async (req, res, next) => {
   const expectedToken = process.env.MCP_AUTH_TOKEN;
   if (
     req.method === "OPTIONS" ||
@@ -226,11 +327,25 @@ app.use((req, res, next) => {
     return next();
   }
 
-  if (!isMCPBearerCredential(req.headers.authorization)) {
-    res.setHeader("WWW-Authenticate", challengeHeader(req));
-    return res.status(401).json({ error: "Unauthorized" });
+  const authorization = req.headers.authorization;
+  if (isMCPBearerCredential(authorization)) return next();
+
+  const bearer = /^Bearer (.+)$/i.exec(authorization || "");
+  if (bearer && oauthEnabled()) {
+    const grant = await resolveOAuthGrant(bearer[1].trim());
+    if (grant) {
+      res.locals.oauthGrant = grant;
+      return next();
+    }
   }
-  next();
+
+  // The refusal is readable from a browser context (§9.4): it carries no
+  // secret, names no tenant and grants nothing, and a 401 a browser can read
+  // is still a 401. The transport's own origin allowlist is untouched.
+  res.setHeader("WWW-Authenticate", challengeHeader(req));
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Expose-Headers", "WWW-Authenticate");
+  return res.status(401).json({ error: "Unauthorized" });
 });
 
 // Railway / Heroku / Fly inject PORT; honor that first so the platform's
@@ -260,8 +375,17 @@ app.use((req, res, next) => {
     "Access-Control-Allow-Headers",
     "Content-Type, Authorization, X-Tenant-Id, X-Step-Up-Token, X-Agent-Id, X-Human-Confirmed, Mcp-Session-Id, X-FHIR-Server-URL, X-FHIR-Access-Token, X-Patient-ID, X-FHIR-Refresh-Token, X-FHIR-Refresh-Url"
   );
-  res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+  res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id, WWW-Authenticate");
   if (req.method === "OPTIONS") {
+    // A browser preflights POST /mcp; without an allow-origin here it never
+    // sends the request and never reads the 401 that says where to go
+    // (§9.4, part 2 of #523). Answering `*` on the preflight lets the request
+    // through to a refusal it can read; the actual response still carries an
+    // allow-origin only for an allowlisted origin, so nothing the transport
+    // returns becomes readable by any other page.
+    if (isMCPTransportPath(req.path) && !res.getHeader("Access-Control-Allow-Origin")) {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+    }
     return res.sendStatus(204);
   }
   next();
@@ -298,8 +422,25 @@ app.use((req, res, next) => {
 
 // --- Helper: extract forwarded headers from HTTP request ---
 
-function extractHeaders(req: express.Request): Record<string, string> {
+function extractHeaders(
+  req: express.Request,
+  grant?: OAuthGrant
+): Record<string, string> {
   const h: Record<string, string> = {};
+  if (grant) {
+    // §3.6: on the OAuth path the tenant comes from introspection and from
+    // nowhere else. The inbound Authorization header, any step-up token and
+    // the bring-your-own-FHIR (SHARP) headers are all dropped: a consented
+    // connection reaches one tenant through the guardrails and nothing else.
+    h["x-tenant-id"] = grant.tenantId;
+    h["x-agent-id"] = `oauth:${grant.clientId}`;
+    h[OAUTH_GRANT_HEADER] = JSON.stringify({
+      tenantId: grant.tenantId,
+      tokenHash: grant.tokenHash,
+      expiresAtMs: grant.expiresAtMs,
+    });
+    return h;
+  }
   if (isPublicDemo()) {
     // Open demo endpoint: pin to the synthetic demo tenant and ignore every
     // client-supplied tenant, step-up, or bring-your-own-FHIR header, so an
@@ -382,6 +523,60 @@ const SHARP_CAPABILITIES = {
   },
 };
 
+const CREDENTIAL_ARGUMENTS = [
+  "_tenantId",
+  "_stepUpToken",
+  "_authorization",
+  "_fhirServerUrl",
+  "_fhirAccessToken",
+  "_patientId",
+];
+
+function stripCredentialArguments(toolArgs: Record<string, unknown>): void {
+  for (const key of CREDENTIAL_ARGUMENTS) delete toolArgs[key];
+}
+
+// The SSE transport lets a client that cannot set HTTP headers pass tenant,
+// step-up, bearer and SHARP context as underscored tool arguments. On the
+// OAuth path (a session whose headers carry the grant marker) none of them is
+// honoured — they are removed, not applied — exactly as the public demo pins
+// them. Pure, so the property is asserted directly (R8 for this transport).
+function applyToolArgumentOverrides(
+  toolArgs: Record<string, unknown>,
+  sessionHeaders: Record<string, string>
+): Record<string, string> {
+  const toolHeaders: Record<string, string> = { ...sessionHeaders };
+  if (sessionHeaders[OAUTH_GRANT_HEADER]) {
+    stripCredentialArguments(toolArgs);
+    return toolHeaders;
+  }
+  if (typeof toolArgs._tenantId === "string") {
+    toolHeaders["x-tenant-id"] = toolArgs._tenantId as string;
+    delete toolArgs._tenantId;
+  }
+  if (typeof toolArgs._stepUpToken === "string") {
+    toolHeaders["x-step-up-token"] = toolArgs._stepUpToken as string;
+    delete toolArgs._stepUpToken;
+  }
+  if (typeof toolArgs._authorization === "string") {
+    toolHeaders["authorization"] = toolArgs._authorization as string;
+    delete toolArgs._authorization;
+  }
+  if (typeof toolArgs._fhirServerUrl === "string") {
+    toolHeaders["x-fhir-server-url"] = toolArgs._fhirServerUrl as string;
+    delete toolArgs._fhirServerUrl;
+  }
+  if (typeof toolArgs._fhirAccessToken === "string") {
+    toolHeaders["x-fhir-access-token"] = toolArgs._fhirAccessToken as string;
+    delete toolArgs._fhirAccessToken;
+  }
+  if (typeof toolArgs._patientId === "string") {
+    toolHeaders["x-patient-id"] = toolArgs._patientId as string;
+    delete toolArgs._patientId;
+  }
+  return toolHeaders;
+}
+
 function createMCPServer(sessionHeaders: Record<string, string> = {}): Server {
   const server = new Server(
     { name: "healthclaw-guardrails", version: SERVER_VERSION },
@@ -397,35 +592,11 @@ function createMCPServer(sessionHeaders: Record<string, string> = {}): Server {
     const toolArgs = (args ?? {}) as Record<string, unknown>;
 
     // Start with session-level headers (captured at connection time for SSE).
-    // Tool-arg headers (_tenantId, _stepUpToken, _authorization) override session
-    // headers, allowing per-call overrides without changing the connection.
-    const toolHeaders: Record<string, string> = { ...sessionHeaders };
-    if (typeof toolArgs._tenantId === "string") {
-      toolHeaders["x-tenant-id"] = toolArgs._tenantId as string;
-      delete toolArgs._tenantId;
-    }
-    if (typeof toolArgs._stepUpToken === "string") {
-      toolHeaders["x-step-up-token"] = toolArgs._stepUpToken as string;
-      delete toolArgs._stepUpToken;
-    }
-    if (typeof toolArgs._authorization === "string") {
-      toolHeaders["authorization"] = toolArgs._authorization as string;
-      delete toolArgs._authorization;
-    }
-    // SHARP-on-MCP tool-arg overrides (Claude Desktop & stdio clients can't
-    // set HTTP headers, so they pass SHARP context as underscored tool args).
-    if (typeof toolArgs._fhirServerUrl === "string") {
-      toolHeaders["x-fhir-server-url"] = toolArgs._fhirServerUrl as string;
-      delete toolArgs._fhirServerUrl;
-    }
-    if (typeof toolArgs._fhirAccessToken === "string") {
-      toolHeaders["x-fhir-access-token"] = toolArgs._fhirAccessToken as string;
-      delete toolArgs._fhirAccessToken;
-    }
-    if (typeof toolArgs._patientId === "string") {
-      toolHeaders["x-patient-id"] = toolArgs._patientId as string;
-      delete toolArgs._patientId;
-    }
+    // Tool-arg headers (_tenantId, _stepUpToken, _authorization, and the
+    // SHARP trio) override session headers, allowing per-call overrides
+    // without changing the connection — except on the OAuth path, where
+    // they are discarded (P3-a, R8).
+    const toolHeaders = applyToolArgumentOverrides(toolArgs, sessionHeaders);
 
     // Demo mode overrides every client-supplied header (incl. _tenantId tool
     // args) with the pinned synthetic tenant — an open caller stays boxed in.
@@ -473,7 +644,7 @@ app.post("/mcp", async (req, res) => {
     });
   }
 
-  const reqHeaders = extractHeaders(req);
+  const reqHeaders = extractHeaders(req, res.locals.oauthGrant as OAuthGrant | undefined);
   const { id, method, params } = body;
   const requestSessionId = req.headers["mcp-session-id"] as string | undefined;
   const existingSession = requestSessionId
@@ -586,6 +757,7 @@ app.post("/mcp", async (req, res) => {
           });
         }
         const toolInput = (rawToolInput ?? {}) as Record<string, unknown>;
+        if (reqHeaders[OAUTH_GRANT_HEADER]) stripCredentialArguments(toolInput);
 
         const result = await executeMCPTool(
           fhirTools,
@@ -690,18 +862,30 @@ const activeSessions = new Map<string, {
   transport: SSEServerTransport;
   headers: Record<string, string>;
   lastActivity: number;
+  credential: string;
 }>();
+
+// An SSE session captures its headers at connect and every later POST to
+// /messages rides on them, so the session is bound to the credential that
+// opened it: the static token, or one OAuth token's hash. A request that
+// authenticates as anything else is refused, or it would execute as the
+// tenant the session was opened for. Streamable HTTP needs no such binding:
+// its headers are resolved per request.
+function sessionCredential(grant: OAuthGrant | undefined): string {
+  return grant ? `oauth:${grant.tokenHash}` : "static";
+}
 
 app.get("/sse", async (req, res) => {
   // Capture headers from the SSE connection request and pass them into the
   // server instance so CallToolRequestSchema forwwards X-Tenant-ID on every tool call.
-  const reqHeaders = extractHeaders(req);
+  const reqHeaders = extractHeaders(req, res.locals.oauthGrant as OAuthGrant | undefined);
   const server = createMCPServer(reqHeaders);
   const transport = new SSEServerTransport("/messages", res);
   activeSessions.set(transport.sessionId, {
     transport,
     headers: reqHeaders,
     lastActivity: Date.now(),
+    credential: sessionCredential(res.locals.oauthGrant as OAuthGrant | undefined),
   });
 
   res.on("close", () => {
@@ -716,6 +900,9 @@ app.post("/messages", async (req, res) => {
   const session = activeSessions.get(sessionId);
   if (!session) {
     return res.status(400).json({ error: "Invalid or expired session" });
+  }
+  if (session.credential !== sessionCredential(res.locals.oauthGrant as OAuthGrant | undefined)) {
+    return res.status(401).json({ error: "Unauthorized" });
   }
   session.lastActivity = Date.now();
   await session.transport.handlePostMessage(req, res, req.body);
@@ -742,7 +929,7 @@ app.post("/mcp/rpc", async (req, res) => {
   }
 
   const { id, method, params } = rpcRequest;
-  const reqHeaders = extractHeaders(req);
+  const reqHeaders = extractHeaders(req, res.locals.oauthGrant as OAuthGrant | undefined);
 
   try {
     switch (method) {
@@ -846,6 +1033,7 @@ app.get("/health", (_req, res) => {
       streamableHttp: streamableSessions.size,
       sse: activeSessions.size,
     },
+    oauth: { enabled: oauthEnabled() },
     cors: {
       mode: ALLOWED_ORIGINS.length > 0 ? "allowlist" : "deny-all",
       allowedOrigins: ALLOWED_ORIGINS.length,
@@ -894,9 +1082,31 @@ function assertMCPCanonicalResourceConfigured(
   }
 }
 
+// Enabled means every piece it depends on is present, or the server does not
+// start: a half-configured OAuth path would refuse every connector token in
+// production and look, from outside, like a deploy that worked (§7).
+function assertMCPOAuthConfigured(env: NodeJS.ProcessEnv = process.env): void {
+  const raw = env.MCP_OAUTH_ENABLED;
+  if (raw !== "true" && raw !== "1") return;
+  const missing = [
+    "MCP_CANONICAL_RESOURCE",
+    "MCP_INTROSPECTION_CLIENT_ID",
+    "MCP_INTROSPECTION_CLIENT_SECRET",
+    "INTERNAL_TOKEN_MINT_SECRET",
+  ].filter((name) => !env[name]?.trim());
+  if (missing.length > 0 || !parseCanonicalResource(env.MCP_CANONICAL_RESOURCE)) {
+    throw new Error(
+      "MCP_OAUTH_ENABLED=true requires a canonical MCP_CANONICAL_RESOURCE, " +
+        "MCP_INTROSPECTION_CLIENT_ID, MCP_INTROSPECTION_CLIENT_SECRET and " +
+        `INTERNAL_TOKEN_MINT_SECRET (missing: ${missing.join(", ") || "none, but the resource is not canonical"})`
+    );
+  }
+}
+
 if (require.main === module) {
   assertMCPAuthConfigured();
   assertMCPCanonicalResourceConfigured();
+  assertMCPOAuthConfigured();
   app.listen(PORT, () => {
     console.error(`FHIR R6 MCP Server v${SERVER_VERSION} running on port ${PORT}`);
     console.error(`FHIR Base URL: ${FHIR_BASE_URL}`);
@@ -935,6 +1145,10 @@ export {
   app,
   assertMCPAuthConfigured,
   assertMCPCanonicalResourceConfigured,
+  assertMCPOAuthConfigured,
+  applyToolArgumentOverrides,
+  resetOAuthStateForTests,
+  sessionCredential,
   cleanupExpiredRuntimeStateForTests,
   closeMCPServerForTests,
   getRuntimeStateForTests,

--- a/services/agent-orchestrator/src/oauth-path.test.ts
+++ b/services/agent-orchestrator/src/oauth-path.test.ts
@@ -20,6 +20,7 @@ import {
   assertMCPOAuthConfigured,
   closeMCPServerForTests,
   resetOAuthStateForTests,
+  resetRateLimitForTests,
   sessionCredential,
 } from "./index";
 import { resetGrantReadTokenCacheForTests } from "./tools";
@@ -105,6 +106,7 @@ beforeEach(() => {
   mockFetch.mockReset();
   installFlask();
   resetOAuthStateForTests();
+  resetRateLimitForTests();
   resetGrantReadTokenCacheForTests();
 });
 
@@ -446,5 +448,39 @@ describe("boot", () => {
         INTERNAL_TOKEN_MINT_SECRET: "c",
       })
     ).not.toThrow();
+  });
+});
+
+describe("the limiter runs before the credential check", () => {
+  // Resolving a bearer token costs a POST to the authorization server. If the
+  // limiter sat after that check, an unauthenticated flood would reach Flask
+  // once per request. Past the limit this server must answer alone.
+  const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX || "120", 10);
+
+  it("a caller past the limit is refused without an introspection call", async () => {
+    // Flask answers "not a live token", so every one of these costs a call.
+    introspection = { active: false };
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      const res = await initialize("Bearer not-a-token-this-server-knows");
+      expect(res.status).toBe(401);
+    }
+    const spent = introspections().length;
+    expect(spent).toBe(RATE_LIMIT_MAX);
+
+    const refused = await initialize("Bearer not-a-token-this-server-knows");
+    expect(refused.status).toBe(429);
+    expect(introspections().length).toBe(spent);
+  });
+
+  it("preflight does not consume the allowance", async () => {
+    for (let i = 0; i < RATE_LIMIT_MAX + 5; i++) {
+      const res = await request(app)
+        .options("/mcp")
+        .set("Host", CANONICAL_HOST)
+        .set("Origin", "https://claude.ai");
+      expect(res.status).toBe(204);
+    }
+    const after = await initialize(`Bearer ${OAUTH_TOKEN}`);
+    expect(after.status).toBe(200);
   });
 });

--- a/services/agent-orchestrator/src/oauth-path.test.ts
+++ b/services/agent-orchestrator/src/oauth-path.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Phase 3: the MCP server accepts authorization-server tokens (spec §3.5,
+ * §3.6, §7, §8.2 R1–R8, §13.6), behind MCP_OAUTH_ENABLED.
+ *
+ * Flask is a mock here (introspection, the read-scoped mint, and the FHIR
+ * read itself), so every assertion is about what this server sends and
+ * refuses: which tenant reaches Flask, which credential, and that nothing a
+ * caller supplied does. The invariant of §7 is asserted at every step: an
+ * unauthenticated initialize never returns anything but 401.
+ */
+import http from "http";
+import { AddressInfo } from "net";
+import request from "supertest";
+
+jest.mock("node-fetch", () => jest.fn());
+import fetch from "node-fetch";
+import {
+  app,
+  applyToolArgumentOverrides,
+  assertMCPOAuthConfigured,
+  closeMCPServerForTests,
+  resetOAuthStateForTests,
+  sessionCredential,
+} from "./index";
+import { resetGrantReadTokenCacheForTests } from "./tools";
+
+const mockFetch = fetch as unknown as jest.Mock;
+
+const CANONICAL = "https://mcp.healthclaw.io/mcp";
+const CANONICAL_HOST = "mcp.healthclaw.io";
+const FHIR_RESOURCE = "https://app.healthclaw.io/r6/fhir";
+const STATIC_TOKEN = "static-mcp-token-for-tests";
+const OAUTH_TOKEN = "an-opaque-access-token-from-flask";
+const TENANT = "ca-real-tenant";
+
+interface Recorded {
+  url: string;
+  init: Record<string, any>;
+}
+
+let calls: Recorded[] = [];
+let introspection: Record<string, unknown> | (() => never);
+
+function respond(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: { get: () => null },
+  };
+}
+
+function installFlask() {
+  mockFetch.mockImplementation(async (url: string, init: Record<string, any> = {}) => {
+    calls.push({ url, init });
+    if (url.endsWith("/oauth/introspect")) {
+      if (typeof introspection === "function") return introspection();
+      return respond(200, introspection);
+    }
+    if (url.endsWith("/internal/step-up-token")) {
+      const body = JSON.parse(init.body || "{}");
+      return respond(200, { token: `read-token-for-${body.tenant_id}`, tenant_id: body.tenant_id, scope: body.scope ?? null });
+    }
+    return respond(200, { resourceType: "Patient", id: "p-1" });
+  });
+}
+
+function liveIntrospection(overrides: Record<string, unknown> = {}) {
+  return {
+    active: true,
+    token_type: "Bearer",
+    aud: CANONICAL,
+    scope: "fhir.read context.read",
+    tenant_id: TENANT,
+    client_id: "cid-claude",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  };
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  "MCP_CANONICAL_RESOURCE",
+  "MCP_AUTH_TOKEN",
+  "MCP_PUBLIC_DEMO",
+  "MCP_OAUTH_ENABLED",
+  "MCP_INTROSPECTION_CLIENT_ID",
+  "MCP_INTROSPECTION_CLIENT_SECRET",
+  "INTERNAL_TOKEN_MINT_SECRET",
+  "ALLOWED_ORIGINS",
+];
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+  delete process.env.MCP_PUBLIC_DEMO;
+  process.env.MCP_AUTH_TOKEN = STATIC_TOKEN;
+  process.env.MCP_CANONICAL_RESOURCE = CANONICAL;
+  process.env.MCP_OAUTH_ENABLED = "true";
+  process.env.MCP_INTROSPECTION_CLIENT_ID = "mcp-server";
+  process.env.MCP_INTROSPECTION_CLIENT_SECRET = "introspection-secret";
+  process.env.INTERNAL_TOKEN_MINT_SECRET = "mint-secret";
+  calls = [];
+  introspection = liveIntrospection();
+  mockFetch.mockReset();
+  installFlask();
+  resetOAuthStateForTests();
+  resetGrantReadTokenCacheForTests();
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+afterAll(() => {
+  closeMCPServerForTests();
+});
+
+function initialize(authorization?: string) {
+  const req = request(app).post("/mcp").set("Host", CANONICAL_HOST);
+  if (authorization) req.set("Authorization", authorization);
+  return req.send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "0" } },
+  });
+}
+
+async function session(): Promise<string> {
+  const res = await initialize(`Bearer ${OAUTH_TOKEN}`);
+  expect(res.status).toBe(200);
+  return res.headers["mcp-session-id"];
+}
+
+function call(sessionId: string, name: string, args: Record<string, unknown>, authorization = `Bearer ${OAUTH_TOKEN}`) {
+  return request(app)
+    .post("/mcp")
+    .set("Host", CANONICAL_HOST)
+    .set("Authorization", authorization)
+    .set("Mcp-Session-Id", sessionId)
+    .send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name, arguments: args } });
+}
+
+const introspections = () => calls.filter((c) => c.url.endsWith("/oauth/introspect"));
+const mints = () => calls.filter((c) => c.url.endsWith("/internal/step-up-token"));
+const flaskReads = () => calls.filter((c) => !c.url.endsWith("/oauth/introspect") && !c.url.endsWith("/internal/step-up-token"));
+
+describe("the refusal chain (§8.2)", () => {
+  test("R1: no credential is 401, readable from a browser, with a way forward", async () => {
+    const res = await initialize();
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toContain("resource_metadata=");
+    expect(res.headers["www-authenticate"]).not.toContain("error=");
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+    expect(res.headers["access-control-expose-headers"]).toContain("WWW-Authenticate");
+    expect(introspections()).toHaveLength(0);
+  });
+
+  test("R2: a random string as bearer is 401 invalid_token", async () => {
+    introspection = { active: false };
+    const res = await initialize("Bearer garbage");
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toContain('error="invalid_token"');
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  test("R3: a token minted for the FHIR audience is refused here, 401 not 403", async () => {
+    introspection = liveIntrospection({ aud: FHIR_RESOURCE });
+    const res = await initialize(`Bearer ${OAUTH_TOKEN}`);
+    expect(res.status).toBe(401);
+    expect(introspections()).toHaveLength(1);
+  });
+
+  test.each([
+    ["expired", { exp: Math.floor(Date.now() / 1000) - 5 }],
+    ["no read scope", { scope: "fhir.write" }],
+    ["no audience at all", { aud: undefined }],
+    ["a near-miss audience", { aud: CANONICAL + "/" }],
+    ["a tenant that is not a tenant id", { tenant_id: "../x; rm" }],
+  ])("R4 and §8.3: %s is 401", async (_label, overrides) => {
+    introspection = liveIntrospection(overrides);
+    const res = await initialize(`Bearer ${OAUTH_TOKEN}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("R5: MCP_AUTH_TOKEN still opens the door and never touches Flask", async () => {
+    const res = await initialize(`Bearer ${STATIC_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(introspections()).toHaveLength(0);
+  });
+
+  test("R7: MCP_OAUTH_ENABLED off refuses an otherwise valid token without asking Flask", async () => {
+    delete process.env.MCP_OAUTH_ENABLED;
+    const res = await initialize(`Bearer ${OAUTH_TOKEN}`);
+    expect(res.status).toBe(401);
+    expect(introspections()).toHaveLength(0);
+  });
+
+  test("introspection failing closed: Flask unreachable is 401, never a guess", async () => {
+    introspection = () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const res = await initialize(`Bearer ${OAUTH_TOKEN}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("a preflight on the transport answers with an allow-origin so the 401 can be read", async () => {
+    const res = await request(app).options("/mcp").set("Origin", "https://claude.ai").set("Host", CANONICAL_HOST);
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  });
+});
+
+describe("the positive chain on a consented tenant (§13.6)", () => {
+  test("A7: a live token initializes and lists tools", async () => {
+    const sessionId = await session();
+    expect(sessionId).toBeTruthy();
+    const res = await request(app)
+      .post("/mcp")
+      .set("Host", CANONICAL_HOST)
+      .set("Authorization", `Bearer ${OAUTH_TOKEN}`)
+      .set("Mcp-Session-Id", sessionId)
+      .send({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+    expect(res.status).toBe(200);
+    expect(res.body.result.tools.length).toBeGreaterThan(20);
+  });
+
+  test("a read reaches Flask as the introspected tenant with a read-scoped token this server minted", async () => {
+    const sessionId = await session();
+    const res = await call(sessionId, "fhir_read", { resource_type: "Patient", resource_id: "p-1" });
+    expect(res.status).toBe(200);
+    expect(res.body.result.isError).toBeUndefined();
+
+    expect(mints()).toHaveLength(1);
+    const mint = mints()[0];
+    expect(JSON.parse(mint.init.body)).toEqual({ tenant_id: TENANT, scope: "read" });
+    expect(mint.init.headers["X-Internal-Secret"]).toBe("mint-secret");
+
+    expect(flaskReads()).toHaveLength(1);
+    const headers = flaskReads()[0].init.headers as Record<string, string>;
+    expect(headers["X-Tenant-Id"]).toBe(TENANT);
+    expect(headers["X-Step-Up-Token"]).toBe(`read-token-for-${TENANT}`);
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-Agent-Id"]).toBe("oauth:cid-claude");
+  });
+
+  test("R8: credentials in tool arguments reach Flask in no form on the OAuth path", async () => {
+    const sessionId = await session();
+    const res = await call(sessionId, "fhir_read", {
+      resource_type: "Patient",
+      resource_id: "p-1",
+      _tenantId: "victim-tenant",
+      _stepUpToken: "forged-step-up",
+      _authorization: "Bearer forged-bearer",
+      _fhirServerUrl: "https://evil.example/fhir",
+      _fhirAccessToken: "upstream-token",
+      _patientId: "someone-else",
+    });
+    expect(res.status).toBe(200);
+    const flask = flaskReads();
+    expect(flask).toHaveLength(1);
+    const headers = flask[0].init.headers as Record<string, string>;
+    expect(headers["X-Tenant-Id"]).toBe(TENANT);
+    expect(headers["X-Step-Up-Token"]).toBe(`read-token-for-${TENANT}`);
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-FHIR-Server-URL"]).toBeUndefined();
+    expect(headers["X-FHIR-Access-Token"]).toBeUndefined();
+    expect(headers["X-Patient-ID"]).toBeUndefined();
+    const everything = JSON.stringify(calls);
+    for (const leaked of ["victim-tenant", "forged-step-up", "forged-bearer", "evil.example", "upstream-token", "someone-else"]) {
+      expect(everything).not.toContain(leaked);
+    }
+  });
+
+  test("the inbound Authorization header is not forwarded either (§3.6)", async () => {
+    const sessionId = await session();
+    await call(sessionId, "fhir_read", { resource_type: "Patient", resource_id: "p-1" });
+    const everything = JSON.stringify(flaskReads());
+    expect(everything).not.toContain(OAUTH_TOKEN);
+  });
+
+  test("a write-tier tool is refused before anything is sent", async () => {
+    const sessionId = await session();
+    const res = await call(sessionId, "fhir_commit_write", {
+      resource: { resourceType: "Observation", status: "final" },
+      operation: "create",
+      _stepUpToken: "a-real-looking-step-up-token",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.result.isError).toBe(true);
+    expect(res.body.result.content[0].text).toContain("read-only");
+    expect(mints()).toHaveLength(0);
+    expect(flaskReads()).toHaveLength(0);
+  });
+
+  test("the mint refusing, or answering without the read scope, is a refusal here, not a wider call", async () => {
+    const sessionId = await session();
+    mockFetch.mockImplementation(async (url: string, init: Record<string, any> = {}) => {
+      calls.push({ url, init });
+      if (url.endsWith("/oauth/introspect")) return respond(200, liveIntrospection());
+      if (url.endsWith("/internal/step-up-token")) return respond(200, { token: "full-token", tenant_id: TENANT, scope: null });
+      return respond(200, { resourceType: "Patient" });
+    });
+    const res = await call(sessionId, "fhir_read", { resource_type: "Patient", resource_id: "p-1" });
+    expect(res.body.result.isError).toBe(true);
+    expect(res.body.result.content[0].text).toContain("read_credential_unavailable");
+    expect(flaskReads()).toHaveLength(0);
+  });
+
+  test("introspection and the mint are cached under the token, once per token", async () => {
+    const sessionId = await session();
+    await call(sessionId, "fhir_read", { resource_type: "Patient", resource_id: "p-1" });
+    await call(sessionId, "fhir_read", { resource_type: "Patient", resource_id: "p-2" });
+    expect(introspections()).toHaveLength(1);
+    expect(mints()).toHaveLength(1);
+    expect(flaskReads()).toHaveLength(2);
+    expect(JSON.stringify(calls)).not.toContain(OAUTH_TOKEN.slice(0, 12) + '"');
+  });
+});
+
+describe("R8 on the SSE transport, where the overrides live", () => {
+  const overrides = {
+    _tenantId: "victim-tenant",
+    _stepUpToken: "forged-step-up",
+    _authorization: "Bearer forged-bearer",
+    _fhirServerUrl: "https://evil.example/fhir",
+    _fhirAccessToken: "upstream-token",
+    _patientId: "someone-else",
+  };
+
+  test("without a grant the overrides apply, as they always have", () => {
+    const args: Record<string, unknown> = { resource_type: "Patient", ...overrides };
+    const headers = applyToolArgumentOverrides(args, { "x-tenant-id": "session-tenant" });
+    expect(headers["x-tenant-id"]).toBe("victim-tenant");
+    expect(headers["x-step-up-token"]).toBe("forged-step-up");
+    expect(headers["authorization"]).toBe("Bearer forged-bearer");
+    expect(headers["x-fhir-server-url"]).toBe("https://evil.example/fhir");
+    expect(args).toEqual({ resource_type: "Patient" });
+  });
+
+  test("with a grant every override is removed and none is applied", () => {
+    const session = {
+      "x-tenant-id": TENANT,
+      "x-agent-id": "oauth:cid-claude",
+      "x-oauth-grant": JSON.stringify({ tenantId: TENANT, tokenHash: "h", expiresAtMs: 1 }),
+    };
+    const args: Record<string, unknown> = { resource_type: "Patient", ...overrides };
+    const headers = applyToolArgumentOverrides(args, session);
+    expect(headers).toEqual(session);
+    expect(args).toEqual({ resource_type: "Patient" });
+  });
+});
+
+describe("an SSE session is bound to the credential that opened it", () => {
+  test("the binding is the static token or one OAuth token's hash", () => {
+    expect(sessionCredential(undefined)).toBe("static");
+    const grant = { tenantId: TENANT, clientId: "c", scopes: ["fhir.read"], tokenHash: "abc", expiresAtMs: 1 };
+    expect(sessionCredential(grant)).toBe("oauth:abc");
+    expect(sessionCredential({ ...grant, tokenHash: "def" })).not.toBe(sessionCredential(grant));
+  });
+
+  test("a POST to /messages under another token is refused; the same token is accepted", async () => {
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    // The stream stays open while the POSTs below run: closing it would
+    // delete the session, and a 400 for a vanished session is not the
+    // refusal under test.
+    let stream: http.ClientRequest | undefined;
+    try {
+      // Open the stream with the OAuth token and read the endpoint event.
+      const sessionId = await new Promise<string>((resolve, reject) => {
+        stream = http.request(
+          { port, path: "/sse", method: "GET", headers: { Host: CANONICAL_HOST, Authorization: `Bearer ${OAUTH_TOKEN}` } },
+          (res) => {
+            if (res.statusCode !== 200) return reject(new Error(`sse ${res.statusCode}`));
+            let buf = "";
+            res.on("data", (chunk) => {
+              buf += chunk.toString();
+              const m = /sessionId=([A-Za-z0-9-]+)/.exec(buf);
+              if (m) resolve(m[1]);
+            });
+          }
+        );
+        stream.on("error", () => { /* destroyed at the end */ });
+        stream.end();
+      });
+
+      const post = (auth: string) =>
+        new Promise<number>((resolve, reject) => {
+          const req = http.request(
+            { port, path: `/messages?sessionId=${sessionId}`, method: "POST",
+              headers: { Host: CANONICAL_HOST, "Content-Type": "application/json", Authorization: auth } },
+            (res) => { res.resume(); res.on("end", () => resolve(res.statusCode || 0)); }
+          );
+          req.on("error", reject);
+          req.end(JSON.stringify({ jsonrpc: "2.0", id: 9, method: "ping" }));
+        });
+
+      // Another token, for another tenant, that introspection also accepts.
+      introspection = liveIntrospection({ tenant_id: "some-other-tenant" });
+      expect(await post("Bearer another-valid-token")).toBe(401);
+      // The static credential is not this session's credential either.
+      expect(await post(`Bearer ${STATIC_TOKEN}`)).toBe(401);
+      // The token that opened it is accepted (the transport may already be
+      // closed by then, which is any status but a refusal).
+      introspection = liveIntrospection();
+      expect(await post(`Bearer ${OAUTH_TOKEN}`)).not.toBe(401);
+    } finally {
+      stream?.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe("boot", () => {
+  test("R6 still holds: production without the static token and without demo refuses to start", () => {
+    const { assertMCPAuthConfigured } = require("./index");
+    expect(() => assertMCPAuthConfigured({ NODE_ENV: "production" })).toThrow(/MCP_AUTH_TOKEN/);
+  });
+
+  test("enabled without every dependency refuses to start; unset is fine", () => {
+    expect(() => assertMCPOAuthConfigured({})).not.toThrow();
+    expect(() =>
+      assertMCPOAuthConfigured({ MCP_OAUTH_ENABLED: "true", MCP_CANONICAL_RESOURCE: CANONICAL })
+    ).toThrow(/MCP_INTROSPECTION_CLIENT_ID/);
+    expect(() =>
+      assertMCPOAuthConfigured({
+        MCP_OAUTH_ENABLED: "true",
+        MCP_CANONICAL_RESOURCE: "https://MCP.healthclaw.io/mcp",
+        MCP_INTROSPECTION_CLIENT_ID: "a",
+        MCP_INTROSPECTION_CLIENT_SECRET: "b",
+        INTERNAL_TOKEN_MINT_SECRET: "c",
+      })
+    ).toThrow(/canonical/);
+    expect(() =>
+      assertMCPOAuthConfigured({
+        MCP_OAUTH_ENABLED: "true",
+        MCP_CANONICAL_RESOURCE: CANONICAL,
+        MCP_INTROSPECTION_CLIENT_ID: "a",
+        MCP_INTROSPECTION_CLIENT_SECRET: "b",
+        INTERNAL_TOKEN_MINT_SECRET: "c",
+      })
+    ).not.toThrow();
+  });
+});

--- a/services/agent-orchestrator/src/tools.ts
+++ b/services/agent-orchestrator/src/tools.ts
@@ -125,6 +125,38 @@ interface CachedReadToken {
 const READ_TOKEN_CACHE = new Map<string, CachedReadToken>();
 const READ_TOKEN_TTL_MS = 5 * 60 * 1000; // assume 5-min server TTL
 const READ_TOKEN_SKEW_MS = 30 * 1000; // re-mint 30s before expiry
+//: Read-scoped tokens minted for consented connections (spec §13.6), keyed
+//: by the SHA-256 of the OAuth token and never by tenant, so a revoked
+//: consent stops being served within the cache window.
+const GRANT_READ_TOKEN_CACHE = new Map<string, CachedReadToken>();
+const OAUTH_GRANT_HEADER = "x-oauth-grant";
+
+interface OAuthGrantMarker {
+  tenantId: string;
+  tokenHash: string;
+  expiresAtMs: number;
+}
+
+function parseGrantMarker(raw: string | undefined): OAuthGrantMarker | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<OAuthGrantMarker>;
+    if (
+      typeof parsed.tenantId === "string" &&
+      typeof parsed.tokenHash === "string" &&
+      typeof parsed.expiresAtMs === "number"
+    ) {
+      return parsed as OAuthGrantMarker;
+    }
+  } catch {
+    /* not a marker */
+  }
+  return null;
+}
+
+export function resetGrantReadTokenCacheForTests(): void {
+  GRANT_READ_TOKEN_CACHE.clear();
+}
 const PRIVILEGED_TOOL_NAMES = new Set(["fhir_get_token", "fhir_seed"]);
 
 export interface FHIRToolsOptions {
@@ -1134,6 +1166,11 @@ export class FHIRTools {
       return { error: `Unknown tool: ${toolName}` };
     }
 
+    const grant = parseGrantMarker(headers?.[OAUTH_GRANT_HEADER]);
+    if (grant) {
+      return this.executeAsGrant(tool, toolName, input, grant, headers?.["x-agent-id"]);
+    }
+
     // Preserve the stdio token tool's long-standing tenant fallback even
     // though its public schema requires tenant_id. HTTP never exposes this
     // privileged tool; local callers inherit the request/env demo tenant.
@@ -1206,6 +1243,89 @@ export class FHIRTools {
     }
 
     return tool.handler({ input: effectiveInput, headers: fwdHeaders, tenantId });
+  }
+
+  /**
+   * A tool call on behalf of a consented connection (spec §13.6). The tenant
+   * is the one introspection named; the only credential Flask sees is a
+   * read-scoped step-up token this server minted for it. A write-tier tool is
+   * refused before anything is sent: a consent to read is not a consent to
+   * write, and writes have their own human-approved rail.
+   */
+  private async executeAsGrant(
+    tool: RegisteredTool,
+    toolName: string,
+    input: Record<string, unknown>,
+    grant: OAuthGrantMarker,
+    agentId: string | undefined
+  ): Promise<Record<string, unknown>> {
+    if (tool.tier === "write") {
+      return {
+        error: "This connection is read-only",
+        tool: toolName,
+        message:
+          "A consented connection can read your records through the " +
+          "guardrails. Writes go through the human-approved action rail, " +
+          "never through this connection.",
+      };
+    }
+    if (!tool.validate(input)) {
+      return {
+        error: "Invalid tool input",
+        tool: toolName,
+        details: this.formatValidationErrors(tool.validate.errors),
+      };
+    }
+    const readToken = await this.ensureGrantReadToken(grant);
+    if (!readToken) {
+      // Fail closed: without a read credential the call is not made. A
+      // consented tenant is never reached with anything less than the
+      // credential its consent describes.
+      return {
+        error: "read_credential_unavailable",
+        tool: toolName,
+        message:
+          "The guardrail layer could not issue a read credential for this " +
+          "connection. Try again shortly.",
+      };
+    }
+    const fwdHeaders: Record<string, string> = {
+      "Content-Type": "application/fhir+json",
+      "X-Tenant-Id": grant.tenantId,
+      "X-Step-Up-Token": readToken,
+    };
+    if (agentId) fwdHeaders["X-Agent-Id"] = agentId;
+    return tool.handler({ input, headers: fwdHeaders, tenantId: grant.tenantId });
+  }
+
+  private async ensureGrantReadToken(grant: OAuthGrantMarker): Promise<string | null> {
+    const now = Date.now();
+    const cacheKey = `${this.serverRoot()}::${grant.tokenHash}`;
+    const cached = GRANT_READ_TOKEN_CACHE.get(cacheKey);
+    if (cached && cached.expiresAtMs - READ_TOKEN_SKEW_MS > now) return cached.token;
+    GRANT_READ_TOKEN_CACHE.delete(cacheKey);
+    const secret = process.env.INTERNAL_TOKEN_MINT_SECRET || "";
+    if (!secret) return null;
+    try {
+      const resp = await fetchWithTimeout(`${this.serverRoot()}/r6/fhir/internal/step-up-token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Tenant-Id": grant.tenantId,
+          "X-Internal-Secret": secret,
+        },
+        body: JSON.stringify({ tenant_id: grant.tenantId, scope: "read" }),
+      });
+      if (!resp.ok) return null;
+      const data = (await resp.json()) as Record<string, unknown>;
+      const token = data.token;
+      if (typeof token !== "string" || !token || data.scope !== "read") return null;
+      const expiresAtMs = Math.min(now + READ_TOKEN_TTL_MS, grant.expiresAtMs);
+      GRANT_READ_TOKEN_CACHE.set(cacheKey, { token, expiresAtMs });
+      return token;
+    } catch {
+      return null;
+    }
   }
 
   async getContext(


### PR DESCRIPTION
## What

Phase 3 of the MCP authorization design (spec §3.5, §3.6, §7 and the §13.6 amendment on #669). Off by default; nothing changes until `MCP_OAUTH_ENABLED=true`, and enabling it without every dependency refuses to start.

- **A bearer that is not `MCP_AUTH_TOKEN` is introspected at Flask** (`POST <FHIR_BASE_URL>/oauth/introspect`, the pre-registered client credential) and accepted only when it is live, its `aud` is exactly `MCP_CANONICAL_RESOURCE`, it carries a read scope and it has not expired. Every other case is the same 401 as today, never a 403 (a wrong audience is a token that was never for us). Flask unreachable is a 401: introspection fails closed.
- **The result is cached under the token's SHA-256 only**, for at most five minutes and never past the token's expiry, so a revoked consent stops being served within the window and the token value is never held.
- **On that path the caller's credentials never reach Flask.** The tenant comes from introspection and nowhere else; the inbound `Authorization`, any step-up token and the SHARP bring-your-own-FHIR headers are dropped; the six credential tool arguments are discarded on both transports (P3-a, R8), with the SSE override logic lifted into a pure helper so the property is asserted directly.
- **The downstream credential is a read-scoped step-up token this server mints** for the consented tenant (`scope: "read"`, the mint's new argument from the introspection branch), cached under the token hash and never past its expiry; a mint that answers without the read scope is a refusal, not a wider call. **A write-tier tool is refused before anything is sent**: a consent to read is not a consent to write.
- **The 401 and the transport preflight are readable from a browser** (`Access-Control-Allow-Origin: *`, `WWW-Authenticate` exposed), which is part 2 of #523. The transport's own origin allowlist is untouched, so nothing the transport returns becomes readable by any other page.
- `/health` reports `oauth.enabled`. Boot: `MCP_OAUTH_ENABLED=true` requires a canonical `MCP_CANONICAL_RESOURCE`, `MCP_INTROSPECTION_CLIENT_ID`, `MCP_INTROSPECTION_CLIENT_SECRET` and `INTERNAL_TOKEN_MINT_SECRET`.

## Evidence

`src/oauth-path.test.ts` (23 tests, Flask mocked at the fetch layer so every assertion is about what this server sends and refuses): R1, R2, R3, R4 with the §8.3 near-misses, R5, R6, R7, R8 on both transports, the positive chain with the exact headers Flask receives, the write refusal, the fail-closed mint, the caches. Whole jest suite 264 passed; `tsc --noEmit` clean. Mutations executed on the same worktree:

| mutation | result |
|---|---|
| audience never checked | caught (3) |
| writes allowed on a consented connection | caught (2) |
| a full-capability mint accepted as the read credential | caught |
| OAuth path on regardless of the flag | caught |
| expiry not enforced at the resource | caught |
| 401 unreadable from a browser | caught |
| SSE overrides honoured on the OAuth path | caught |
| extractHeaders falls through and the grant dispatch is gone (two-ended) | caught |
| extractHeaders alone keeps `Authorization` on the grant path | **inert by construction**: the grant path builds Flask's headers from scratch and never copies it, so the test stays green; the two-ended row above is the one that measures the property |

## Not in this PR

Flask's introspection endpoint and the read-only mint argument are on the held branch `feat/oauth-introspection-and-read-mint` (opens after #669). Until both are deployed and the flag is set, this server behaves exactly as today. No deploy: the MCP server deploy is a founder-authorized step, and production enablement comes after the staging walkthrough (spec §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)