### PR TITLE
fix(intake): the review gate refuses an attestation beside a confirmed allergy (#667)

### DIFF
--- a/r6/actions/review.py
+++ b/r6/actions/review.py
@@ -440,6 +440,19 @@ def review_submit(action_id):
                            '"No known allergies (patient confirmed)". No '
                            'known allergies is never assumed.')
 
+    # (3a) The two answers cannot both be true. "No known allergies" beside a
+    # confirmed allergy row is not a stricter reading of the same fact, it is
+    # a contradiction, and the reviewed response would carry both (#667). The
+    # extraction engine ignores the attestation structurally and writes the
+    # confirmed rows, so the record would hold an allergy while the response
+    # attests there are none. The message names both halves and neither the
+    # substance nor the reaction: the person is looking at the row.
+    if nka_affirmed and confirmed_allergy:
+        return _error(422, 'You confirmed an allergy and also checked "No '
+                           'known allergies (patient confirmed)". Both cannot '
+                           'be true: uncheck the box, or remove the allergy '
+                           'rows you confirmed.')
+
     # (4) Conditions are confirmable but not gating.
     condition_decisions = [
         submitted.get('condition-%d' % i, 'confirm').strip().lower()

--- a/tests/test_intake_attestation_gate.py
+++ b/tests/test_intake_attestation_gate.py
@@ -1,0 +1,157 @@
+"""The intake review gate, where "no known allergies" is decided (#667).
+
+The gate has always refused silence: an absence of allergies is never
+inferred, so a submit that neither confirms a row nor affirms the attestation
+is a 422. What it also accepted, until this module, was the opposite defect —
+both answers at once. A response carrying a confirmed allergy *and* the
+attestation is not a stricter statement of the same fact; the two contradict,
+and the extraction engine resolves the contradiction structurally by writing
+the row and ignoring the attestation. The record would then hold an allergy
+while the response it came from says there are none.
+"""
+import json
+
+import pytest
+
+from models import db
+from r6.models import R6Resource
+
+TENANT = 'test-tenant'
+PATIENT_ID = 'gate-patient-1'
+PATIENT_REF = 'Patient/%s' % PATIENT_ID
+
+
+def _store(resource, tenant_id):
+    row = R6Resource(resource_type=resource['resourceType'],
+                     resource_json=json.dumps(resource),
+                     resource_id=resource.get('id'), tenant_id=tenant_id)
+    db.session.add(row)
+    db.session.commit()
+
+
+def _patient():
+    return {'resourceType': 'Patient', 'id': PATIENT_ID,
+            'name': [{'family': 'Gatekeeper', 'given': ['Ada']}],
+            'gender': 'female', 'birthDate': '1962-03-04'}
+
+
+def _medication():
+    return {'resourceType': 'MedicationRequest', 'id': 'gate-med-1',
+            'status': 'active', 'intent': 'order',
+            'medicationCodeableConcept': {
+                'coding': [{'system': 'http://www.nlm.nih.gov/research/umls/rxnorm',
+                            'code': '860975'}]},
+            'subject': {'reference': PATIENT_REF}}
+
+
+def _allergy():
+    return {'resourceType': 'AllergyIntolerance', 'id': 'gate-allergy-1',
+            'code': {'coding': [{'system': 'http://snomed.info/sct',
+                                 'code': '227493005'}]},
+            'patient': {'reference': PATIENT_REF}}
+
+
+@pytest.fixture
+def intake_ready(app, tenant_headers):
+    """A patient with one medication and one allergy to review."""
+    with app.app_context():
+        for resource in (_patient(), _medication(), _allergy()):
+            _store(resource, tenant_headers['X-Tenant-Id'])
+
+
+def _committed_action(client, tenant_headers, auth_headers):
+    proposed = client.post('/r6/actions/propose', headers=tenant_headers,
+                           json={'kind': 'form-fill',
+                                 'payload': {'to': 'Intake portal',
+                                             'questionnaire': 'healthclaw-intake',
+                                             'body': 'new patient intake form'}})
+    assert proposed.status_code == 201, proposed.get_data(as_text=True)
+    action_id = proposed.get_json()['id']
+    committed = client.post('/r6/actions/%s/commit' % action_id,
+                            headers=auth_headers)
+    assert committed.status_code == 202, committed.get_data(as_text=True)
+    return action_id
+
+
+def _review(client, auth_headers, action_id, **answers):
+    return client.post('/r6/actions/%s/review' % action_id,
+                       headers=auth_headers, json=answers)
+
+
+def test_the_gate_refuses_the_attestation_beside_a_confirmed_allergy(
+        client, app, tenant_headers, auth_headers, action_registry,
+        intake_ready):
+    """MUTATION: drop the (3a) branch in r6/actions/review.py -> green here."""
+    action_id = _committed_action(client, tenant_headers, auth_headers)
+
+    refused = _review(client, auth_headers, action_id,
+                      **{'med-0': 'yes', 'allergy-0': 'confirm', 'nka': 'on'})
+
+    assert refused.status_code == 422, refused.get_data(as_text=True)
+    message = refused.get_json()['error']
+    # The refusal has to say which two things collide and what to do about
+    # them; "invalid submission" sends the person back to guess.
+    assert 'confirmed an allergy' in message, message
+    assert 'No known allergies' in message, message
+    assert 'uncheck the box' in message, message
+
+
+def test_nothing_is_recorded_when_the_contradiction_is_refused(
+        client, app, tenant_headers, auth_headers, action_registry,
+        intake_ready):
+    """A refusal that still writes the response is the defect with a 422 on
+    top: the extraction engine reads the stored response, not the status."""
+    action_id = _committed_action(client, tenant_headers, auth_headers)
+    with app.app_context():
+        before = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', tenant_id=TENANT).count()
+
+    refused = _review(client, auth_headers, action_id,
+                      **{'med-0': 'yes', 'allergy-0': 'confirm', 'nka': 'on'})
+    assert refused.status_code == 422, refused.get_data(as_text=True)
+
+    with app.app_context():
+        after = R6Resource.query.filter_by(
+            resource_type='QuestionnaireResponse', tenant_id=TENANT).count()
+    assert after == before, (
+        'the refused submit stored a reviewed QuestionnaireResponse; the '
+        'contradiction reaches the extractor whatever the caller was told')
+
+
+def test_a_confirmed_allergy_alone_is_still_accepted(
+        client, app, tenant_headers, auth_headers, action_registry,
+        intake_ready):
+    action_id = _committed_action(client, tenant_headers, auth_headers)
+
+    accepted = _review(client, auth_headers, action_id,
+                       **{'med-0': 'yes', 'allergy-0': 'confirm'})
+
+    assert accepted.status_code == 200, accepted.get_data(as_text=True)
+    assert accepted.get_json()['reviewed_qr_id']
+
+
+def test_the_attestation_alone_is_still_accepted(
+        client, app, tenant_headers, auth_headers, action_registry,
+        intake_ready):
+    """The reverse case the issue keeps: every row removed, NKA affirmed."""
+    action_id = _committed_action(client, tenant_headers, auth_headers)
+
+    accepted = _review(client, auth_headers, action_id,
+                       **{'med-0': 'yes', 'allergy-0': 'remove', 'nka': 'on'})
+
+    assert accepted.status_code == 200, accepted.get_data(as_text=True)
+    assert accepted.get_json()['reviewed_qr_id']
+
+
+def test_silence_about_allergies_is_still_refused(
+        client, app, tenant_headers, auth_headers, action_registry,
+        intake_ready):
+    """The older half of the gate, pinned here so this module fails if the
+    new branch is written in a way that swallows it."""
+    action_id = _committed_action(client, tenant_headers, auth_headers)
+
+    refused = _review(client, auth_headers, action_id,
+                      **{'med-0': 'yes', 'allergy-0': 'remove'})
+
+    assert refused.status_code == 422, refused.get_data(as_text=True)
+    assert 'never assumed' in refused.get_json()['error']


### PR DESCRIPTION
Closes #667.

## The defect

The intake review gate has always refused silence: a submit that neither confirms an allergy row nor affirms "no known allergies" is a 422, because an absence of allergies is never inferred. It accepted the opposite. A person could confirm an allergy **and** tick the attestation in the same submit, and the reviewed QuestionnaireResponse recorded both.

The two statements contradict, and the contradiction does not survive contact with the extraction engine, which writes the confirmed rows and ignores the attestation structurally. The record would carry an allergy while the response it was built from attests there are none.

## The change

The gate refuses that combination, names both halves, and gives the two ways out: untick the box, or remove the rows that were confirmed. The message carries no substance and no reaction, because the person is looking at the row.

The reverse case the issue keeps stays valid: every row removed with the attestation affirmed. So does a confirmed row on its own.

## Verified from the person's side of the screen

`templates/action_review.html` renders `error` from the response body when the submit is refused, so the wording above is what the person actually reads. The fix is not stuck on the server side.

## Tests

Five, in a new module: the refusal and its wording, that nothing is stored when it is refused (the extractor reads the stored response, not the status code), both accepted shapes, and the older silence half, pinned here so a rewrite of this branch cannot swallow it.

Disabling the new branch turns two of them red.

Full suite 3666 passed, 13 skipped, 1 xfailed. `uv run ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)